### PR TITLE
Adopt SafeTextMarkerData in more places

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2814,9 +2814,11 @@ Ref<Document> AXObjectCache::protectedDocument() const
     return document();
 }
 
-template<typename TextMarkerDataType>
-VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarkerDataType& textMarkerData)
+VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarkerData& textMarkerData)
 {
+    if (!textMarkerData.node)
+        return { };
+
     Ref node = *textMarkerData.node;
     if (!isNodeInUse(node) || node->isPseudoElement())
         return { };
@@ -2831,16 +2833,13 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
         return { };
 
     auto* cache = renderer->document().axObjectCache();
-    if (cache && !cache->m_idsInUse.contains(textMarkerData.axObjectID()))
+    if (cache && !cache->m_idsInUse.contains(textMarkerData.objectID))
         return { };
 
     return visiblePosition;
 }
 
-template VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarkerData&);
-template VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const SafeTextMarkerData&);
-
-CharacterOffset AXObjectCache::characterOffsetForTextMarkerData(const SafeTextMarkerData& textMarkerData)
+CharacterOffset AXObjectCache::characterOffsetForTextMarkerData(const TextMarkerData& textMarkerData)
 {
     if (textMarkerData.ignored || !textMarkerData.node)
         return { };
@@ -3381,7 +3380,7 @@ CharacterOffset AXObjectCache::characterOffsetFromVisiblePosition(const VisibleP
     return result;
 }
 
-AccessibilityObject* AXObjectCache::accessibilityObjectForTextMarkerData(const SafeTextMarkerData& textMarkerData)
+AccessibilityObject* AXObjectCache::accessibilityObjectForTextMarkerData(const TextMarkerData& textMarkerData)
 {
     if (textMarkerData.ignored)
         return nullptr;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -450,14 +450,14 @@ public:
     AXTextMarker nextTextMarker(const AXTextMarker&);
     TextMarkerData textMarkerDataForPreviousCharacterOffset(const CharacterOffset&);
     AXTextMarker previousTextMarker(const AXTextMarker&);
-    template<typename TextMarkerDataType> VisiblePosition visiblePositionForTextMarkerData(const TextMarkerDataType&);
-    CharacterOffset characterOffsetForTextMarkerData(const SafeTextMarkerData&);
+    VisiblePosition visiblePositionForTextMarkerData(const TextMarkerData&);
+    CharacterOffset characterOffsetForTextMarkerData(const TextMarkerData&);
     // Use ignoreNextNodeStart/ignorePreviousNodeEnd to determine the behavior when we are at node boundary.
     CharacterOffset nextCharacterOffset(const CharacterOffset&, bool ignoreNextNodeStart = true);
     CharacterOffset previousCharacterOffset(const CharacterOffset&, bool ignorePreviousNodeEnd = true);
     TextMarkerData startOrEndTextMarkerDataForRange(const SimpleRange&, bool);
     CharacterOffset startOrEndCharacterOffsetForRange(const SimpleRange&, bool, bool enterTextControls = false);
-    AccessibilityObject* accessibilityObjectForTextMarkerData(const SafeTextMarkerData&);
+    AccessibilityObject* accessibilityObjectForTextMarkerData(const TextMarkerData&);
     std::optional<SimpleRange> rangeForUnorderedCharacterOffsets(const CharacterOffset&, const CharacterOffset&);
     static SimpleRange rangeForNodeContents(Node&);
     static unsigned lengthForRange(const SimpleRange&);
@@ -573,6 +573,8 @@ public:
     static bool clientIsInTestMode();
 #endif
 
+    bool isNodeInUse(Node& node) const { return m_textMarkerNodes.contains(node); }
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void scheduleObjectRegionsUpdate(bool scheduleImmediately = false) { m_geometryManager->scheduleObjectRegionsUpdate(scheduleImmediately); }
     void willUpdateObjectRegions() { m_geometryManager->willUpdateObjectRegions(); }
@@ -626,7 +628,6 @@ protected:
     // This is a weak reference cache for knowing if Nodes used by TextMarkers are valid.
     void setNodeInUse(Node& node) { m_textMarkerNodes.add(node); }
     void removeNodeForUse(Node& node) { m_textMarkerNodes.remove(node); }
-    bool isNodeInUse(Node& node) { return m_textMarkerNodes.contains(node); }
 
     // CharacterOffset functions.
     enum TraverseOption { TraverseOptionDefault = 1 << 0, TraverseOptionToNodeEnd = 1 << 1, TraverseOptionIncludeStart = 1 << 2, TraverseOptionValidateOffset = 1 << 3, TraverseOptionDoNotEnterTextControls = 1 << 4 };

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,9 +48,9 @@ enum class LineRangeType : uint8_t {
     Right,
 };
 
-struct SafeTextMarkerData;
+struct TextMarkerData;
 
-struct TextMarkerData {
+struct RawTextMarkerData {
     unsigned treeID;
     unsigned objectID;
 
@@ -63,15 +63,15 @@ struct TextMarkerData {
     unsigned characterOffset;
     bool ignored;
 
-    // Constructors of TextMarkerData must zero the struct's block of memory because platform client code may rely on a byte-comparison to determine instances equality.
+    // Constructors of RawTextMarkerData must zero the struct's block of memory because platform client code may rely on a byte-comparison to determine instances equality.
     // Members initialization alone is not enough to guaranty that all bytes in the struct memeory are initialized, and may cause random inequalities when doing byte-comparisons.
-    // For an exampel of such byte-comparison, see the TestRunner WTR::AccessibilityTextMarker::isEqual.
-    TextMarkerData()
+    // For an example of such byte-comparison, see the TestRunner WTR::AccessibilityTextMarker::isEqual.
+    RawTextMarkerData()
     {
         memset(static_cast<void*>(this), 0, sizeof(*this));
     }
 
-    TextMarkerData(AXID axTreeID, AXID axObjectID,
+    RawTextMarkerData(AXID axTreeID, AXID axObjectID,
         Node* nodeParam = nullptr, unsigned offsetParam = 0,
         Position::AnchorType anchorTypeParam = Position::PositionIsOffsetInAnchor,
         Affinity affinityParam = Affinity::Downstream,
@@ -89,29 +89,13 @@ struct TextMarkerData {
         ignored = ignoredParam;
     }
 
-    TextMarkerData(AXObjectCache&, Node*, const VisiblePosition&, int charStart = 0, int charOffset = 0, bool ignoredParam = false);
-    TextMarkerData(AXObjectCache&, const CharacterOffset&, bool ignoredParam = false);
-
-    AXID axTreeID() const
-    {
-        return ObjectIdentifier<AXIDType>(treeID);
-    }
-
-    AXID axObjectID() const
-    {
-        return ObjectIdentifier<AXIDType>(objectID);
-    }
-
-    SafeTextMarkerData toSafeTextMarkerData() const;
-
-private:
-    void initializeAXIDs(AXObjectCache&, Node*);
+    TextMarkerData toTextMarkerData() const;
 };
 
-// Safer version of TextMarkerData with a WeakPtr for Node.
-// TextMarkerData uses a raw pointer for Node because it is
+// Safer version of RawTextMarkerData with a WeakPtr for Node.
+// RawTextMarkerData uses a raw pointer for Node because it is
 // used with memset / memcmp.
-struct SafeTextMarkerData {
+struct TextMarkerData {
     AXID treeID;
     AXID objectID;
 
@@ -124,18 +108,27 @@ struct SafeTextMarkerData {
     unsigned characterOffset { 0 };
     bool ignored { false };
 
-    TextMarkerData toTextMarkerData() const;
-    AXID axObjectID() const { return objectID; }
+    TextMarkerData() = default;
+    TextMarkerData(AXObjectCache&, Node*, const VisiblePosition&, int charStart = 0, int charOffset = 0, bool ignoredParam = false);
+    TextMarkerData(AXID treeID, AXID objectID, Node* node, unsigned offset, Position::AnchorType anchorType = Position::AnchorType::PositionIsOffsetInAnchor, Affinity affinity = Affinity::Upstream, unsigned characterStart = 0, unsigned characterOffset = 0, bool ignored = false)
+        : treeID(treeID)
+        , objectID(objectID)
+        , node(node)
+        , offset(offset)
+        , anchorType(anchorType)
+        , affinity(affinity)
+        , characterStart(characterStart)
+        , characterOffset(characterOffset)
+        , ignored(ignored)
+    { }
+    TextMarkerData(AXObjectCache&, const CharacterOffset&, bool ignoredParam = false);
+
+    RawTextMarkerData toRawTextMarkerData() const;
 };
 
-inline TextMarkerData SafeTextMarkerData::toTextMarkerData() const
+inline RawTextMarkerData TextMarkerData::toRawTextMarkerData() const
 {
     return { treeID, objectID, node.get(), offset, anchorType, affinity, characterStart, characterOffset, ignored };
-}
-
-inline SafeTextMarkerData TextMarkerData::toSafeTextMarkerData() const
-{
-    return { axTreeID(), axObjectID(), node, offset, anchorType, affinity, characterStart, characterOffset, ignored };
 }
 
 #if PLATFORM(MAC)
@@ -157,7 +150,7 @@ public:
         : m_data(data)
     { }
     AXTextMarker(TextMarkerData&& data)
-        : m_data(data)
+        : m_data(WTFMove(data))
     { }
 #if PLATFORM(COCOA)
     AXTextMarker(PlatformTextMarkerData);
@@ -178,8 +171,8 @@ public:
     operator PlatformTextMarkerData() const { return platformData().autorelease(); }
 #endif
 
-    AXID treeID() const { return m_data.axTreeID(); }
-    AXID objectID() const { return m_data.axObjectID(); }
+    AXID treeID() const { return m_data.treeID; }
+    AXID objectID() const { return m_data.objectID; }
     unsigned offset() const { return m_data.offset; }
     bool isNull() const { return !treeID().isValid() || !objectID().isValid(); }
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -245,7 +238,7 @@ private:
     bool atLineEnd() const { return atLineBoundaryForDirection(AXDirection::Next); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    TextMarkerData m_data; // FIXME: This should be a SafeTextMarkerData.
+    TextMarkerData m_data;
 };
 
 class AXTextMarkerRange {
@@ -296,7 +289,7 @@ private:
 inline Node* AXTextMarker::node() const
 {
     ASSERT(isMainThread());
-    return m_data.node;
+    return m_data.node.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -46,14 +46,18 @@ AXTextMarker::AXTextMarker(PlatformTextMarkerData platformData)
         return;
     }
 
-    if (AXTextMarkerGetLength(platformData) != sizeof(m_data)) {
+    RawTextMarkerData rawTextMarkerData;
+    if (AXTextMarkerGetLength(platformData) != sizeof(rawTextMarkerData)) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    memcpy(&m_data, AXTextMarkerGetBytePtr(platformData), sizeof(m_data));
+    memcpy(&rawTextMarkerData, AXTextMarkerGetBytePtr(platformData), sizeof(rawTextMarkerData));
+    m_data = rawTextMarkerData.toTextMarkerData();
 #else // PLATFORM(IOS_FAMILY)
-    [platformData getBytes:&m_data length:sizeof(m_data)];
+    RawTextMarkerData rawTextMarkerData;
+    [platformData getBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
+    m_data = rawTextMarkerData.toTextMarkerData();
 #endif
 
     if (isMainThread())
@@ -62,10 +66,11 @@ AXTextMarker::AXTextMarker(PlatformTextMarkerData platformData)
 
 RetainPtr<PlatformTextMarkerData> AXTextMarker::platformData() const
 {
+    auto rawTextMarkerData = m_data.toRawTextMarkerData();
 #if PLATFORM(MAC)
-    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&m_data, sizeof(m_data)));
+    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&rawTextMarkerData, sizeof(rawTextMarkerData)));
 #else // PLATFORM(IOS_FAMILY)
-    return [NSData dataWithBytes:&m_data length:sizeof(m_data)];
+    return [NSData dataWithBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
 #endif
 }
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -126,7 +126,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 @interface WebAccessibilityTextMarker : NSObject
 {
     AXObjectCache* _cache;
-    SafeTextMarkerData _safeTextMarkerData;
+    TextMarkerData _textMarkerData;
 }
 
 + (WebAccessibilityTextMarker *)textMarkerWithVisiblePosition:(VisiblePosition&)visiblePos cache:(AXObjectCache*)cache;
@@ -142,9 +142,9 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 {
     if (!(self = [super init]))
         return nil;
-    
+
     _cache = cache;
-    _safeTextMarkerData = data->toSafeTextMarkerData();
+    _textMarkerData = *data;
     return self;
 }
 
@@ -154,9 +154,9 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
         return nil;
     
     _cache = cache;
-    TextMarkerData textMarkerData;
-    [data getBytes:&textMarkerData length:sizeof(TextMarkerData)];
-    _safeTextMarkerData = textMarkerData.toSafeTextMarkerData();
+    RawTextMarkerData rawTextMarkerData;
+    [data getBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
+    _textMarkerData = rawTextMarkerData.toTextMarkerData();
     
     return self;
 }
@@ -203,38 +203,38 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
 - (NSData *)dataRepresentation
 {
-    auto textMarkerData = _safeTextMarkerData.toTextMarkerData();
-    return [NSData dataWithBytes:&textMarkerData length:sizeof(TextMarkerData)];
+    auto rawTextMarkerData = _textMarkerData.toRawTextMarkerData();
+    return [NSData dataWithBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
 }
 
 - (VisiblePosition)visiblePosition
 {
-    return _cache->visiblePositionForTextMarkerData(_safeTextMarkerData);
+    return _cache->visiblePositionForTextMarkerData(_textMarkerData);
 }
 
 - (CharacterOffset)characterOffset
 {
-    return _cache->characterOffsetForTextMarkerData(_safeTextMarkerData);
+    return _cache->characterOffsetForTextMarkerData(_textMarkerData);
 }
 
 - (BOOL)isIgnored
 {
-    return _safeTextMarkerData.ignored;
+    return _textMarkerData.ignored;
 }
 
 - (AccessibilityObject*)accessibilityObject
 {
-    return _cache->accessibilityObjectForTextMarkerData(_safeTextMarkerData);
+    return _cache->accessibilityObjectForTextMarkerData(_textMarkerData);
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"[AXTextMarker %p] = node: %p offset: %d", self, _safeTextMarkerData.node.get(), _safeTextMarkerData.offset];
+    return [NSString stringWithFormat:@"[AXTextMarker %p] = node: %p offset: %d", self, _textMarkerData.node.get(), _textMarkerData.offset];
 }
 
 - (TextMarkerData)textMarkerData
 {
-    return _safeTextMarkerData.toTextMarkerData();
+    return _textMarkerData;
 }
 
 @end

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -760,7 +760,8 @@ static RetainPtr<AXTextMarkerRef> previousTextMarker(AXObjectCache* cache, const
     if (!textMarkerData)
         return nil;
 
-    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&textMarkerData.value(), sizeof(textMarkerData.value())));
+    auto rawTextMarkerData = textMarkerData->toRawTextMarkerData();
+    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&rawTextMarkerData, sizeof(rawTextMarkerData)));
 }
 
 static NSAttributedString *attributedStringForTextMarkerRange(const AXCoreObject& object, AXTextMarkerRangeRef textMarkerRangeRef, AXCoreObject::SpellCheck spellCheck)


### PR DESCRIPTION
#### c0cc24bd0684971e90b5a3dd82e3c6fb03495b02
<pre>
Adopt SafeTextMarkerData in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=274035">https://bugs.webkit.org/show_bug.cgi?id=274035</a>
<a href="https://rdar.apple.com/127935353">rdar://127935353</a>

Reviewed by Darin Adler.

Rename TextMarkerData to RawTextMarkerData since it contains
raw pointers. Rename SafeTextMarkerData to TextMarkerData and
adopt as much as possible in the code base.

RawTextMarkerData is now only used to convert to and from
bytes.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::setNodeIfNeeded const):
(WebCore::AXTextMarker::operator CharacterOffset const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::treeID const):
(WebCore::AXTextMarker::objectID const):
(WebCore::AXTextMarker::node const):

Canonical link: <a href="https://commits.webkit.org/278666@main">https://commits.webkit.org/278666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96da5463a75e731cb99754bf2e6fd95ec92d3749

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54517 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53359 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22863 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1449 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56113 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49145 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48297 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28506 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7454 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->