### PR TITLE
Skip class modification if possible

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -812,7 +812,7 @@ protected:
 
     void setTabIndexExplicitly(std::optional<int>);
 
-    void classAttributeChanged(const AtomString& newClassString);
+    void classAttributeChanged(const AtomString& newClassString, AttributeModificationReason);
     void partAttributeChanged(const AtomString& newValue);
 
     void addShadowRoot(Ref<ShadowRoot>&&);

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -78,6 +78,8 @@ public:
         m_refCount = tempRefCount;
     }
 
+    const AtomString& keyString() const { return m_keyString; }
+
     static ptrdiff_t tokensMemoryOffset() { return sizeof(SpaceSplitStringData); }
 
 private:
@@ -108,6 +110,13 @@ public:
 
     enum class ShouldFoldCase : bool { No, Yes };
     SpaceSplitString(const AtomString&, ShouldFoldCase);
+
+    const AtomString& keyString() const
+    {
+        if (m_data)
+            return m_data->keyString();
+        return nullAtom();
+    }
 
     friend bool operator==(const SpaceSplitString&, const SpaceSplitString&) = default;
     void set(const AtomString&, ShouldFoldCase);

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1021,7 +1021,7 @@ void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
     }
 
     if (attrName == HTMLNames::classAttr) {
-        classAttributeChanged(className());
+        classAttributeChanged(className(), AttributeModificationReason::Directly);
         invalidateInstances();
         return;
     }


### PR DESCRIPTION
#### bff7571e1974aeb72cf9f7e426debd4092504508
<pre>
Skip class modification if possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=274048">https://bugs.webkit.org/show_bug.cgi?id=274048</a>
<a href="https://rdar.apple.com/127948676">rdar://127948676</a>

Reviewed by Ryosuke Niwa.

When changing class attribute via parserSetAttributes,

1. We may be able to skip SpaceSplitString creation. If the ElementData is shareable one,
   it is possible that it already has SpaceSplitString materialized before. We check the keyString,
   and if it is true, then skip the creation.
2. Cache / style invalidation is not necessary at this point yet since it is not attached to the tree,
   and never rendered before.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeChanged):
(WebCore::Element::classAttributeChanged):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::keyString const):
(WebCore::SpaceSplitString::keyString const):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/278733@main">https://commits.webkit.org/278733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abc568afce3aa6cd23a4ca2f19ce85474b13c167

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54660 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41861 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22980 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1581 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56250 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49253 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48434 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28643 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7491 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->