### PR TITLE
SVG non-rendered elements should not get 'focus' despite tabindex

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/autofocus-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/autofocus-attribute-expected.txt
@@ -1,5 +1,5 @@
 
 PASS <a> should support autofocus
 PASS Renderable element with tabindex should support autofocus
-FAIL Never-rendered element with tabindex should not support autofocus assert_equals: expected "svg" but got "metadata"
+FAIL Never-rendered element with tabindex should not support autofocus promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'w.document.activeElement.tagName')"
 

--- a/LayoutTests/svg/custom/tabindex-order-expected.txt
+++ b/LayoutTests/svg/custom/tabindex-order-expected.txt
@@ -7,7 +7,6 @@ To test, put focus in "a". Pressing Tab should focus "a" through "k" in order, a
 id: a tabindex: 1 [object SVGCircleElement] is focused.
 id: b tabindex: 1 [object SVGGElement] is focused.
 id: c tabindex: 1 [object SVGEllipseElement] is focused.
-id: symbol tabindex: 1 [object SVGSymbolElement] is focused.
 id: d tabindex: 1 [object SVGPathElement] is focused.
 id: e tabindex: 3 [object SVGAElement] is focused.
 id: f tabindex: 4 [object SVGPolylineElement] is focused.
@@ -28,7 +27,6 @@ id: g tabindex: 6 [object SVGRectElement] is focused.
 id: f tabindex: 4 [object SVGPolylineElement] is focused.
 id: e tabindex: 3 [object SVGAElement] is focused.
 id: d tabindex: 1 [object SVGPathElement] is focused.
-id: symbol tabindex: 1 [object SVGSymbolElement] is focused.
 id: c tabindex: 1 [object SVGEllipseElement] is focused.
 id: b tabindex: 1 [object SVGGElement] is focused.
 id: a tabindex: 1 [object SVGCircleElement] is focused.

--- a/Source/WebCore/svg/SVGDescElement.h
+++ b/Source/WebCore/svg/SVGDescElement.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -35,6 +36,7 @@ private:
     SVGDescElement(const QualifiedName&, Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool supportsFocus() const final { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,6 +56,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 
     bool selfHasRelativeLengths() const override;
+    bool supportsFocus() const final { return false; }
 
     Ref<SVGAnimatedLength> m_x1 { SVGAnimatedLength::create(this, SVGLengthMode::Width, "0%"_s) };
     Ref<SVGAnimatedLength> m_y1 { SVGAnimatedLength::create(this, SVGLengthMode::Height, "0%"_s) };

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -84,6 +84,8 @@ private:
     bool needsPendingResourceHandling() const override { return false; }
 
     bool selfHasRelativeLengths() const override;
+
+    bool supportsFocus() const final { return false; }
 
     void invalidateMarkerResource();
 

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Alexander Kellett <lypanov@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -64,6 +64,7 @@ private:
     bool isValid() const final { return SVGTests::isValid(); }
     bool needsPendingResourceHandling() const final { return false; }
     bool selfHasRelativeLengths() const final { return true; }
+    bool supportsFocus() const final { return false; }
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width, "-10%"_s) };
     Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height, "-10%"_s) };

--- a/Source/WebCore/svg/SVGMetadataElement.h
+++ b/Source/WebCore/svg/SVGMetadataElement.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -33,6 +34,7 @@ private:
     SVGMetadataElement(const QualifiedName&, Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool supportsFocus() const final { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -72,6 +72,7 @@ private:
     bool isValid() const final { return SVGTests::isValid(); }
     bool needsPendingResourceHandling() const final { return false; }
     bool selfHasRelativeLengths() const final { return true; }
+    bool supportsFocus() const final { return false; }
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
     Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height) };

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -60,6 +60,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 
     bool selfHasRelativeLengths() const override;
+    bool supportsFocus() const final { return false; }
 
     Ref<SVGAnimatedLength> m_cx { SVGAnimatedLength::create(this, SVGLengthMode::Width, "50%"_s) };
     Ref<SVGAnimatedLength> m_cy { SVGAnimatedLength::create(this, SVGLengthMode::Height, "50%"_s) };

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2008-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -53,6 +53,7 @@ private:
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool supportsFocus() const final { return false; }
 
     // ScriptElement
     String sourceAttributeValue() const final { return href(); }

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -53,6 +53,7 @@ private:
     void childrenChanged(const ChildChange&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool supportsFocus() const final { return false; }
 
     void finishParsingChildren() final;
 

--- a/Source/WebCore/svg/SVGSymbolElement.h
+++ b/Source/WebCore/svg/SVGSymbolElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -40,6 +40,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 
     bool selfHasRelativeLengths() const override;
+    bool supportsFocus() const final { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTitleElement.h
+++ b/Source/WebCore/svg/SVGTitleElement.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,6 +39,7 @@ private:
     void childrenChanged(const ChildChange&) final;
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool supportsFocus() const final { return false; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7d5909d3097739b97a428e30836341088875c88d
<pre>
SVG non-rendered elements should not get &apos;focus&apos; despite tabindex

<a href="https://bugs.webkit.org/show_bug.cgi?id=274051">https://bugs.webkit.org/show_bug.cgi?id=274051</a>

Reviewed by Simon Fraser.

As per SVG2 specification [1]:

&quot;A non-rendered element can never receive focus, regardless of the value of the ‘tabindex’
attribute, If a script programmatically assigns focus to a non-rendered or otherwise un
focusable element, the focusing call is aborted...&quot;

[1] <a href="https://svgwg.org/svg2-draft/interact.html#Focus">https://svgwg.org/svg2-draft/interact.html#Focus</a>

This patch is to extend the &apos;supportFocus()&apos; as false to such elements.

* Source/WebCore/svg/SVGDescElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.h:
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGMetadataElement.h:
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.h:
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGStyleElement.h:
* Source/WebCore/svg/SVGSymbolElement.h:
* Source/WebCore/svg/SVGTitleElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/autofocus-attribute-expected.txt:
* LayoutTests/svg/custom/tabindex-order-expected.txt:

Canonical link: <a href="https://commits.webkit.org/278694@main">https://commits.webkit.org/278694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a430b1ca269e32a193ecb900c6cf458679dea7d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1448 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56111 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11227 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->