### PR TITLE
Cache environment identifier in MediaCapability

### DIFF
--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -77,6 +77,7 @@ private:
     State m_state { State::Inactive };
     URL m_webPageURL;
     RetainPtr<BEMediaEnvironment> m_mediaEnvironment;
+    String m_environmentIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -46,6 +46,13 @@ MediaCapability::MediaCapability(URL&& webPageURL)
     , m_mediaEnvironment { createMediaEnvironment(m_webPageURL) }
 {
     setPlatformCapability([BEProcessCapability mediaPlaybackAndCaptureWithEnvironment:m_mediaEnvironment.get()]);
+#if USE(EXTENSIONKIT)
+    xpc_object_t xpcObject = [m_mediaEnvironment createXPCRepresentation];
+    if (!xpcObject)
+        return;
+    m_environmentIdentifier = String::fromUTF8(xpc_dictionary_get_string(xpcObject, "identifier"));
+#endif
+
 }
 
 bool MediaCapability::isActivatingOrActive() const
@@ -65,14 +72,7 @@ bool MediaCapability::isActivatingOrActive() const
 
 String MediaCapability::environmentIdentifier() const
 {
-#if USE(EXTENSIONKIT)
-    xpc_object_t xpcObject = [m_mediaEnvironment createXPCRepresentation];
-    if (!xpcObject)
-        return emptyString();
-    return String::fromUTF8(xpc_dictionary_get_string(xpcObject, "identifier"));
-#endif
-
-    return { };
+    return m_environmentIdentifier;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### c14649a9a9f21be9f20ef4af1f80f5c27b23a4b3
<pre>
Cache environment identifier in MediaCapability
<a href="https://bugs.webkit.org/show_bug.cgi?id=274047">https://bugs.webkit.org/show_bug.cgi?id=274047</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Cache environment identifier in MediaCapability for performance reasons.

* Source/WebKit/Platform/cocoa/MediaCapability.h:
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::MediaCapability::environmentIdentifier const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c14649a9a9f21be9f20ef4af1f80f5c27b23a4b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1922 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41721 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25506 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56085 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49121 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48269 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->