### PR TITLE
Pasting a web archive drops <picture> when wrapped in a <span>

### DIFF
--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -63,6 +63,12 @@ void SimplifyMarkupCommand::doApply()
         RefPtr currentNode = startingNode;
         RefPtr<Node> topNodeWithStartingStyle;
         while (currentNode != rootNode) {
+            // FIXME: The simplification algorithm should be rewritten to eliminate redundant
+            // parents in cases where the children affect rendered content, as observed with
+            // <span><picture></picture></span>.
+            if (currentNode->hasTagName(HTMLNames::pictureTag))
+                break;
+
             if (currentNode->parentNode() != rootNode && isRemovableBlock(currentNode.get()))
                 nodesToRemove.append(*currentNode);
             


### PR DESCRIPTION
#### efc8e7c710e136ba7f1472e2e8e4fe829f592af8
<pre>
Pasting a web archive drops &lt;picture&gt; when wrapped in a &lt;span&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=274062">https://bugs.webkit.org/show_bug.cgi?id=274062</a>
<a href="https://rdar.apple.com/127319160">rdar://127319160</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Pasting a web archive results in markup simplification being performed in
`SimplifyMarkupCommand`, via `ReplaceSelectionCommand`.

However, the logic for simplifying markup is incorrect. It currently
treats all inline elements that have the same style as equivalent. Then,
equivalent elements are removed bottom-up. This means that a `&lt;picture&gt;`
inside a `&lt;span&gt;` will be removed, as `&lt;picture&gt;` is an inline element,
with no custom style. Removing `&lt;picture&gt;` is incorrect, as it can affect the
rendered content due to source selection.

Fix by excluding `&lt;picture&gt;` from markup simplification. A better solution
would be to eliminate the `&lt;span&gt;` rather than the `&lt;picture&gt;`. However, that
approach requires a complete rewrite of the markup simplification algorithm.

* Source/WebCore/editing/SimplifyMarkupCommand.cpp:
(WebCore::SimplifyMarkupCommand::doApply):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm:
(TEST(PasteWebArchive, PreservesPictureInsideSpan)):

Canonical link: <a href="https://commits.webkit.org/278714@main">https://commits.webkit.org/278714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c8ae637c1285c1bd4bc4c98384fc67aa35f885

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41751 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1457 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56121 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49151 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44262 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48306 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->