### PR TITLE
Reduce use of `const char*` in string concatenations

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -114,7 +114,7 @@ public:
         if (!state->client.alwaysOnLoggingAllowed())
             return;
 
-        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::", methodName, ' '), state->contextId.toUInt64(), state->flags, arguments...);
+        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, span(methodName), ' '), state->contextId.toUInt64(), state->flags, arguments...);
     }
 
     template<typename... Arguments>
@@ -123,7 +123,7 @@ public:
         if (!m_manager.alwaysOnLoggingAllowed())
             return;
 
-        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::", methodName, ' '), arguments...);
+        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, span(methodName), ' '), arguments...);
     }
 
 private:

--- a/Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp
@@ -51,7 +51,7 @@ static ExceptionOr<Vector<String>> convertAndValidate(Document& document, unsign
     for (auto& supportedNetwork : supportedNetworks) {
         auto validatedNetwork = paymentCoordinator.validatedPaymentNetwork(document, version, supportedNetwork);
         if (!validatedNetwork)
-            return Exception { ExceptionCode::TypeError, makeString("\"", supportedNetwork, "\" is not a valid payment network.") };
+            return Exception { ExceptionCode::TypeError, makeString("\""_s, supportedNetwork, "\" is not a valid payment network."_s) };
         result.append(*validatedNetwork);
     }
 
@@ -61,7 +61,7 @@ static ExceptionOr<Vector<String>> convertAndValidate(Document& document, unsign
 ExceptionOr<ApplePaySessionPaymentRequest> convertAndValidate(Document& document, unsigned version, const ApplePayRequestBase& request, const PaymentCoordinator& paymentCoordinator)
 {
     if (!version || !paymentCoordinator.supportsVersion(document, version))
-        return Exception { ExceptionCode::InvalidAccessError, makeString('"', version, "\" is not a supported version.") };
+        return Exception { ExceptionCode::InvalidAccessError, makeString('"', version, "\" is not a supported version."_s) };
 
     ApplePaySessionPaymentRequest result;
     result.setVersion(version);

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -78,7 +78,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePaySession);
 static ExceptionOr<ApplePayLineItem> convertAndValidateTotal(ApplePayLineItem&& lineItem)
 {
     if (!isValidDecimalMonetaryValue(lineItem.amount))
-        return Exception { ExceptionCode::TypeError, makeString("\"" + lineItem.amount, "\" is not a valid amount.") };
+        return Exception { ExceptionCode::TypeError, makeString("\""_s, lineItem.amount, "\" is not a valid amount."_s) };
 
     auto validatedTotal = PaymentRequestValidator::validateTotal(lineItem);
     if (validatedTotal.hasException())
@@ -94,7 +94,7 @@ static ExceptionOr<ApplePayLineItem> convertAndValidate(ApplePayLineItem&& lineI
         lineItem.amount = nullString();
     } else {
         if (!isValidDecimalMonetaryValue(lineItem.amount))
-            return Exception { ExceptionCode::TypeError, makeString("\"" + lineItem.amount, "\" is not a valid amount.") };
+            return Exception { ExceptionCode::TypeError, makeString("\""_s, lineItem.amount, "\" is not a valid amount."_s) };
     }
 
     return WTFMove(lineItem);
@@ -121,7 +121,7 @@ static ExceptionOr<Vector<ApplePayLineItem>> convertAndValidate(std::optional<Ve
 static ExceptionOr<ApplePayShippingMethod> convertAndValidate(ApplePayShippingMethod&& shippingMethod)
 {
     if (!isValidDecimalMonetaryValue(shippingMethod.amount))
-        return Exception { ExceptionCode::TypeError, makeString("\"" + shippingMethod.amount, "\" is not a valid amount.") };
+        return Exception { ExceptionCode::TypeError, makeString("\""_s, shippingMethod.amount, "\" is not a valid amount."_s) };
 
     return WTFMove(shippingMethod);
 }
@@ -151,7 +151,7 @@ static ExceptionOr<ApplePayRecurringPaymentRequest> convertAndValidate(ApplePayR
     if (!regularBilling.label)
         return Exception(ExceptionCode::TypeError, "Missing label for 'regularBilling'."_s);
     if (!isValidDecimalMonetaryValue(regularBilling.amount) && regularBilling.type != ApplePayLineItem::Type::Pending)
-        return Exception(ExceptionCode::TypeError, makeString('"', regularBilling.amount, "\" is not a valid amount."));
+        return Exception(ExceptionCode::TypeError, makeString('"', regularBilling.amount, "\" is not a valid amount."_s));
 
     if (auto& trialBilling = recurringPaymentRequest.trialBilling) {
         if (trialBilling->paymentTiming != ApplePayPaymentTiming::Recurring)
@@ -203,7 +203,7 @@ static ExceptionOr<ApplePayAutomaticReloadPaymentRequest> convertAndValidate(App
 static ExceptionOr<ApplePayPaymentTokenContext> convertAndValidate(ApplePayPaymentTokenContext&& tokenContext)
 {
     if (!isValidDecimalMonetaryValue(tokenContext.amount))
-        return Exception { ExceptionCode::TypeError, makeString("\"" + tokenContext.amount, "\" is not a valid amount.") };
+        return Exception { ExceptionCode::TypeError, makeString("\""_s, tokenContext.amount, "\" is not a valid amount."_s) };
 
     return WTFMove(tokenContext);
 }

--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
@@ -121,7 +121,7 @@ static ExceptionOr<void> validateCountryCode(const String& countryCode)
             return { };
     }
 
-    return Exception { ExceptionCode::TypeError, makeString("\"" + countryCode, "\" is not a valid country code.") };
+    return Exception { ExceptionCode::TypeError, makeString("\""_s, countryCode, "\" is not a valid country code."_s) };
 }
 
 static ExceptionOr<void> validateCurrencyCode(const String& currencyCode)
@@ -138,7 +138,7 @@ static ExceptionOr<void> validateCurrencyCode(const String& currencyCode)
             return { };
     }
 
-    return Exception { ExceptionCode::TypeError, makeString("\"" + currencyCode, "\" is not a valid currency code.") };
+    return Exception { ExceptionCode::TypeError, makeString("\""_s, currencyCode, "\" is not a valid currency code."_s) };
 }
 
 static ExceptionOr<void> validateMerchantCapabilities(const ApplePaySessionPaymentRequest::MerchantCapabilities& merchantCapabilities)

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -151,7 +151,7 @@ PaymentCoordinator& ApplePayPaymentHandler::paymentCoordinator() const
 static ExceptionOr<void> validate(const PaymentCurrencyAmount& amount, const String& expectedCurrency)
 {
     if (amount.currency != expectedCurrency)
-        return Exception { ExceptionCode::TypeError, makeString("\"", amount.currency, "\" does not match the expected currency of \"", expectedCurrency, "\". Apple Pay requires all PaymentCurrencyAmounts to use the same currency code.") };
+        return Exception { ExceptionCode::TypeError, makeString("\""_s, amount.currency, "\" does not match the expected currency of \""_s, expectedCurrency, "\". Apple Pay requires all PaymentCurrencyAmounts to use the same currency code."_s) };
     return { };
 }
 

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
@@ -63,7 +63,7 @@ Exception convertToExceptionAndLog(ScriptExecutionContext* context, Error error)
 {
     auto exception = convertToException(error);
     if (context)
-        context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Cache API operation failed: ", exception.message()));
+        context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Cache API operation failed: "_s, exception.message()));
     return exception;
 }
 

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -211,7 +211,7 @@ static void logConsolePersistencyError(ScriptExecutionContext* context, const St
     if (!context)
         return;
 
-    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("There was an error making ", cacheName, " persistent on the filesystem"));
+    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("There was an error making "_s, cacheName, " persistent on the filesystem"_s));
 }
 
 void DOMCacheStorage::open(const String& name, DOMPromiseDeferred<IDLInterface<DOMCache>>&& promise)

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -382,7 +382,7 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
 
         // FIXME: <rdar://85515842> Obtain the encoded length without allocating and encoding.
         if (cookie.domain.utf8().length() > maximumAttributeValueSize) {
-            promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the domain must not be greater than ", maximumAttributeValueSize, " bytes") });
+            promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the domain must not be greater than "_s, maximumAttributeValueSize, " bytes"_s) });
             return;
         }
     }
@@ -399,7 +399,7 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
 
         // FIXME: <rdar://85515842> Obtain the encoded length without allocating and encoding.
         if (cookie.path.utf8().length() > maximumAttributeValueSize) {
-            promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the path must not be greater than ", maximumAttributeValueSize, " bytes") });
+            promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the path must not be greater than "_s, maximumAttributeValueSize, " bytes"_s) });
             return;
         }
     }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -65,7 +65,7 @@ void provideMediaKeySystemTo(Page& page, MediaKeySystemClient& client)
 void MediaKeySystemController::logRequestMediaKeySystemDenial(Document& document)
 {
     if (RefPtr window = document.domWindow())
-        window->printErrorMessage(makeString("Not allowed to access MediaKeySystem."));
+        window->printErrorMessage("Not allowed to access MediaKeySystem."_str);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -55,7 +55,7 @@ ExceptionOr<FetchBody> FetchBody::extract(Init&& value, String& contentType)
     }, [&](RefPtr<DOMFormData>& value) mutable -> ExceptionOr<FetchBody> {
         Ref<DOMFormData> domFormData = value.releaseNonNull();
         auto formData = FormData::createMultiPart(domFormData.get());
-        contentType = makeString("multipart/form-data; boundary=", formData->boundary());
+        contentType = makeString("multipart/form-data; boundary="_s, formData->boundary());
         return FetchBody(WTFMove(formData));
     }, [&](RefPtr<URLSearchParams>& value) mutable -> ExceptionOr<FetchBody> {
         Ref<const URLSearchParams> params = value.releaseNonNull();

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -196,7 +196,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
     auto form = DOMFormData::create(context, PAL::UTF8Encoding());
     auto mimeType = parseMIMEType(contentType);
     if (auto multipartBoundary = parseMultipartBoundary(mimeType)) {
-        auto boundaryWithDashes = makeString("--", *multipartBoundary);
+        auto boundaryWithDashes = makeString("--"_s, *multipartBoundary);
         CString boundary = boundaryWithDashes.utf8();
         size_t boundaryLength = boundary.length();
 

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -42,10 +42,10 @@ static void removePrivilegedNoCORSRequestHeaders(HTTPHeaderMap& headers)
 static ExceptionOr<bool> canWriteHeader(const String& name, const String& value, const String& combinedValue, FetchHeaders::Guard guard)
 {
     if (!isValidHTTPToken(name))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '", name, "'") };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '"_s, name, '\'') };
     ASSERT(value.isEmpty() || (!isASCIIWhitespaceWithoutFF(value[0]) && !isASCIIWhitespaceWithoutFF(value[value.length() - 1])));
     if (!isValidHTTPHeaderValue((value)))
-        return Exception { ExceptionCode::TypeError, makeString("Header '", name, "' has invalid value: '", value, "'") };
+        return Exception { ExceptionCode::TypeError, makeString("Header '"_s, name, "' has invalid value: '"_s, value, '\'') };
     if (guard == FetchHeaders::Guard::Immutable)
         return Exception { ExceptionCode::TypeError, "Headers object's guard is 'immutable'"_s };
     if (guard == FetchHeaders::Guard::Request && isForbiddenHeader(name, value))
@@ -60,7 +60,7 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
 static ExceptionOr<void> appendSetCookie(const String& value, Vector<String>& setCookieValues, FetchHeaders::Guard guard)
 {
     if (!isValidHTTPHeaderValue((value)))
-        return Exception { ExceptionCode::TypeError, makeString("Header 'Set-Cookie' has invalid value: '", value, "'") };
+        return Exception { ExceptionCode::TypeError, makeString("Header 'Set-Cookie' has invalid value: '"_s, value, '\'') };
     if (guard == FetchHeaders::Guard::Immutable)
         return Exception { ExceptionCode::TypeError, "Headers object's guard is 'immutable'"_s };
 
@@ -181,7 +181,7 @@ ExceptionOr<void> FetchHeaders::append(const String& name, const String& value)
 ExceptionOr<void> FetchHeaders::remove(const String& name)
 {
     if (!isValidHTTPToken(name))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '", name, "'") };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '"_s, name, '\'') };
     if (m_guard == FetchHeaders::Guard::Immutable)
         return Exception { ExceptionCode::TypeError, "Headers object's guard is 'immutable'"_s };
     if (m_guard == FetchHeaders::Guard::Request && isForbiddenHeaderName(name))
@@ -206,7 +206,7 @@ ExceptionOr<void> FetchHeaders::remove(const String& name)
 ExceptionOr<String> FetchHeaders::get(const String& name) const
 {
     if (!isValidHTTPToken(name))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '"_s, name, '\'') };
 
     if (equalIgnoringASCIICase(name, "set-cookie"_s)) {
         if (m_setCookieValues.isEmpty())
@@ -230,7 +230,7 @@ const Vector<String>& FetchHeaders::getSetCookie() const
 ExceptionOr<bool> FetchHeaders::has(const String& name) const
 {
     if (!isValidHTTPToken(name))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '", name, "'") };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '"_s, name, '\'') };
 
     if (equalIgnoringASCIICase(name, "set-cookie"_s))
         return !m_setCookieValues.isEmpty();

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -262,7 +262,7 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
 ExceptionOr<void> FetchRequest::setBody(FetchBody::Init&& body)
 {
     if (!methodCanHaveBody(m_request))
-        return Exception { ExceptionCode::TypeError, makeString("Request has method '", m_request.httpMethod(), "' and cannot have a body") };
+        return Exception { ExceptionCode::TypeError, makeString("Request has method '"_s, m_request.httpMethod(), "' and cannot have a body"_s) };
 
     ASSERT(scriptExecutionContext());
     auto result = extractBody(WTFMove(body));
@@ -281,7 +281,7 @@ ExceptionOr<void> FetchRequest::setBody(FetchRequest& request)
 
     if (!request.isBodyNull()) {
         if (!methodCanHaveBody(m_request))
-            return Exception { ExceptionCode::TypeError, makeString("Request has method '", m_request.httpMethod(), "' and cannot have a body") };
+            return Exception { ExceptionCode::TypeError, makeString("Request has method '"_s, m_request.httpMethod(), "' and cannot have a body"_s) };
         // FIXME: If body has a readable stream, we should pipe it to this new body stream.
         m_body = WTFMove(*request.m_body);
         request.setDisturbed();

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -151,11 +151,11 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::redirect(ScriptExecutionContext& 
 {
     URL requestURL = context.completeURL(url, ScriptExecutionContext::ForceUTF8::Yes);
     if (!requestURL.isValid())
-        return Exception { ExceptionCode::TypeError, makeString("Redirection URL '", requestURL.string(), "' is invalid") };
+        return Exception { ExceptionCode::TypeError, makeString("Redirection URL '"_s, requestURL.string(), "' is invalid"_s) };
     if (requestURL.hasCredentials())
         return Exception { ExceptionCode::TypeError, "Redirection URL contains credentials"_s };
     if (!ResourceResponse::isRedirectionStatusCode(status))
-        return Exception { ExceptionCode::RangeError, makeString("Status code ", status, "is not a redirection status code") };
+        return Exception { ExceptionCode::RangeError, makeString("Status code "_s, status, "is not a redirection status code"_s) };
     auto redirectResponse = adoptRef(*new FetchResponse(&context, { }, FetchHeaders::create(FetchHeaders::Guard::Immutable), { }));
     redirectResponse->suspendIfNeeded();
     redirectResponse->m_internalResponse.setHTTPStatusCode(status);

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -95,7 +95,7 @@ ExceptionOr<void> IDBIndex::setName(const String& name)
         return { };
 
     if (m_objectStore.info().hasIndex(name))
-        return Exception { ExceptionCode::ConstraintError, makeString("Failed set property 'name' on 'IDBIndex': The owning object store already has an index named '", name, "'.") };
+        return Exception { ExceptionCode::ConstraintError, makeString("Failed set property 'name' on 'IDBIndex': The owning object store already has an index named '"_s, name, "'."_s) };
 
     m_objectStore.transaction().database().renameIndex(*this, name);
     m_info.rename(name);

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -358,12 +358,12 @@ String IDBKeyData::loggingString() const
         break;
     }
     case IndexedDB::KeyType::String:
-        result = "<string> - " + std::get<String>(m_value);
+        result = makeString("<string> - "_s, std::get<String>(m_value));
         break;
     case IndexedDB::KeyType::Date:
-        return makeString("<date> - ", std::get<Date>(m_value).value);
+        return makeString("<date> - "_s, std::get<Date>(m_value).value);
     case IndexedDB::KeyType::Number:
-        return makeString("<number> - ", std::get<double>(m_value));
+        return makeString("<number> - "_s, std::get<double>(m_value));
     case IndexedDB::KeyType::Max:
         return "<maximum>"_s;
     case IndexedDB::KeyType::Min:

--- a/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
@@ -210,7 +210,7 @@ bool isIDBKeyPathValid(const IDBKeyPath& keyPath)
 String loggingString(const IDBKeyPath& path)
 {
     auto visitor = WTF::makeVisitor([](const String& string) {
-        return makeString("< ", string, " >");
+        return makeString("< "_s, string, " >"_s);
     }, [](const Vector<String>& strings) {
         if (strings.isEmpty())
             return "< >"_str;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -104,7 +104,7 @@ ExceptionOr<void> IDBObjectStore::setName(const String& name)
         return { };
 
     if (m_transaction.database().info().hasObjectStore(name))
-        return Exception { ExceptionCode::ConstraintError, makeString("Failed set property 'name' on 'IDBObjectStore': The database already has an object store named '", name, "'.") };
+        return Exception { ExceptionCode::ConstraintError, makeString("Failed set property 'name' on 'IDBObjectStore': The database already has an object store named '"_s, name, "'."_s) };
 
     m_transaction.database().renameObjectStore(*this, name);
     m_info.rename(name);

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -100,7 +100,7 @@ static int idbKeyCollate(std::span<const uint8_t> aBuffer, std::span<const uint8
 
 static const String v1RecordsTableSchema(ASCIILiteral tableName)
 {
-    return makeString("CREATE TABLE ", tableName, " (objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE, value NOT NULL ON CONFLICT FAIL)");
+    return makeString("CREATE TABLE "_s, tableName, " (objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT REPLACE, value NOT NULL ON CONFLICT FAIL)"_s);
 }
 
 static const String& v1RecordsTableSchema()
@@ -117,7 +117,7 @@ static const String& v1RecordsTableSchemaAlternate()
 
 static const String v2RecordsTableSchema(ASCIILiteral tableName)
 {
-    return makeString("CREATE TABLE ", tableName, " (objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL, value NOT NULL ON CONFLICT FAIL)");
+    return makeString("CREATE TABLE "_s, tableName, " (objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL, value NOT NULL ON CONFLICT FAIL)"_s);
 }
 
 static const String& v2RecordsTableSchema()
@@ -149,7 +149,7 @@ static ASCIILiteral v3RecordsTableSchemaTemp()
 
 static const String v1IndexRecordsTableSchema(ASCIILiteral tableName)
 {
-    return makeString("CREATE TABLE ", tableName, " (indexID INTEGER NOT NULL ON CONFLICT FAIL, objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL, value NOT NULL ON CONFLICT FAIL)");
+    return makeString("CREATE TABLE "_s, tableName, " (indexID INTEGER NOT NULL ON CONFLICT FAIL, objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL, value NOT NULL ON CONFLICT FAIL)"_s);
 }
 
 static const String& v1IndexRecordsTableSchema()
@@ -166,7 +166,7 @@ static const String& v1IndexRecordsTableSchemaAlternate()
 
 static const String v2IndexRecordsTableSchema(ASCIILiteral tableName)
 {
-    return makeString("CREATE TABLE ", tableName, " (indexID INTEGER NOT NULL ON CONFLICT FAIL, objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL, value TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL)");
+    return makeString("CREATE TABLE "_s, tableName, " (indexID INTEGER NOT NULL ON CONFLICT FAIL, objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, key TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL, value TEXT COLLATE IDBKEY NOT NULL ON CONFLICT FAIL)"_s);
 }
 
 static const String& v2IndexRecordsTableSchema()
@@ -218,12 +218,12 @@ static ASCIILiteral blobFilesTableSchemaAlternate()
 
 static String createV1ObjectStoreInfoSchema(ASCIILiteral tableName)
 {
-    return makeString("CREATE TABLE ", tableName, " (id INTEGER PRIMARY KEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, keyPath BLOB NOT NULL ON CONFLICT FAIL, autoInc INTEGER NOT NULL ON CONFLICT FAIL, maxIndexID INTEGER NOT NULL ON CONFLICT FAIL)");
+    return makeString("CREATE TABLE "_s, tableName, " (id INTEGER PRIMARY KEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, keyPath BLOB NOT NULL ON CONFLICT FAIL, autoInc INTEGER NOT NULL ON CONFLICT FAIL, maxIndexID INTEGER NOT NULL ON CONFLICT FAIL)"_s);
 }
 
 static String createV2ObjectStoreInfoSchema(ASCIILiteral tableName)
 {
-    return makeString("CREATE TABLE ", tableName, " (id INTEGER PRIMARY KEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, keyPath BLOB NOT NULL ON CONFLICT FAIL, autoInc INTEGER NOT NULL ON CONFLICT FAIL)");
+    return makeString("CREATE TABLE "_s, tableName, " (id INTEGER PRIMARY KEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, keyPath BLOB NOT NULL ON CONFLICT FAIL, autoInc INTEGER NOT NULL ON CONFLICT FAIL)"_s);
 }
 
 static ASCIILiteral indexInfoTableSchema()
@@ -253,7 +253,7 @@ static IDBError createOrMigrateRecordsTableIfNecessary(SQLiteDatabase& database)
     String tableStatement = database.tableSQL("Records"_s);
     if (tableStatement.isEmpty()) {
         if (!database.executeCommand(v3RecordsTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating Records table (", database.lastError(), ") - ", database.lastErrorMsg()) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating Records table ("_s, database.lastError(), ") - "_s, database.lastErrorMsg()) };
 
         return IDBError { };
     }
@@ -273,16 +273,16 @@ static IDBError createOrMigrateRecordsTableIfNecessary(SQLiteDatabase& database)
 
     // Create a temporary table with the correct schema and migrate all existing content over.
     if (!database.executeCommand(v3RecordsTableSchemaTemp()))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary Records table (", database.lastError(), ") - ", database.lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary Records table ("_s, database.lastError(), ") - "_s, database.lastErrorMsg()) };
 
     if (!database.executeCommand("INSERT INTO _Temp_Records (objectStoreID, key, value) SELECT objectStoreID, CAST(key AS TEXT), value FROM Records"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating Records table (", database.lastError(), ") - ", database.lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating Records table ("_s, database.lastError(), ") - "_s, database.lastErrorMsg()) };
 
     if (!database.executeCommand("DROP TABLE Records"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping Records table (", database.lastError(), ") - ", database.lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping Records table ("_s, database.lastError(), ") - "_s, database.lastErrorMsg()) };
 
     if (!database.executeCommand("ALTER TABLE _Temp_Records RENAME TO Records"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary Records table (", database.lastError(), ") - ", database.lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary Records table ("_s, database.lastError(), ") - "_s, database.lastErrorMsg()) };
 
     transaction.commit();
 
@@ -297,7 +297,7 @@ IDBError SQLiteIDBBackingStore::ensureValidBlobTables()
     String recordsTableStatement = m_sqliteDB->tableSQL("BlobRecords"_s);
     if (recordsTableStatement.isEmpty()) {
         if (!m_sqliteDB->executeCommand(blobRecordsTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobRecords table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
         recordsTableStatement = blobRecordsTableSchema();
     }
@@ -307,7 +307,7 @@ IDBError SQLiteIDBBackingStore::ensureValidBlobTables()
     String filesTableStatement = m_sqliteDB->tableSQL("BlobFiles"_s);
     if (filesTableStatement.isEmpty()) {
         if (!m_sqliteDB->executeCommand(blobFilesTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobFiles table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobFiles table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
         filesTableStatement = blobFilesTableSchema();
     }
@@ -328,7 +328,7 @@ IDBError SQLiteIDBBackingStore::ensureValidRecordsTable()
     // Whether the updated records table already existed or if it was just created and the data migrated over,
     // make sure the uniqueness index exists.
     if (!m_sqliteDB->executeCommand("CREATE UNIQUE INDEX IF NOT EXISTS RecordsIndex ON Records (objectStoreID, key);"_s))
-        error = IDBError { ExceptionCode::UnknownError, makeString("Error creating RecordsIndex on Records table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        error = IDBError { ExceptionCode::UnknownError, makeString("Error creating RecordsIndex on Records table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     return error;
 }
@@ -341,7 +341,7 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsTable()
     String tableStatement = m_sqliteDB->tableSQL("IndexRecords"_s);
     if (tableStatement.isEmpty()) {
         if (!m_sqliteDB->executeCommand(v3IndexRecordsTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecords table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
         return IDBError { };
     }
@@ -357,16 +357,16 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsTable()
 
     // Create a temporary table with the correct schema and migrate all existing content over.
     if (!m_sqliteDB->executeCommand(v3IndexRecordsTableSchemaTemp()))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary IndexRecords table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     if (!m_sqliteDB->executeCommand("INSERT INTO _Temp_IndexRecords SELECT IndexRecords.indexID, IndexRecords.objectStoreID, IndexRecords.key, IndexRecords.value, Records.rowid FROM IndexRecords INNER JOIN Records ON Records.key = IndexRecords.value AND Records.objectStoreID = IndexRecords.objectStoreID"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating IndexRecords table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     if (!m_sqliteDB->executeCommand("DROP TABLE IndexRecords"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecords table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     if (!m_sqliteDB->executeCommand("ALTER TABLE _Temp_IndexRecords RENAME TO IndexRecords"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary IndexRecords table (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     transaction.commit();
 
@@ -383,10 +383,10 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsIndex()
         return IDBError { };
     
     if (!m_sqliteDB->executeCommand("DROP INDEX IF EXISTS IndexRecordsIndex"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsIndex index (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     if (!m_sqliteDB->executeCommand(IndexRecordsIndexSchema))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsIndex index (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     return IDBError { };
 }
@@ -401,10 +401,10 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsRecordIndex()
         return IDBError { };
     
     if (!m_sqliteDB->executeCommand("DROP INDEX IF EXISTS IndexRecordsRecordIndex"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsRecordIndex index (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsRecordIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     if (!m_sqliteDB->executeCommand(v1IndexRecordsRecordIndexSchema))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsRecordIndex index (", m_sqliteDB->lastError(), ") - ", m_sqliteDB->lastErrorMsg()) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsRecordIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, m_sqliteDB->lastErrorMsg()) };
 
     return IDBError { };
 }

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -134,31 +134,31 @@ void SQLiteIDBCursor::currentData(IDBGetResult& result, const std::optional<IDBK
 
 static String buildPreIndexStatement(bool isDirectionNext)
 {
-    return makeString("SELECT rowid, key, value FROM IndexRecords WHERE indexID = ? AND key = CAST(? AS TEXT) AND value ",
-        isDirectionNext ? '>' : '<', " CAST(? AS TEXT) ORDER BY value", isDirectionNext ? "" : " DESC", ';');
+    return makeString("SELECT rowid, key, value FROM IndexRecords WHERE indexID = ? AND key = CAST(? AS TEXT) AND value "_s,
+        isDirectionNext ? '>' : '<', " CAST(? AS TEXT) ORDER BY value"_s, isDirectionNext ? ""_s : " DESC"_s, ';');
 }
 
 static String buildIndexStatement(const IDBKeyRangeData& keyRange, IndexedDB::CursorDirection cursorDirection)
 {
-    return makeString("SELECT rowid, key, value FROM IndexRecords WHERE indexID = ? AND key ",
-        !keyRange.lowerKey.isNull() && !keyRange.lowerOpen ? ">=" : ">",
-        " CAST(? AS TEXT) AND key ",
-        !keyRange.upperKey.isNull() && !keyRange.upperOpen ? "<=" : "<",
-        " CAST(? AS TEXT) ORDER BY key",
-        cursorDirection == IndexedDB::CursorDirection::Prev || cursorDirection == IndexedDB::CursorDirection::Prevunique ? " DESC" : "",
-        ", value",
-        cursorDirection == IndexedDB::CursorDirection::Prev ? " DESC" : "",
+    return makeString("SELECT rowid, key, value FROM IndexRecords WHERE indexID = ? AND key "_s,
+        !keyRange.lowerKey.isNull() && !keyRange.lowerOpen ? ">="_s : ">"_s,
+        " CAST(? AS TEXT) AND key "_s,
+        !keyRange.upperKey.isNull() && !keyRange.upperOpen ? "<="_s : "<"_s,
+        " CAST(? AS TEXT) ORDER BY key"_s,
+        cursorDirection == IndexedDB::CursorDirection::Prev || cursorDirection == IndexedDB::CursorDirection::Prevunique ? " DESC"_s : ""_s,
+        ", value"_s,
+        cursorDirection == IndexedDB::CursorDirection::Prev ? " DESC"_s : ""_s,
         ';');
 }
 
 static String buildObjectStoreStatement(const IDBKeyRangeData& keyRange, IndexedDB::CursorDirection cursorDirection)
 {
-    return makeString("SELECT rowid, key, value FROM Records WHERE objectStoreID = ? AND key ",
-        !keyRange.lowerKey.isNull() && !keyRange.lowerOpen ? ">=" : ">",
-        " CAST(? AS TEXT) AND key ",
-        !keyRange.upperKey.isNull() && !keyRange.upperOpen ? "<=" : "<",
-        " CAST(? AS TEXT) ORDER BY key",
-        cursorDirection == IndexedDB::CursorDirection::Prev || cursorDirection == IndexedDB::CursorDirection::Prevunique ? " DESC" : "",
+    return makeString("SELECT rowid, key, value FROM Records WHERE objectStoreID = ? AND key "_s,
+        !keyRange.lowerKey.isNull() && !keyRange.lowerOpen ? ">="_s : ">"_s,
+        " CAST(? AS TEXT) AND key "_s,
+        !keyRange.upperKey.isNull() && !keyRange.upperOpen ? "<="_s : "<"_s,
+        " CAST(? AS TEXT) ORDER BY key"_s,
+        cursorDirection == IndexedDB::CursorDirection::Prev || cursorDirection == IndexedDB::CursorDirection::Prevunique ? " DESC"_s : ""_s,
         ';');
 }
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.cpp
@@ -103,9 +103,9 @@ IDBCursorInfo IDBCursorInfo::isolatedCopy() const
 String IDBCursorInfo::loggingString() const
 {
     if (m_source == IndexedDB::CursorSource::Index)
-        return makeString("<Crsr: ", m_cursorIdentifier.loggingString(), " Idx ", m_sourceIdentifier, ", OS ", m_objectStoreIdentifier, ", tx ", m_transactionIdentifier.loggingString(), '>');
+        return makeString("<Crsr: "_s, m_cursorIdentifier.loggingString(), " Idx "_s, m_sourceIdentifier, ", OS "_s, m_objectStoreIdentifier, ", tx "_s, m_transactionIdentifier.loggingString(), '>');
 
-    return makeString("<Crsr: ", m_cursorIdentifier.loggingString(), " OS ", m_objectStoreIdentifier, ", tx ", m_transactionIdentifier.loggingString(), '>');
+    return makeString("<Crsr: "_s, m_cursorIdentifier.loggingString(), " OS "_s, m_objectStoreIdentifier, ", tx "_s, m_transactionIdentifier.loggingString(), '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp
@@ -41,8 +41,8 @@ IDBGetAllRecordsData IDBGetAllRecordsData::isolatedCopy() const
 String IDBGetAllRecordsData::loggingString() const
 {
     if (indexIdentifier)
-        return makeString("<GetAllRecords: Idx ", indexIdentifier, ", OS ", objectStoreIdentifier, ", ", getAllType == IndexedDB::GetAllType::Keys ? "Keys" : "Values", ", range ", keyRangeData.loggingString(), '>');
-    return makeString("<GetAllRecords: OS ", objectStoreIdentifier, ", ", getAllType == IndexedDB::GetAllType::Keys ? "Keys" : "Values", ", range ", keyRangeData.loggingString(), '>');
+        return makeString("<GetAllRecords: Idx "_s, indexIdentifier, ", OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", range "_s, keyRangeData.loggingString(), '>');
+    return makeString("<GetAllRecords: OS "_s, objectStoreIdentifier, ", "_s, getAllType == IndexedDB::GetAllType::Keys ? "Keys"_s : "Values"_s, ", range "_s, keyRangeData.loggingString(), '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.cpp
@@ -39,7 +39,7 @@ IDBGetRecordData IDBGetRecordData::isolatedCopy() const
 
 String IDBGetRecordData::loggingString() const
 {
-    return makeString("<GetRecord: ", type == IDBGetRecordDataType::KeyOnly ? "KeyOnly" : "Key+Value", ' ', keyRangeData.loggingString(), '>');
+    return makeString("<GetRecord: "_s, type == IDBGetRecordDataType::KeyOnly ? "KeyOnly"_s : "Key+Value"_s, ' ', keyRangeData.loggingString(), '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.cpp
@@ -62,12 +62,12 @@ String IDBIndexInfo::loggingString(int indent) const
     StringBuilder indentString;
     for (int i = 0; i < indent; ++i)
         indentString.append(' ');
-    return makeString(indentString.toString(), "Index: ", m_name, " (", m_identifier, ") keyPath: ", WebCore::loggingString(m_keyPath), '\n');
+    return makeString(indentString.toString(), "Index: "_s, m_name, " ("_s, m_identifier, ") keyPath: "_s, WebCore::loggingString(m_keyPath), '\n');
 }
 
 String IDBIndexInfo::condensedLoggingString() const
 {
-    return makeString("<Idx: ", m_name, " (", m_identifier, "), OS (", m_objectStoreIdentifier, ")>");
+    return makeString("<Idx: "_s, m_name, " ("_s, m_identifier, "), OS ("_s, m_objectStoreIdentifier, ")>"_s);
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBIterateCursorData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBIterateCursorData.cpp
@@ -38,7 +38,7 @@ IDBIterateCursorData IDBIterateCursorData::isolatedCopy() const
 
 String IDBIterateCursorData::loggingString() const
 {
-    return makeString("<Itr8Crsr: key ", keyData.loggingString(), ", primaryKey ", primaryKeyData.loggingString(), ", count ", count, '>');
+    return makeString("<Itr8Crsr: key "_s, keyData.loggingString(), ", primaryKey "_s, primaryKeyData.loggingString(), ", count "_s, count, '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
@@ -143,7 +143,7 @@ String IDBObjectStoreInfo::loggingString(int indent) const
 
 String IDBObjectStoreInfo::condensedLoggingString() const
 {
-    return makeString("<OS: ", m_name, " (", m_identifier, ")>");
+    return makeString("<OS: "_s, m_name, " ("_s, m_identifier, ")>"_s);
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp
@@ -88,7 +88,7 @@ IDBResourceIdentifier IDBResourceIdentifier::emptyValue()
 
 String IDBResourceIdentifier::loggingString() const
 {
-    return makeString('<', m_idbConnectionIdentifier.toUInt64(), ", ", m_resourceNumber, '>');
+    return makeString('<', m_idbConnectionIdentifier.toUInt64(), ", "_s, m_resourceNumber, '>');
 }
 
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp
@@ -111,7 +111,7 @@ String IDBTransactionInfo::loggingString() const
         ASSERT_NOT_REACHED();
     }
     
-    return makeString("Transaction: ", m_identifier.loggingString(), " mode ", modeString, " newVersion ", m_newVersion);
+    return makeString("Transaction: "_s, m_identifier.loggingString(), " mode "_s, modeString, " newVersion "_s, m_newVersion);
 }
 
 #endif

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
@@ -99,7 +99,7 @@ void MediaSessionCoordinator::join(DOMPromiseDeferred<void>&& promise)
 
     if (m_state != MediaSessionCoordinatorState::Waiting) {
         ERROR_LOG(identifier, "invalid state");
-        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to join when state is ", convertEnumerationToString(m_state)) });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to join when state is "_s, convertEnumerationToString(m_state)) });
         return;
     }
     ASSERT(m_privateCoordinator, "We must be in Waiting state if no private coordinator is set");
@@ -126,7 +126,7 @@ ExceptionOr<void> MediaSessionCoordinator::leave()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     if (m_state != MediaSessionCoordinatorState::Joined)
-        return Exception { ExceptionCode::InvalidStateError, makeString("Unable to leave when state is ", convertEnumerationToString(m_state)) };
+        return Exception { ExceptionCode::InvalidStateError, makeString("Unable to leave when state is "_s, convertEnumerationToString(m_state)) };
 
     close();
 
@@ -157,7 +157,7 @@ void MediaSessionCoordinator::seekTo(double time, DOMPromiseDeferred<void>&& pro
 
     if (m_state != MediaSessionCoordinatorState::Joined) {
         ERROR_LOG(identifier, ".state is ", m_state);
-        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to seekTo when state is ", convertEnumerationToString(m_state)) });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to seekTo when state is "_s, convertEnumerationToString(m_state)) });
         return;
     }
 
@@ -190,7 +190,7 @@ void MediaSessionCoordinator::play(DOMPromiseDeferred<void>&& promise)
 
     if (m_state != MediaSessionCoordinatorState::Joined) {
         ERROR_LOG(identifier, ".state is ", m_state);
-        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to play when state is ", convertEnumerationToString(m_state)) });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to play when state is "_s, convertEnumerationToString(m_state)) });
         return;
     }
 
@@ -223,7 +223,7 @@ void MediaSessionCoordinator::pause(DOMPromiseDeferred<void>&& promise)
 
     if (m_state != MediaSessionCoordinatorState::Joined) {
         ERROR_LOG(identifier, ".state is ", m_state);
-        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to pause when state is ", convertEnumerationToString(m_state)) });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to pause when state is "_s, convertEnumerationToString(m_state)) });
         return;
     }
 
@@ -256,7 +256,7 @@ void MediaSessionCoordinator::setTrack(const String& track, DOMPromiseDeferred<v
 
     if (m_state != MediaSessionCoordinatorState::Joined) {
         ERROR_LOG(identifier, ".state is ", m_state);
-        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to setTrack when state is ", convertEnumerationToString(m_state)) });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, makeString("Unable to setTrack when state is "_s, convertEnumerationToString(m_state)) });
         return;
     }
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1471,7 +1471,7 @@ WTFLogChannel& MediaSource::logChannel() const
 void MediaSource::failedToCreateRenderer(RendererType type)
 {
     if (auto context = scriptExecutionContext())
-        context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource ", type == RendererType::Video ? "video" : "audio", " renderer creation failed."));
+        context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource "_s, type == RendererType::Video ? "video"_s : "audio"_s, " renderer creation failed."_s));
 }
 
 void MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged()

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -75,7 +75,7 @@ NetworkSendQueue RTCDataChannel::createMessageQueue(ScriptExecutionContext& cont
     }, [&channel](ExceptionCode errorCode) {
         if (RefPtr context = channel.scriptExecutionContext()) {
             auto code = static_cast<int>(errorCode);
-            context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Error ", code, " in retrieving a blob data to be sent through RTCDataChannel."));
+            context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Error "_s, code, " in retrieving a blob data to be sent through RTCDataChannel."_s));
         }
         return NetworkSendQueue::Continue::Yes;
     } };

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -59,13 +59,13 @@ void provideUserMediaTo(Page* page, UserMediaClient* client)
 void UserMediaController::logGetUserMediaDenial(Document& document)
 {
     if (RefPtr window = document.domWindow())
-        window->printErrorMessage(makeString("Not allowed to call getUserMedia."));
+        window->printErrorMessage("Not allowed to call getUserMedia."_s);
 }
 
 void UserMediaController::logGetDisplayMediaDenial(Document& document)
 {
     if (RefPtr window = document.domWindow())
-        window->printErrorMessage(makeString("Not allowed to call getDisplayMedia."));
+        window->printErrorMessage("Not allowed to call getDisplayMedia."_s);
 }
 
 void UserMediaController::logEnumerateDevicesDenial(Document& document)
@@ -74,7 +74,7 @@ void UserMediaController::logEnumerateDevicesDenial(Document& document)
     isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::Yes);
     isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::Yes);
     if (RefPtr window = document.domWindow())
-        window->printErrorMessage(makeString("Not allowed to call enumerateDevices."));
+        window->printErrorMessage("Not allowed to call enumerateDevices."_s);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -87,7 +87,7 @@ GStreamerDataChannelHandler::GStreamerDataChannelHandler(GRefPtr<GstWebRTCDataCh
     : m_channel(WTFMove(channel))
 {
     static Atomic<uint64_t> nChannel = 0;
-    m_channelId = makeString("webkit-webrtc-data-channel-", nChannel.exchangeAdd(1));
+    m_channelId = makeString("webkit-webrtc-data-channel-"_s, nChannel.exchangeAdd(1));
 
     ASSERT(m_channel);
     static std::once_flag debugRegisteredFlag;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -94,7 +94,7 @@ GStreamerMediaEndpoint::~GStreamerMediaEndpoint()
 bool GStreamerMediaEndpoint::initializePipeline()
 {
     static uint32_t nPipeline = 0;
-    auto pipelineName = makeString("webkit-webrtc-pipeline-", nPipeline);
+    auto pipelineName = makeString("webkit-webrtc-pipeline-"_s, nPipeline);
     m_pipeline = gst_pipeline_new(pipelineName.ascii().data());
     registerActivePipeline(m_pipeline);
 
@@ -102,7 +102,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
         handleMessage(message);
     });
 
-    auto binName = makeString("webkit-webrtcbin-", nPipeline++);
+    auto binName = makeString("webkit-webrtcbin-"_s, nPipeline++);
     m_webrtcBin = makeGStreamerElement("webrtcbin", binName.ascii().data());
     if (!m_webrtcBin)
         return false;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -534,7 +534,7 @@ GRefPtr<GstCaps> capsFromRtpCapabilities(RefPtr<UniqueSSRCGenerator> ssrcGenerat
 
         if (!index) {
             for (unsigned i = 1; auto& extension : capabilities.headerExtensions)
-                gst_structure_set(codecStructure, makeString("extmap-", i++).ascii().data(), G_TYPE_STRING, extension.uri.ascii().data(), nullptr);
+                gst_structure_set(codecStructure, makeString("extmap-"_s, i++).ascii().data(), G_TYPE_STRING, extension.uri.ascii().data(), nullptr);
         }
         gst_caps_append_structure(caps.get(), codecStructure);
         index++;

--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
@@ -170,49 +170,49 @@ ExceptionOr<NotificationOptionsPayload> NotificationJSONParser::parseNotificatio
     NotificationDirection direction = NotificationDirection::Auto;
     if (auto value = object.getValue(dirKey())) {
         if (value->type() != JSON::Value::Type::String)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", dirKey(), "' member is specified but is not a string") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', dirKey(), "' member is specified but is not a string"_s) };
         auto directionString = object.getString(dirKey());
         auto parsedDirection = parseEnumerationFromString<NotificationDirection>(directionString);
         if (parsedDirection == std::nullopt)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", dirKey(), "' member is specified but is not a valid NotificationDirection") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', dirKey(), "' member is specified but is not a valid NotificationDirection"_s) };
         direction = *parsedDirection;
     }
 
     String lang;
     if (auto value = object.getValue(langKey())) {
         if (value->type() != JSON::Value::Type::String)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", langKey(), "' member is specified but is not a string") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', langKey(), "' member is specified but is not a string"_s) };
         lang = value->asString();
     }
 
     String body;
     if (auto value = object.getValue(bodyKey())) {
         if (value->type() != JSON::Value::Type::String)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", bodyKey(), "' member is specified but is not a string") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', bodyKey(), "' member is specified but is not a string"_s) };
         body = value->asString();
     }
 
     String tag;
     if (auto value = object.getValue(tagKey())) {
         if (value->type() != JSON::Value::Type::String)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", tagKey(), "' member is specified but is not a string") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', tagKey(), "' member is specified but is not a string"_s) };
         tag = value->asString();
     }
 
     URL iconURL;
     if (auto value = object.getValue(iconKey())) {
         if (value->type() != JSON::Value::Type::String)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", iconKey(), "' member is specified but is not a string") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', iconKey(), "' member is specified but is not a string"_s) };
 
         iconURL = URL { value->asString() };
         if (!iconURL.isValid())
-            return Exception { ExceptionCode::SyntaxError, makeString("'", iconKey(), "' member is specified but does not represent a valid URL") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', iconKey(), "' member is specified but does not represent a valid URL"_s) };
     }
 
     std::optional<bool> silent;
     if (auto value = object.getValue(silentKey())) {
         if (value->type() != JSON::Value::Type::Boolean)
-            return Exception { ExceptionCode::SyntaxError, makeString("'", silentKey(), "' member is specified but is not a boolean") };
+            return Exception { ExceptionCode::SyntaxError, makeString('\'', silentKey(), "' member is specified but is not a boolean"_s) };
         silent = value->asBoolean();
     }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -90,10 +90,10 @@ static ExceptionOr<String> checkAndCanonicalizeData(ScriptExecutionContext& cont
 static ExceptionOr<void> checkAndCanonicalizeAmount(PaymentCurrencyAmount& amount)
 {
     if (!isWellFormedCurrencyCode(amount.currency))
-        return Exception { ExceptionCode::RangeError, makeString("\"", amount.currency, "\" is not a valid currency code.") };
+        return Exception { ExceptionCode::RangeError, makeString('"', amount.currency, "\" is not a valid currency code."_s) };
 
     if (!isValidDecimalMonetaryValue(amount.value))
-        return Exception { ExceptionCode::TypeError, makeString("\"", amount.value, "\" is not a valid decimal monetary value.") };
+        return Exception { ExceptionCode::TypeError, makeString('"', amount.value, "\" is not a valid decimal monetary value."_s) };
 
     amount.currency = amount.currency.convertToASCIIUppercase();
     return { };

--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -223,7 +223,7 @@ static Expected<UniqueRef<SQLiteDatabase>, ShouldDeleteAndRetry> openAndMigrateD
             }
         }
 
-        if (!db->executeCommandSlow(makeString("PRAGMA user_version = ", currentPushDatabaseVersion)))
+        if (!db->executeCommandSlow(makeString("PRAGMA user_version = "_s, currentPushDatabaseVersion)))
             RELEASE_LOG_ERROR(Push, "Error setting user version for PushDatabase at path %s: %d", path.utf8().data(), db->lastError());
 
         transaction.commit();

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -201,7 +201,7 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
     }
 
     if (name.length() > WebLock::maxNameLength) {
-        releasePromise->reject(ExceptionCode::NotSupportedError, makeString("Lock name cannot cannot be longer than "_s, WebLock::maxNameLength, " characters"));
+        releasePromise->reject(ExceptionCode::NotSupportedError, makeString("Lock name cannot cannot be longer than "_s, WebLock::maxNameLength, " characters"_s));
         return;
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -105,11 +105,11 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
         for (auto& descriptor : parameterDescriptors) {
             auto addResult = paramNames.add(descriptor.name);
             if (!addResult.isNewEntry)
-                return Exception { ExceptionCode::NotSupportedError, makeString("parameterDescriptors contain duplicate AudioParam name: ", name) };
+                return Exception { ExceptionCode::NotSupportedError, makeString("parameterDescriptors contain duplicate AudioParam name: "_s, name) };
             if (descriptor.defaultValue < descriptor.minValue)
-                return Exception { ExceptionCode::InvalidStateError, makeString("AudioParamDescriptor with name '", name, "' has a defaultValue that is less than the minValue") };
+                return Exception { ExceptionCode::InvalidStateError, makeString("AudioParamDescriptor with name '"_s, name, "' has a defaultValue that is less than the minValue"_s) };
             if (descriptor.defaultValue > descriptor.maxValue)
-                return Exception { ExceptionCode::InvalidStateError, makeString("AudioParamDescriptor with name '", name, "' has a defaultValue that is greater than the maxValue") };
+                return Exception { ExceptionCode::InvalidStateError, makeString("AudioParamDescriptor with name '"_s, name, "' has a defaultValue that is greater than the maxValue"_s) };
         }
     }
 

--- a/Source/WebCore/Modules/webaudio/DelayNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayNode.cpp
@@ -53,7 +53,7 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
         return Exception { ExceptionCode::NotSupportedError, "maxDelayTime should be a positive value"_s };
 
     if (options.maxDelayTime >= maximumAllowedDelayTime || std::isnan(options.maxDelayTime))
-        return Exception { ExceptionCode::NotSupportedError, makeString("maxDelayTime should be less than ", maximumAllowedDelayTime) };
+        return Exception { ExceptionCode::NotSupportedError, makeString("maxDelayTime should be less than "_s, maximumAllowedDelayTime) };
 
     auto delayNode = adoptRef(*new DelayNode(context, options.maxDelayTime));
 

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -49,7 +49,7 @@ OfflineAudioContext::OfflineAudioContext(Document& document, const OfflineAudioC
     , m_length(options.length)
 {
     if (!renderTarget())
-        document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Failed to construct internal AudioBuffer with ", options.numberOfChannels, " channel(s), a sample rate of ", options.sampleRate, " and a length of ", options.length, "."));
+        document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Failed to construct internal AudioBuffer with "_s, options.numberOfChannels, " channel(s), a sample rate of "_s, options.sampleRate, " and a length of "_s, options.length, '.'));
     else if (noiseInjectionPolicy() == NoiseInjectionPolicy::Minimal)
         renderTarget()->setNeedsAdditionalNoise();
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -278,7 +278,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::encode(Ref<WebCodecsAudioData>&& frame)
             --m_beingEncodedQueueSize;
             if (!result.isNull()) {
                 if (auto* context = scriptExecutionContext())
-                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("AudioEncoder encode failed: ", result));
+                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("AudioEncoder encode failed: "_s, result));
                 closeEncoder(Exception { ExceptionCode::EncodingError, WTFMove(result) });
                 return;
             }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -259,7 +259,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&& frame
             --(protectedThis->m_beingEncodedQueueSize);
             if (!result.isNull()) {
                 if (RefPtr context = protectedThis->scriptExecutionContext())
-                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: ", result));
+                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: "_s, result));
                 protectedThis->closeEncoder(Exception { ExceptionCode::EncodingError, WTFMove(result) });
                 return;
             }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -299,7 +299,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     
     auto layout = layoutOrException.releaseReturnValue();
     if (data.length() < layout.allocationSize)
-        return Exception { ExceptionCode::TypeError, makeString("Data is too small ", data.length(), " / ", layout.allocationSize) };
+        return Exception { ExceptionCode::TypeError, makeString("Data is too small "_s, data.length(), " / "_s, layout.allocationSize) };
 
     auto colorSpace = videoFramePickColorSpace(init.colorSpace, init.format);
     RefPtr<VideoFrame> videoFrame;

--- a/Source/WebCore/Modules/webdatabase/ChangeVersionWrapper.cpp
+++ b/Source/WebCore/Modules/webdatabase/ChangeVersionWrapper.cpp
@@ -48,7 +48,7 @@ bool ChangeVersionWrapper::performPreflight(SQLTransaction& transaction)
     String actualVersion;
     if (!database.getVersionFromDatabase(actualVersion)) {
         int sqliteError = database.sqliteDatabase().lastError();
-        m_sqlError = SQLError::create(SQLError::UNKNOWN_ERR, "unable to read the current version", sqliteError, database.sqliteDatabase().lastErrorMsg());
+        m_sqlError = SQLError::create(SQLError::UNKNOWN_ERR, "unable to read the current version"_s, sqliteError, database.sqliteDatabase().lastErrorMsg());
         return false;
     }
 
@@ -66,7 +66,7 @@ bool ChangeVersionWrapper::performPostflight(SQLTransaction& transaction)
 
     if (!database.setVersionInDatabase(m_newVersion)) {
         int sqliteError = database.sqliteDatabase().lastError();
-        m_sqlError = SQLError::create(SQLError::UNKNOWN_ERR, "unable to set new version in database", sqliteError, database.sqliteDatabase().lastErrorMsg());
+        m_sqlError = SQLError::create(SQLError::UNKNOWN_ERR, "unable to set new version in database"_s, sqliteError, database.sqliteDatabase().lastErrorMsg());
         return false;
     }
 

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -448,7 +448,7 @@ void Database::closeDatabase()
 
 bool Database::getVersionFromDatabase(String& version, bool shouldCacheVersion)
 {
-    auto query = makeString("SELECT value FROM ", fullyQualifiedInfoTableName(),  " WHERE key = '", versionKey, "';");
+    auto query = makeString("SELECT value FROM "_s, fullyQualifiedInfoTableName(),  " WHERE key = '"_s, versionKey, "';"_s);
 
     m_databaseAuthorizer->disable();
 
@@ -468,7 +468,7 @@ bool Database::setVersionInDatabase(const String& version, bool shouldCacheVersi
 {
     // The INSERT will replace an existing entry for the database with the new version number, due to the UNIQUE ON CONFLICT REPLACE
     // clause in the CREATE statement (see Database::performOpenAndVerify()).
-    auto query = makeString("INSERT INTO ", fullyQualifiedInfoTableName(),  " (key, value) VALUES ('", versionKey, "', ?);");
+    auto query = makeString("INSERT INTO "_s, fullyQualifiedInfoTableName(),  " (key, value) VALUES ('"_s, versionKey, "', ?);"_s);
 
     m_databaseAuthorizer->disable();
 

--- a/Source/WebCore/Modules/webdatabase/SQLError.h
+++ b/Source/WebCore/Modules/webdatabase/SQLError.h
@@ -36,13 +36,13 @@ namespace WebCore {
 class SQLError : public ThreadSafeRefCounted<SQLError> {
 public:
     static Ref<SQLError> create(unsigned code, String&& message) { return adoptRef(*new SQLError(code, WTFMove(message))); }
-    static Ref<SQLError> create(unsigned code, const char* message, int sqliteCode)
+    static Ref<SQLError> create(unsigned code, ASCIILiteral message, int sqliteCode)
     {
-        return create(code, makeString(message, " (", sqliteCode, ')'));
+        return create(code, makeString(message, " ("_s, sqliteCode, ')'));
     }
-    static Ref<SQLError> create(unsigned code, const char* message, int sqliteCode, const char* sqliteMessage)
+    static Ref<SQLError> create(unsigned code, ASCIILiteral message, int sqliteCode, const char* sqliteMessage)
     {
-        return create(code, makeString(message, " (", sqliteCode, ' ', sqliteMessage, ')'));
+        return create(code, makeString(message, " ("_s, sqliteCode, ' ', span(sqliteMessage), ')'));
     }
 
     unsigned code() const { return m_code; }

--- a/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
@@ -116,9 +116,9 @@ bool SQLStatement::execute(Database& db)
     if (!statement) {
         LOG(StorageAPI, "Unable to verify correctness of statement %s - error %i (%s)", m_statement.ascii().data(), statement.error(), database.lastErrorMsg());
         if (statement.error() == SQLITE_INTERRUPT)
-            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not prepare statement", statement.error(), "interrupted");
+            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not prepare statement"_s, statement.error(), "interrupted"_s);
         else
-            m_error = SQLError::create(SQLError::SYNTAX_ERR, "could not prepare statement", statement.error(), database.lastErrorMsg());
+            m_error = SQLError::create(SQLError::SYNTAX_ERR, "could not prepare statement"_s, statement.error(), database.lastErrorMsg());
         return false;
     }
 
@@ -139,7 +139,7 @@ bool SQLStatement::execute(Database& db)
 
         if (result != SQLITE_OK) {
             LOG(StorageAPI, "Failed to bind value index %i to statement for query '%s'", i + 1, m_statement.ascii().data());
-            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not bind value", result, database.lastErrorMsg());
+            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not bind value"_s, result, database.lastErrorMsg());
             return false;
         }
     }
@@ -164,7 +164,7 @@ bool SQLStatement::execute(Database& db)
         } while (result == SQLITE_ROW);
 
         if (result != SQLITE_DONE) {
-            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not iterate results", result, database.lastErrorMsg());
+            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not iterate results"_s, result, database.lastErrorMsg());
             return false;
         }
         break;
@@ -180,10 +180,10 @@ bool SQLStatement::execute(Database& db)
         setFailureDueToQuota();
         return false;
     case SQLITE_CONSTRAINT:
-        m_error = SQLError::create(SQLError::CONSTRAINT_ERR, "could not execute statement due to a constaint failure", result, database.lastErrorMsg());
+        m_error = SQLError::create(SQLError::CONSTRAINT_ERR, "could not execute statement due to a constaint failure"_s, result, database.lastErrorMsg());
         return false;
     default:
-        m_error = SQLError::create(SQLError::DATABASE_ERR, "could not execute statement", result, database.lastErrorMsg());
+        m_error = SQLError::create(SQLError::DATABASE_ERR, "could not execute statement"_s, result, database.lastErrorMsg());
         return false;
     }
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -259,7 +259,7 @@ void SQLTransaction::openTransactionAndPreflight()
     // Spec 4.3.2.1+2: Open a transaction to the database, jumping to the error callback if that fails
     if (!m_sqliteTransaction->inProgress()) {
         ASSERT(!m_database->sqliteDatabase().transactionInProgress());
-        m_transactionError = SQLError::create(SQLError::DATABASE_ERR, "unable to begin transaction", m_database->sqliteDatabase().lastError(), m_database->sqliteDatabase().lastErrorMsg());
+        m_transactionError = SQLError::create(SQLError::DATABASE_ERR, "unable to begin transaction"_s, m_database->sqliteDatabase().lastError(), m_database->sqliteDatabase().lastErrorMsg());
         m_sqliteTransaction = nullptr;
 
         handleTransactionError();
@@ -271,7 +271,7 @@ void SQLTransaction::openTransactionAndPreflight()
     // the actual version. In single-process browsers, this is just a map lookup.
     String actualVersion;
     if (!m_database->getActualVersionForTransaction(actualVersion)) {
-        m_transactionError = SQLError::create(SQLError::DATABASE_ERR, "unable to read version", m_database->sqliteDatabase().lastError(), m_database->sqliteDatabase().lastErrorMsg());
+        m_transactionError = SQLError::create(SQLError::DATABASE_ERR, "unable to read version"_s, m_database->sqliteDatabase().lastError(), m_database->sqliteDatabase().lastErrorMsg());
         m_database->disableAuthorizer();
         m_sqliteTransaction = nullptr;
         m_database->enableAuthorizer();
@@ -613,7 +613,7 @@ void SQLTransaction::postflightAndCommit()
     if (m_sqliteTransaction->inProgress()) {
         if (m_wrapper)
             m_wrapper->handleCommitFailedAfterPostflight(*this);
-        m_transactionError = SQLError::create(SQLError::DATABASE_ERR, "unable to commit transaction", m_database->sqliteDatabase().lastError(), m_database->sqliteDatabase().lastErrorMsg());
+        m_transactionError = SQLError::create(SQLError::DATABASE_ERR, "unable to commit transaction"_s, m_database->sqliteDatabase().lastError(), m_database->sqliteDatabase().lastErrorMsg());
 
         handleTransactionError();
         return;

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -60,7 +60,7 @@ RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(ScriptExec
 {
     if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(context)) {
         WorkerRunLoop& runLoop = workerGlobalScope->thread().runLoop();
-        return WorkerThreadableWebSocketChannel::create(*workerGlobalScope, client, makeString("webSocketChannelMode", runLoop.createUniqueId()), provider);
+        return WorkerThreadableWebSocketChannel::create(*workerGlobalScope, client, makeString("webSocketChannelMode"_s, runLoop.createUniqueId()), provider);
     }
 
     return create(downcast<Document>(context), client, provider);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -231,7 +231,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     auto& context = *scriptExecutionContext();
 
     if (!m_url.isValid()) {
-        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Invalid url for WebSocket " + m_url.stringCenterEllipsizedToLength());
+        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Invalid url for WebSocket "_s, m_url.stringCenterEllipsizedToLength()));
         m_state = CLOSED;
         return Exception { ExceptionCode::SyntaxError };
     }
@@ -242,12 +242,12 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         m_url.setProtocol("wss"_s);
 
     if (!m_url.protocolIs("ws"_s) && !m_url.protocolIs("wss"_s)) {
-        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Wrong url scheme for WebSocket " + m_url.stringCenterEllipsizedToLength());
+        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Wrong url scheme for WebSocket "_s, m_url.stringCenterEllipsizedToLength()));
         m_state = CLOSED;
         return Exception { ExceptionCode::SyntaxError };
     }
     if (m_url.hasFragmentIdentifier()) {
-        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, "URL has fragment component " + m_url.stringCenterEllipsizedToLength());
+        context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("URL has fragment component "_s, m_url.stringCenterEllipsizedToLength()));
         m_state = CLOSED;
         return Exception { ExceptionCode::SyntaxError };
     }
@@ -260,7 +260,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     if (!portAllowed(m_url)) {
         String message;
         if (m_url.port())
-            message = makeString("WebSocket port ", m_url.port().value(), " blocked");
+            message = makeString("WebSocket port "_s, m_url.port().value(), " blocked"_s);
         else
             message = "WebSocket without port blocked"_s;
         context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, message);
@@ -291,7 +291,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     // comply with WebSocket API specification, but it seems to be the only reasonable way to handle this conflict.
     for (auto& protocol : protocols) {
         if (!isValidProtocolString(protocol)) {
-            context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Wrong protocol for WebSocket '" + encodeProtocolString(protocol) + "'");
+            context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Wrong protocol for WebSocket '"_s, encodeProtocolString(protocol), '\''));
             m_state = CLOSED;
             return Exception { ExceptionCode::SyntaxError };
         }
@@ -299,7 +299,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     HashSet<String> visited;
     for (auto& protocol : protocols) {
         if (!visited.add(protocol).isNewEntry) {
-            context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, "WebSocket protocols contain duplicates: '" + encodeProtocolString(protocol) + "'");
+            context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("WebSocket protocols contain duplicates: '"_s, encodeProtocolString(protocol), '\''));
             m_state = CLOSED;
             return Exception { ExceptionCode::SyntaxError };
         }

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -71,7 +71,7 @@ const String WebSocketExtensionDispatcher::createHeaderValue() const
 
 void WebSocketExtensionDispatcher::appendAcceptedExtension(const String& extensionToken, HashMap<String, String>& extensionParameters)
 {
-    m_acceptedExtensionsBuilder.append(m_acceptedExtensionsBuilder.isEmpty() ? "" : ", ", extensionToken);
+    m_acceptedExtensionsBuilder.append(m_acceptedExtensionsBuilder.isEmpty() ? ""_s : ", "_s, extensionToken);
     // FIXME: Should use ListHashSet to keep the order of the parameters.
     for (auto& parameter : extensionParameters) {
         m_acceptedExtensionsBuilder.append("; "_s, parameter.key);
@@ -121,7 +121,7 @@ bool WebSocketExtensionDispatcher::processHeaderValue(const String& headerValue)
         }
         // There is no extension which can process the response.
         if (index == m_processors.size()) {
-            fail("Received unexpected extension: " + extensionToken);
+            fail(makeString("Received unexpected extension: "_s + extensionToken));
             return false;
         }
     }

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionProcessor.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionProcessor.h
@@ -52,7 +52,7 @@ public:
     virtual bool processResponse(const HashMap<String, String>&) = 0;
 
     // If procecssResponse() returns false, this should provide the reason.
-    virtual String failureReason() { return "Extension " + m_extensionToken + " failed"; }
+    virtual String failureReason() { return makeString("Extension "_s, m_extensionToken, " failed"_s); }
 
 protected:
     explicit WebSocketExtensionProcessor(const String& extensionToken)

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
@@ -94,7 +94,7 @@ WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(uint8_t* data, size_
     constexpr uint64_t maxPayloadLength = UINT64_C(0x7FFFFFFFFFFFFFFF);
     size_t maskingKeyLength = masked ? maskingKeyWidthInBytes : 0;
     if (payloadLength64 > maxPayloadLength || payloadLength64 + maskingKeyLength > std::numeric_limits<size_t>::max()) {
-        errorString = makeString("WebSocket frame length too large: ", payloadLength64, " bytes");
+        errorString = makeString("WebSocket frame length too large: "_s, payloadLength64, " bytes"_s);
         return FrameError;
     }
     size_t payloadLength = static_cast<size_t>(payloadLength64);

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -66,7 +66,7 @@ static String resourceName(const URL& url)
     auto path = url.path();
     auto result = makeString(
         path,
-        path.isEmpty() ? "/" : "",
+        path.isEmpty() ? "/"_s : ""_s,
         url.queryWithLeadingQuestionMark()
     );
     ASSERT(!result.isEmpty());
@@ -154,7 +154,7 @@ bool WebSocketHandshake::secure() const
 
 String WebSocketHandshake::clientLocation() const
 {
-    return makeString(m_secure ? "wss" : "ws", "://", hostName(m_url, m_secure), resourceName(m_url));
+    return makeString(m_secure ? "wss"_s : "ws"_s, "://"_s, hostName(m_url, m_secure), resourceName(m_url));
 }
 
 CString WebSocketHandshake::clientHandshakeMessage() const
@@ -169,19 +169,19 @@ CString WebSocketHandshake::clientHandshakeMessage() const
     // doesn't contain these headers.
 
     auto extensions = m_extensionDispatcher.createHeaderValue();
-    return makeString("GET ", resourceName(m_url), " HTTP/1.1\r\n"
+    return makeString("GET "_s, resourceName(m_url), " HTTP/1.1\r\n"
         "Upgrade: websocket\r\n"
         "Connection: Upgrade\r\n"
-        "Host: ", hostName(m_url, m_secure), "\r\n"
-        "Origin: ", m_clientOrigin, "\r\n",
-        m_clientProtocol.isEmpty() ? "" : "Sec-WebSocket-Protocol: ", m_clientProtocol, m_clientProtocol.isEmpty() ? "" : "\r\n",
+        "Host: "_s, hostName(m_url, m_secure), "\r\n"
+        "Origin: "_s, m_clientOrigin, "\r\n"_s,
+        m_clientProtocol.isEmpty() ? ""_s : "Sec-WebSocket-Protocol: "_s, m_clientProtocol, m_clientProtocol.isEmpty() ? ""_s : "\r\n"_s,
         "Pragma: no-cache\r\n"
         "Cache-Control: no-cache\r\n"
-        "Sec-WebSocket-Key: ", m_secWebSocketKey, "\r\n"
-        "Sec-WebSocket-Version: 13\r\n",
-        extensions.isEmpty() ? "" : "Sec-WebSocket-Extensions: ", extensions, extensions.isEmpty() ? "" : "\r\n",
-        "User-Agent: ", m_userAgent, "\r\n"
-        "\r\n").utf8();
+        "Sec-WebSocket-Key: "_s, m_secWebSocketKey, "\r\n"
+        "Sec-WebSocket-Version: 13\r\n"_s,
+        extensions.isEmpty() ? ""_s : "Sec-WebSocket-Extensions: "_s, extensions, extensions.isEmpty() ? ""_s : "\r\n"_s,
+        "User-Agent: "_s, m_userAgent, "\r\n"
+        "\r\n"_s).utf8();
 }
 
 ResourceRequest WebSocketHandshake::clientHandshakeRequest(const Function<String(const URL&)>& cookieRequestHeaderFieldValue) const
@@ -237,7 +237,7 @@ int WebSocketHandshake::readServerHandshake(std::span<const uint8_t> header)
 
     if (statusCode != 101) {
         m_mode = Failed;
-        m_failureReason = makeString("Unexpected response code: ", statusCode);
+        m_failureReason = makeString("Unexpected response code: "_s, statusCode);
         return header.size();
     }
     m_mode = Normal;
@@ -404,13 +404,13 @@ int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& sta
     }
 
     if (!firstSpaceIndex || !secondSpaceIndex) {
-        m_failureReason = makeString("No response code found: ", trimInputSample(header.first(lineLength - 2)));
+        m_failureReason = makeString("No response code found: "_s, trimInputSample(header.first(lineLength - 2)));
         return lineLength;
     }
 
     StringView httpStatusLine(header.first(*firstSpaceIndex));
     if (!headerHasValidHTTPVersion(httpStatusLine)) {
-        m_failureReason = makeString("Invalid HTTP version string: ", httpStatusLine);
+        m_failureReason = makeString("Invalid HTTP version string: "_s, httpStatusLine);
         return lineLength;
     }
 
@@ -419,7 +419,7 @@ int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& sta
         return lineLength;
     for (int i = 0; i < 3; ++i) {
         if (!isASCIIDigit(statusCodeString[i])) {
-            m_failureReason = makeString("Invalid status code: ", statusCodeString);
+            m_failureReason = makeString("Invalid status code: "_s, statusCodeString);
             return lineLength;
         }
     }
@@ -459,7 +459,7 @@ std::span<const uint8_t> WebSocketHandshake::readHTTPHeaders(std::span<const uin
             || headerName == HTTPHeaderName::SecWebSocketAccept
             || headerName == HTTPHeaderName::SecWebSocketProtocol)
             && !value.containsOnlyASCII()) {
-            m_failureReason = makeString(name, " header value should only contain ASCII characters");
+            m_failureReason = makeString(name, " header value should only contain ASCII characters"_s);
             return { };
         }
         

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -415,7 +415,7 @@ void WorkerThreadableWebSocketChannel::Bridge::connect(const URL& url, const Str
         auto& document = downcast<Document>(context);
         
         if (RefPtr frame = document.frame(); frame && MixedContentChecker::shouldBlockRequestForRunnableContent(*frame, document.securityOrigin(), url, MixedContentChecker::ShouldLogWarning::No)) {
-            peer->fail(makeString("The page at ", document.url().stringCenterEllipsizedToLength(), " was blocked from connecting insecurely to ", url.stringCenterEllipsizedToLength(), " either because the protocol is insecure or the page is embedded from an insecure page."));
+            peer->fail(makeString("The page at "_s, document.url().stringCenterEllipsizedToLength(), " was blocked from connecting insecurely to "_s, url.stringCenterEllipsizedToLength(), " either because the protocol is insecure or the page is embedded from an insecure page."_s));
             return;
         }
 

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -209,7 +209,7 @@ AXCoreObject::AXValue AXCoreObject::value()
 
     if (isColorWell()) {
         auto color = convertColor<SRGBA<float>>(colorValue()).resolved();
-        return makeString("rgb ", String::numberToStringFixedPrecision(color.red, 6, TrailingZerosPolicy::Keep), " ", String::numberToStringFixedPrecision(color.green, 6, TrailingZerosPolicy::Keep), " ", String::numberToStringFixedPrecision(color.blue, 6, TrailingZerosPolicy::Keep), " 1");
+        return makeString("rgb "_s, String::numberToStringFixedPrecision(color.red, 6, TrailingZerosPolicy::Keep), ' ', String::numberToStringFixedPrecision(color.green, 6, TrailingZerosPolicy::Keep), ' ', String::numberToStringFixedPrecision(color.blue, 6, TrailingZerosPolicy::Keep), " 1"_s);
     }
 
     return stringValue();

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -240,7 +240,7 @@ void AXLogger::log(const String& collectionName, const AXObjectCache::DeferredCo
             return;
         });
     if (size)
-        log(makeString(collectionName, " size: ", size));
+        log(makeString(collectionName, " size: "_s, size));
 }
 
 #endif // !LOG_DISABLED

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -127,6 +127,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 #if COMPILER(MSVC)
 // See https://msdn.microsoft.com/en-us/library/1wea5zwe.aspx
@@ -263,7 +264,7 @@ AXObjectCache::AXObjectCache(Document& document)
     AXTRACE(makeString("AXObjectCache::AXObjectCache 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
 #ifndef NDEBUG
     if (m_pageID)
-        AXLOG(makeString("pageID ", m_pageID->loggingString()));
+        AXLOG(makeString("pageID "_s, m_pageID->loggingString()));
     else
         AXLOG("No pageID.");
 #endif
@@ -1065,7 +1066,7 @@ AccessibilityObject* AXObjectCache::create(AccessibilityRole role)
 void AXObjectCache::remove(AXID axID)
 {
     AXTRACE(makeString("AXObjectCache::remove 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
-    AXLOG(makeString("AXID ", axID.loggingString()));
+    AXLOG(makeString("AXID "_s, axID.loggingString()));
 
     if (!axID.isValid())
         return;
@@ -2434,7 +2435,7 @@ static bool isTableOrRowRole(const AtomString& attrValue)
 void AXObjectCache::handleRoleChanged(Element& element, const AtomString& oldValue, const AtomString& newValue)
 {
     AXTRACE("AXObjectCache::handleRoleChanged"_s);
-    AXLOG(makeString("oldValue ", oldValue, " new value ", newValue));
+    AXLOG(makeString("oldValue "_s, oldValue, " new value "_s, newValue));
     ASSERT(oldValue != newValue);
 
     auto* object = get(element);
@@ -2485,7 +2486,7 @@ void AXObjectCache::deferAttributeChangeIfNeeded(Element& element, const Qualifi
         m_deferredAttributeChange.append({ element, attrName, oldValue, newValue });
         if (!m_performCacheUpdateTimer.isActive())
             m_performCacheUpdateTimer.startOneShot(0_s);
-        AXLOG(makeString("Deferring handling of attribute ", attrName.localName().string(), " for element ", element.debugDescription()));
+        AXLOG(makeString("Deferring handling of attribute "_s, attrName.localName().string(), " for element "_s, element.debugDescription()));
         return;
     }
     Ref protectedElement { element };
@@ -2512,8 +2513,8 @@ bool AXObjectCache::shouldProcessAttributeChange(Element* element, const Qualifi
 void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName& attrName, const AtomString& oldValue, const AtomString& newValue)
 {
     AXTRACE(makeString("AXObjectCache::handleAttributeChange 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
-    AXLOG(makeString("attribute ", attrName.localName(), " for element ", element ? element->debugDescription() : String("nullptr"_s)));
-    AXLOG(makeString("old value: ", oldValue, " new value: ", newValue));
+    AXLOG(makeString("attribute "_s, attrName.localName(), " for element "_s, element ? element->debugDescription() : "nullptr"_str));
+    AXLOG(makeString("old value: "_s, oldValue, " new value: "_s, newValue));
 
     enum class TableProperty : uint8_t { Exposed = 1 << 0, CellSlots = 1 << 1 };
     auto recomputeParentTableProperties = [this] (Element* element, OptionSet<TableProperty> properties) {
@@ -4226,9 +4227,9 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
 
     if (m_deferredFocusedNodeChange) {
         AXLOG(makeString(
-            "Processing deferred focused node change. Old node ",
+            "Processing deferred focused node change. Old node "_s,
             m_deferredFocusedNodeChange->first ? m_deferredFocusedNodeChange->first->debugDescription() : "nullptr"_s,
-            ", new node ",
+            ", new node "_s,
             m_deferredFocusedNodeChange->second ? m_deferredFocusedNodeChange->second->debugDescription() : "nullptr"_s
         ));
         // Don't update the modal with this focus change since it may need to be updated again as a result of processing m_deferredModalChangedList below.
@@ -4873,7 +4874,7 @@ static bool validRelation(Element& origin, Element& target, AXRelationType relat
 bool AXObjectCache::addRelation(Element& origin, Element& target, AXRelationType relationType)
 {
     AXTRACE("AXObjectCache::addRelation"_s);
-    AXLOG(makeString("origin: ", origin.debugDescription(), " target: ", target.debugDescription(), " relationType ", String::number(static_cast<uint8_t>(relationType))));
+    AXLOG(makeString("origin: "_s, origin.debugDescription(), " target: "_s, target.debugDescription(), " relationType "_s, static_cast<uint8_t>(relationType)));
 
     if (!validRelation(origin, target, relationType)) {
         ASSERT_NOT_REACHED();
@@ -4990,7 +4991,7 @@ bool AXObjectCache::addRelation(AccessibilityObject* origin, AccessibilityObject
 
 void AXObjectCache::removeAllRelations(AXID axID)
 {
-    AXTRACE("AXObjectCache::removeRelations"_s + " for axID " + axID.loggingString());
+    AXTRACE(makeString("AXObjectCache::removeRelations for axID "_s, axID.loggingString()));
 
     auto it = m_relations.find(axID);
     if (it == m_relations.end())
@@ -5014,7 +5015,7 @@ void AXObjectCache::removeAllRelations(AXID axID)
 
 bool AXObjectCache::removeRelation(Element& origin, AXRelationType relationType)
 {
-    AXTRACE("AXObjectCache::removeRelations"_s + " for " + origin.debugDescription());
+    AXTRACE(makeString("AXObjectCache::removeRelations for "_s, origin.debugDescription()));
     AXLOG(relationType);
 
     auto* object = get(&origin);
@@ -5043,7 +5044,7 @@ bool AXObjectCache::removeRelation(Element& origin, AXRelationType relationType)
 void AXObjectCache::removeRelationByID(AXID originID, AXID targetID, AXRelationType relationType)
 {
     AXTRACE("AXObjectCache::removeRelationByID"_s);
-    AXLOG(makeString("originID ", originID.loggingString(), " targetID ", targetID.loggingString()));
+    AXLOG(makeString("originID "_s, originID.loggingString(), " targetID "_s, targetID.loggingString()));
     AXLOG(relationType);
 
     auto relationsIterator = m_relations.find(originID);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -92,7 +92,7 @@ struct CharacterOffset {
 
     String debugDescription()
     {
-        return makeString("CharacterOffset {node: ", node ? node->debugDescription() : "null"_s, ", startIndex: ", startIndex, ", offset: ", offset, ", remainingOffset: ", remainingOffset, "}");
+        return makeString("CharacterOffset {node: "_s, node ? node->debugDescription() : "null"_s, ", startIndex: "_s, startIndex, ", offset: "_s, offset, ", remainingOffset: "_s, remainingOffset, '}');
     }
 };
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -218,19 +218,19 @@ RefPtr<AXCoreObject> AXTextMarker::object() const
 
 String AXTextMarker::debugDescription() const
 {
-    auto separator = ", ";
+    auto separator = ", "_s;
     RefPtr object = this->object();
     return makeString(
-        "treeID ", treeID().loggingString()
-        , separator, "objectID ", objectID().loggingString()
-        , separator, "role ", object ? accessibilityRoleToString(object->roleValue()) : String("no object"_s)
+        "treeID "_s, treeID().loggingString()
+        , separator, "objectID "_s, objectID().loggingString()
+        , separator, "role "_s, object ? accessibilityRoleToString(object->roleValue()) : "no object"_str
         , isIgnored() ? makeString(separator, "ignored") : ""_s
         , isMainThread() && node() ? makeString(separator, node()->debugDescription()) : ""_s
-        , separator, "anchor ", m_data.anchorType
-        , separator, "affinity ", m_data.affinity
-        , separator, "offset ", m_data.offset
-        , separator, "characterStart ", m_data.characterStart
-        , separator, "characterOffset ", m_data.characterOffset
+        , separator, "anchor "_s, m_data.anchorType
+        , separator, "affinity "_s, m_data.affinity
+        , separator, "offset "_s, m_data.offset
+        , separator, "characterStart "_s, m_data.characterStart
+        , separator, "characterOffset "_s, m_data.characterOffset
     );
 }
 
@@ -349,7 +349,7 @@ std::optional<AXTextMarkerRange> AXTextMarkerRange::intersectionWith(const AXTex
 
 String AXTextMarkerRange::debugDescription() const
 {
-    return makeString("start: {", m_start.debugDescription(), "}\nend:   {", m_end.debugDescription(), "}");
+    return makeString("start: {"_s, m_start.debugDescription(), "}\nend:   {"_s, m_end.debugDescription(), '}');
 }
 
 std::partial_ordering partialOrder(const AXTextMarker& marker1, const AXTextMarker& marker2)

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -124,14 +124,14 @@ String AccessibilityObject::dbg() const
 {
     String backingEntityDescription;
     if (auto* renderer = this->renderer())
-        backingEntityDescription = makeString(", ", renderer->debugDescription());
+        backingEntityDescription = makeString(", "_s, renderer->debugDescription());
     else if (auto* node = this->node())
-        backingEntityDescription = makeString(", ", node->debugDescription());
+        backingEntityDescription = makeString(", "_s, node->debugDescription());
 
     return makeString(
-        "{role: ", accessibilityRoleToString(roleValue()),
-        ", ID ", objectID().loggingString(),
-        backingEntityDescription, "}"
+        "{role: "_s, accessibilityRoleToString(roleValue()),
+        ", ID "_s, objectID().loggingString(),
+        backingEntityDescription, '}'
     );
 }
 
@@ -2514,7 +2514,7 @@ bool AccessibilityObject::replaceTextInRange(const String& replacementString, co
 
 bool AccessibilityObject::insertText(const String& text)
 {
-    AXTRACE(makeString("AccessibilityObject::insertText text = ", text));
+    AXTRACE(makeString("AccessibilityObject::insertText text = "_s, text));
 
     if (!renderer())
         return false;

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -72,7 +72,7 @@ String AccessibilityProgressIndicator::valueDescription() const
 
     String gaugeRegionValue = gaugeRegionValueDescription();
     if (!gaugeRegionValue.isEmpty())
-        description = description.isEmpty() ? gaugeRegionValue : description + ", " + gaugeRegionValue;
+        description = description.isEmpty() ? gaugeRegionValue : description + ", "_s + gaugeRegionValue;
 
     return description;
 }

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -289,7 +289,7 @@ void AccessibilityAtspi::registerRoot(AccessibilityRootAtspi& rootObject, Vector
     }
 
     ensureCache();
-    String path = makeString("/org/a11y/webkit/accessible/", makeStringByReplacingAll(createVersion4UUIDString(), '-', '_'));
+    String path = makeString("/org/a11y/webkit/accessible/"_s, makeStringByReplacingAll(createVersion4UUIDString(), '-', '_'));
     auto registeredObjects = WTF::map<3>(interfaces, [&](auto& interface) -> unsigned {
         return g_dbus_connection_register_object(m_connection.get(), path.utf8().data(), interface.first, interface.second, &rootObject, nullptr, nullptr);
     });
@@ -330,7 +330,7 @@ String AccessibilityAtspi::registerObject(AccessibilityObjectAtspi& atspiObject,
         return { };
 
     ensureCache();
-    String path = makeString("/org/a11y/atspi/accessible/", makeStringByReplacingAll(createVersion4UUIDString(), '-', '_'));
+    String path = makeString("/org/a11y/atspi/accessible/"_s, makeStringByReplacingAll(createVersion4UUIDString(), '-', '_'));
     auto registeredObjects = WTF::map<7>(interfaces, [&](auto& interface) -> unsigned {
         return g_dbus_connection_register_object(m_connection.get(), path.utf8().data(), interface.first, interface.second, &atspiObject, nullptr, nullptr);
     });
@@ -377,7 +377,7 @@ String AccessibilityAtspi::registerHyperlink(AccessibilityObjectAtspi& atspiObje
     if (!m_connection)
         return { };
 
-    String path = makeString("/org/a11y/atspi/accessible/", makeStringByReplacingAll(createVersion4UUIDString(), '-', '_'));
+    String path = makeString("/org/a11y/atspi/accessible/"_s, makeStringByReplacingAll(createVersion4UUIDString(), '-', '_'));
     auto registeredObjects = WTF::map<1>(interfaces, [&](auto& interface) -> unsigned {
         return g_dbus_connection_register_object(m_connection.get(), path.utf8().data(), interface.first, interface.second, &atspiObject, nullptr, nullptr);
     });

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1324,7 +1324,7 @@ bool AXIsolatedObject::replaceTextInRange(const String& replacementText, const C
 
 bool AXIsolatedObject::insertText(const String& text)
 {
-    AXTRACE(makeString("AXIsolatedObject::insertText text = ", text));
+    AXTRACE(makeString("AXIsolatedObject::insertText text = "_s, text));
 
     // Dispatch to the main thread without waiting since AXObject::insertText waits for the UI process that can be waiting resulting in a deadlock. That is the case when running LayoutTests.
     // The return value of insertText is not used, so not waiting does not result in any loss of functionality.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -327,16 +327,16 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     ASSERT(isMainThread());
 
     if (m_unconnectedNodes.contains(axObject->objectID())) {
-        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode exiting because an isolated object for ", axObject->objectID().loggingString(), " already exists."));
+        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode exiting because an isolated object for "_s, axObject->objectID().loggingString(), " already exists."_s));
         return;
     }
 
     if (axObject->isDetached() || !axObject->wrapper()) {
-        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode bailing because associated live object ID ", axObject->objectID().loggingString(), " had no wrapper or is detached. Object is:"));
+        AXLOG(makeString("AXIsolatedTree::addUnconnectedNode bailing because associated live object ID "_s, axObject->objectID().loggingString(), " had no wrapper or is detached. Object is:"_s));
         AXLOG(axObject.ptr());
         return;
     }
-    AXLOG(makeString("AXIsolatedTree::addUnconnectedNode creating isolated object from live object ID ", axObject->objectID().loggingString()));
+    AXLOG(makeString("AXIsolatedTree::addUnconnectedNode creating isolated object from live object ID "_s, axObject->objectID().loggingString()));
 
     // Because we are queuing a change for an object not intended to be connected to the rest of the tree,
     // we don't need to update m_nodeMap or m_pendingChildrenUpdates for this object or its parent as is
@@ -546,7 +546,7 @@ void AXIsolatedTree::updatePropertiesForSelfAndDescendants(AccessibilityObject& 
 void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXPropertyNameSet& properties)
 {
     AXTRACE("AXIsolatedTree::updateNodeProperties"_s);
-    AXLOG(makeString("Updating properties for objectID ", axObject.objectID().loggingString(), ": "));
+    AXLOG(makeString("Updating properties for objectID "_s, axObject.objectID().loggingString(), ": "_s));
     ASSERT(isMainThread());
 
     if (isUpdatingSubtree())
@@ -554,7 +554,7 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXProper
 
     AXPropertyMap propertyMap;
     for (const auto& property : properties) {
-        AXLOG(makeString("Property: ", property));
+        AXLOG(makeString("Property: "_s, property));
         switch (property) {
         case AXPropertyName::AccessKey:
             propertyMap.set(AXPropertyName::AccessKey, axObject.accessKey().isolatedCopy());
@@ -844,7 +844,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
     }
 
     if (axAncestor != &axObject) {
-        AXLOG(makeString("Original object with ID ", axObject.objectID().loggingString(), " wasn't in the isolated tree, so instead updating the closest in-isolated-tree ancestor:"));
+        AXLOG(makeString("Original object with ID "_s, axObject.objectID().loggingString(), " wasn't in the isolated tree, so instead updating the closest in-isolated-tree ancestor:"_s));
         AXLOG(axAncestor);
 
         // An explicit copy is necessary here because the nested calls to updateChildren
@@ -898,7 +898,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         else {
             // This is a new child, add it to the tree.
             childrenChanged = true;
-            AXLOG(makeString("AXID ", axAncestor->objectID().loggingString(), " gaining new subtree, starting at ID ", newChildren[i]->objectID().loggingString(), ":"));
+            AXLOG(makeString("AXID "_s, axAncestor->objectID().loggingString(), " gaining new subtree, starting at ID "_s, newChildren[i]->objectID().loggingString(), ':'));
             AXLOG(newChildren[i]);
             collectNodeChangesForSubtree(*newChildren[i]);
         }
@@ -1022,7 +1022,7 @@ void AXIsolatedTree::setRootNode(AXIsolatedObject* root)
 void AXIsolatedTree::setFocusedNodeID(AXID axID)
 {
     AXTRACE("AXIsolatedTree::setFocusedNodeID"_s);
-    AXLOG(makeString("axID ", axID.loggingString()));
+    AXLOG(makeString("axID "_s, axID.loggingString()));
     ASSERT(isMainThread());
 
     Locker locker { m_changeLogLock };
@@ -1058,7 +1058,7 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
 void AXIsolatedTree::updateLoadingProgress(double newProgressValue)
 {
     AXTRACE("AXIsolatedTree::updateLoadingProgress"_s);
-    AXLOG(makeString("Updating loading progress to ", newProgressValue, " for treeID ", treeID().loggingString()));
+    AXLOG(makeString("Updating loading progress to "_s, newProgressValue, " for treeID "_s, treeID().loggingString()));
     ASSERT(isMainThread());
 
     m_loadingProgress = newProgressValue;
@@ -1095,7 +1095,7 @@ void AXIsolatedTree::updateRootScreenRelativePosition()
 void AXIsolatedTree::removeNode(const AccessibilityObject& axObject)
 {
     AXTRACE("AXIsolatedTree::removeNode"_s);
-    AXLOG(makeString("objectID ", axObject.objectID().loggingString()));
+    AXLOG(makeString("objectID "_s, axObject.objectID().loggingString()));
     ASSERT(isMainThread());
 
     auto labeledObjectIDs = axObjectCache() ? axObjectCache()->relatedObjectIDsFor(axObject, AXRelationType::LabelFor, AXObjectCache::UpdateRelations::No) : std::nullopt;
@@ -1115,7 +1115,7 @@ void AXIsolatedTree::removeNode(const AccessibilityObject& axObject)
 void AXIsolatedTree::removeSubtreeFromNodeMap(AXID objectID, AccessibilityObject* axParent)
 {
     AXTRACE("AXIsolatedTree::removeSubtreeFromNodeMap"_s);
-    AXLOG(makeString("Removing subtree for objectID ", objectID.loggingString()));
+    AXLOG(makeString("Removing subtree for objectID "_s, objectID.loggingString()));
     ASSERT(isMainThread());
 
     if (!objectID.isValid())
@@ -1125,13 +1125,13 @@ void AXIsolatedTree::removeSubtreeFromNodeMap(AXID objectID, AccessibilityObject
         return;
 
     if (!m_nodeMap.contains(objectID)) {
-        AXLOG(makeString("Tried to remove AXID ", objectID.loggingString(), " that is no longer in m_nodeMap."));
+        AXLOG(makeString("Tried to remove AXID "_s, objectID.loggingString(), " that is no longer in m_nodeMap."_s));
         return;
     }
 
     AXID axParentID = axParent ? axParent->objectID() : AXID();
     if (axParentID != m_nodeMap.get(objectID).parentID) {
-        AXLOG(makeString("Tried to remove object ID ", objectID.loggingString(), " from a different parent ", axParentID.loggingString(), ", actual parent ", m_nodeMap.get(objectID).parentID.loggingString(), ", bailing out."));
+        AXLOG(makeString("Tried to remove object ID "_s, objectID.loggingString(), " from a different parent "_s, axParentID.loggingString(), ", actual parent "_s, m_nodeMap.get(objectID).parentID.loggingString(), ", bailing out."_s));
         return;
     }
 
@@ -1199,7 +1199,7 @@ void AXIsolatedTree::applyPendingChanges()
     }
 
     if (m_pendingFocusedNodeID != m_focusedNodeID) {
-        AXLOG(makeString("focusedNodeID ", m_focusedNodeID.loggingString(), " pendingFocusedNodeID ", m_pendingFocusedNodeID.loggingString()));
+        AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID.loggingString(), " pendingFocusedNodeID "_s, m_pendingFocusedNodeID.loggingString()));
         m_focusedNodeID = m_pendingFocusedNodeID;
     }
 
@@ -1207,7 +1207,7 @@ void AXIsolatedTree::applyPendingChanges()
         auto axID = m_pendingSubtreeRemovals.takeLast();
         if (m_pendingProtectedFromDeletionIDs.contains(axID))
             continue;
-        AXLOG(makeString("removing subtree axID ", axID.loggingString()));
+        AXLOG(makeString("removing subtree axID "_s, axID.loggingString()));
         if (RefPtr object = objectForID(axID)) {
             // There's no need to call the more comprehensive AXCoreObject::detach here since
             // we're deleting the entire subtree of this object and thus don't need to `detachRemoteParts`.
@@ -1220,7 +1220,7 @@ void AXIsolatedTree::applyPendingChanges()
 
     for (const auto& item : m_pendingAppends) {
         AXID axID = item.isolatedObject->objectID();
-        AXLOG(makeString("appending axID ", axID.loggingString()));
+        AXLOG(makeString("appending axID "_s, axID.loggingString()));
         if (!axID.isValid())
             continue;
 
@@ -1261,7 +1261,7 @@ void AXIsolatedTree::applyPendingChanges()
     m_pendingParentUpdates.clear();
 
     for (auto& update : m_pendingChildrenUpdates) {
-        AXLOG(makeString("updating children for axID ", update.first.loggingString()));
+        AXLOG(makeString("updating children for axID "_s, update.first.loggingString()));
         if (RefPtr object = objectForID(update.first))
             object->setChildrenIDs(WTFMove(update.second));
     }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1536,11 +1536,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attributeName
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityAttributeValue:", String(attributeName)));
+    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityAttributeValue:"_s, String(attributeName)));
 
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject) {
-        AXLOG(makeString("No backingObject for wrapper ", hex(reinterpret_cast<uintptr_t>(self))));
+        AXLOG(makeString("No backingObject for wrapper "_s, hex(reinterpret_cast<uintptr_t>(self))));
         return nil;
     }
 
@@ -2680,7 +2680,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     RefPtr<AXCoreObject> backingObject = self.axBackingObject;
     if (!backingObject) {
-        AXLOG(makeString("No backingObject for wrapper ", hex(reinterpret_cast<uintptr_t>(self))));
+        AXLOG(makeString("No backingObject for wrapper "_s, hex(reinterpret_cast<uintptr_t>(self))));
         return;
     }
 
@@ -2703,7 +2703,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     RefPtr<AXCoreObject> backingObject = self.axBackingObject;
     if (!backingObject) {
-        AXLOG(makeString("No backingObject for wrapper ", hex(reinterpret_cast<uintptr_t>(self))));
+        AXLOG(makeString("No backingObject for wrapper "_s, hex(reinterpret_cast<uintptr_t>(self))));
         return;
     }
 
@@ -2807,11 +2807,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_accessibilitySetValue:(id)value forAttribute:(NSString *)attributeName
 {
-    AXTRACE(makeString("WebAccessibilityObjectWrapper _accessibilitySetValue: forAttribute:", String(attributeName)));
+    AXTRACE(makeString("WebAccessibilityObjectWrapper _accessibilitySetValue: forAttribute:"_s, String(attributeName)));
 
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject) {
-        AXLOG(makeString("No backingObject for wrapper ", hex(reinterpret_cast<uintptr_t>(self))));
+        AXLOG(makeString("No backingObject for wrapper "_s, hex(reinterpret_cast<uintptr_t>(self))));
         return;
     }
 
@@ -3020,7 +3020,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 static void formatForDebugger(const VisiblePositionRange& range, char* buffer, unsigned length)
 {
-    strlcpy(buffer, makeString("from ", range.start.debugDescription(), " to ", range.end.debugDescription()).utf8().data(), length);
+    strlcpy(buffer, makeString("from "_s, range.start.debugDescription(), " to "_s, range.end.debugDescription()).utf8().data(), length);
 }
 #endif
 
@@ -3163,7 +3163,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString*)attribute forParameter:(id)parameter
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityAttributeValue:", String(attribute)));
+    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityAttributeValue:"_s, String(attribute)));
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
         return nil;
@@ -3858,7 +3858,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (NSUInteger)accessibilityArrayAttributeCount:(NSString *)attribute
 {
-    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityArrayAttributeCount:", String(attribute)));
+    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityArrayAttributeCount:"_s, String(attribute)));
 
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
@@ -3897,7 +3897,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray *)accessibilityArrayAttributeValues:(NSString *)attribute index:(NSUInteger)index maxCount:(NSUInteger)maxCount
 {
-    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityArrayAttributeValue:", String(attribute)));
+    AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityArrayAttributeValue:"_s, String(attribute)));
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
         return nil;

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -71,7 +71,7 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
 
         callData = JSC::getCallData(function);
         if (callData.type == CallData::Type::None) {
-            returnedException = JSC::Exception::create(vm, createTypeError(lexicalGlobalObject, makeString("'", String(functionName.uid()), "' property of callback interface should be callable")));
+            returnedException = JSC::Exception::create(vm, createTypeError(lexicalGlobalObject, makeString('\'', String(functionName.uid()), "' property of callback interface should be callable"_s)));
             return JSValue();
         }
 

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -48,7 +48,7 @@ static String remoteFrameAccessError(JSC::JSGlobalObject* lexicalGlobalObject)
 {
     auto& active = activeDOMWindow(*lexicalGlobalObject);
     Ref activeOrigin = active.document()->securityOrigin();
-    return makeString("Blocked a frame with origin \"", activeOrigin->toString(), "\" from accessing a cross-origin frame. Protocols, domains, and ports must match.");
+    return makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a cross-origin frame. Protocols, domains, and ports must match."_s);
 }
 
 // FIXME: Refactor to share more code with canAccessDocument.

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
@@ -41,7 +41,7 @@ static const int64_t kJSMaxInteger = 0x20000000000000LL - 1; // 2^53 - 1, larges
 
 static String rangeErrorString(double value, double min, double max)
 {
-    return makeString("Value ", value, " is outside the range [", min, ", ", max, ']');
+    return makeString("Value "_s, value, " is outside the range ["_s, min, ", "_s, max, ']');
 }
 
 static double enforceRange(JSGlobalObject& lexicalGlobalObject, double x, double minimum, double maximum)

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -264,17 +264,17 @@ JSC::EncodedJSValue throwArgumentTypeError(JSC::JSGlobalObject& lexicalGlobalObj
 
 void throwAttributeTypeError(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope, const char* interfaceName, const char* attributeName, const char* expectedType)
 {
-    throwTypeError(lexicalGlobalObject, scope, makeString("The ", interfaceName, '.', attributeName, " attribute must be an instance of ", expectedType));
+    throwTypeError(lexicalGlobalObject, scope, makeString("The "_s, interfaceName, '.', attributeName, " attribute must be an instance of "_s, expectedType));
 }
 
 JSC::EncodedJSValue throwRequiredMemberTypeError(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope, const char* memberName, const char* dictionaryName, const char* expectedType)
 {
-    return throwVMTypeError(&lexicalGlobalObject, scope, makeString("Member ", dictionaryName, '.', memberName, " is required and must be an instance of ", expectedType));
+    return throwVMTypeError(&lexicalGlobalObject, scope, makeString("Member "_s, dictionaryName, '.', memberName, " is required and must be an instance of "_s, expectedType));
 }
 
 JSC::EncodedJSValue throwConstructorScriptExecutionContextUnavailableError(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope, const char* interfaceName)
 {
-    return throwVMError(&lexicalGlobalObject, scope, createReferenceError(&lexicalGlobalObject, makeString(interfaceName, " constructor associated execution context is unavailable")));
+    return throwVMError(&lexicalGlobalObject, scope, createReferenceError(&lexicalGlobalObject, makeString(interfaceName, " constructor associated execution context is unavailable"_s)));
 }
 
 void throwSequenceTypeError(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope)
@@ -294,12 +294,12 @@ JSC::EncodedJSValue rejectPromiseWithGetterTypeError(JSC::JSGlobalObject& lexica
 
 String makeThisTypeErrorMessage(const char* interfaceName, const char* functionName)
 {
-    return makeString("Can only call ", interfaceName, '.', functionName, " on instances of ", interfaceName);
+    return makeString("Can only call "_s, interfaceName, '.', functionName, " on instances of "_s, interfaceName);
 }
 
 String makeUnsupportedIndexedSetterErrorMessage(const char* interfaceName)
 {
-    return makeString("Failed to set an indexed property on ", interfaceName, ": Indexed property setter is not supported.");
+    return makeString("Failed to set an indexed property on "_s, interfaceName, ": Indexed property setter is not supported."_s);
 }
 
 EncodedJSValue throwThisTypeError(JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope, const char* interfaceName, const char* functionName)

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -491,7 +491,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, makeString("'", cachedScript.response().mimeType(), "' is not a valid JavaScript MIME type."));
+            rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, makeString('\'', cachedScript.response().mimeType(), "' is not a valid JavaScript MIME type."_s));
             return;
         }
 
@@ -499,7 +499,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             String integrity = parameters->integrity();
             if (!integrity.isEmpty()) {
                 if (!matchIntegrityMetadata(cachedScript, integrity)) {
-                    m_context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script ", integrityMismatchDescription(cachedScript, integrity)));
+                    m_context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script "_s, integrityMismatchDescription(cachedScript, integrity)));
                     rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, "Cannot load script due to integrity mismatch"_s);
                     return;
                 }
@@ -558,7 +558,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, makeString("'", loader.responseMIMEType(), "' is not a valid JavaScript MIME type."));
+            rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, makeString('\'', loader.responseMIMEType(), "' is not a valid JavaScript MIME type."_s));
             return;
         }
 

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -308,14 +308,14 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
         if (results.summary.madeHTTPS) {
             ASSERT(url.protocolIs("http"_s) || url.protocolIs("ws"_s));
             String newProtocol = url.protocolIs("http"_s) ? "https"_s : "wss"_s;
-            currentDocument->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Info, makeString("Promoted URL from ", url.string(), " to ", newProtocol));
+            currentDocument->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Info, makeString("Promoted URL from "_s, url.string(), " to "_s, newProtocol));
         }
         if (results.summary.blockedLoad) {
             String consoleMessage;
             if (auto message = customTrackerBlockingMessageForConsole(results, url, mainDocumentURL))
                 consoleMessage = WTFMove(*message);
             else
-                consoleMessage = makeString("Content blocker prevented frame displaying ", mainDocumentURL.string(), " from loading a resource from ", url.string());
+                consoleMessage = makeString("Content blocker prevented frame displaying "_s, mainDocumentURL.string(), " from loading a resource from "_s, url.string());
             currentDocument->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Info, WTFMove(consoleMessage));
         
             // Quirk for content-blocker interference with Google's anti-flicker optimization (rdar://problem/45968770).

--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -40,7 +40,7 @@ CSSCanvasValue::~CSSCanvasValue() = default;
 
 String CSSCanvasValue::customCSSText() const
 {
-    return makeString("-webkit-canvas(", m_name, ')');
+    return makeString("-webkit-canvas("_s, m_name, ')');
 }
 
 bool CSSCanvasValue::equals(const CSSCanvasValue& other) const

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -54,7 +54,7 @@ bool CSSFilterImageValue::equalInputImages(const CSSFilterImageValue& other) con
 
 String CSSFilterImageValue::customCSSText() const
 {
-    return makeString("filter(", m_imageValueOrNone->cssText(), ", ", m_filterValue->cssText(), ')');
+    return makeString("filter("_s, m_imageValueOrNone->cssText(), ", "_s, m_filterValue->cssText(), ')');
 }
 
 RefPtr<StyleImage> CSSFilterImageValue::createStyleImage(Style::BuilderState& state) const

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -69,7 +69,7 @@ String CSSFontFaceRule::cssTextInternal(const String& declarations) const
     if (declarations.isEmpty())
         return "@font-face { }"_s;
 
-    return makeString("@font-face { ", declarations, " }");
+    return makeString("@font-face { "_s, declarations, " }"_s);
 }
 
 void CSSFontFaceRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -64,7 +64,7 @@ void CSSFontFaceSrcLocalValue::setSVGFontFaceElement(SVGFontFaceElement& element
 
 String CSSFontFaceSrcLocalValue::customCSSText() const
 {
-    return makeString("local(", serializeString(m_fontFaceName), ')');
+    return makeString("local("_s, serializeString(m_fontFaceName), ')');
 }
 
 bool CSSFontFaceSrcLocalValue::equals(const CSSFontFaceSrcLocalValue& other) const

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
@@ -41,7 +41,7 @@ Ref<CSSFontStyleWithAngleValue> CSSFontStyleWithAngleValue::create(Ref<CSSPrimit
 
 String CSSFontStyleWithAngleValue::customCSSText() const
 {
-    return makeString("oblique ", m_obliqueAngle->cssText());
+    return makeString("oblique "_s, m_obliqueAngle->cssText());
 }
 
 bool CSSFontStyleWithAngleValue::equals(const CSSFontStyleWithAngleValue& other) const

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -40,7 +40,7 @@ CSSNamedImageValue::~CSSNamedImageValue() = default;
 
 String CSSNamedImageValue::customCSSText() const
 {
-    return makeString("-webkit-named-image(", m_name, ')');
+    return makeString("-webkit-named-image("_s, m_name, ')');
 }
 
 bool CSSNamedImageValue::equals(const CSSNamedImageValue& other) const

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -57,7 +57,7 @@ String CSSPageRule::selectorText() const
     if (auto* selector = m_pageRule->selector()) {
         String pageSpecification = selector->selectorText();
         if (!pageSpecification.isEmpty() && pageSpecification != starAtom())
-            return makeString("@page ", pageSpecification);
+            return makeString("@page "_s, pageSpecification);
     }
     return "@page"_s;
 }

--- a/Source/WebCore/css/CSSPaintImageValue.cpp
+++ b/Source/WebCore/css/CSSPaintImageValue.cpp
@@ -45,7 +45,7 @@ CSSPaintImageValue::~CSSPaintImageValue() = default;
 String CSSPaintImageValue::customCSSText() const
 {
     // FIXME: This should include the arguments too.
-    return makeString("paint(", m_name, ')');
+    return makeString("paint("_s, m_name, ')');
 }
 
 RefPtr<StyleImage> CSSPaintImageValue::createStyleImage(Style::BuilderState&) const

--- a/Source/WebCore/css/CSSTimingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSTimingFunctionValue.cpp
@@ -56,7 +56,7 @@ bool CSSLinearTimingFunctionValue::equals(const CSSLinearTimingFunctionValue& ot
 
 String CSSCubicBezierTimingFunctionValue::customCSSText() const
 {
-    return makeString("cubic-bezier(", m_x1, ", ", m_y1, ", ", m_x2, ", ", m_y2, ')');
+    return makeString("cubic-bezier("_s, m_x1, ", "_s, m_y1, ", "_s, m_x2, ", "_s, m_y2, ')');
 }
 
 bool CSSCubicBezierTimingFunctionValue::equals(const CSSCubicBezierTimingFunctionValue& other) const
@@ -96,7 +96,7 @@ bool CSSStepsTimingFunctionValue::equals(const CSSStepsTimingFunctionValue& othe
 
 String CSSSpringTimingFunctionValue::customCSSText() const
 {
-    return makeString("spring(", FormattedNumber::fixedPrecision(m_mass), ' ', FormattedNumber::fixedPrecision(m_stiffness), ' ', FormattedNumber::fixedPrecision(m_damping), ' ', FormattedNumber::fixedPrecision(m_initialVelocity), ')');
+    return makeString("spring("_s, FormattedNumber::fixedPrecision(m_mass), ' ', FormattedNumber::fixedPrecision(m_stiffness), ' ', FormattedNumber::fixedPrecision(m_damping), ' ', FormattedNumber::fixedPrecision(m_initialVelocity), ')');
 }
 
 bool CSSSpringTimingFunctionValue::equals(const CSSSpringTimingFunctionValue& other) const

--- a/Source/WebCore/css/CSSUnicodeRangeValue.cpp
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.cpp
@@ -33,9 +33,9 @@ namespace WebCore {
 String CSSUnicodeRangeValue::customCSSText() const
 {
     if (m_from == m_to)
-        return makeString("U+", hex(m_from, Lowercase));
+        return makeString("U+"_s, hex(m_from, Lowercase));
 
-    return makeString("U+", hex(m_from, Lowercase), '-', hex(m_to, Lowercase));
+    return makeString("U+"_s, hex(m_from, Lowercase), '-', hex(m_to, Lowercase));
 }
 
 bool CSSUnicodeRangeValue::equals(const CSSUnicodeRangeValue& other) const

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -412,9 +412,9 @@ ExceptionOr<String> DOMMatrixReadOnly::toString() const
         return Exception { ExceptionCode::InvalidStateError, "Matrix contains non-finite values"_s };
 
     if (is2D())
-        return makeString("matrix(", m_matrix.a(), ", ", m_matrix.b(), ", ", m_matrix.c(), ", ", m_matrix.d(), ", ", m_matrix.e(), ", ", m_matrix.f(), ')');
+        return makeString("matrix("_s, m_matrix.a(), ", "_s, m_matrix.b(), ", "_s, m_matrix.c(), ", "_s, m_matrix.d(), ", "_s, m_matrix.e(), ", "_s, m_matrix.f(), ')');
 
-    return makeString("matrix3d(", m_matrix.m11(), ", ", m_matrix.m12(), ", ", m_matrix.m13(), ", ", m_matrix.m14(), ", ", m_matrix.m21(), ", ", m_matrix.m22(), ", ", m_matrix.m23(), ", ", m_matrix.m24(), ", ", m_matrix.m31(), ", ", m_matrix.m32(), ", ", m_matrix.m33(), ", ", m_matrix.m34(), ", ", m_matrix.m41(), ", ", m_matrix.m42(), ", ", m_matrix.m43(), ", ", m_matrix.m44(), ')');
+    return makeString("matrix3d("_s, m_matrix.m11(), ", "_s, m_matrix.m12(), ", "_s, m_matrix.m13(), ", "_s, m_matrix.m14(), ", "_s, m_matrix.m21(), ", "_s, m_matrix.m22(), ", "_s, m_matrix.m23(), ", "_s, m_matrix.m24(), ", "_s, m_matrix.m31(), ", "_s, m_matrix.m32(), ", "_s, m_matrix.m33(), ", "_s, m_matrix.m34(), ", "_s, m_matrix.m41(), ", "_s, m_matrix.m42(), ", "_s, m_matrix.m43(), ", "_s, m_matrix.m44(), ')');
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1090,8 +1090,8 @@ String ShorthandSerializer::serializeGrid() const
         return String();
 
     if (isValueIDIncludingList(autoRows, CSSValueAuto))
-        return makeString("auto-flow", dense, " / ", serializeLonghandValue(columnsIndex));
-    return makeString("auto-flow", dense, " ", serializeLonghandValue(autoRowsIndex), " / ", serializeLonghandValue(columnsIndex));
+        return makeString("auto-flow"_s, dense, " / "_s, serializeLonghandValue(columnsIndex));
+    return makeString("auto-flow"_s, dense, ' ', serializeLonghandValue(autoRowsIndex), " / "_s, serializeLonghandValue(columnsIndex));
 }
 
 static bool isCustomIdentValue(const CSSValue& value)

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -413,11 +413,11 @@ bool StyleSheetContents::parseAuthorStyleSheet(const CachedCSSStyleSheet* cached
         if (auto* document = singleOwnerDocument()) {
             if (auto* page = document->page()) {
                 if (isStrictParserMode(m_parserContext.mode))
-                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '", cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed in strict mode."));
+                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '"_s, cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed in strict mode."_s));
                 else if (!cachedStyleSheet->mimeTypeAllowedByNosniff())
-                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '", cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed when 'X-Content-Type-Options: nosniff' is given."));
+                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '"_s, cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed when 'X-Content-Type-Options: nosniff' is given."_s));
                 else
-                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '", cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed for cross-origin stylesheets."));
+                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse stylesheet at '"_s, cachedStyleSheet->url().stringCenterEllipsizedToLength(), "' because non CSS MIME types are not allowed for cross-origin stylesheets."_s));
             }
         }
         return false;

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -140,7 +140,7 @@ std::optional<CSSUnparsedSegment> CSSUnparsedValue::item(size_t index)
 ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::setItem(size_t index, CSSUnparsedSegment&& val)
 {
     if (index > m_segments.size())
-        return Exception { ExceptionCode::RangeError, makeString("Index ", index, " exceeds index range for unparsed segments.") };
+        return Exception { ExceptionCode::RangeError, makeString("Index "_s, index, " exceeds index range for unparsed segments."_s) };
     if (index == m_segments.size())
         m_segments.append(WTFMove(val));
     else

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -64,7 +64,7 @@ ExceptionOr<RefPtr<CSSStyleValue>> MainThreadStylePropertyMapReadOnly::get(Scrip
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, &document->settings()))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid property ", property) };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (isShorthand(propertyID))
         return CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID), { *document });
@@ -84,7 +84,7 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> MainThreadStylePropertyMapReadOnly::g
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, &document->settings()))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid property ", property) };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (isShorthand(propertyID)) {
         if (RefPtr value = CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID), { *document }))

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -80,7 +80,7 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
     }
     auto propertyID = cssPropertyID(property);
     if (propertyID == CSSPropertyInvalid || !isExposed(propertyID, document.settings()))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid property ", property) };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (!CSSProperty::isListValuedProperty(propertyID) && values.size() > 1)
         return Exception { ExceptionCode::TypeError, makeString(property, " is not a list-valued property but more than one value was provided"_s) };
@@ -139,7 +139,7 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
 
     auto propertyID = cssPropertyID(property);
     if (propertyID == CSSPropertyInvalid || !isExposed(propertyID, document.settings()))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid property ", property) };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     if (!CSSProperty::isListValuedProperty(propertyID))
         return Exception { ExceptionCode::TypeError, makeString(property, " does not support multiple values"_s) };
@@ -179,7 +179,7 @@ ExceptionOr<void> StylePropertyMap::remove(Document& document, const AtomString&
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, document.settings()))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid property ", property) };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid property "_s, property) };
 
     removeProperty(propertyID);
     return { };

--- a/Source/WebCore/css/typedom/numeric/CSSNumericType.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericType.cpp
@@ -146,15 +146,15 @@ std::optional<CSSNumericType> CSSNumericType::multiplyTypes(const Vector<Ref<CSS
 
 String CSSNumericType::debugString() const
 {
-    return makeString("{",
-        length ? makeString(" length:", *length) : String(),
-        angle ? makeString(" angle:", *angle) : String(),
-        time ? makeString(" time:", *time) : String(),
-        frequency ? makeString(" frequency:", *frequency) : String(),
-        resolution ? makeString(" resolution:", *resolution) : String(),
-        flex ? makeString(" flex:", *flex) : String(),
-        percent ? makeString(" percent:", *percent) : String(),
-        percentHint ? makeString(" percentHint:", WebCore::debugString(*percentHint)) : String(),
+    return makeString('{',
+        length ? makeString(" length:"_s, *length) : String(),
+        angle ? makeString(" angle:"_s, *angle) : String(),
+        time ? makeString(" time:"_s, *time) : String(),
+        frequency ? makeString(" frequency:"_s, *frequency) : String(),
+        resolution ? makeString(" resolution:"_s, *resolution) : String(),
+        flex ? makeString(" flex:"_s, *flex) : String(),
+        percent ? makeString(" percent:"_s, *percent) : String(),
+        percentHint ? makeString(" percentHint:"_s, WebCore::debugString(*percentHint)) : String(),
     " }");
 }
 

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -126,7 +126,7 @@ RefPtr<CSSTransformComponent> CSSTransformValue::item(size_t index)
 ExceptionOr<Ref<CSSTransformComponent>> CSSTransformValue::setItem(size_t index, Ref<CSSTransformComponent>&& value)
 {
     if (index > m_components.size())
-        return Exception { ExceptionCode::RangeError, makeString("Index ", index, " exceeds the range of CSSTransformValue.") };
+        return Exception { ExceptionCode::RangeError, makeString("Index "_s, index, " exceeds the range of CSSTransformValue."_s) };
 
     if (index == m_components.size())
         m_components.append(WTFMove(value));

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -142,7 +142,7 @@ void DeviceMotionEvent::requestPermission(Document& document, PermissionPromise&
 
     String errorMessage;
     if (!window->isAllowedToUseDeviceMotion(errorMessage)) {
-        document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Call to requestPermission() failed, reason: ", errorMessage, "."));
+        document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Call to requestPermission() failed, reason: "_s, errorMessage, '.'));
         return promise.resolve(PermissionState::Denied);
     }
 

--- a/Source/WebCore/dom/DeviceOrientationEvent.cpp
+++ b/Source/WebCore/dom/DeviceOrientationEvent.cpp
@@ -128,7 +128,7 @@ void DeviceOrientationEvent::requestPermission(Document& document, PermissionPro
 
     String errorMessage;
     if (!window->isAllowedToUseDeviceOrientation(errorMessage)) {
-        document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Call to requestPermission() failed, reason: ", errorMessage, "."));
+        document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Call to requestPermission() failed, reason: "_s, errorMessage, '.'));
         return promise.resolve(PermissionState::Denied);
     }
 

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -223,7 +223,7 @@ inline String DocumentMarker::description() const
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     if (auto* data = std::get_if<DocumentMarker::UnifiedTextReplacementData>(&m_data))
-        return makeString("('", data->originalText, "', state: ", enumToUnderlyingType(data->state), ")");
+        return makeString("('"_s, data->originalText, "', state: "_s, enumToUnderlyingType(data->state), ')');
 #endif
 
     return emptyString();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1957,7 +1957,7 @@ const AtomString& Element::getAttributeNS(const AtomString& namespaceURI, const 
 ExceptionOr<bool> Element::toggleAttribute(const AtomString& qualifiedName, std::optional<bool> force)
 {
     if (!Document::isValidName(qualifiedName))
-        return Exception { ExceptionCode::InvalidCharacterError, makeString("Invalid qualified name: '", qualifiedName, "'") };
+        return Exception { ExceptionCode::InvalidCharacterError, makeString("Invalid qualified name: '"_s, qualifiedName, '\'') };
 
     synchronizeAttribute(qualifiedName);
 
@@ -1981,7 +1981,7 @@ ExceptionOr<bool> Element::toggleAttribute(const AtomString& qualifiedName, std:
 ExceptionOr<void> Element::setAttribute(const AtomString& qualifiedName, const AtomString& value)
 {
     if (!Document::isValidName(qualifiedName))
-        return Exception { ExceptionCode::InvalidCharacterError, makeString("Invalid qualified name: '", qualifiedName, "'") };
+        return Exception { ExceptionCode::InvalidCharacterError, makeString("Invalid qualified name: '"_s, qualifiedName, '\'') };
 
     synchronizeAttribute(qualifiedName);
     auto caseAdjustedQualifiedName = shouldIgnoreAttributeCase(*this) ? qualifiedName.convertToASCIILowercase() : qualifiedName;

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -108,7 +108,7 @@ void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const
             ConsoleMessage {
                 MessageSource::Security,
                 MessageLevel::Error,
-                makeString("Refused to execute ", cachedScript->url().stringCenterEllipsizedToLength(), " as script because \"X-Content-Type-Options: nosniff\" was given and its Content-Type is not a script MIME type.")
+                makeString("Refused to execute "_s, cachedScript->url().stringCenterEllipsizedToLength(), " as script because \"X-Content-Type-Options: nosniff\" was given and its Content-Type is not a script MIME type."_s)
             },
             { }
         };
@@ -120,7 +120,7 @@ void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const
             ConsoleMessage {
                 MessageSource::Security,
                 MessageLevel::Error,
-                makeString("Refused to execute ", cachedScript->url().stringCenterEllipsizedToLength(), " as script because ", cachedScript->response().mimeType(), " is not a script MIME type.")
+                makeString("Refused to execute "_s, cachedScript->url().stringCenterEllipsizedToLength(), " as script because "_s, cachedScript->response().mimeType(), " is not a script MIME type."_s)
             },
             { }
         };
@@ -129,7 +129,7 @@ void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const
     if (!m_error && !resource.errorOccurred() && !matchIntegrityMetadata(resource, m_integrity)) {
         m_error = Error {
             ErrorType::FailedIntegrityCheck,
-            ConsoleMessage { MessageSource::Security, MessageLevel::Error, makeString("Cannot load script ", integrityMismatchDescription(resource, m_integrity)) },
+            ConsoleMessage { MessageSource::Security, MessageLevel::Error, makeString("Cannot load script "_s, integrityMismatchDescription(resource, m_integrity)) },
             { }
         };
     }

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1395,7 +1395,7 @@ String Position::debugDescription() const
 {
     if (isNull())
         return "<null>"_s;
-    return makeString("offset ", m_offset, " of ", deprecatedNode()->debugDescription());
+    return makeString("offset "_s, m_offset, " of "_s, deprecatedNode()->debugDescription());
 }
 
 void Position::showAnchorTypeAndOffset() const

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -907,7 +907,7 @@ ExceptionOr<void> Range::setStartBefore(Node& node)
 #if ENABLE(TREE_DEBUGGING)
 String Range::debugDescription() const
 {
-    return makeString("from offset ", m_start.offset(), " of ", startContainer().debugDescription(), " to offset ", m_end.offset(), " of ", endContainer().debugDescription());
+    return makeString("from offset "_s, m_start.offset(), " of "_s, startContainer().debugDescription(), " to offset "_s, m_end.offset(), " of "_s, endContainer().debugDescription());
 }
 #endif
 

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -167,7 +167,7 @@ ExceptionOr<String> trustedTypeCompliantString(TrustedType expectedType, ScriptE
         auto allowMissingTrustedTypes = contentSecurityPolicy->allowMissingTrustedTypesForSinkGroup(trustedTypeToString(expectedType), sink, "script"_s, stringValue);
 
         if (!allowMissingTrustedTypes)
-            return Exception { ExceptionCode::TypeError, makeString("This assignment requires a ", trustedTypeToString(expectedType)) };
+            return Exception { ExceptionCode::TypeError, makeString("This assignment requires a "_s, trustedTypeToString(expectedType)) };
     }
 
     return stringValue;
@@ -225,7 +225,7 @@ ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecuti
         auto allowMissingTrustedTypes = contentSecurityPolicy->allowMissingTrustedTypesForSinkGroup(trustedTypeToString(expectedType), sink, sinkGroup, scriptSource);
 
         if (!allowMissingTrustedTypes)
-            return Exception { ExceptionCode::TypeError, makeString("This assignment requires a ", trustedTypeToString(expectedType)) };
+            return Exception { ExceptionCode::TypeError, makeString("This assignment requires a "_s, trustedTypeToString(expectedType)) };
 
         return String(urlString);
     }

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -61,7 +61,7 @@ public:
     uint64_t beingTransferredCount();
 
 #if !LOG_DISABLED
-    String logString() const { return makeString(m_ports[0].logString(), ":", m_ports[1].logString()); }
+    String logString() const { return makeString(m_ports[0].logString(), ':', m_ports[1].logString()); }
 #endif
 
 private:

--- a/Source/WebCore/editing/HTMLInterchange.cpp
+++ b/Source/WebCore/editing/HTMLInterchange.cpp
@@ -41,7 +41,7 @@ String convertHTMLTextToInterchangeFormat(const String& in, const Text* node)
     if (node->renderer() && node->renderer()->style().preserveNewline())
         return in;
 
-    static NeverDestroyed<const String> convertedSpaceString { makeString("<span class=\"", AppleConvertedSpace, "\">", noBreakSpace, "</span>") };
+    static NeverDestroyed<const String> convertedSpaceString { makeString("<span class=\""_s, AppleConvertedSpace, "\">"_s, noBreakSpace, "</span>"_s) };
 
     StringBuilder s;
 

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -713,7 +713,7 @@ void VisiblePosition::showTreeForThis() const
 
 String VisiblePositionRange::debugDescription() const
 {
-    return makeString("start: ", start.debugDescription(), ", end: ", end.debugDescription());
+    return makeString("start: "_s, start.debugDescription(), ", end: "_s, end.debugDescription());
 }
 #endif // ENABLE(TREE_DEBUGGING)
 

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -744,7 +744,7 @@ String VisibleSelection::debugDescription() const
 {
     if (isNone())
         return "<none>"_s;
-    return makeString("from ", start().debugDescription(), " to ", end().debugDescription());
+    return makeString("from "_s, start().debugDescription(), " to "_s, end().debugDescription());
 }
 
 void VisibleSelection::showTreeForThis() const

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1861,14 +1861,14 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
         String listStyleType = _caches->propertyValueForNode(element, CSSPropertyListStyleType);
         if (!listStyleType.length())
             listStyleType = @"disc";
-        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:String("{" + listStyleType + "}") options:0]);
+        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:makeString("{"_s, listStyleType, "}"_s) options:0]);
         [_textLists addObject:list.get()];
     } else if (element.hasTagName(olTag)) {
         RetainPtr<NSTextList> list;
         String listStyleType = _caches->propertyValueForNode(element, CSSPropertyListStyleType);
         if (!listStyleType.length())
             listStyleType = "decimal"_s;
-        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:String("{" + listStyleType + "}") options:0]);
+        list = adoptNS([[PlatformNSTextList alloc] initWithMarkerFormat:makeString('{', listStyleType, '}') options:0]);
         if (RefPtr olElement = dynamicDowncast<HTMLOListElement>(element)) {
             auto startingItemNumber = olElement->start();
             [list setStartingItemNumber:startingItemNumber];

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -999,7 +999,7 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
 static String serializePreservingVisualAppearanceInternal(const Position& start, const Position& end, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializeComposedTree serializeComposedTree, IgnoreUserSelectNone ignoreUserSelectNone,
     AnnotateForInterchange annotate, ConvertBlocksToInlines convertBlocksToInlines, StandardFontFamilySerializationMode standardFontFamilySerializationMode, MSOListMode msoListMode, PreserveBaseElement preserveBaseElement)
 {
-    static NeverDestroyed<const String> interchangeNewlineString { makeString("<br class=\"", AppleInterchangeNewline, "\">") };
+    static NeverDestroyed<const String> interchangeNewlineString { makeString("<br class=\""_s, AppleInterchangeNewline, "\">"_s) };
 
     if (!(start < end))
         return emptyString();

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -358,7 +358,7 @@ void FileReaderLoader::convertToText()
 
 void FileReaderLoader::convertToDataURL()
 {
-    m_stringResult = makeString("data:", m_dataType.isEmpty() ? "application/octet-stream"_s : m_dataType, ";base64,", base64Encoded(m_rawData ? m_rawData->data() : nullptr, m_bytesLoaded));
+    m_stringResult = makeString("data:"_s, m_dataType.isEmpty() ? "application/octet-stream"_s : m_dataType, ";base64,"_s, base64Encoded(m_rawData ? m_rawData->data() : nullptr, m_bytesLoaded));
 }
 
 bool FileReaderLoader::isCompleted() const

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -457,7 +457,7 @@ int HistoryItem::showTreeWithIndent(unsigned indentLevel) const
 #if !LOG_DISABLED
 String HistoryItem::logString() const
 {
-    return makeString("HistoryItem current URL ", urlString(), ", identifier ", m_identifier.toString());
+    return makeString("HistoryItem current URL "_s, urlString(), ", identifier "_s, m_identifier.toString());
 }
 #endif
 

--- a/Source/WebCore/html/BaseTextInputType.cpp
+++ b/Source/WebCore/html/BaseTextInputType.cpp
@@ -43,7 +43,7 @@ bool BaseTextInputType::patternMismatch(const String& value) const
     if (rawPattern.isNull() || value.isEmpty() || !JSC::Yarr::RegularExpression(rawPattern, { JSC::Yarr::Flags::UnicodeSets }).isValid())
         return false;
 
-    String pattern = makeString("^(?:", rawPattern, ")$");
+    String pattern = makeString("^(?:"_s, rawPattern, ")$"_s);
     JSC::Yarr::RegularExpression regex(pattern, { JSC::Yarr::Flags::UnicodeSets });
     auto valuePatternMismatch = [&regex](auto& value) {
         int matchLength = 0;

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -335,7 +335,7 @@ RefPtr<ImageBuffer> CanvasBase::allocateImageBuffer() const
     if (!area)
         return nullptr;
     if (area > maxCanvasArea()) {
-        auto message = makeString("Canvas area exceeds the maximum limit (width * height > ", maxCanvasArea(), ").");
+        auto message = makeString("Canvas area exceeds the maximum limit (width * height > "_s, maxCanvasArea(), ")."_s);
         scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, message);
         return nullptr;
     }

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -50,7 +50,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)
     ASSERT(base.isValid() || base.isNull());
     URL completeURL { base, url };
     if (!completeURL.isValid())
-        return Exception { ExceptionCode::TypeError, makeString("\"", url, "\" cannot be parsed as a URL.") };
+        return Exception { ExceptionCode::TypeError, makeString('"', url, "\" cannot be parsed as a URL."_s) };
     return adoptRef(*new DOMURL(WTFMove(completeURL)));
 }
 
@@ -58,7 +58,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
 {
     URL baseURL { base };
     if (!base.isNull() && !baseURL.isValid())
-        return Exception { ExceptionCode::TypeError, makeString("\"", url, "\" cannot be parsed as a URL against \"", base, "\".") };
+        return Exception { ExceptionCode::TypeError, makeString('"', url, "\" cannot be parsed as a URL against \""_s, base, "\"."_s) };
     return create(url, baseURL);
 }
 

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -210,12 +210,12 @@ static String processFileDateString(const FTPTime& fileTime)
         if (hour < 12) {
             if (hour == 0)
                 hour = 12;
-            timeOfDay = makeString(", ", hour, ':', pad('0', 2, fileTime.tm_min), " AM");
+            timeOfDay = makeString(", "_s, hour, ':', pad('0', 2, fileTime.tm_min), " AM"_s);
         } else {
             hour = hour - 12;
             if (hour == 0)
                 hour = 12;
-            timeOfDay = makeString(", ", hour, ':', pad('0', 2, fileTime.tm_min), " PM");
+            timeOfDay = makeString(", "_s, hour, ':', pad('0', 2, fileTime.tm_min), " PM"_s);
         }
     }
 

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -202,7 +202,7 @@ String FileInputType::firstElementPathForInputValue() const
     // decided to try to parse the value by looking for backslashes
     // (because that's what Windows file paths use). To be compatible
     // with that code, we make up a fake path for the file.
-    return makeString("C:\\fakepath\\", m_fileList->file(0).name());
+    return makeString("C:\\fakepath\\"_s, m_fileList->file(0).name());
 }
 
 void FileInputType::setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection)

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -522,7 +522,7 @@ std::optional<PrivateClickMeasurement> HTMLAnchorElement::parsePrivateClickMeasu
     }
     
     if (attributionSourceID.value() > std::numeric_limits<uint8_t>::max()) {
-        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("attributionsourceid must have a non-negative value less than or equal to ", std::numeric_limits<uint8_t>::max(), " for Private Click Measurement."));
+        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("attributionsourceid must have a non-negative value less than or equal to "_s, std::numeric_limits<uint8_t>::max(), " for Private Click Measurement."_s));
         return std::nullopt;
     }
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -457,7 +457,7 @@ void HTMLLinkElement::setCSSStyleSheet(const String& href, const URL& baseURL, c
     Ref<HTMLLinkElement> protectedThis(*this);
 
     if (!cachedStyleSheet->errorOccurred() && !matchIntegrityMetadata(*cachedStyleSheet, m_integrityMetadataForPendingSheetRequest)) {
-        document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load stylesheet ", integrityMismatchDescription(*cachedStyleSheet, m_integrityMetadataForPendingSheetRequest)));
+        document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load stylesheet "_s, integrityMismatchDescription(*cachedStyleSheet, m_integrityMetadataForPendingSheetRequest)));
 
         m_loading = false;
         sheetLoaded();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8306,7 +8306,7 @@ RefPtr<VideoPlaybackQuality> HTMLMediaElement::getVideoPlaybackQuality() const
 DOMWrapperWorld& HTMLMediaElement::ensureIsolatedWorld()
 {
     if (!m_isolatedWorld)
-        m_isolatedWorld = DOMWrapperWorld::create(Ref { commonVM() }, DOMWrapperWorld::Type::Internal, makeString("Media Controls (", localName(), ')'));
+        m_isolatedWorld = DOMWrapperWorld::create(Ref { commonVM() }, DOMWrapperWorld::Type::Internal, makeString("Media Controls ("_s, localName(), ')'));
     return *m_isolatedWorld;
 }
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -466,7 +466,7 @@ ExceptionOr<void> HTMLSelectElement::setItem(unsigned index, HTMLOptionElement* 
 
     // If we are adding options, we should check 'index > maxSelectItems' first to avoid integer overflow.
     if (index > length() && index >= maxSelectItems) {
-        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list and set an option at index. The maximum list length is ", maxSelectItems, '.'));
+        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list and set an option at index. The maximum list length is "_s, maxSelectItems, '.'));
         return { };
     }
 
@@ -499,7 +499,7 @@ ExceptionOr<void> HTMLSelectElement::setLength(unsigned newLength)
 {
     // If we are adding options, we should check 'index > maxSelectItems' first to avoid integer overflow.
     if (newLength > length() && newLength > maxSelectItems) {
-        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list to length ", newLength, " items. The maximum number of items allowed is ", maxSelectItems, '.'));
+        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list to length "_s, newLength, " items. The maximum number of items allowed is "_s, maxSelectItems, '.'));
         return { };
     }
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -289,7 +289,7 @@ void ImageDocument::imageUpdated()
 #if PLATFORM(IOS_FAMILY)
         FloatSize screenSize = page()->chrome().screenSize();
         if (imageSize.width() > screenSize.width())
-            processViewport(makeString("width=", imageSize.width().toInt(), ",viewport-fit=cover"), ViewportArguments::Type::ImageDocument);
+            processViewport(makeString("width="_s, imageSize.width().toInt(), ",viewport-fit=cover"_s), ViewportArguments::Type::ImageDocument);
 
         if (page())
             page()->chrome().client().imageOrMediaDocumentSizeChanged(IntSize(imageSize.width(), imageSize.height()));

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -94,7 +94,7 @@ bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type ty
     while (ancestorDocument.get() != topDocument.ptr()) {
         if (!ancestorDocument) {
             if (logFailure == LogPermissionsPolicyFailure::Yes && document.domWindow())
-                document.domWindow()->printErrorMessage(makeString("Permission policy '", policyTypeName(type), "' check failed."));
+                document.domWindow()->printErrorMessage(makeString("Permission policy '"_s, policyTypeName(type), "' check failed."_s));
             return false;
         }
 
@@ -112,7 +112,7 @@ bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type ty
                 String allowValue;
                 if (iframe)
                     allowValue = iframe->attributeWithoutSynchronization(HTMLNames::allowAttr);
-                document.domWindow()->printErrorMessage(makeString("Permission policy '", policyTypeName(type), "' check failed for element with origin '", document.securityOrigin().toString(), "' and allow attribute '", allowValue, "'."));
+                document.domWindow()->printErrorMessage(makeString("Permission policy '"_s, policyTypeName(type), "' check failed for element with origin '"_s, document.securityOrigin().toString(), "' and allow attribute '"_s, allowValue, "'."_s));
             }
             return false;
         }

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -176,7 +176,7 @@ void ValidatedFormListedElement::reportNonFocusableControlError()
 {
     auto& document = asHTMLElement().document();
     if (document.frame()) {
-        auto message = makeString("An invalid form control with name='", name(), "' is not focusable.");
+        auto message = makeString("An invalid form control with name='"_s, name(), "' is not focusable."_s);
         document.addConsoleMessage(MessageSource::Rendering, MessageLevel::Error, message);
     }
 }

--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -254,7 +254,7 @@ ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float hei
 
     // 2. If radii is not a list of size one, two, three, or four, then throw a RangeError.
     if (radii.size() > 4 || radii.empty())
-        return Exception { ExceptionCode::RangeError, makeString("radii must contain at least 1 element, up to 4. It contained ", radii.size(), " elements.") };
+        return Exception { ExceptionCode::RangeError, makeString("radii must contain at least 1 element, up to 4. It contained "_s, radii.size(), " elements."_s) };
 
     // 3. Let normalizedRadii be an empty list.
     Vector<FloatPoint, 4> normalizedRadii;
@@ -273,7 +273,7 @@ ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float hei
 
                 // 4.1.2 If radius["x"] or radius["y"] is negative, then throw a RangeError.
                 if (point.x < 0 || point.y < 0)
-                    return Exception { ExceptionCode::RangeError, makeString("radius point coordinates must be positive") };
+                    return Exception { ExceptionCode::RangeError, "radius point coordinates must be positive"_s };
 
                 // 4.1.3 Otherwise, append radius to normalizedRadii.
                 normalizedRadii.append({ static_cast<float>(point.x), static_cast<float>(point.y) });
@@ -290,7 +290,7 @@ ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float hei
 
                 // 4.2.2 If radius is negative, then throw a RangeError.
                 if (radiusValue < 0)
-                    return Exception { ExceptionCode::RangeError, makeString("radius value must be positive") };
+                    return Exception { ExceptionCode::RangeError, "radius value must be positive"_s };
 
                 // 4.2.3 Otherwise append «[ "x" → radius, "y" → radius ]» to normalizedRadii.
                 normalizedRadii.append({ static_cast<float>(radiusValue), static_cast<float>(radiusValue) });

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2569,7 +2569,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     RefPtr pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
     if (!pixelBuffer) {
         canvasBase().scriptExecutionContext()->addConsoleMessage(MessageSource::Rendering, MessageLevel::Error,
-            makeString("Unable to get image data from canvas. Requested size was ", imageDataRect.width(), " x ", imageDataRect.height()));
+            makeString("Unable to get image data from canvas. Requested size was "_s, imageDataRect.width(), " x "_s, imageDataRect.height()));
         return Exception { ExceptionCode::InvalidStateError };
     }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5419,7 +5419,7 @@ void WebGLRenderingContextBase::synthesizeGLError(GCGLenum error, const char* fu
 {
     auto errorCode = GraphicsContextGL::enumToErrorCode(error);
     if (shouldPrintToConsole())
-        printToConsole(MessageLevel::Error, makeString("WebGL: ", errorCodeToString(errorCode), ": ", functionName, ": ", description));
+        printToConsole(MessageLevel::Error, makeString("WebGL: "_s, errorCodeToString(errorCode), ": "_s, functionName, ": "_s, description));
     m_errors.add(errorCode);
 }
 
@@ -5427,7 +5427,7 @@ void WebGLRenderingContextBase::synthesizeLostContextGLError(GCGLenum error, con
 {
     auto errorCode = GraphicsContextGL::enumToErrorCode(error);
     if (shouldPrintToConsole())
-        printToConsole(MessageLevel::Error, makeString("WebGL: ", errorCodeToString(errorCode), ": ", functionName, ": ", description));
+        printToConsole(MessageLevel::Error, makeString("WebGL: "_s, errorCodeToString(errorCode), ": "_s, functionName, ": "_s, description));
     m_contextLostState->errors.add(errorCode);
 }
 

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -105,7 +105,7 @@ static inline bool isLegalNode(Node& node)
 
 static Exception invalidNodeException(Node& node)
 {
-    return Exception { ExceptionCode::InvalidNodeTypeError, makeString("Invalid node type: ", node.nodeName()) };
+    return Exception { ExceptionCode::InvalidNodeTypeError, makeString("Invalid node type: "_s, node.nodeName()) };
 }
 
 static ExceptionOr<void> checkForInvalidNodeTypes(Node& root)

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -174,7 +174,7 @@ void TrackBase::setLanguage(const AtomString& language)
     if (language.contains((UChar)'\0'))
         message = "The language contains a null character and is not a valid BCP 47 language tag."_s;
     else
-        message = makeString("The language '", language, "' is not a valid BCP 47 language tag.");
+        message = makeString("The language '"_s, language, "' is not a valid BCP 47 language tag."_s);
 
     context->addConsoleMessage(MessageSource::Rendering, MessageLevel::Warning, message);
 }

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
@@ -142,7 +142,7 @@ void InspectorFrontendAPIDispatcher::dispatchCommandWithResultAsync(const String
 
 void InspectorFrontendAPIDispatcher::dispatchMessageAsync(const String& message)
 {
-    evaluateOrQueueExpression(makeString("InspectorFrontendAPI.dispatchMessageAsync(", message, ")"));
+    evaluateOrQueueExpression(makeString("InspectorFrontendAPI.dispatchMessageAsync("_s, message, ')'));
 }
 
 void InspectorFrontendAPIDispatcher::evaluateOrQueueExpression(const String& expression, EvaluationResultHandler&& optionalResultHandler)

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -550,7 +550,7 @@ WebAnimation* InspectorAnimationAgent::assertAnimation(Inspector::Protocol::Erro
 
 void InspectorAnimationAgent::bindAnimation(WebAnimation& animation, RefPtr<Inspector::Protocol::Console::StackTrace> backtrace)
 {
-    auto animationId = makeString("animation:" + IdentifiersFactory::createIdentifier());
+    auto animationId = makeString("animation:"_s, IdentifiersFactory::createIdentifier());
     m_animationIdMap.set(animationId, &animation);
 
     auto animationPayload = Inspector::Protocol::Animation::Animation::create()

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -176,7 +176,7 @@ public:
     String mergeId() override
     {
         ASSERT(m_styleSheet->id() == m_cssId.styleSheetId());
-        return makeString("SetStyleText ", m_styleSheet->id(), ':', m_cssId.ordinal());
+        return makeString("SetStyleText "_s, m_styleSheet->id(), ':', m_cssId.ordinal());
     }
 
     void merge(std::unique_ptr<Action> action) override
@@ -936,7 +936,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Ins
 
         auto pseudoClass = Inspector::Protocol::Helpers::parseEnumValueFromString<Inspector::Protocol::CSS::ForceablePseudoClass>(pseudoClassString);
         if (!pseudoClass)
-            return makeUnexpected(makeString("Unknown forcedPseudoClass: ", pseudoClassString));
+            return makeUnexpected(makeString("Unknown forcedPseudoClass: "_s, pseudoClassString));
 
         switch (*pseudoClass) {
         case Inspector::Protocol::CSS::ForceablePseudoClass::Active:

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1907,7 +1907,7 @@ static String computeContentSecurityPolicySHA256Hash(const Element& element)
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     cryptoDigest->addBytes(content.span());
     auto digest = cryptoDigest->computeHash();
-    return makeString("sha256-", base64Encoded(digest.data(), digest.size()));
+    return makeString("sha256-"_s, base64Encoded(digest.data(), digest.size()));
 }
 
 Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int depth)

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -689,7 +689,7 @@ public:
         auto result = idbObjectStore->clear();
         ASSERT(!result.hasException());
         if (result.hasException()) {
-            m_requestCallback->sendFailure(makeString("Could not clear object store '", m_objectStoreName, "': ", static_cast<int>(result.releaseException().code())));
+            m_requestCallback->sendFailure(makeString("Could not clear object store '"_s, m_objectStoreName, "': "_s, static_cast<int>(result.releaseException().code())));
             return;
         }
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1382,7 +1382,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequest
     if (loader.reachedTerminalState())
         return makeUnexpected("Unable to abort request, it has already been processed"_s);
 
-    addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::Network, MessageType::Log, MessageLevel::Info, makeString("Web Inspector blocked ", loader.url().string(), " from loading"), loader.identifier().toUInt64()));
+    addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::Network, MessageType::Log, MessageLevel::Info, makeString("Web Inspector blocked "_s, loader.url().string(), " from loading"_s), loader.identifier().toUInt64()));
 
     loader.didFail(ResourceError(InspectorNetworkAgent::errorDomain(), 0, loader.url(), "Blocked by Web Inspector"_s, toResourceErrorType(errorType)));
     return { };

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -168,7 +168,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::setInstruments(
 
         auto instrument = Inspector::Protocol::Helpers::parseEnumValueFromString<Inspector::Protocol::Timeline::Instrument>(instrumentString);
         if (!instrument)
-            return makeUnexpected(makeString("Unknown instrument: ", instrumentString));
+            return makeUnexpected(makeString("Unknown instrument: "_s, instrumentString));
 
         newInstruments.append(*instrument);
     }
@@ -298,7 +298,7 @@ void InspectorTimelineAgent::startFromConsole(JSC::JSGlobalObject* globalObject,
             if (recordTitle == title) {
                 if (auto* consoleAgent = m_instrumentingAgents.webConsoleAgent()) {
                     // FIXME: Send an enum to the frontend for localization?
-                    String warning = title.isEmpty() ? "Unnamed Profile already exists"_s : makeString("Profile \"", ScriptArguments::truncateStringForConsoleMessage(title), "\" already exists");
+                    String warning = title.isEmpty() ? "Unnamed Profile already exists"_s : makeString("Profile \""_s, ScriptArguments::truncateStringForConsoleMessage(title), "\" already exists"_s);
                     consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Profile, MessageLevel::Warning, warning));
                 }
                 return;

--- a/Source/WebCore/inspector/agents/WebConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebConsoleAgent.cpp
@@ -75,7 +75,7 @@ void WebConsoleAgent::frameWindowDiscarded(LocalDOMWindow& window)
 void WebConsoleAgent::didReceiveResponse(ResourceLoaderIdentifier requestIdentifier, const ResourceResponse& response)
 {
     if (response.httpStatusCode() >= 400) {
-        auto message = makeString("Failed to load resource: the server responded with a status of ", response.httpStatusCode(), " (", ScriptArguments::truncateStringForConsoleMessage(response.httpStatusText()), ')');
+        auto message = makeString("Failed to load resource: the server responded with a status of "_s, response.httpStatusCode(), " ("_s, ScriptArguments::truncateStringForConsoleMessage(response.httpStatusText()), ')');
         addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::Network, MessageType::Log, MessageLevel::Error, message, response.url().string(), 0, 0, nullptr, requestIdentifier.toUInt64()));
     }
 }
@@ -92,7 +92,7 @@ void WebConsoleAgent::didFailLoading(ResourceLoaderIdentifier requestIdentifier,
     auto level = MessageLevel::Error;
     auto message = blockedTrackerErrorMessage(error);
     if (message.isEmpty())
-        message = makeString("Failed to load resource", error.localizedDescription().isEmpty() ? "" : ": ", error.localizedDescription());
+        message = makeString("Failed to load resource"_s, error.localizedDescription().isEmpty() ? ""_s : ": "_s, error.localizedDescription());
     else
         level = MessageLevel::Info;
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -188,10 +188,10 @@ CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&& requ
 String validateCrossOriginRedirectionURL(const URL& redirectURL)
 {
     if (!LegacySchemeRegistry::shouldTreatURLSchemeAsCORSEnabled(redirectURL.protocol()))
-        return makeString("not allowed to follow a cross-origin CORS redirection with non CORS scheme");
+        return "not allowed to follow a cross-origin CORS redirection with non CORS scheme"_s;
 
     if (redirectURL.hasCredentials())
-        return makeString("redirection URL ", redirectURL.string(), " has credentials");
+        return makeString("redirection URL "_s, redirectURL.string(), " has credentials"_s);
 
     return { };
 }
@@ -279,7 +279,7 @@ Expected<void, String> passesAccessControlCheck(const ResourceResponse& response
             return makeUnexpected("Cannot use wildcard in Access-Control-Allow-Origin when credentials flag is true."_s);
         if (accessControlOriginString.find(',') != notFound)
             return makeUnexpected("Access-Control-Allow-Origin cannot contain more than one origin."_s);
-        return makeUnexpected(makeString("Origin ", securityOriginString, " is not allowed by Access-Control-Allow-Origin.", " Status code: ", response.httpStatusCode()));
+        return makeUnexpected(makeString("Origin "_s, securityOriginString, " is not allowed by Access-Control-Allow-Origin."_s, " Status code: "_s, response.httpStatusCode()));
     }
 
     if (storedCredentialsPolicy == StoredCredentialsPolicy::Use) {
@@ -294,7 +294,7 @@ Expected<void, String> passesAccessControlCheck(const ResourceResponse& response
 Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
 {
     if (!response.isSuccessful())
-        return makeUnexpected(makeString("Preflight response is not successful. Status code: ", response.httpStatusCode()));
+        return makeUnexpected(makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode()));
 
     auto accessControlCheckResult = passesAccessControlCheck(response, storedCredentialsPolicy, securityOrigin, checkDisabler);
     if (!accessControlCheckResult)
@@ -347,7 +347,7 @@ static inline bool shouldCrossOriginResourcePolicyCancelLoad(CrossOriginEmbedder
 std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue coep, const SecurityOrigin& origin, const URL& requestURL, bool isResponseNull, const URL& responseURL, const String& crossOriginResourcePolicyHeaderValue, ForNavigation forNavigation, const OriginAccessPatterns& patterns)
 {
     if (shouldCrossOriginResourcePolicyCancelLoad(coep, origin, isResponseNull, responseURL, crossOriginResourcePolicyHeaderValue, forNavigation, patterns))
-        return ResourceError { errorDomainWebKitInternal, 0, requestURL, makeString("Cancelled load to ", responseURL.stringCenterEllipsizedToLength(), " because it violates the resource's Cross-Origin-Resource-Policy response header."), ResourceError::Type::AccessControl };
+        return ResourceError { errorDomainWebKitInternal, 0, requestURL, makeString("Cancelled load to "_s, responseURL.stringCenterEllipsizedToLength(), " because it violates the resource's Cross-Origin-Resource-Policy response header."_s), ResourceError::Type::AccessControl };
     return std::nullopt;
 }
 

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -98,14 +98,14 @@ void CrossOriginEmbedderPolicy::addPolicyHeadersTo(ResourceResponse& response) c
         if (reportingEndpoint.isEmpty())
             response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, "require-corp"_s);
         else
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, makeString("require-corp; report-to=\"", reportingEndpoint, '\"'));
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicy, makeString("require-corp; report-to=\""_s, reportingEndpoint, '\"'));
     }
     if (reportOnlyValue != CrossOriginEmbedderPolicyValue::UnsafeNone) {
         ASSERT(reportOnlyValue == CrossOriginEmbedderPolicyValue::RequireCORP);
         if (reportOnlyReportingEndpoint.isEmpty())
             response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicyReportOnly, "require-corp"_s);
         else
-            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicyReportOnly, makeString("require-corp; report-to=\"", reportOnlyReportingEndpoint, '\"'));
+            response.setHTTPHeaderField(HTTPHeaderName::CrossOriginEmbedderPolicyReportOnly, makeString("require-corp; report-to=\""_s, reportOnlyReportingEndpoint, '\"'));
     }
 }
 

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -172,7 +172,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
     // FIXME: Ideally, we should ask platformLoadResourceSynchronously to set ResourceResponse isRedirected and use it here.
     bool isRedirect = preflightRequest.url().strippedForUseAsReferrer().string != response.url().strippedForUseAsReferrer().string;
     if (isRedirect || !response.isSuccessful()) {
-        auto errorMessage = makeString("Preflight response is not successful. Status code: ", response.httpStatusCode());
+        auto errorMessage = makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode());
         loader.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
 
         loader.preflightFailure(identifier, ResourceError { errorDomainWebKitInternal, 0, request.url(), errorMessage, ResourceError::Type::AccessControl });

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
@@ -57,11 +57,11 @@ Expected<UniqueRef<CrossOriginPreflightResultCacheItem>, String> CrossOriginPref
 {
     auto methods = parseAccessControlAllowList(response.httpHeaderField(HTTPHeaderName::AccessControlAllowMethods));
     if (!methods)
-        return makeUnexpected(makeString("Header Access-Control-Allow-Methods has an invalid value: ", response.httpHeaderField(HTTPHeaderName::AccessControlAllowMethods)));
+        return makeUnexpected(makeString("Header Access-Control-Allow-Methods has an invalid value: "_s, response.httpHeaderField(HTTPHeaderName::AccessControlAllowMethods)));
 
     auto headers = parseAccessControlAllowList<ASCIICaseInsensitiveHash>(response.httpHeaderField(HTTPHeaderName::AccessControlAllowHeaders));
     if (!headers)
-        return makeUnexpected(makeString("Header Access-Control-Allow-Headers has an invalid value: ", response.httpHeaderField(HTTPHeaderName::AccessControlAllowHeaders)));
+        return makeUnexpected(makeString("Header Access-Control-Allow-Headers has an invalid value: "_s, response.httpHeaderField(HTTPHeaderName::AccessControlAllowHeaders)));
 
     Seconds expiryDelta = 0_s;
     if (parseAccessControlMaxAge(response.httpHeaderField(HTTPHeaderName::AccessControlMaxAge), expiryDelta)) {
@@ -76,10 +76,10 @@ Expected<UniqueRef<CrossOriginPreflightResultCacheItem>, String> CrossOriginPref
 std::optional<String> CrossOriginPreflightResultCacheItem::validateMethodAndHeaders(const String& method, const HTTPHeaderMap& requestHeaders) const
 {
     if (!allowsCrossOriginMethod(method, m_storedCredentialsPolicy))
-        return makeString("Method ", method, " is not allowed by Access-Control-Allow-Methods.");
+        return makeString("Method "_s, method, " is not allowed by Access-Control-Allow-Methods."_s);
 
     if (auto badHeader = validateCrossOriginHeaders(requestHeaders, m_storedCredentialsPolicy))
-        return makeString("Request header field ", *badHeader, " is not allowed by Access-Control-Allow-Headers.");
+        return makeString("Request header field "_s, *badHeader, " is not allowed by Access-Control-Allow-Headers."_s);
     return { };
 }
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -666,11 +666,11 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
             if (m_frame && requestingDocument->isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*m_frame, newRequest.url())) {
                 DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - cross-site redirect of top frame triggered by third-party iframe");
                 if (m_frame->document()) {
-                    auto message = makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"
+                    auto message = makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"_s
                         , m_frame->document()->url().string()
-                        , "' from frame with URL '"
+                        , "' from frame with URL '"_s
                         , requestingDocument->url().string()
-                        , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.");
+                        , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame."_s);
                     m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
                 }
                 cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
@@ -1103,7 +1103,7 @@ bool DocumentLoader::disallowDataRequest() const
         ResourceLoaderIdentifier identifier = m_identifierForLoadWithoutResourceLoader ? m_identifierForLoadWithoutResourceLoader : m_mainResource->identifier();
         ASSERT(identifier);
 
-        currentDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Not allowed to navigate top frame to data URL '", m_response.url().stringCenterEllipsizedToLength(), "'."), identifier.toUInt64());
+        currentDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Not allowed to navigate top frame to data URL '"_s, m_response.url().stringCenterEllipsizedToLength(), "'."_s), identifier.toUInt64());
     }
     DOCUMENTLOADER_RELEASE_LOG("continueAfterContentPolicy: cannot show URL");
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1852,7 +1852,7 @@ void FrameLoader::reportLocalLoadFailed(LocalFrame* frame, const String& url)
 void FrameLoader::reportBlockedLoadFailed(LocalFrame& frame, const URL& url)
 {
     ASSERT(!url.isEmpty());
-    auto message = makeString("Not allowed to use restricted network port ", url.port().value(), ": ", url.stringCenterEllipsizedToLength());
+    auto message = makeString("Not allowed to use restricted network port "_s, url.port().value(), ": "_s, url.stringCenterEllipsizedToLength());
     frame.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
 }
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -425,7 +425,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         m_hasPendingErrorEvent = true;
         loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
 
-        auto message = makeString("Cannot load image ", imageURL.string(), " due to access control checks.");
+        auto message = makeString("Cannot load image "_s, imageURL.string(), " due to access control checks."_s);
         element().protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
 
         if (hasPendingDecodePromises())

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -237,7 +237,7 @@ void MixedContentChecker::checkFormForMixedContent(LocalFrame& frame, const URL&
     if (!isMixedContent(*frame.document(), url))
         return;
 
-    auto message = makeString("The page at ", frame.document()->url().stringCenterEllipsizedToLength(), " contains a form which targets an insecure URL ", url.stringCenterEllipsizedToLength(), ".\n");
+    auto message = makeString("The page at "_s, frame.document()->url().stringCenterEllipsizedToLength(), " contains a form which targets an insecure URL "_s, url.stringCenterEllipsizedToLength(), ".\n"_s);
     frame.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, message);
 
     frame.checkedLoader()->client().didDisplayInsecureContent();

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -263,7 +263,7 @@ bool PrivateClickMeasurement::hasHigherPriorityThan(const PrivateClickMeasuremen
 
 static URL makeValidURL(const RegistrableDomain& domain, const char* path)
 {
-    URL validURL { makeString("https://", domain.string(), path) };
+    URL validURL { makeString("https://"_s, domain.string(), span(path)) };
     return validURL.isValid() ? validURL : URL { };
 }
 

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -556,7 +556,7 @@ void ResourceLoader::didBlockAuthenticationChallenge()
     if (m_options.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials)
         return;
     if (m_frame && !shouldAllowResourceToAskForCredentials())
-        m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked ", m_request.url().stringCenterEllipsizedToLength(), " from asking for credentials because it is a cross-origin request."));
+        m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked "_s, m_request.url().stringCenterEllipsizedToLength(), " from asking for credentials because it is a cross-origin request."_s));
 }
 
 void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHandler<void()>&& policyCompletionHandler)
@@ -573,7 +573,7 @@ void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHan
             if (!document->usedLegacyTLS()) {
                 if (RefPtr page = document->page()) {
                     RESOURCELOADER_RELEASE_LOG("usedLegacyTLS:");
-                    page->console().addMessage(MessageSource::Network, MessageLevel::Warning, makeString("Loaded resource from ", r.url().host(), " using TLS 1.0 or 1.1, which are deprecated protocols that will be removed. Please use TLS 1.2 or newer instead."), 0, document.get());
+                    page->console().addMessage(MessageSource::Network, MessageLevel::Warning, makeString("Loaded resource from "_s, r.url().host(), " using TLS 1.0 or 1.1, which are deprecated protocols that will be removed. Please use TLS 1.2 or newer instead."_s), 0, document.get());
                 }
                 document->setUsedLegacyTLS(true);
             }

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -255,7 +255,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         CachedResourceHandle resource = m_resource.get();
         if (options().redirect != FetchOptions::Redirect::Follow) {
             if (options().redirect == FetchOptions::Redirect::Error) {
-                ResourceError error { errorDomainWebKitInternal, 0, request().url(), makeString("Not allowed to follow a redirection while loading ", request().url().string()), ResourceError::Type::AccessControl };
+                ResourceError error { errorDomainWebKitInternal, 0, request().url(), makeString("Not allowed to follow a redirection while loading "_s, request().url().string()), ResourceError::Type::AccessControl };
 
                 if (m_frame && m_frame->document())
                     m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
@@ -318,7 +318,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
 
         auto accessControlCheckResult = checkRedirectionCrossOriginAccessControl(request(), redirectResponse, newRequest);
         if (!accessControlCheckResult) {
-            auto errorMessage = makeString("Cross-origin redirection to ", newRequest.url().string(), " denied by Cross-Origin Resource Sharing policy: ", accessControlCheckResult.error());
+            auto errorMessage = makeString("Cross-origin redirection to "_s, newRequest.url().string(), " denied by Cross-Origin Resource Sharing policy: "_s, accessControlCheckResult.error());
             if (m_frame && m_frame->document())
                 m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because crosss-origin redirection denied by CORS policy");

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -71,7 +71,7 @@ void WorkerThreadableLoader::loadResourceSynchronously(WorkerOrWorkletGlobalScop
     WorkerRunLoop& runLoop = workerOrWorkletGlobalScope.workerOrWorkletThread()->runLoop();
 
     // Create a unique mode just for this synchronous resource load.
-    auto mode = makeString("loadResourceSynchronouslyMode", runLoop.createUniqueId());
+    auto mode = makeString("loadResourceSynchronouslyMode"_s, runLoop.createUniqueId());
 
     Ref loader = WorkerThreadableLoader::create(workerOrWorkletGlobalScope, client, mode, WTFMove(request), options, String());
     bool success = true;

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -566,7 +566,7 @@ void ApplicationCacheGroup::didFailLoadingEntry(ApplicationCacheResourceLoader::
     m_pendingEntries.remove(url.string());
 
     if ((type & ApplicationCacheResource::Explicit) || (type & ApplicationCacheResource::Fallback)) {
-        m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache update failed, because ", url.stringCenterEllipsizedToLength(), (m_entryLoader && m_entryLoader->hasRedirection() ? " was redirected." : " could not be fetched.")));
+        m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache update failed, because "_s, url.stringCenterEllipsizedToLength(), (m_entryLoader && m_entryLoader->hasRedirection() ? " was redirected."_s : " could not be fetched."_s)));
         // Note that cacheUpdateFailed() can cause the cache group to be deleted.
         cacheUpdateFailed();
         return;
@@ -676,12 +676,12 @@ void ApplicationCacheGroup::didFailLoadingManifest(ApplicationCacheResourceLoade
         break;
     case ApplicationCacheResourceLoader::Error::NotFound:
         InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().documentLoader(), m_currentResourceIdentifier, m_frame->loader().cancelledError(m_manifestLoader->resource()->resourceRequest()));
-        m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache manifest could not be fetched, because the manifest had a ", m_manifestLoader->resource()->response().httpStatusCode(), " response."));
+        m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache manifest could not be fetched, because the manifest had a "_s, m_manifestLoader->resource()->response().httpStatusCode(), " response."_s));
         manifestNotFound();
         break;
     case ApplicationCacheResourceLoader::Error::NotOK:
         InspectorInstrumentation::didFailLoading(m_frame.get(), m_frame->loader().documentLoader(), m_currentResourceIdentifier, m_frame->loader().cancelledError(m_manifestLoader->resource()->resourceRequest()));
-        m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache manifest could not be fetched, because the manifest had a ", m_manifestLoader->resource()->response().httpStatusCode(), " response."));
+        m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, makeString("Application Cache manifest could not be fetched, because the manifest had a "_s, m_manifestLoader->resource()->response().httpStatusCode(), " response."_s));
         cacheUpdateFailed();
         break;
     case ApplicationCacheResourceLoader::Error::RedirectForbidden:

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -567,7 +567,7 @@ void ApplicationCacheStorage::verifySchemaVersion()
     SQLiteTransaction setDatabaseVersion(m_database);
     setDatabaseVersion.begin();
 
-    auto statement = m_database.prepareStatementSlow(makeString("PRAGMA user_version=", schemaVersion));
+    auto statement = m_database.prepareStatementSlow(makeString("PRAGMA user_version="_s, schemaVersion));
     if (!statement)
         return;
     

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -753,7 +753,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
 
         auto extension = MIMETypeRegistry::preferredExtensionForMIMEType(textHTMLContentTypeAtom());
         if (!extension.isEmpty())
-            extension = makeString(".", extension);
+            extension = makeString('.', extension);
         auto mainFrameFilePathWithExtension = mainFrameFilePath.endsWith(extension) ? mainFrameFilePath : makeString(mainFrameFilePath, extension);
         auto filePathWithExtension = frame.isMainFrame() ? mainFrameFilePathWithExtension : makeString(subresourcesDirectoryName, "/frame_"_s, frame.frameID().toString(), extension);
 

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -137,7 +137,7 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
     pageSerializer.serialize(*page);
 
     String boundary = generateRandomBoundary();
-    String endOfResourceBoundary = makeString("--", boundary, "\r\n");
+    String endOfResourceBoundary = makeString("--"_s, boundary, "\r\n"_s);
 
     GregorianDateTime now;
     now.setToCurrentLocalTime();
@@ -198,7 +198,7 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
         }
     }
 
-    asciiString = makeString("--", boundary, "--\r\n").utf8();
+    asciiString = makeString("--"_s, boundary, "--\r\n"_s).utf8();
     mhtmlData.append(asciiString.span());
 
     return mhtmlData.take();

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -66,7 +66,7 @@ private:
         bool result = m_font->ensureCustomFontData();
         if (!result && m_font->didRefuseToParseCustomFontWithSafeFontParser()) {
             if (RefPtr context = m_context.get()) {
-                auto message = makeString("[Lockdown Mode] This font wasn't parsed: ", m_font->url().string());
+                auto message = makeString("[Lockdown Mode] This font wasn't parsed: "_s, m_font->url().string());
                 context->addConsoleMessage(MessageSource::Security, MessageLevel::Info, message);
             }
         }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1492,9 +1492,9 @@ void CachedResourceLoader::printAccessDeniedMessage(const URL& url) const
 
     String message;
     if (!m_document || m_document->url().isNull())
-        message = makeString("Unsafe attempt to load URL ", url.stringCenterEllipsizedToLength(), '.');
+        message = makeString("Unsafe attempt to load URL "_s, url.stringCenterEllipsizedToLength(), '.');
     else
-        message = makeString("Unsafe attempt to load URL ", url.stringCenterEllipsizedToLength(), " from origin ", m_document->securityOrigin().toString(), ". Domains, protocols and ports must match.\n");
+        message = makeString("Unsafe attempt to load URL "_s, url.stringCenterEllipsizedToLength(), " from origin "_s, m_document->securityOrigin().toString(), ". Domains, protocols and ports must match.\n"_s);
 
     if (RefPtr frameDocument = frame->document())
         frameDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);

--- a/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
@@ -50,7 +50,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
     {
         auto serverPublicKeyData = base64URLDecode(serverPublicKeyBase64URL);
         if (!serverPublicKeyData)
-            return makeString("Could not decode the ", contextForLogMessage, "'s public key data.");
+            return makeString("Could not decode the "_s, contextForLogMessage, "'s public key data."_s);
         auto serverPublicKey = adoptNS([[NSData alloc] initWithBytes:serverPublicKeyData->data() length:serverPublicKeyData->size()]);
 
         NSError* nsError = 0;
@@ -58,7 +58,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
         if (nsError)
             return nsError.localizedDescription;
         if (!unlinkableToken.blinder)
-            return makeString("Did not get a ", contextForLogMessage, " unlinkable token blinder.");
+            return makeString("Did not get a "_s, contextForLogMessage, " unlinkable token blinder."_s);
     }
 
     NSError* nsError = 0;
@@ -66,7 +66,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
     if (nsError)
         return nsError.localizedDescription;
     if (!unlinkableToken.waitingToken)
-        return makeString("Did not get a ", contextForLogMessage, " unlinkable token waiting token.");
+        return makeString("Did not get a "_s, contextForLogMessage, " unlinkable token waiting token."_s);
 
     unlinkableToken.valueBase64URL = base64URLEncodeToString([unlinkableToken.waitingToken blindedMessage].bytes, [unlinkableToken.waitingToken blindedMessage].length);
     return std::nullopt;
@@ -101,12 +101,12 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateSecretToken(con
 {
 #if HAVE(RSA_BSSA)
     if (!unlinkableToken.waitingToken)
-        return makeString("Did not find a ", contextForLogMessage, " unlinkable token waiting token.");
+        return makeString("Did not find a "_s, contextForLogMessage, " unlinkable token waiting token."_s);
 
     {
         auto serverResponseData = base64URLDecode(serverResponseBase64URL);
         if (!serverResponseData)
-            return makeString("Could not decode ", contextForLogMessage, " response data.");
+            return makeString("Could not decode "_s, contextForLogMessage, " response data."_s);
         auto serverResponse = adoptNS([[NSData alloc] initWithBytes:serverResponseData->data() length:serverResponseData->size()]);
 
         NSError* nsError = 0;
@@ -114,7 +114,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateSecretToken(con
         if (nsError)
             return nsError.localizedDescription;
         if (!unlinkableToken.readyToken)
-            return makeString("Did not get a ", contextForLogMessage, " unlinkable token ready token.");
+            return makeString("Did not get a "_s, contextForLogMessage, " unlinkable token ready token."_s);
     }
 
     secretToken.tokenBase64URL = base64URLEncodeToString([unlinkableToken.readyToken tokenContent].bytes, [unlinkableToken.readyToken tokenContent].length);

--- a/Source/WebCore/page/ClientOrigin.h
+++ b/Source/WebCore/page/ClientOrigin.h
@@ -47,7 +47,7 @@ struct ClientOrigin {
     SecurityOriginData topOrigin;
     SecurityOriginData clientOrigin;
 
-    String loggingString() const { return makeString(topOrigin.toString(), "-", clientOrigin.toString()); }
+    String loggingString() const { return makeString(topOrigin.toString(), '-', clientOrigin.toString()); }
 };
 
 inline void add(Hasher& hasher, const ClientOrigin& origin)

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -179,7 +179,7 @@ bool EventSource::responseIsValid(const ResourceResponse& response) const
         return false;
 
     if (!equalLettersIgnoringASCIICase(response.mimeType(), "text/event-stream"_s)) {
-        auto message = makeString("EventSource's response has a MIME type (\"", response.mimeType(), "\") that is not \"text/event-stream\". Aborting the connection.");
+        auto message = makeString("EventSource's response has a MIME type (\""_s, response.mimeType(), "\") that is not \"text/event-stream\". Aborting the connection."_s);
         // FIXME: Console message would be better with a source code location; where would we get that?
         scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, WTFMove(message));
         return false;
@@ -189,7 +189,7 @@ bool EventSource::responseIsValid(const ResourceResponse& response) const
     // message but keep going anyway.
     auto& charset = response.textEncodingName();
     if (!charset.isEmpty() && !equalLettersIgnoringASCIICase(charset, "utf-8"_s)) {
-        auto message = makeString("EventSource's response has a charset (\"", charset, "\") that is not UTF-8. The response will be decoded as UTF-8.");
+        auto message = makeString("EventSource's response has a charset (\""_s, charset, "\") that is not UTF-8. The response will be decoded as UTF-8."_s);
         // FIXME: Console message would be better with a source code location; where would we get that?
         scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, WTFMove(message));
     }

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -268,8 +268,8 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
     
     if (mainHistory->m_currentStateObjectTimeSpanObjectsAdded >= perStateObjectTimeSpanLimit) {
         if (stateObjectType == StateObjectType::Replace)
-            return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.replaceState() more than ", perStateObjectTimeSpanLimit, " times per ", stateObjectTimeSpan.seconds(), " seconds") };
-        return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.pushState() more than ", perStateObjectTimeSpanLimit, " times per ", stateObjectTimeSpan.seconds(), " seconds") };
+            return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.replaceState() more than "_s, perStateObjectTimeSpanLimit, " times per "_s, stateObjectTimeSpan.seconds(), " seconds"_s) };
+        return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.pushState() more than "_s, perStateObjectTimeSpanLimit, " times per "_s, stateObjectTimeSpan.seconds(), " seconds"_s) };
     }
 
     Checked<unsigned> urlSize = fullURL.string().length();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -939,7 +939,7 @@ void LocalDOMWindow::processPostMessage(JSC::JSGlobalObject& lexicalGlobalObject
             // Check target origin now since the target document may have changed since the timer was scheduled.
             if (!targetOrigin->isSameSchemeHostPort(document->protectedSecurityOrigin())) {
                 if (CheckedPtr pageConsole = console()) {
-                    auto message = makeString("Unable to post message to ", targetOrigin->toString(), ". Recipient has origin ", document->securityOrigin().toString(), ".\n");
+                    auto message = makeString("Unable to post message to "_s, targetOrigin->toString(), ". Recipient has origin "_s, document->securityOrigin().toString(), ".\n"_s);
                     if (stackTrace)
                         pageConsole->addMessage(MessageSource::Security, MessageLevel::Error, message, *stackTrace);
                     else
@@ -2147,7 +2147,7 @@ void LocalDOMWindow::startListeningForDeviceOrientationIfNecessary()
     String innerMessage;
     if (!isAllowedToUseDeviceOrientation(innerMessage) || !hasPermissionToReceiveDeviceMotionOrOrientationEvents(innerMessage)) {
         if (RefPtr document = this->document())
-            document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("No device orientation events will be fired, reason: ", innerMessage, "."));
+            document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("No device orientation events will be fired, reason: "_s, innerMessage, '.'));
         return;
     }
 
@@ -2176,7 +2176,7 @@ void LocalDOMWindow::startListeningForDeviceMotionIfNecessary()
     if (!isAllowedToUseDeviceMotion(innerMessage) || !hasPermissionToReceiveDeviceMotionOrOrientationEvents(innerMessage)) {
         failedToRegisterDeviceMotionEventListener();
         if (RefPtr document = this->document())
-            document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("No device motion events will be fired, reason: ", innerMessage, "."));
+            document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("No device motion events will be fired, reason: "_s, innerMessage, '.'));
         return;
     }
 
@@ -2504,24 +2504,24 @@ String LocalDOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activ
     // FIXME: This message, and other console messages, have extra newlines. Should remove them.
     String message;
     if (includeTargetOrigin == IncludeTargetOrigin::Yes)
-        message = makeString("Blocked a frame with origin \"", activeOrigin->toString(), "\" from accessing a frame with origin \"", targetOrigin->toString(), "\". ");
+        message = makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a frame with origin \""_s, targetOrigin->toString(), "\". "_s);
     else
-        message = makeString("Blocked a frame with origin \"", activeOrigin->toString(), "\" from accessing a cross-origin frame. ");
+        message = makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a cross-origin frame. "_s);
 
     // Sandbox errors: Use the origin of the frames' location, rather than their actual origin (since we know that at least one will be "null").
     URL activeURL = activeWindow.document()->url();
     URL targetURL = document()->url();
     if (document()->isSandboxed(SandboxOrigin) || activeWindow.document()->isSandboxed(SandboxOrigin)) {
         if (includeTargetOrigin == IncludeTargetOrigin::Yes)
-            message = makeString("Blocked a frame at \"", SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a frame at \"", SecurityOrigin::create(targetURL).get().toString(), "\". ");
+            message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a frame at \""_s, SecurityOrigin::create(targetURL).get().toString(), "\". "_s);
         else
-            message = makeString("Blocked a frame at \"", SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a cross-origin frame. ");
+            message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a cross-origin frame. "_s);
 
         if (document()->isSandboxed(SandboxOrigin) && activeWindow.document()->isSandboxed(SandboxOrigin))
-            return makeString("Sandbox access violation: ", message, " Both frames are sandboxed and lack the \"allow-same-origin\" flag.");
+            return makeString("Sandbox access violation: "_s, message, " Both frames are sandboxed and lack the \"allow-same-origin\" flag."_s);
         if (document()->isSandboxed(SandboxOrigin))
-            return makeString("Sandbox access violation: ", message, " The frame being accessed is sandboxed and lacks the \"allow-same-origin\" flag.");
-        return makeString("Sandbox access violation: ", message, " The frame requesting access is sandboxed and lacks the \"allow-same-origin\" flag.");
+            return makeString("Sandbox access violation: "_s, message, " The frame being accessed is sandboxed and lacks the \"allow-same-origin\" flag."_s);
+        return makeString("Sandbox access violation: "_s, message, " The frame requesting access is sandboxed and lacks the \"allow-same-origin\" flag."_s);
     }
 
     if (includeTargetOrigin == IncludeTargetOrigin::Yes) {

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1478,7 +1478,7 @@ void LocalFrameView::logMockScrollbarsControllerMessage(const String& message) c
 
 String LocalFrameView::debugDescription() const
 {
-    return makeString("LocalFrameView 0x", hex(reinterpret_cast<uintptr_t>(this), Lowercase), ' ', m_frame->debugDescription());
+    return makeString("LocalFrameView 0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase), ' ', m_frame->debugDescription());
 }
 
 bool LocalFrameView::canShowNonOverlayScrollbars() const

--- a/Source/WebCore/page/LoggedInStatus.cpp
+++ b/Source/WebCore/page/LoggedInStatus.cpp
@@ -51,7 +51,7 @@ ExceptionOr<UniqueRef<LoggedInStatus>> LoggedInStatus::create(const RegistrableD
 
     unsigned length = username.length();
     if (length > UsernameMaxLength)
-        return Exception { ExceptionCode::SyntaxError, makeString("IsLoggedIn usernames cannot be longer than ", UsernameMaxLength) };
+        return Exception { ExceptionCode::SyntaxError, makeString("IsLoggedIn usernames cannot be longer than "_s, UsernameMaxLength) };
 
     auto spaceOrNewline = username.find([](UChar ch) {
         return deprecatedIsSpaceOrNewline(ch);

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -239,7 +239,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
             continue;
         String tagName = displayNameForVMTag(i);
         if (!tagName)
-            tagName = makeString("Tag ", i);
+            tagName = makeString("Tag "_s, i);
         RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %lu MB in %zu regions", tagName.latin1().data(), dirty / MB, pages[i].regionCount);
     }
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -322,7 +322,7 @@ URL PageSerializer::urlForBlankFrame(LocalFrame* frame)
     auto iterator = m_blankFrameURLs.find(frame);
     if (iterator != m_blankFrameURLs.end())
         return iterator->value;
-    URL fakeURL { makeString("wyciwyg://frame/", m_blankFrameCounter++) };
+    URL fakeURL { makeString("wyciwyg://frame/"_s, m_blankFrameCounter++) };
     m_blankFrameURLs.add(frame, fakeURL);
     return fakeURL;
 }

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -148,7 +148,7 @@ ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const String& 
     if (iterator != m_marksMap.end())
         return iterator->value.last()->startTime();
 
-    return Exception { ExceptionCode::SyntaxError, makeString("No mark named '", mark, "' exists") };
+    return Exception { ExceptionCode::SyntaxError, makeString("No mark named '"_s, mark, "' exists"_s) };
 }
 
 ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(double mark) const

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -385,7 +385,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const char* propertyName, i
     if (!strcmp(propertyName, "size"))
         return makeString(style->pageSize().width.value(), ' ', style->pageSize().height.value());
 
-    return makeString("pageProperty() unimplemented for: ", propertyName);
+    return makeString("pageProperty() unimplemented for: "_s, propertyName);
 }
 
 bool PrintContext::isPageBoxVisible(LocalFrame* frame, int pageNumber)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1195,7 +1195,7 @@ Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(Completio
         return Quirks::StorageAccessResult::ShouldNotCancelEvent;
     }
 
-    document->addConsoleMessage(MessageSource::Other, MessageLevel::Info, makeString("requestStorageAccess is invoked on behalf of domain \"", domainInNeedOfStorageAccess.string(), "\""));
+    document->addConsoleMessage(MessageSource::Other, MessageLevel::Info, makeString("requestStorageAccess is invoked on behalf of domain \""_s, domainInNeedOfStorageAccess.string(), "\""_s));
     DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(*document, WTFMove(domainInNeedOfStorageAccess), [firstPartyDomain, domainInNeedOfStorageAccess, completionHandler = WTFMove(completionHandler)](StorageAccessWasGranted storageAccessGranted) mutable {
         if (storageAccessGranted == StorageAccessWasGranted::No) {
             completionHandler(ShouldDispatchClick::Yes);

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -463,7 +463,7 @@ void ResourceUsageOverlay::platformDraw(CGContextRef context)
     CGContextClearRect(context, viewBounds);
 
     static NeverDestroyed<RetainPtr<CGColorRef>> colorForLabels = createColor(0.9, 0.9, 0.9, 1);
-    showText(context, 10, 20, colorForLabels.get().get(), makeString("        CPU: ", FormattedNumber::fixedPrecision(data.cpu.last(), 6, TrailingZerosPolicy::Keep)));
+    showText(context, 10, 20, colorForLabels.get().get(), makeString("        CPU: "_s, FormattedNumber::fixedPrecision(data.cpu.last(), 6, TrailingZerosPolicy::Keep)));
     showText(context, 10, 30, colorForLabels.get().get(), "  Footprint: " + formatByteNumber(memoryFootprint()));
     showText(context, 10, 40, colorForLabels.get().get(), "   External: " + formatByteNumber(data.totalExternalSize.last()));
 
@@ -475,9 +475,9 @@ void ResourceUsageOverlay::platformDraw(CGContextRef context)
         
         auto label = makeString(pad(' ', 11, category.name), ": ", formatByteNumber(dirty));
         if (external)
-            label = label + makeString(" + ", formatByteNumber(external));
+            label = label + makeString(" + "_s, formatByteNumber(external));
         if (reclaimable)
-            label = label + makeString(" [", formatByteNumber(reclaimable), ']');
+            label = label + makeString(" ["_s, formatByteNumber(reclaimable), ']');
 
         // FIXME: Show size/capacity of GC heap.
         showText(context, 10, y, category.color.get(), label);

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -978,7 +978,7 @@ void ContentSecurityPolicy::reportUnsupportedDirective(const String& name) const
     else if (equalLettersIgnoringASCIICase(name, "policy-uri"_s))
         message = "The 'policy-uri' directive has been removed from the specification. Please specify a complete policy via the Content-Security-Policy header."_s;
     else
-        message = makeString("Unrecognized Content-Security-Policy directive '", name, "'.\n"); // FIXME: Why does this include a newline?
+        message = makeString("Unrecognized Content-Security-Policy directive '"_s, name, "'.\n"_s); // FIXME: Why does this include a newline?
 
     logToConsole(message);
 }
@@ -990,7 +990,7 @@ void ContentSecurityPolicy::reportDirectiveAsSourceExpression(const String& dire
 
 void ContentSecurityPolicy::reportDuplicateDirective(const String& name) const
 {
-    logToConsole(makeString("Ignoring duplicate Content-Security-Policy directive '", name, "'.\n"));
+    logToConsole(makeString("Ignoring duplicate Content-Security-Policy directive '"_s, name, "'.\n"_s));
 }
 
 void ContentSecurityPolicy::reportInvalidPluginTypes(const String& pluginType) const
@@ -999,13 +999,13 @@ void ContentSecurityPolicy::reportInvalidPluginTypes(const String& pluginType) c
     if (pluginType.isNull())
         message = "'plugin-types' Content Security Policy directive is empty; all plugins will be blocked.\n"_s;
     else
-        message = makeString("Invalid plugin type in 'plugin-types' Content Security Policy directive: '", pluginType, "'.\n");
+        message = makeString("Invalid plugin type in 'plugin-types' Content Security Policy directive: '"_s, pluginType, "'.\n"_s);
     logToConsole(message);
 }
 
 void ContentSecurityPolicy::reportInvalidTrustedTypesPolicy(const String& policyName) const
 {
-    String message = makeString("Invalid policy name in 'trusted-types' Content Security Policy directive: '", policyName, "'.\n");
+    String message = makeString("Invalid policy name in 'trusted-types' Content Security Policy directive: '"_s, policyName, "'.\n"_s);
     logToConsole(message);
 }
 
@@ -1017,7 +1017,7 @@ void ContentSecurityPolicy::reportInvalidTrustedTypesNoneKeyword() const
 
 void ContentSecurityPolicy::reportInvalidTrustedTypesSinkGroup(const String& sinkGroup) const
 {
-    String message = makeString("Invalid sink group in 'require-trusted-types-for' Content Security Policy directive: '", sinkGroup, "'.\n");
+    String message = makeString("Invalid sink group in 'require-trusted-types-for' Content Security Policy directive: '"_s, sinkGroup, "'.\n"_s);
     logToConsole(message);
 }
 
@@ -1044,7 +1044,7 @@ void ContentSecurityPolicy::reportInvalidDirectiveInHTTPEquivMeta(const String& 
 
 void ContentSecurityPolicy::reportInvalidDirectiveValueCharacter(const String& directiveName, const String& value) const
 {
-    logToConsole(makeString("The value for Content Security Policy directive '", directiveName, "' contains an invalid character: '", value, "'. Non-whitespace characters outside ASCII 0x21-0x7E must be percent-encoded, as described in RFC 3986, section 2.1: http://tools.ietf.org/html/rfc3986#section-2.1."));
+    logToConsole(makeString("The value for Content Security Policy directive '"_s, directiveName, "' contains an invalid character: '"_s, value, "'. Non-whitespace characters outside ASCII 0x21-0x7E must be percent-encoded, as described in RFC 3986, section 2.1: http://tools.ietf.org/html/rfc3986#section-2.1."_s));
 }
 
 void ContentSecurityPolicy::reportInvalidPathCharacter(const String& directiveName, const String& value, const char invalidChar) const
@@ -1061,8 +1061,8 @@ void ContentSecurityPolicy::reportInvalidPathCharacter(const String& directiveNa
 
 void ContentSecurityPolicy::reportInvalidSourceExpression(const String& directiveName, const String& source) const
 {
-    logToConsole(makeString("The source list for Content Security Policy directive '", directiveName, "' contains an invalid source: '", source, "'. It will be ignored.",
-        equalLettersIgnoringASCIICase(source, "'none'"_s) ? " Note that 'none' has no effect unless it is the only expression in the source list." : ""));
+    logToConsole(makeString("The source list for Content Security Policy directive '"_s, directiveName, "' contains an invalid source: '"_s, source, "'. It will be ignored."_s,
+        equalLettersIgnoringASCIICase(source, "'none'"_s) ? " Note that 'none' has no effect unless it is the only expression in the source list."_s : ""_s));
 }
 
 void ContentSecurityPolicy::reportMissingReportURI(const String& policy) const

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -150,10 +150,10 @@ std::unique_ptr<ContentSecurityPolicyDirectiveList> ContentSecurityPolicyDirecti
     directives->parse(header, from);
 
     if (!checkEval(directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)))
-        directives->setEvalDisabledErrorMessage(makeString("Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"", directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"));
+        directives->setEvalDisabledErrorMessage(makeString("Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \""_s, directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"_s));
 
     if (!checkWasmEval(directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)))
-        directives->setWebAssemblyDisabledErrorMessage(makeString("Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"", directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"));
+        directives->setWebAssemblyDisabledErrorMessage(makeString("Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \""_s, directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"_s));
 
     if (directives->isReportOnly() && (directives->reportToTokens().isEmpty() && directives->reportURIs().isEmpty()))
         policy.reportMissingReportToTokens(header);

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -133,7 +133,7 @@ static HashMap<pid_t, ThreadInfo>& threadInfoMap()
 
 static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
 {
-    String path = makeString("/proc/self/task/", id, "/stat");
+    String path = makeString("/proc/self/task/"_s, id, "/stat"_s);
     int fd = open(path.utf8().data(), O_RDONLY);
     if (fd < 0)
         return false;

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -1637,7 +1637,7 @@ ScrollView::ProhibitScrollingWhenChangingContentSizeForScope::~ProhibitScrolling
 
 String ScrollView::debugDescription() const
 {
-    return makeString("ScrollView 0x", hex(reinterpret_cast<uintptr_t>(this), Lowercase));
+    return makeString("ScrollView 0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase));
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -177,7 +177,7 @@ double TimingFunction::transformProgress(double progress, double duration, bool 
 ExceptionOr<RefPtr<TimingFunction>> TimingFunction::createFromCSSText(const String& cssText)
 {
     auto properties = MutableStyleProperties::create();
-    properties->parseDeclaration(makeString("animation-timing-function:", cssText), CSSParserContext(HTMLStandardMode));
+    properties->parseDeclaration(makeString("animation-timing-function:"_s, cssText), CSSParserContext(HTMLStandardMode));
     if (auto value = properties->getPropertyCSSValue(CSSPropertyAnimationTimingFunction)) {
         if (auto function = createFromCSSValue(*value))
             return function;
@@ -236,12 +236,12 @@ String TimingFunction::cssText() const
             return "ease-out"_s;
         if (function->x1() == 0.42 && !function->y1() && function->x2() == 0.58 && function->y2() == 1.0)
             return "ease-in-out"_s;
-        return makeString("cubic-bezier(", function->x1(), ", ", function->y1(), ", ", function->x2(), ", ", function->y2(), ')');
+        return makeString("cubic-bezier("_s, function->x1(), ", "_s, function->y1(), ", "_s, function->x2(), ", "_s, function->y2(), ')');
     }
 
     if (auto* function = dynamicDowncast<StepsTimingFunction>(*this)) {
         if (function->stepPosition() == StepsTimingFunction::StepPosition::JumpEnd || function->stepPosition() == StepsTimingFunction::StepPosition::End)
-            return makeString("steps(", function->numberOfSteps(), ')');
+            return makeString("steps("_s, function->numberOfSteps(), ')');
     }
 
     TextStream stream;

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -152,7 +152,7 @@ bool HRTFElevation::calculateKernelsForAzimuthElevation(int azimuth, int elevati
     AudioChannel* leftEarImpulseResponse = response->channel(AudioBus::ChannelLeft);
     AudioChannel* rightEarImpulseResponse = response->channel(AudioBus::ChannelRight);
 #else
-    auto resourceName = makeString("IRC_", subjectName, "_C_R0195_T", pad('0', 3, azimuth), "_P", pad('0', 3, positiveElevation)).utf8();
+    auto resourceName = makeString("IRC_"_s, subjectName, "_C_R0195_T"_s, pad('0', 3, azimuth), "_P"_s, pad('0', 3, positiveElevation)).utf8();
 
     RefPtr<AudioBus> impulseResponse(AudioBus::loadPlatformResource(resourceName.data(), sampleRate));
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -235,7 +235,7 @@ bool MediaSessionGLib::ensureMprisSessionRegistered()
     }
 
     const auto& applicationID = getApplicationID();
-    m_instanceId = applicationID.isEmpty() ? makeString("org.mpris.MediaPlayer2.webkit.instance", getpid(), "-", m_identifier.toUInt64()) : makeString("org.mpris.MediaPlayer2.", applicationID.ascii().data(), ".Sandboxed.instance-", m_identifier.toUInt64());
+    m_instanceId = applicationID.isEmpty() ? makeString("org.mpris.MediaPlayer2.webkit.instance"_s, getpid(), '-', m_identifier.toUInt64()) : makeString("org.mpris.MediaPlayer2."_s, applicationID.ascii().data(), ".Sandboxed.instance-"_s, m_identifier.toUInt64());
 
     m_ownerId = g_bus_own_name_on_connection(m_connection.get(), m_instanceId.ascii().data(), G_BUS_NAME_OWNER_FLAGS_NONE, nullptr, nullptr, this, nullptr);
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -113,7 +113,7 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
     , m_renderBus(AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize, false))
 {
     static Atomic<uint32_t> pipelineId;
-    m_pipeline = gst_pipeline_new(makeString("audio-destination-", pipelineId.exchangeAdd(1)).ascii().data());
+    m_pipeline = gst_pipeline_new(makeString("audio-destination-"_s, pipelineId.exchangeAdd(1)).ascii().data());
     registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get(), [this](GstMessage* message) {
         this->handleMessage(message);

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -112,7 +112,7 @@ void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::
     if (!error.isEmpty()) {
         encoder->m_internalEncoder->postTask([callback = WTFMove(callback), error = WTFMove(error)]() mutable {
             GST_WARNING("Error creating encoder: %s", error.ascii().data());
-            callback(makeUnexpected(makeString("GStreamer encoding initialization failed with error: ", error)));
+            callback(makeUnexpected(makeString("GStreamer encoding initialization failed with error: "_s, error)));
         });
         return;
     }

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -387,7 +387,7 @@ void AudioFileReader::decodeAudioForBusCreation()
     // Build the pipeline giostreamsrc ! decodebin
     // A deinterleave element is added once a src pad becomes available in decodebin.
     static Atomic<uint32_t> pipelineId;
-    m_pipeline = gst_pipeline_new(makeString("audio-file-reader-", pipelineId.exchangeAdd(1)).ascii().data());
+    m_pipeline = gst_pipeline_new(makeString("audio-file-reader-"_s, pipelineId.exchangeAdd(1)).ascii().data());
     registerActivePipeline(m_pipeline);
 
     GRefPtr<GstBus> bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));

--- a/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
+++ b/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
@@ -480,7 +480,7 @@ String keyIdentifierForCharCode(unichar charCode)
             // FIXME: We should use something other than the vendor-area Unicode values for the above keys.
             // For now, just fall through to the default.
         default:
-            return makeString("U+", hex(toASCIIUpper(charCode), 4));
+            return makeString("U+"_s, hex(toASCIIUpper(charCode), 4));
     }
 }
 

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.cpp
@@ -106,7 +106,7 @@ static String vectorToHexString(const Vector<uint8_t>& vec)
 
 String KeyHandle::idAsString() const
 {
-    return makeString("[", vectorToHexString(m_id), "]");
+    return makeString('[', vectorToHexString(m_id), ']');
 }
 
 KeyStoreIDType keyStoreBaseNextID()

--- a/Source/WebCore/platform/graphics/ColorSerialization.cpp
+++ b/Source/WebCore/platform/graphics/ColorSerialization.cpp
@@ -203,8 +203,8 @@ template<typename ColorType> static String serializationUsingColorFunction(const
 
     auto [c1, c2, c3, alpha] = color.unresolved();
     if (WTF::areEssentiallyEqual(alpha, 1.0f))
-        return makeString("color(", serialization(ColorSpaceFor<ColorType>), ' ', numericComponent(c1), ' ', numericComponent(c2), ' ', numericComponent(c3), ')');
-    return makeString("color(", serialization(ColorSpaceFor<ColorType>), ' ', numericComponent(c1), ' ', numericComponent(c2), ' ', numericComponent(c3), " / ", numericComponent(alpha), ')');
+        return makeString("color("_s, serialization(ColorSpaceFor<ColorType>), ' ', numericComponent(c1), ' ', numericComponent(c2), ' ', numericComponent(c3), ')');
+    return makeString("color("_s, serialization(ColorSpaceFor<ColorType>), ' ', numericComponent(c1), ' ', numericComponent(c2), ' ', numericComponent(c3), " / "_s, numericComponent(alpha), ')');
 }
 
 static String serializationUsingColorFunction(const SRGBA<uint8_t>& color)

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -706,7 +706,7 @@ FloatRect GraphicsLayer::adjustCoverageRectForMovement(const FloatRect& coverage
 String GraphicsLayer::animationNameForTransition(AnimatedProperty property)
 {
     // | is not a valid identifier character in CSS, so this can never conflict with a keyframe identifier.
-    return makeString("-|transition", static_cast<int>(property), '-');
+    return makeString("-|transition"_s, static_cast<int>(property), '-');
 }
 
 void GraphicsLayer::suspendAnimations(MonotonicTime)

--- a/Source/WebCore/platform/graphics/HEVCUtilities.cpp
+++ b/Source/WebCore/platform/graphics/HEVCUtilities.cpp
@@ -74,7 +74,7 @@ std::optional<AVCParameters> parseAVCCodecParameters(StringView codecString)
 String createAVCCodecParametersString(const AVCParameters& parameters)
 {
     // The format of the 'avc1' codec string is specified in ISO/IEC 14496-15:2014, Annex E.2.
-    return makeString("avc1."
+    return makeString("avc1."_s
         , hex(parameters.profileIDC, 2)
         , hex(parameters.constraintsFlags, 2)
         , hex(parameters.levelIDC, 2));

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -431,7 +431,7 @@ String ImageBuffer::toDataURL(Ref<ImageBuffer> source, const String& mimeType, s
     auto encodedData = toData(WTFMove(source), mimeType, quality, preserveResolution);
     if (encodedData.isEmpty())
         return "data:,"_s;
-    return makeString("data:", mimeType, ";base64,", base64Encoded(encodedData));
+    return makeString("data:"_s, mimeType, ";base64,"_s, base64Encoded(encodedData));
 }
 
 Vector<uint8_t> ImageBuffer::toData(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 Ref<MediaResourceSniffer> MediaResourceSniffer::create(PlatformMediaResourceLoader& loader, ResourceRequest&& request, std::optional<size_t> maxSize)
 {
     if (maxSize)
-        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes=", 0, '-', *maxSize));
+        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes="_s, 0, '-', *maxSize));
     auto resource = loader.requestResource(WTFMove(request), PlatformMediaResourceLoader::LoadOption::DisallowCaching);
     if (!resource)
         return adoptRef(*new MediaResourceSniffer());

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -104,7 +104,7 @@ template<>
 struct LogArgument<WebCore::SourceBufferEvictionData> {
     static String toString(const WebCore::SourceBufferEvictionData& evictionData)
     {
-        return makeString("{ contentSize:", evictionData.contentSize, " evictableData:", evictionData.evictableSize, " maximumBufferSize:", evictionData.maximumBufferSize, " numSamples:", evictionData.numMediaSamples, " }");
+        return makeString("{ contentSize:"_s, evictionData.contentSize, " evictableData:"_s, evictionData.evictableSize, " maximumBufferSize:"_s, evictionData.maximumBufferSize, " numSamples:"_s, evictionData.numMediaSamples, " }"_s);
     }
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -209,7 +209,7 @@ MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported
     String outputCodecs = type.parameter(ContentType::codecsParameter());
     if (!outputCodecs.isEmpty() && [PAL::getAVStreamDataParserClass() respondsToSelector:@selector(outputMIMECodecParameterForInputMIMECodecParameter:)]) {
         outputCodecs = [PAL::getAVStreamDataParserClass() outputMIMECodecParameterForInputMIMECodecParameter:outputCodecs];
-        extendedType = makeString(type.containerType(), "; codecs=\"", outputCodecs, "\"");
+        extendedType = makeString(type.containerType(), "; codecs=\""_s, outputCodecs, "\""_s);
     }
 
     return AVStreamDataParserMIMETypeCache::singleton().canDecodeType(extendedType);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -310,7 +310,7 @@ void WebCoreAVFResourceLoader::startLoading()
     if (dataRequest && m_requestedLength > 0
         && !request.hasHTTPHeaderField(HTTPHeaderName::Range)) {
         String rangeEnd = dataRequest.requestsAllDataToEndOfResource ? emptyString() : makeString(m_requestedOffset + m_requestedLength - 1);
-        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes=", m_requestedOffset, '-', rangeEnd));
+        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes="_s, m_requestedOffset, '-', rangeEnd));
     }
 
     if (request.url().protocolIsData()) {

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -479,8 +479,8 @@ String GraphicsLayerCA::debugName() const
 #if ENABLE(TREE_DEBUGGING)
     String caLayerDescription;
     if (m_layer->type() == PlatformCALayer::Type::Cocoa)
-        caLayerDescription = makeString("CALayer(0x", hex(reinterpret_cast<uintptr_t>(m_layer->platformLayer()), Lowercase), ") ");
-    return makeString(caLayerDescription, "GraphicsLayer(0x", hex(reinterpret_cast<uintptr_t>(this), Lowercase), ", ", primaryLayerID().object(), ") ", name());
+        caLayerDescription = makeString("CALayer(0x"_s, hex(reinterpret_cast<uintptr_t>(m_layer->platformLayer()), Lowercase), ") "_s);
+    return makeString(caLayerDescription, "GraphicsLayer(0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase), ", "_s, primaryLayerID().object(), ") "_s, name());
 #else
     return name();
 #endif
@@ -1199,7 +1199,7 @@ void GraphicsLayerCA::setContentsToSolidColor(const Color& color)
             m_contentsLayerPurpose = ContentsLayerPurpose::BackgroundColor;
             m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
 #if ENABLE(TREE_DEBUGGING)
-            m_contentsLayer->setName(makeString("contents color ", m_contentsLayer->layerID().object()));
+            m_contentsLayer->setName(makeString("contents color "_s, m_contentsLayer->layerID().object()));
 #else
             m_contentsLayer->setName(MAKE_STATIC_STRING_IMPL("contents color"));
 #endif
@@ -1260,7 +1260,7 @@ void GraphicsLayerCA::setContentsToModel(RefPtr<Model>&& model, ModelInteraction
     if (model) {
         m_contentsLayer = createPlatformCALayer(*model, this);
 #if ENABLE(TREE_DEBUGGING)
-        m_contentsLayer->setName(makeString("contents model ", m_contentsLayer->layerID().object()));
+        m_contentsLayer->setName(makeString("contents model "_s, m_contentsLayer->layerID().object()));
 #else
         m_contentsLayer->setName(MAKE_STATIC_STRING_IMPL("contents model"));
 #endif
@@ -1817,7 +1817,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
         constexpr auto washBorderColor = Color::red.colorWithAlphaByte(100);
         
         m_visibleTileWashLayer = createPlatformCALayer(PlatformCALayer::LayerTypeLayer, this);
-        m_visibleTileWashLayer->setName(makeString("Visible Tile Wash Layer 0x", hex(reinterpret_cast<uintptr_t>(m_visibleTileWashLayer->platformLayer()), Lowercase)));
+        m_visibleTileWashLayer->setName(makeString("Visible Tile Wash Layer 0x"_s, hex(reinterpret_cast<uintptr_t>(m_visibleTileWashLayer->platformLayer()), Lowercase)));
         m_visibleTileWashLayer->setAnchorPoint(FloatPoint3D(0, 0, 0));
         m_visibleTileWashLayer->setBorderColor(washBorderColor);
         m_visibleTileWashLayer->setBorderWidth(8);
@@ -2898,7 +2898,7 @@ void GraphicsLayerCA::updateContentsImage()
         if (!m_contentsLayer.get()) {
             m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
 #if ENABLE(TREE_DEBUGGING)
-            m_contentsLayer->setName(makeString("contents image ", m_contentsLayer->layerID().object()));
+            m_contentsLayer->setName(makeString("contents image "_s, m_contentsLayer->layerID().object()));
 #else
             m_contentsLayer->setName(MAKE_STATIC_STRING_IMPL("contents image"));
 #endif
@@ -3010,7 +3010,7 @@ void GraphicsLayerCA::updateContentsRects()
             m_contentsClippingLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
             m_contentsClippingLayer->setAnchorPoint({ });
 #if ENABLE(TREE_DEBUGGING)
-            m_contentsClippingLayer->setName(makeString("contents clipping ", m_contentsClippingLayer->layerID().object()));
+            m_contentsClippingLayer->setName(makeString("contents clipping "_s, m_contentsClippingLayer->layerID().object()));
 #else
             m_contentsClippingLayer->setName(MAKE_STATIC_STRING_IMPL("contents clipping"));
 #endif
@@ -4652,7 +4652,7 @@ RefPtr<PlatformCALayer> GraphicsLayerCA::findOrMakeClone(const CloneID& cloneID,
     } else {
         resultLayer = cloneLayer(sourceLayer, cloneLevel);
 #if ENABLE(TREE_DEBUGGING)
-        resultLayer->setName(makeString("clone ", hex(cloneID[0U]), " of ", sourceLayer->layerID().object()));
+        resultLayer->setName(makeString("clone "_s, hex(cloneID[0U]), " of "_s, sourceLayer->layerID().object()));
 #else
         resultLayer->setName("clone of " + m_name);
 #endif

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -815,7 +815,7 @@ Ref<PlatformCALayer> TileController::createTileLayer(const IntRect& tileRect, Ti
     layer->setBorderWidth(m_tileDebugBorderWidth);
     layer->setAntialiasesEdges(false);
     layer->setOpaque(m_tilesAreOpaque);
-    layer->setName(makeString("tile at ", tileRect.location().x(), ',', tileRect.location().y()));
+    layer->setName(makeString("tile at "_s, tileRect.location().x(), ',', tileRect.location().y()));
     layer->setContentsScale(m_deviceScaleFactor * temporaryScaleFactor);
     layer->setAcceleratesDrawing(m_acceleratesDrawing);
     layer->setWantsDeepColorBackingStore(m_wantsDeepColorBackingStore);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -131,7 +131,7 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
         auto& canonicalFilterOperation = *canonicalFilterOperations[i];
         auto& initialFilterOperation = i < numberOfInitialFilters ? *initialFilterOperations[i] : passthroughFilter(canonicalFilterOperation.type());
         ASSERT(canonicalFilterOperation.type() == initialFilterOperation.type());
-        auto filterName = makeString("filter_", i);
+        auto filterName = makeString("filter_"_s, i);
         auto type = initialFilterOperation.type();
         switch (type) {
         case FilterOperation::Type::Default:
@@ -156,7 +156,7 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
         case FilterOperation::Type::Brightness:
         case FilterOperation::Type::Contrast:
         case FilterOperation::Type::Blur: {
-            auto keyValueName = makeString("filters.", filterName, ".", animatedFilterPropertyName(initialFilterOperation.type()));
+            auto keyValueName = makeString("filters."_s, filterName, '.', animatedFilterPropertyName(initialFilterOperation.type()));
             presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:keyValueName initialValue:filterValueForOperation(&initialFilterOperation).get() additive:NO group:group.get()]) });
             continue;
         }
@@ -242,7 +242,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
 
     unsigned i = 0;
     auto array = createNSArray(filters.operations(), [&] (auto& operationPtr) -> id {
-        auto filterName = makeString("filter_", i++);
+        auto filterName = makeString("filter_"_s, i++);
         auto& filterOperation = *operationPtr;
         switch (filterOperation.type()) {
         case FilterOperation::Type::Default:

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -242,7 +242,7 @@ template<typename Source> static String encodeToDataURL(Source&& source, const S
     if (encodedData.isEmpty())
         return "data:,"_s;
 
-    return makeString("data:", mimeType, ";base64,", base64Encoded(encodedData));
+    return makeString("data:"_s, mimeType, ";base64,"_s, base64Encoded(encodedData));
 }
 
 Vector<uint8_t> encodeData(CGImageRef image, const String& mimeType, std::optional<double> quality)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -115,7 +115,7 @@ ImageDecoderGStreamer::ImageDecoderGStreamer(FragmentedSharedBuffer& data, const
     });
 
     static Atomic<uint32_t> decoderId;
-    GRefPtr<GstElement> parsebin = gst_element_factory_make("parsebin", makeString("image-decoder-parser-", decoderId.exchangeAdd(1)).utf8().data());
+    GRefPtr<GstElement> parsebin = gst_element_factory_make("parsebin", makeString("image-decoder-parser-"_s, decoderId.exchangeAdd(1)).utf8().data());
     m_parserHarness = GStreamerElementHarness::create(WTFMove(parsebin), [](auto&, auto&&) { }, [this](auto& pad) -> RefPtr<GStreamerElementHarness> {
         auto caps = adoptGRef(gst_pad_query_caps(pad.get(), nullptr));
         auto identityHarness = GStreamerElementHarness::create(GRefPtr<GstElement>(gst_element_factory_make("identity", nullptr)), [](auto&, const auto&) { });

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -366,7 +366,7 @@ void MediaPlayerPrivateGStreamer::load(const URL&, const ContentType&, MediaSour
 void MediaPlayerPrivateGStreamer::load(MediaStreamPrivate& stream)
 {
     m_streamPrivate = &stream;
-    load(makeString("mediastream://", stream.id()));
+    load(makeString("mediastream://"_s, stream.id()));
     syncOnClock(false);
 
     if (RefPtr player = m_player.get())

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -111,7 +111,7 @@ AppendPipeline::AppendPipeline(SourceBufferPrivateGStreamer& sourceBufferPrivate
     // FIXME: give a name to the pipeline, maybe related with the track it's managing.
     // The track name is still unknown at this time, though.
     static size_t appendPipelineCount = 0;
-    String pipelineName = makeString("append-pipeline-",
+    String pipelineName = makeString("append-pipeline-"_s,
         makeStringByReplacingAll(m_sourceBufferPrivate.type().containerType(), '/', '-'), '-', appendPipelineCount++);
     m_pipeline = gst_pipeline_new(pipelineName.utf8().data());
     registerActivePipeline(m_pipeline);
@@ -610,7 +610,7 @@ void AppendPipeline::resetParserState()
     {
         static unsigned i = 0;
         // This is here for debugging purposes. It does not make sense to have it as class member.
-        String dotFileName = makeString("reset-pipeline-", ++i);
+        String dotFileName = makeString("reset-pipeline-"_s, ++i);
         gst_debug_bin_to_dot_file(GST_BIN(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
     }
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -143,7 +143,7 @@ void MediaPlayerPrivateGStreamerMSE::load(const String&)
 
 void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const ContentType&, MediaSourcePrivateClient& mediaSource)
 {
-    auto mseBlobURI = makeString("mediasource", url.string().isEmpty() ? "blob://"_s : url.string());
+    auto mseBlobURI = makeString("mediasource"_s, url.string().isEmpty() ? "blob://"_s : url.string());
     GST_DEBUG("Loading %s", mseBlobURI.ascii().data());
     m_mediaSourcePrivate = MediaSourcePrivateGStreamer::open(mediaSource, *this);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -216,7 +216,7 @@ static void dumpPipeline(const char* description, const RefPtr<Stream>& stream)
     [[maybe_unused]] fileNamePattern;
     [[maybe_unused]] stream;
 #else
-    auto fileName = makeString("playback-pipeline-", stream->track->stringId(), "-", description);
+    auto fileName = makeString("playback-pipeline-"_s, stream->track->stringId(), '-', description);
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(findPipeline(GRefPtr<GstElement>(GST_ELEMENT(stream->source))).get()),
         GST_DEBUG_GRAPH_SHOW_ALL, fileName.utf8().data());
 #endif
@@ -328,7 +328,7 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
             continue;
         }
 
-        GRefPtr<WebKitMediaSrcPad> pad = WEBKIT_MEDIA_SRC_PAD(g_object_new(webkit_media_src_pad_get_type(), "name", makeString("src_", track->stringId()).utf8().data(), "direction", GST_PAD_SRC, NULL));
+        GRefPtr<WebKitMediaSrcPad> pad = WEBKIT_MEDIA_SRC_PAD(g_object_new(webkit_media_src_pad_get_type(), "name", makeString("src_"_s, track->stringId()).utf8().data(), "direction", GST_PAD_SRC, NULL));
         gst_pad_set_activatemode_function(GST_PAD(pad.get()), webKitMediaSrcActivateMode);
 
         ASSERT(track->initialCaps());

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -69,7 +69,7 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
     registerWebKitGStreamerElements();
 
     static Atomic<uint32_t> pipelineId;
-    m_pipeline = gst_pipeline_new(makeString("speech-synthesizer-", pipelineId.exchangeAdd(1)).ascii().data());
+    m_pipeline = gst_pipeline_new(makeString("speech-synthesizer-"_s, pipelineId.exchangeAdd(1)).ascii().data());
     registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get(), [this](GstMessage* message) {
         this->handleMessage(message);

--- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
@@ -882,7 +882,7 @@ String PlatformKeyboardEvent::keyIdentifierForGdkKeyCode(unsigned keyCode)
     case GDK_KEY_Tab:
         return "U+0009"_s;
     default:
-        return makeString("U+", hex(gdk_keyval_to_unicode(gdk_keyval_to_upper(keyCode)), 4));
+        return makeString("U+"_s, hex(gdk_keyval_to_unicode(gdk_keyval_to_upper(keyCode)), 4));
     }
 }
 

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -90,11 +90,11 @@ String standardUserAgentWithApplicationName(const String& applicationName, const
     auto separator = applicationName.isEmpty() ? "" : " ";
 
     if (type == UserAgentType::Desktop)
-        return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)", separator, applicationName);
+        return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, separator, applicationName);
 
 #if ENABLE(STATIC_IPAD_USER_AGENT_VALUE)
     UNUSED_PARAM(userAgentOSVersion);
-    return makeString("Mozilla/5.0 (iPad; CPU OS 16_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)", separator, applicationName);
+    return makeString("Mozilla/5.0 (iPad; CPU OS 16_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, separator, applicationName);
 #else
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DoesNotOverrideUAFromNSUserDefault)) {
         if (auto override = dynamic_cf_cast<CFStringRef>(adoptCF(CFPreferencesCopyAppValue(CFSTR("UserAgent"), CFSTR("com.apple.WebFoundation"))))) {
@@ -108,7 +108,7 @@ String standardUserAgentWithApplicationName(const String& applicationName, const
     }
 
     auto osVersion = userAgentOSVersion.isEmpty() ? systemMarketingVersionForUserAgentString() : userAgentOSVersion;
-    return makeString("Mozilla/5.0 (", deviceNameForUserAgent(), "; CPU ", osNameForUserAgent(), " ", osVersion, " like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)", separator, applicationName);
+    return makeString("Mozilla/5.0 ("_s, deviceNameForUserAgent(), "; CPU "_s, osNameForUserAgent(), ' ', osVersion, " like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, separator, applicationName);
 #endif
 }
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -148,7 +148,7 @@ void LibWebRTCVPXInternalVideoDecoder::decode(std::span<const uint8_t> data, boo
             return;
 
         if (error)
-            protectedThis->m_outputCallback(makeUnexpected(makeString("VPx decoding failed with error ", error)));
+            protectedThis->m_outputCallback(makeUnexpected(makeString("VPx decoding failed with error "_s, error)));
 
         callback({ });
     });

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -90,7 +90,7 @@ void LibWebRTCVPXVideoEncoder::create(Type type, const VideoEncoder::Config& con
         auto internalEncoder = encoder->m_internalEncoder;
         internalEncoder->postTask([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error]() mutable {
             if (error) {
-                callback(makeUnexpected(makeString("VPx encoding initialization failed with error ", error)));
+                callback(makeUnexpected(makeString("VPx encoding initialization failed with error "_s, error)));
                 return;
             }
             callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
@@ -262,7 +262,7 @@ void LibWebRTCVPXInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame,
 
         String result;
         if (error)
-            result = makeString("VPx encoding failed with error ", error);
+            result = makeString("VPx encoding failed with error "_s, error);
         callback(WTFMove(result));
     });
 }

--- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
@@ -883,7 +883,7 @@ String PlatformKeyboardEvent::keyIdentifierForWPEKeyCode(unsigned keyCode)
         break;
     }
 
-    return makeString("U+", hex(wpe_key_code_to_unicode(keyCode), 4));
+    return makeString("U+"_s, hex(wpe_key_code_to_unicode(keyCode), 4));
 }
 
 int PlatformKeyboardEvent::windowsKeyCodeForWPEKeyCode(unsigned keycode)

--- a/Source/WebCore/platform/mac/UserAgentMac.mm
+++ b/Source/WebCore/platform/mac/UserAgentMac.mm
@@ -38,9 +38,9 @@ String standardUserAgentWithApplicationName(const String& applicationName, const
     if (!osVersion.startsWith("10"_s))
         osVersion = "10_15_7"_s;
     
-    String appNameSuffix = applicationName.isEmpty() ? emptyString() : makeString(" ", applicationName);
+    String appNameSuffix = applicationName.isEmpty() ? emptyString() : makeString(' ', applicationName);
 
-    return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X ", osVersion, ") AppleWebKit/605.1.15 (KHTML, like Gecko)", appNameSuffix);
+    return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X "_s, osVersion, ") AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, appNameSuffix);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
@@ -176,7 +176,7 @@ void CGDisplayStreamScreenCaptureSource::screenCaptureDevices(Vector<CaptureDevi
 {
     auto screenID = displayID([NSScreen mainScreen]);
     if (CGDisplayIDToOpenGLDisplayMask(screenID)) {
-        CaptureDevice displayDevice(String::number(screenID), CaptureDevice::DeviceType::Screen, makeString("Screen 0"));
+        CaptureDevice displayDevice(String::number(screenID), CaptureDevice::DeviceType::Screen, "Screen 0"_str);
         displayDevice.setEnabled(true);
         displays.append(WTFMove(displayDevice));
         return;
@@ -203,7 +203,7 @@ void CGDisplayStreamScreenCaptureSource::screenCaptureDevices(Vector<CaptureDevi
 
     int count = 0;
     for (auto displayID : activeDisplays) {
-        CaptureDevice displayDevice(String::number(displayID), CaptureDevice::DeviceType::Screen, makeString("Screen ", String::number(count++)));
+        CaptureDevice displayDevice(String::number(displayID), CaptureDevice::DeviceType::Screen, makeString("Screen "_s, String::number(count++)));
         displayDevice.setEnabled(CGDisplayIDToOpenGLDisplayMask(displayID));
         displays.append(WTFMove(displayDevice));
     }
@@ -215,7 +215,7 @@ std::optional<CaptureDevice> CGDisplayStreamScreenCaptureSource::screenCaptureDe
     if (!CGDisplayIDToOpenGLDisplayMask(screenID))
         return std::nullopt;
 
-    CaptureDevice device(String::number(screenID), CaptureDevice::DeviceType::Screen, makeString("Screen 0"));
+    CaptureDevice device(String::number(screenID), CaptureDevice::DeviceType::Screen, "Screen 0"_str);
     device.setEnabled(true);
     return { WTFMove(device) };
 }

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -284,7 +284,7 @@ void ScreenCaptureKitCaptureSource::sessionFilterDidChange(SCContentFilter* cont
     }
     case SCContentFilterTypeDisplay: {
         auto *display = [contentFilter displayInfo].display;
-        device = CaptureDevice(String::number(display.displayID), CaptureDevice::DeviceType::Screen, makeString("Screen"), emptyString(), true);
+        device = CaptureDevice(String::number(display.displayID), CaptureDevice::DeviceType::Screen, "Screen"_str, emptyString(), true);
         m_content = display;
         break;
     }

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -285,7 +285,7 @@ void ScreenCaptureKitSharingSessionManager::completeDeviceSelection(SCContentFil
         break;
     }
     case SCContentFilterTypeDisplay:
-        device = CaptureDevice(String::number(contentFilter.displayInfo.display.displayID), CaptureDevice::DeviceType::Screen, makeString("Screen "), emptyString(), true);
+        device = CaptureDevice(String::number(contentFilter.displayInfo.display.displayID), CaptureDevice::DeviceType::Screen, "Screen "_str, emptyString(), true);
         break;
     case SCContentFilterTypeNothing:
     case SCContentFilterTypeAppsAndWindowsPinnedToDisplay:

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -556,21 +556,21 @@ void MockRealtimeVideoSource::drawText(GraphicsContext& context)
     context.drawText(drawingState.timeFont(), TextRun(StringView(string)), timeLocation);
 
     FloatPoint statsLocation(captureSize.width() * .45, captureSize.height() * .75);
-    string = makeString("Requested frame rate: ", FormattedNumber::fixedWidth(frameRate(), 1), " fps");
+    string = makeString("Requested frame rate: "_s, FormattedNumber::fixedWidth(frameRate(), 1), " fps"_s);
     context.drawText(drawingState.statsFont(), TextRun(StringView(string)), statsLocation);
 
     statsLocation.move(0, drawingState.statsFontSize());
-    string = makeString("Observed frame rate: ", FormattedNumber::fixedWidth(observedFrameRate(), 1), " fps");
+    string = makeString("Observed frame rate: "_s, FormattedNumber::fixedWidth(observedFrameRate(), 1), " fps"_s);
     context.drawText(drawingState.statsFont(), TextRun(StringView(string)), statsLocation);
 
     auto size = this->size();
     statsLocation.move(0, drawingState.statsFontSize());
-    string = makeString("Size: ", size.width(), " x ", size.height());
+    string = makeString("Size: "_s, size.width(), " x "_s, size.height());
     context.drawText(drawingState.statsFont(), TextRun(StringView(string)), statsLocation);
 
     if (mockCamera()) {
         statsLocation.move(0, drawingState.statsFontSize());
-        string = makeString("Preset size: ", captureSize.width(), " x ", captureSize.height());
+        string = makeString("Preset size: "_s, captureSize.width(), " x "_s, captureSize.height());
         context.drawText(drawingState.statsFont(), TextRun(StringView(string)), statsLocation);
 
         ASCIILiteral camera;

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -156,7 +156,7 @@ Ref<DataSegment> BlobRegistryImpl::createDataSegment(Vector<uint8_t>&& movedData
 
     static uint64_t blobMappingFileCounter;
     static NeverDestroyed<Ref<WorkQueue>> workQueue(WorkQueue::create("BlobRegistryImpl Data Queue"_s));
-    auto filePath = FileSystem::pathByAppendingComponent(m_fileDirectory, makeString("mapping-file-", ++blobMappingFileCounter, ".blob"));
+    auto filePath = FileSystem::pathByAppendingComponent(m_fileDirectory, makeString("mapping-file-"_s, ++blobMappingFileCounter, ".blob"_s));
     workQueue.get()->dispatch([blobData = Ref { blobData }, data, filePath = WTFMove(filePath).isolatedCopy()]() mutable {
         auto mappedFileData = storeInMappedFileData(filePath, data->span());
         if (!mappedFileData)

--- a/Source/WebCore/platform/network/CredentialBase.cpp
+++ b/Source/WebCore/platform/network/CredentialBase.cpp
@@ -98,7 +98,7 @@ bool CredentialBase::compare(const Credential& a, const Credential& b)
 String CredentialBase::serializationForBasicAuthorizationHeader() const
 {
     auto credentialStringData = makeString(m_user, ':', m_password).utf8();
-    return makeString("Basic ", base64Encoded(credentialStringData));
+    return makeString("Basic "_s, base64Encoded(credentialStringData));
 }
 
 auto CredentialBase::nonPlatformData() const -> NonPlatformData

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -722,13 +722,13 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
             if (name.isEmpty()) {
                 if (p + 1 < end && *(p + 1) == '\n')
                     return (p + 2) - data.data();
-                failureReason = makeString("CR doesn't follow LF in header name at ", trimInputSample(std::span { p, end }));
+                failureReason = makeString("CR doesn't follow LF in header name at "_s, trimInputSample(std::span { p, end }));
                 return 0;
             }
-            failureReason = makeString("Unexpected CR in header name at ", trimInputSample(name.span()));
+            failureReason = makeString("Unexpected CR in header name at "_s, trimInputSample(name.span()));
             return 0;
         case '\n':
-            failureReason = makeString("Unexpected LF in header name at ", trimInputSample(name.span()));
+            failureReason = makeString("Unexpected LF in header name at "_s, trimInputSample(name.span()));
             return 0;
         case ':':
             break;
@@ -737,7 +737,7 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
                 if (name.size() < 1)
                     failureReason = "Unexpected start character in header name"_s;
                 else
-                    failureReason = makeString("Unexpected character in header name at ", trimInputSample(name.span()));
+                    failureReason = makeString("Unexpected character in header name at "_s, trimInputSample(name.span()));
                 return 0;
             }
             name.append(*p);
@@ -764,7 +764,7 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
             break;
         case '\n':
             if (strict) {
-                failureReason = makeString("Unexpected LF in header value at ", trimInputSample(value.span()));
+                failureReason = makeString("Unexpected LF in header value at "_s, trimInputSample(value.span()));
                 return 0;
             }
             break;
@@ -777,7 +777,7 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
         }
     }
     if (p >= end || (strict && *p != '\n')) {
-        failureReason = makeString("CR doesn't follow LF after header value at ", trimInputSample(std::span { p, end }));
+        failureReason = makeString("CR doesn't follow LF after header value at "_s, trimInputSample(std::span { p, end }));
         return 0;
     }
     valueStr = String::fromUTF8(value.span());

--- a/Source/WebCore/platform/network/ParsedContentRange.cpp
+++ b/Source/WebCore/platform/network/ParsedContentRange.cpp
@@ -134,8 +134,8 @@ String ParsedContentRange::headerValue() const
     if (!isValid())
         return String();
     if (m_instanceLength == unknownLength)
-        return makeString("bytes ", m_firstBytePosition, '-', m_lastBytePosition, "/*");
-    return makeString("bytes ", m_firstBytePosition, '-', m_lastBytePosition, '/', m_instanceLength);
+        return makeString("bytes "_s, m_firstBytePosition, '-', m_lastBytePosition, "/*"_s);
+    return makeString("bytes "_s, m_firstBytePosition, '-', m_lastBytePosition, '/', m_instanceLength);
 }
 
 }

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -344,7 +344,7 @@ String ResourceResponseBase::sanitizeSuggestedFilename(const String& suggestedFi
     response.setHTTPStatusCode(200);
     String escapedSuggestedFilename = makeStringByReplacingAll(suggestedFilename, '\\', "\\\\"_s);
     escapedSuggestedFilename = makeStringByReplacingAll(escapedSuggestedFilename, '"', "\\\""_s);
-    response.setHTTPHeaderField(HTTPHeaderName::ContentDisposition, makeString("attachment; filename=\"", escapedSuggestedFilename, '"'));
+    response.setHTTPHeaderField(HTTPHeaderName::ContentDisposition, makeString("attachment; filename=\""_s, escapedSuggestedFilename, '"'));
     return response.suggestedFilename();
 }
 

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -105,7 +105,7 @@ static ResourceResponse synthesizedResponseForRange(const ResourceResponse& orig
     auto begin = parsedRequestRange.begin;
     auto end = parsedRequestRange.end;
 
-    auto newContentRange = makeString("bytes ", begin, "-", end, "/", (totalContentLength ? makeString(*totalContentLength) : "*"_s));
+    auto newContentRange = makeString("bytes "_s, begin, '-', end, '/', (totalContentLength ? makeString(*totalContentLength) : "*"_s));
     auto newContentLength = makeString(end - begin + 1);
 
     ResourceResponse newResponse = originalResponse;

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -212,7 +212,7 @@ void CookieJarDB::verifySchemaVersion()
     }
 
     // Update version
-    executeSQLStatement(m_database.prepareStatementSlow(makeString("PRAGMA user_version=", schemaVersion)));
+    executeSQLStatement(m_database.prepareStatementSlow(makeString("PRAGMA user_version="_s, schemaVersion)));
 }
 
 void CookieJarDB::deleteAllTables()
@@ -360,7 +360,7 @@ bool CookieJarDB::hasCookies(const URL& url)
         statement.bindNull(2);
     } else {
         statement.bindText(1, registrableDomain.string());
-        statement.bindText(2, makeString("*.", registrableDomain.string()));
+        statement.bindText(2, makeString("*."_s, registrableDomain.string()));
     }
 
     return statement.step() == SQLITE_ROW;
@@ -403,7 +403,7 @@ std::optional<Vector<Cookie>> CookieJarDB::searchCookies(const URL& firstParty, 
     if (CookieUtil::isIPAddress(requestHost) || !requestHost.contains('.') || registrableDomain.isEmpty())
         pstmt->bindNull(6);
     else
-        pstmt->bindText(6, makeString("*.", registrableDomain.string()));
+        pstmt->bindText(6, makeString("*."_s, registrableDomain.string()));
 
     Vector<Cookie> results;
 

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -58,7 +58,7 @@ static std::optional<CString> extractBoundary(const CurlResponse& response)
         if (boundary.isEmpty())
             return std::nullopt;
 
-        return makeString("--", boundary).latin1();
+        return makeString("--"_s, boundary).latin1();
     }
 
     return std::nullopt;

--- a/Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp
+++ b/Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp
@@ -67,7 +67,7 @@ static ProtectionSpace protectionSpaceFromSoupAuthAndURL(SoupAuth* soupAuth, con
     if (!port)
         port = defaultPortForProtocol(url.protocol());
 #else
-    URL authURL({ }, makeString("http://", soup_auth_get_authority(soupAuth)));
+    URL authURL({ }, makeString("http://"_s, soup_auth_get_authority(soupAuth)));
     auto host = authURL.host();
     auto port = authURL.port();
 #endif

--- a/Source/WebCore/platform/playstation/UserAgentPlayStation.cpp
+++ b/Source/WebCore/platform/playstation/UserAgentPlayStation.cpp
@@ -68,7 +68,7 @@ static String standardUserAgentStatic()
 {
     // Version/X is mandatory *before* Safari/X to be a valid Safari UA. See
     // https://bugs.webkit.org/show_bug.cgi?id=133403 for details.
-    static NeverDestroyed<String> uaStatic(makeString("Mozilla/5.0 (PlayStation; ", getSystemSoftwareName(), '/', getSystemSoftwareVersion(), ") AppleWebKit/", versionForUAString(), " (KHTML, like Gecko) ", "Version/17.0 Safari/", versionForUAString()));
+    static NeverDestroyed<String> uaStatic(makeString("Mozilla/5.0 (PlayStation; "_s, getSystemSoftwareName(), '/', getSystemSoftwareVersion(), ") AppleWebKit/"_s, versionForUAString(), " (KHTML, like Gecko) "_s, "Version/17.0 Safari/"_s, versionForUAString()));
     return uaStatic;
 }
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -56,7 +56,7 @@ static const char notOpenErrorMessage[] = "database is not open";
 static void unauthorizedSQLFunction(sqlite3_context *context, int, sqlite3_value **)
 {
     const char* functionName = (const char*)sqlite3_user_data(context);
-    sqlite3_result_error(context, makeString("Function ", functionName, " is unauthorized").utf8().data(), -1);
+    sqlite3_result_error(context, makeString("Function "_s, functionName, " is unauthorized"_s).utf8().data(), -1);
 }
 
 static void initializeSQLiteIfNecessary()
@@ -366,7 +366,7 @@ void SQLiteDatabase::setMaximumSize(int64_t size)
     Locker locker { m_authorizerLock };
     enableAuthorizer(false);
 
-    auto statement = prepareStatementSlow(makeString("PRAGMA max_page_count = ", newMaxPageCount));
+    auto statement = prepareStatementSlow(makeString("PRAGMA max_page_count = "_s, newMaxPageCount));
     if (!statement || statement->step() != SQLITE_ROW)
         LOG_ERROR("Failed to set maximum size of database to %lli bytes", static_cast<long long>(size));
 
@@ -424,7 +424,7 @@ int64_t SQLiteDatabase::totalSize()
 
 void SQLiteDatabase::setSynchronous(SynchronousPragma sync)
 {
-    executeCommandSlow(makeString("PRAGMA synchronous = ", static_cast<unsigned>(sync)));
+    executeCommandSlow(makeString("PRAGMA synchronous = "_s, static_cast<unsigned>(sync)));
 }
 
 void SQLiteDatabase::setBusyTimeout(int ms)
@@ -511,7 +511,7 @@ void SQLiteDatabase::clearAllTables()
     while (statement->step() == SQLITE_ROW)
         tables.append(statement->columnText(0));
     for (auto& table : tables) {
-        if (!executeCommandSlow(makeString("DROP TABLE ", table)))
+        if (!executeCommandSlow(makeString("DROP TABLE "_s, table)))
             LOG(SQLDatabase, "Unable to drop table %s", table.ascii().data());
     }
 }

--- a/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
@@ -98,7 +98,7 @@ static UnixFileDescriptor createSharedMemory()
 #else
     CString tempName;
     for (int tries = 0; fileDescriptor == -1 && tries < 10; ++tries) {
-        auto name = makeString("/WK2SharedMemory.", cryptographicallyRandomNumber<unsigned>());
+        auto name = makeString("/WK2SharedMemory."_s, cryptographicallyRandomNumber<unsigned>());
         tempName = name.utf8();
 
         do {

--- a/Source/WebCore/platform/win/KeyEventWin.cpp
+++ b/Source/WebCore/platform/win/KeyEventWin.cpp
@@ -145,7 +145,7 @@ static String keyIdentifierForWindowsKeyCode(unsigned short keyCode)
         case VK_DELETE:
             return "U+007F"_s;
         default:
-            return makeString("U+", hex(toASCIIUpper(keyCode), 4));
+            return makeString("U+"_s, hex(toASCIIUpper(keyCode), 4));
     }
 }
 

--- a/Source/WebCore/platform/win/SearchPopupMenuDB.cpp
+++ b/Source/WebCore/platform/win/SearchPopupMenuDB.cpp
@@ -255,7 +255,7 @@ void SearchPopupMenuDB::verifySchemaVersion()
 
     // Update version
 
-    executeSQLStatement(m_database.prepareStatementSlow(makeString("PRAGMA user_version=", schemaVersion)));
+    executeSQLStatement(m_database.prepareStatementSlow(makeString("PRAGMA user_version="_s, schemaVersion)));
 }
 
 void SearchPopupMenuDB::checkSQLiteReturnCode(int actual)

--- a/Source/WebCore/platform/win/UserAgentWin.cpp
+++ b/Source/WebCore/platform/win/UserAgentWin.cpp
@@ -34,8 +34,8 @@ namespace WebCore {
 String standardUserAgent(const String& applicationName, const String& applicationVersion)
 {
     auto version = applicationName.isEmpty() ? emptyString() : applicationVersion;
-    return makeString("Mozilla/5.0 (", windowsVersionForUAString(), ") AppleWebKit/605.1.15 (KHTML, like Gecko)",
-        applicationName.isEmpty() ? "" : " ", applicationName, version.isEmpty() ? "" : "/", version);
+    return makeString("Mozilla/5.0 ("_s, windowsVersionForUAString(), ") AppleWebKit/605.1.15 (KHTML, like Gecko)"_s,
+        applicationName.isEmpty() ? ""_s : " "_s, applicationName, version.isEmpty() ? ""_s : "/"_s, version);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
@@ -55,7 +55,7 @@ inline String resultToString(XrResult value, XrInstance instance)
     XrResult result = xrResultToString(instance, value, buffer);
     if (result == XR_SUCCESS)
         return String::fromLatin1(buffer);
-    return makeString("<unknown ", int(value), ">");
+    return makeString("<unknown "_s, int(value), '>');
 }
 
 #define RETURN_IF_FAILED(call, label, instance, ...)                                                      \

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2659,13 +2659,13 @@ String RenderLayer::debugDescription() const
         compositedDescription = stream.release();
     }
 
-    return makeString("RenderLayer 0x", hex(reinterpret_cast<uintptr_t>(this), Lowercase),
+    return makeString("RenderLayer 0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase),
         ' ', size().width(), 'x', size().height(),
-        transform() ? " has transform" : "",
-        hasFilter() ? " has filter" : "",
-        hasBackdropFilter() ? " has backdrop filter" : "",
-        hasBlendMode() ? " has blend mode" : "",
-        isolatesBlending() ? " isolates blending" : "",
+        transform() ? " has transform"_s : ""_s,
+        hasFilter() ? " has filter"_s : ""_s,
+        hasBackdropFilter() ? " has backdrop filter"_s : ""_s,
+        hasBlendMode() ? " has blend mode"_s : ""_s,
+        isolatesBlending() ? " isolates blending"_s : ""_s,
         compositedDescription);
 }
 

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -232,7 +232,7 @@ String RenderThemeAdwaita::mediaControlsStyleSheet()
 String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const String& iconName, const String& iconType)
 {
 #if USE(GLIB)
-    auto path = makeString("/org/webkit/media-controls/", iconName, '.', iconType);
+    auto path = makeString("/org/webkit/media-controls/"_s, iconName, '.', iconType);
     auto data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return emptyString();

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -117,7 +117,7 @@ template<typename CharacterType> std::optional<FloatRect> SVGFitToViewBox::parse
         Ref document = m_viewBox->contextElement()->document();
 
         if (!x || !y || !width || !height) {
-            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\"", stringToParse, "\""));
+            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));
             return std::nullopt;
         }
 
@@ -136,7 +136,7 @@ template<typename CharacterType> std::optional<FloatRect> SVGFitToViewBox::parse
         // Nothing should come after the last, fourth number.
         skipOptionalSVGSpaces(buffer);
         if (buffer.hasCharactersRemaining()) {
-            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\"", stringToParse, "\""));
+            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));
             return std::nullopt;
         }
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -823,7 +823,7 @@ Vector<Ref<SVGSVGElement>> Internals::allSVGSVGElements() const
 
 String Internals::address(Node& node)
 {
-    return makeString("0x", hex(reinterpret_cast<uintptr_t>(&node)));
+    return makeString("0x"_s, hex(reinterpret_cast<uintptr_t>(&node)));
 }
 
 bool Internals::nodeNeedsStyleRecalc(Node& node)
@@ -2303,7 +2303,7 @@ ExceptionOr<String> Internals::configurationForViewport(float devicePixelRatio, 
     restrictScaleFactorToInitialScaleIfNotUserScalable(attributes);
 
     // FIXME: Using fixed precision here because of test results that contain numbers with specific precision. Would be nice to update the test results and move to default formatting.
-    return makeString("viewport size ", FormattedNumber::fixedPrecision(attributes.layoutSize.width()), 'x', FormattedNumber::fixedPrecision(attributes.layoutSize.height()), " scale ", FormattedNumber::fixedPrecision(attributes.initialScale), " with limits [", FormattedNumber::fixedPrecision(attributes.minimumScale), ", ", FormattedNumber::fixedPrecision(attributes.maximumScale), "] and userScalable ", (attributes.userScalable ? "true" : "false"));
+    return makeString("viewport size "_s, FormattedNumber::fixedPrecision(attributes.layoutSize.width()), 'x', FormattedNumber::fixedPrecision(attributes.layoutSize.height()), " scale "_s, FormattedNumber::fixedPrecision(attributes.initialScale), " with limits ["_s, FormattedNumber::fixedPrecision(attributes.minimumScale), ", "_s, FormattedNumber::fixedPrecision(attributes.maximumScale), "] and userScalable "_s, (attributes.userScalable ? "true"_s : "false"_s));
 }
 
 ExceptionOr<bool> Internals::wasLastChangeUserEdit(Element& textField)
@@ -5327,7 +5327,7 @@ String Internals::createTemporaryFile(const String& name, const String& contents
     if (name.isEmpty())
         return nullString();
 
-    auto [path, file] = FileSystem::openTemporaryFile(makeString("WebCoreTesting-", name));
+    auto [path, file] = FileSystem::openTemporaryFile(makeString("WebCoreTesting-"_s, name));
     if (!FileSystem::isHandleValid(file))
         return nullString();
 
@@ -5348,7 +5348,7 @@ void Internals::queueMicroTask(int testNumber)
     ScriptExecutionContext* context = document;
     auto& eventLoop = context->eventLoop();
     eventLoop.queueMicrotask([document = Ref { *document }, testNumber]() {
-        document->addConsoleMessage(MessageSource::JS, MessageLevel::Debug, makeString("MicroTask #", testNumber, " has run."));
+        document->addConsoleMessage(MessageSource::JS, MessageLevel::Debug, makeString("MicroTask #"_s, testNumber, " has run."_s));
     });
 }
 

--- a/Source/WebCore/testing/MockContentFilterSettings.cpp
+++ b/Source/WebCore/testing/MockContentFilterSettings.cpp
@@ -87,7 +87,7 @@ void MockContentFilterSettings::setModifiedRequestURL(const String& modifiedRequ
 
 const String& MockContentFilterSettings::unblockRequestURL() const
 {
-    static NeverDestroyed<String> unblockRequestURL = makeString(ContentFilter::urlScheme(), "://", unblockURLHost());
+    static NeverDestroyed<String> unblockRequestURL = makeString(ContentFilter::urlScheme(), "://"_s, unblockURLHost());
     return unblockRequestURL;
 }
 

--- a/Source/WebCore/testing/MockPageOverlayClient.cpp
+++ b/Source/WebCore/testing/MockPageOverlayClient.cpp
@@ -107,7 +107,7 @@ bool MockPageOverlayClient::mouseEvent(PageOverlay& overlay, const PlatformMouse
 {
     if (auto* localMainFrame = dynamicDowncast<LocalFrame>(overlay.page()->mainFrame())) {
         localMainFrame->document()->addConsoleMessage(MessageSource::Other, MessageLevel::Debug,
-            makeString("MockPageOverlayClient::mouseEvent location (", event.position().x(), ", ", event.position().y(), ')'));
+            makeString("MockPageOverlayClient::mouseEvent location ("_s, event.position().x(), ", "_s, event.position().y(), ')'));
     }
     return false;
 }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -193,7 +193,7 @@ std::unique_ptr<ResourceRequest> WorkerScriptLoader::createResourceRequest(const
 
 static ResourceError constructJavaScriptMIMETypeError(const ResourceResponse& response)
 {
-    auto message = makeString("Refused to execute ", response.url().stringCenterEllipsizedToLength(), " as script because ", response.mimeType(), " is not a script MIME type.");
+    auto message = makeString("Refused to execute "_s, response.url().stringCenterEllipsizedToLength(), " as script because "_s, response.mimeType(), " is not a script MIME type."_s);
     return { errorDomainWebKitInternal, 0, response.url(), WTFMove(message), ResourceError::Type::AccessControl };
 }
 
@@ -203,7 +203,7 @@ ResourceError WorkerScriptLoader::validateWorkerResponse(const ResourceResponse&
         return { errorDomainWebKitInternal, 0, response.url(), "Response is not 2xx"_s, ResourceError::Type::General };
 
     if (!isScriptAllowedByNosniff(response)) {
-        auto message = makeString("Refused to execute ", response.url().stringCenterEllipsizedToLength(), " as script because \"X-Content-Type-Options: nosniff\" was given and its Content-Type is not a script MIME type.");
+        auto message = makeString("Refused to execute "_s, response.url().stringCenterEllipsizedToLength(), " as script because \"X-Content-Type-Options: nosniff\" was given and its Content-Type is not a script MIME type."_s);
         return { errorDomainWebKitInternal, 0, response.url(), WTFMove(message), ResourceError::Type::General };
     }
 

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -77,7 +77,7 @@ FetchEvent::~FetchEvent()
 
 ResourceError FetchEvent::createResponseError(const URL& url, const String& errorMessage, ResourceError::IsSanitized isSanitized)
 {
-    return ResourceError { errorDomainWebKitServiceWorker, 0, url, makeString("FetchEvent.respondWith received an error: ", errorMessage), ResourceError::Type::General, isSanitized };
+    return ResourceError { errorDomainWebKitServiceWorker, 0, url, makeString("FetchEvent.respondWith received an error: "_s, errorMessage), ResourceError::Type::General, isSanitized };
 
 }
 

--- a/Source/WebCore/workers/service/SWClientConnection.cpp
+++ b/Source/WebCore/workers/service/SWClientConnection.cpp
@@ -124,7 +124,7 @@ void SWClientConnection::startScriptFetchForServer(ServiceWorkerJobIdentifier jo
         job.startScriptFetch(cachePolicy);
     });
     if (!isPosted)
-        finishFetchingScriptInServer({ serverConnectionIdentifier(), jobIdentifier }, WTFMove(registrationKey), workerFetchError(ResourceError { errorDomainWebKitInternal, 0, { }, makeString("Failed to fetch script for service worker with scope ", registrationKey.scope().string()) }));
+        finishFetchingScriptInServer({ serverConnectionIdentifier(), jobIdentifier }, WTFMove(registrationKey), workerFetchError(ResourceError { errorDomainWebKitInternal, 0, { }, makeString("Failed to fetch script for service worker with scope "_s, registrationKey.scope().string()) }));
 }
 
 static void postMessageToContainer(ScriptExecutionContext& context, MessageWithMessagePorts&& message, ServiceWorkerData&& sourceData, String&& sourceOrigin)

--- a/Source/WebCore/workers/service/ServiceWorkerClients.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClients.cpp
@@ -101,7 +101,7 @@ void ServiceWorkerClients::openWindow(ScriptExecutionContext& context, const Str
 
     auto url = context.completeURL(urlString);
     if (!url.isValid()) {
-        promise->reject(Exception { ExceptionCode::TypeError, makeString("URL string ", urlString, " cannot successfully be parsed"_s) });
+        promise->reject(Exception { ExceptionCode::TypeError, makeString("URL string "_s, urlString, " cannot successfully be parsed"_s) });
         return;
     }
 

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -182,7 +182,7 @@ void ServiceWorkerJob::notifyFinished()
     auto& error = scriptLoader->error();
     ASSERT(!error.isNull());
 
-    m_client.jobFailedLoadingScript(*this, error, Exception { error.isAccessControl() ? ExceptionCode::SecurityError : ExceptionCode::TypeError, makeString("Script ", scriptLoader->url().string(), " load failed") });
+    m_client.jobFailedLoadingScript(*this, error, Exception { error.isAccessControl() ? ExceptionCode::SecurityError : ExceptionCode::TypeError, makeString("Script "_s, scriptLoader->url().string(), " load failed"_s) });
 }
 
 bool ServiceWorkerJob::cancelPendingLoad()

--- a/Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h
@@ -37,7 +37,7 @@ struct ServiceWorkerJobDataIdentifier {
 
     String loggingString() const
     {
-        return connectionIdentifier.loggingString() + "-" + jobIdentifier.loggingString();
+        return makeString(connectionIdentifier.loggingString(), '-', jobIdentifier.loggingString());
     }
 };
 

--- a/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
@@ -74,12 +74,12 @@ void ServiceWorkerWindowClient::navigate(ScriptExecutionContext& context, const 
     auto url = context.completeURL(urlString);
 
     if (!url.isValid()) {
-        promise->reject(Exception { ExceptionCode::TypeError, makeString("URL string ", urlString, " cannot successfully be parsed") });
+        promise->reject(Exception { ExceptionCode::TypeError, makeString("URL string "_s, urlString, " cannot successfully be parsed"_s) });
         return;
     }
 
     if (url.protocolIsAbout()) {
-        promise->reject(Exception { ExceptionCode::TypeError, makeString("ServiceWorkerClients.navigate() cannot be called with URL ", url.string()) });
+        promise->reject(Exception { ExceptionCode::TypeError, makeString("ServiceWorkerClients.navigate() cannot be called with URL "_s, url.string()) });
         return;
     }
 

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -69,7 +69,7 @@ static String databaseFilePath(const String& directory)
     if (directory.isEmpty())
         return emptyString();
 
-    return FileSystem::pathByAppendingComponent(directory, makeString("ServiceWorkerRegistrations-", SWRegistrationDatabase::schemaVersion, ".sqlite3"));
+    return FileSystem::pathByAppendingComponent(directory, makeString("ServiceWorkerRegistrations-"_s, SWRegistrationDatabase::schemaVersion, ".sqlite3"_s));
 }
 
 static String scriptDirectoryPath(const String& directory)

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -83,7 +83,7 @@ void SWServerJobQueue::scriptFetchFinished(const ServiceWorkerJobDataIdentifier&
 
     if (!result.error.isNull()) {
         // Invoke Reject Job Promise with job and TypeError.
-        server->rejectJob(job, ExceptionData { ExceptionCode::TypeError, makeString("Script URL ", job.scriptURL.string(), " fetch resulted in error: ", result.error.localizedDescription()) });
+        server->rejectJob(job, ExceptionData { ExceptionCode::TypeError, makeString("Script URL "_s, job.scriptURL.string(), " fetch resulted in error: "_s, result.error.localizedDescription()) });
 
         // If newestWorker is null, invoke Clear Registration algorithm passing registration as its argument.
         if (!newestWorker)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -416,7 +416,7 @@ std::optional<ExceptionOr<void>> XMLHttpRequest::prepareToSend()
     auto& context = *scriptExecutionContext();
 
     if (RefPtr contextDocument = dynamicDowncast<Document>(context); contextDocument && contextDocument->shouldIgnoreSyncXHRs()) {
-        logConsoleError(&context, makeString("Ignoring XMLHttpRequest.send() call for '", m_url.url().string(), "' because the maximum number of synchronous failures was reached."));
+        logConsoleError(&context, makeString("Ignoring XMLHttpRequest.send() call for '"_s, m_url.url().string(), "' because the maximum number of synchronous failures was reached."_s));
         return ExceptionOr<void> { };
     }
 
@@ -557,7 +557,7 @@ ExceptionOr<void> XMLHttpRequest::send(DOMFormData& body)
     if (m_method != "GET"_s && m_method != "HEAD"_s) {
         m_requestEntityBody = FormData::createMultiPart(body);
         if (!m_requestHeaders.contains(HTTPHeaderName::ContentType))
-            m_requestHeaders.set(HTTPHeaderName::ContentType, makeString("multipart/form-data; boundary=", m_requestEntityBody->boundary()));
+            m_requestHeaders.set(HTTPHeaderName::ContentType, makeString("multipart/form-data; boundary="_s, m_requestEntityBody->boundary()));
     }
 
     return createRequest();

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -498,12 +498,12 @@ static void* openFunc(const char* uri)
 
             if (response.url().isEmpty()) {
                 if (Page* page = document ? document->page() : nullptr)
-                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse external entity resource at '", url.stringCenterEllipsizedToLength(), "' because cross-origin loads are not allowed."));
+                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse external entity resource at '"_s, url.stringCenterEllipsizedToLength(), "' because cross-origin loads are not allowed."_s));
                 return &globalDescriptor;
             }
             if (!externalEntityMimeTypeAllowed(response)) {
                 if (Page* page = document ? document->page() : nullptr)
-                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse external entity resource at '", url.stringCenterEllipsizedToLength(), "' because only XML MIME types are allowed."));
+                    page->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse external entity resource at '"_s, url.stringCenterEllipsizedToLength(), "' because only XML MIME types are allowed."_s));
                 return &globalDescriptor;
             }
         }

--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -1674,7 +1674,7 @@ void Session::getElementProperty(const String& elementID, const String& property
         parameters->setString("browsingContextHandle"_s, m_toplevelBrowsingContext.value());
         if (m_currentBrowsingContext)
             parameters->setString("frameHandle"_s, m_currentBrowsingContext.value());
-        parameters->setString("function"_s, makeString("function(element) { return element.", property, "; }"));
+        parameters->setString("function"_s, makeString("function(element) { return element."_s, property, "; }"_s));
         parameters->setArray("arguments"_s, WTFMove(arguments));
         m_host->sendCommandToBackend("evaluateJavaScriptFunction"_s, WTFMove(parameters), [protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) {
             if (response.isError || !response.responseObject) {
@@ -1718,7 +1718,7 @@ void Session::getElementCSSValue(const String& elementID, const String& cssPrope
         parameters->setString("browsingContextHandle"_s, m_toplevelBrowsingContext.value());
         if (m_currentBrowsingContext)
             parameters->setString("frameHandle"_s, m_currentBrowsingContext.value());
-        parameters->setString("function"_s, makeString("function(element) { return document.defaultView.getComputedStyle(element).getPropertyValue('", cssProperty, "'); }"));
+        parameters->setString("function"_s, makeString("function(element) { return document.defaultView.getComputedStyle(element).getPropertyValue('"_s, cssProperty, "'); }"_s));
         parameters->setArray("arguments"_s, WTFMove(arguments));
         m_host->sendCommandToBackend("evaluateJavaScriptFunction"_s, WTFMove(parameters), [protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) {
             if (response.isError || !response.responseObject) {

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -420,7 +420,7 @@ static std::optional<Proxy> deserializeProxy(JSON::Object& proxyObject)
             if (!ftpProxy)
                 return std::nullopt;
 
-            proxy.ftpURL = URL({ }, makeString("ftp://", ftpProxy));
+            proxy.ftpURL = URL({ }, makeString("ftp://"_s, ftpProxy));
             if (!proxy.ftpURL->isValid())
                 return std::nullopt;
         }
@@ -429,7 +429,7 @@ static std::optional<Proxy> deserializeProxy(JSON::Object& proxyObject)
             if (!httpProxy)
                 return std::nullopt;
 
-            proxy.httpURL = URL({ }, makeString("http://", httpProxy));
+            proxy.httpURL = URL({ }, makeString("http://"_s, httpProxy));
             if (!proxy.httpURL->isValid())
                 return std::nullopt;
         }
@@ -438,7 +438,7 @@ static std::optional<Proxy> deserializeProxy(JSON::Object& proxyObject)
             if (!sslProxy)
                 return std::nullopt;
 
-            proxy.httpsURL = URL({ }, makeString("https://", sslProxy));
+            proxy.httpsURL = URL({ }, makeString("https://"_s, sslProxy));
             if (!proxy.httpsURL->isValid())
                 return std::nullopt;
         }
@@ -447,7 +447,7 @@ static std::optional<Proxy> deserializeProxy(JSON::Object& proxyObject)
             if (!socksProxy)
                 return std::nullopt;
 
-            proxy.socksURL = URL({ }, makeString("socks://", socksProxy));
+            proxy.socksURL = URL({ }, makeString("socks://"_s, socksProxy));
             if (!proxy.socksURL->isValid())
                 return std::nullopt;
 
@@ -766,7 +766,7 @@ Vector<Capabilities> WebDriverService::processCapabilities(const JSON::Object& p
         for (auto it = firstMatchCapabilities->begin(); it != firstMatchEnd; ++it) {
             if (requiredCapabilities->find(it->key) != requiredEnd) {
                 completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument,
-                    makeString("Invalid firstMatch capabilities: key ", it->key, " is present in alwaysMatch")));
+                    makeString("Invalid firstMatch capabilities: key "_s, it->key, " is present in alwaysMatch"_s)));
                 return { };
             }
         }
@@ -829,7 +829,7 @@ void WebDriverService::connectToBrowser(Vector<Capabilities>&& capabilitiesList,
     sessionHostPtr->setHostAddress(m_targetAddress, m_targetPort);
     sessionHostPtr->connectToBrowser([this, capabilitiesList = WTFMove(capabilitiesList), sessionHost = WTFMove(sessionHost), completionHandler = WTFMove(completionHandler)](std::optional<String> error) mutable {
         if (error) {
-            completionHandler(CommandResult::fail(CommandResult::ErrorCode::SessionNotCreated, makeString("Failed to connect to browser: ", error.value())));
+            completionHandler(CommandResult::fail(CommandResult::ErrorCode::SessionNotCreated, makeString("Failed to connect to browser: "_s, error.value())));
             return;
         }
 

--- a/Source/WebDriver/socket/SessionHostSocket.cpp
+++ b/Source/WebDriver/socket/SessionHostSocket.cpp
@@ -68,7 +68,7 @@ void SessionHost::connectToBrowser(Function<void (std::optional<String> error)>&
     }
 
     if (targetIp.isEmpty() || !targetPort) {
-        completionHandler(makeString("Target IP/port is invalid, or not specified."));
+        completionHandler(makeString("Target IP/port is invalid, or not specified."_s));
         return;
     }
 


### PR DESCRIPTION
#### a22beaff5d98c62e68b5f4ffd43b3fe3d9a1d914
<pre>
Reduce use of `const char*` in string concatenations
<a href="https://bugs.webkit.org/show_bug.cgi?id=274063">https://bugs.webkit.org/show_bug.cgi?id=274063</a>

Reviewed by Tim Nguyen.

* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionLogger::logAlways const):
* Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp:
(WebCore::convertAndValidate):
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::convertAndValidateTotal):
(WebCore::convertAndValidate):
* Source/WebCore/Modules/applepay/PaymentRequestValidator.mm:
(WebCore::validateCountryCode):
(WebCore::validateCurrencyCode):
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::validate):
* Source/WebCore/Modules/cache/DOMCacheEngine.cpp:
(WebCore::DOMCacheEngine::convertToExceptionAndLog):
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::logConsolePersistencyError):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp:
(WebCore::MediaKeySystemController::logRequestMediaKeySystemDenial):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::extract):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::canWriteHeader):
(WebCore::appendSetCookie):
(WebCore::FetchHeaders::remove):
(WebCore::FetchHeaders::get const):
(WebCore::FetchHeaders::has const):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::setBody):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::redirect):
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::setName):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::loggingString const):
* Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp:
(WebCore::loggingString):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::setName):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::v1RecordsTableSchema):
(WebCore::IDBServer::v2RecordsTableSchema):
(WebCore::IDBServer::v1IndexRecordsTableSchema):
(WebCore::IDBServer::v2IndexRecordsTableSchema):
(WebCore::IDBServer::createV1ObjectStoreInfoSchema):
(WebCore::IDBServer::createV2ObjectStoreInfoSchema):
(WebCore::IDBServer::createOrMigrateRecordsTableIfNecessary):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidBlobTables):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidRecordsTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsRecordIndex):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::buildPreIndexStatement):
(WebCore::IDBServer::buildIndexStatement):
(WebCore::IDBServer::buildObjectStoreStatement):
* Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.cpp:
(WebCore::IDBCursorInfo::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.cpp:
(WebCore::IDBGetAllRecordsData::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.cpp:
(WebCore::IDBGetRecordData::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBIndexInfo.cpp:
(WebCore::IDBIndexInfo::loggingString const):
(WebCore::IDBIndexInfo::condensedLoggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBIterateCursorData.cpp:
(WebCore::IDBIterateCursorData::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp:
(WebCore::IDBObjectStoreInfo::condensedLoggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp:
(WebCore::IDBResourceIdentifier::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp:
(WebCore::IDBTransactionInfo::loggingString const):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp:
(WebCore::MediaSessionCoordinator::join):
(WebCore::MediaSessionCoordinator::leave):
(WebCore::MediaSessionCoordinator::seekTo):
(WebCore::MediaSessionCoordinator::play):
(WebCore::MediaSessionCoordinator::pause):
(WebCore::MediaSessionCoordinator::setTrack):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::failedToCreateRenderer):
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::createMessageQueue):
* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::logGetUserMediaDenial):
(WebCore::UserMediaController::logGetDisplayMediaDenial):
(WebCore::UserMediaController::logEnumerateDevicesDenial):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::GStreamerDataChannelHandler):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::capsFromRtpCapabilities):
* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
(WebCore::NotificationJSONParser::parseNotificationOptions):
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::checkAndCanonicalizeAmount):
* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::openAndMigrateDatabaseImpl):
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::request):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::registerProcessor):
* Source/WebCore/Modules/webaudio/DelayNode.cpp:
(WebCore::DelayNode::create):
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::OfflineAudioContext):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::encode):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::encode):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webdatabase/ChangeVersionWrapper.cpp:
(WebCore::ChangeVersionWrapper::performPreflight):
(WebCore::ChangeVersionWrapper::performPostflight):
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::Database::getVersionFromDatabase):
(WebCore::Database::setVersionInDatabase):
* Source/WebCore/Modules/webdatabase/SQLError.h:
(WebCore::SQLError::create):
* Source/WebCore/Modules/webdatabase/SQLStatement.cpp:
(WebCore::SQLStatement::execute):
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
(WebCore::SQLTransaction::openTransactionAndPreflight):
(WebCore::SQLTransaction::postflightAndCommit):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::create):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::appendAcceptedExtension):
(WebCore::WebSocketExtensionDispatcher::processHeaderValue):
* Source/WebCore/Modules/websockets/WebSocketExtensionProcessor.h:
(WebCore::WebSocketExtensionProcessor::failureReason):
* Source/WebCore/Modules/websockets/WebSocketFrame.cpp:
(WebCore::WebSocketFrame::parseFrame):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::resourceName):
(WebCore::WebSocketHandshake::clientLocation const):
(WebCore::WebSocketHandshake::clientHandshakeMessage const):
(WebCore::WebSocketHandshake::readServerHandshake):
(WebCore::WebSocketHandshake::readStatusLine):
(WebCore::WebSocketHandshake::readHTTPHeaders):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Bridge::connect):
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::value):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::AXLogger::log):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::handleRoleChanged):
(WebCore::AXObjectCache::deferAttributeChangeIfNeeded):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::addRelation):
(WebCore::AXObjectCache::removeAllRelations):
(WebCore::AXObjectCache::removeRelation):
(WebCore::AXObjectCache::removeRelationByID):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::CharacterOffset::debugDescription):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::debugDescription const):
(WebCore::AXTextMarkerRange::debugDescription const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::dbg const):
(WebCore::AccessibilityObject::insertText):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::valueDescription const):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
(WebCore::AccessibilityAtspi::registerRoot):
(WebCore::AccessibilityAtspi::registerObject):
(WebCore::AccessibilityAtspi::registerHyperlink):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::insertText):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::setFocusedNodeID):
(WebCore::AXIsolatedTree::updateLoadingProgress):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeSubtreeFromNodeMap):
(WebCore::AXIsolatedTree::applyPendingChanges):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(-[WebAccessibilityObjectWrapper accessibilityPerformShowMenuAction]):
(-[WebAccessibilityObjectWrapper _accessibilityShowContextMenu]):
(-[WebAccessibilityObjectWrapper _accessibilitySetValue:forAttribute:]):
(formatForDebugger):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
(-[WebAccessibilityObjectWrapper accessibilityArrayAttributeCount:]):
(-[WebAccessibilityObjectWrapper accessibilityArrayAttributeValues:index:maxCount:]):
* Source/WebCore/bindings/js/JSCallbackData.cpp:
(WebCore::JSCallbackData::invokeCallback):
* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::remoteFrameAccessError):
* Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp:
(WebCore::rangeErrorString):
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::throwAttributeTypeError):
(WebCore::throwRequiredMemberTypeError):
(WebCore::throwConstructorScriptExecutionContextUnavailableError):
(WebCore::makeThisTypeErrorMessage):
(WebCore::makeUnsupportedIndexedSetterErrorMessage):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/css/CSSCanvasValue.cpp:
(WebCore::CSSCanvasValue::customCSSText const):
* Source/WebCore/css/CSSFilterImageValue.cpp:
(WebCore::CSSFilterImageValue::customCSSText const):
* Source/WebCore/css/CSSFontFaceRule.cpp:
(WebCore::CSSFontFaceRule::cssTextInternal const):
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcLocalValue::customCSSText const):
* Source/WebCore/css/CSSFontStyleWithAngleValue.cpp:
(WebCore::CSSFontStyleWithAngleValue::customCSSText const):
* Source/WebCore/css/CSSNamedImageValue.cpp:
(WebCore::CSSNamedImageValue::customCSSText const):
* Source/WebCore/css/CSSPageRule.cpp:
(WebCore::CSSPageRule::selectorText const):
* Source/WebCore/css/CSSPaintImageValue.cpp:
(WebCore::CSSPaintImageValue::customCSSText const):
* Source/WebCore/css/CSSTimingFunctionValue.cpp:
(WebCore::CSSCubicBezierTimingFunctionValue::customCSSText const):
(WebCore::CSSSpringTimingFunctionValue::customCSSText const):
* Source/WebCore/css/CSSUnicodeRangeValue.cpp:
(WebCore::CSSUnicodeRangeValue::customCSSText const):
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(WebCore::DOMMatrixReadOnly::toString const):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeGrid const):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parseAuthorStyleSheet):
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::setItem):
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
(WebCore::MainThreadStylePropertyMapReadOnly::get const):
(WebCore::MainThreadStylePropertyMapReadOnly::getAll const):
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):
(WebCore::StylePropertyMap::append):
(WebCore::StylePropertyMap::remove):
* Source/WebCore/css/typedom/numeric/CSSNumericType.cpp:
(WebCore::CSSNumericType::debugString const):
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::setItem):
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::DeviceMotionEvent::requestPermission):
* Source/WebCore/dom/DeviceOrientationEvent.cpp:
(WebCore::DeviceOrientationEvent::requestPermission):
* Source/WebCore/dom/Document.cpp:
(WebCore::printNavigationErrorMessage):
(WebCore::Document::createElementForBindings):
(WebCore::Document::createProcessingInstruction):
(WebCore::Document::processMetaHttpEquiv):
(WebCore::Document::parseQualifiedName):
(WebCore::Document::createAttribute):
(WebCore::Document::initSecurityContext):
(WebCore::Document::applyQuickLookSandbox):
* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::description const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::toggleAttribute):
(WebCore::Element::setAttribute):
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::notifyFinished):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::debugDescription const):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::debugDescription const):
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeCompliantString):
(WebCore::requireTrustedTypesForPreNavigationCheckPasses):
* Source/WebCore/dom/messageports/MessagePortChannel.h:
(WebCore::MessagePortChannel::logString const):
* Source/WebCore/editing/HTMLInterchange.cpp:
(WebCore::convertHTMLTextToInterchangeFormat):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePositionRange::debugDescription const):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::debugDescription const):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processElement):
* Source/WebCore/editing/markup.cpp:
(WebCore::serializePreservingVisualAppearanceInternal):
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::convertToDataURL):
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::logString const):
* Source/WebCore/html/BaseTextInputType.cpp:
(WebCore::BaseTextInputType::patternMismatch const):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::allocateImageBuffer const):
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::create):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::processFileDateString):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::firstElementPathForInputValue const):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurement const):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::setCSSStyleSheet):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::ensureIsolatedWorld):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::setItem):
(WebCore::HTMLSelectElement::setLength):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::imageUpdated):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::isPermissionsPolicyAllowedByDocumentAndAllOwners):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::reportNonFocusableControlError):
* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::CanvasPath::roundRect):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getImageData const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::synthesizeGLError):
(WebCore::WebGLRenderingContextBase::synthesizeLostContextGLError):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::invalidNodeException):
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::setLanguage):
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp:
(WebCore::InspectorFrontendAPIDispatcher::dispatchMessageAsync):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::bindAnimation):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::forcePseudoState):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::computeContentSecurityPolicySHA256Hash):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::interceptRequestWithError):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::setInstruments):
(WebCore::InspectorTimelineAgent::startFromConsole):
* Source/WebCore/inspector/agents/WebConsoleAgent.cpp:
(WebCore::WebConsoleAgent::didReceiveResponse):
(WebCore::WebConsoleAgent::didFailLoading):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::validateCrossOriginRedirectionURL):
(WebCore::passesAccessControlCheck):
(WebCore::validatePreflightResponse):
(WebCore::validateCrossOriginResourcePolicy):
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
(WebCore::CrossOriginEmbedderPolicy::addPolicyHeadersTo const):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebCore/loader/CrossOriginPreflightResultCache.cpp:
(WebCore::CrossOriginPreflightResultCacheItem::create):
(WebCore::CrossOriginPreflightResultCacheItem::validateMethodAndHeaders const):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::disallowDataRequest const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::reportBlockedLoadFailed):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::notifyFinished):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::checkFormForMixedContent):
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::makeValidURL):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::didBlockAuthenticationChallenge):
(WebCore::ResourceLoader::didReceiveResponse):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::loadResourceSynchronously):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::didFailLoadingEntry):
(WebCore::ApplicationCacheGroup::didFailLoadingManifest):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::verifySchemaVersion):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::printAccessDeniedMessage const):
* Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm:
(WebCore::PrivateClickMeasurement::calculateAndUpdateUnlinkableToken):
(WebCore::PrivateClickMeasurement::calculateAndUpdateSecretToken):
* Source/WebCore/page/ClientOrigin.h:
(WebCore::ClientOrigin::loggingString const):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::responseIsValid const):
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::startListeningForDeviceOrientationIfNecessary):
(WebCore::LocalDOMWindow::startListeningForDeviceMotionIfNecessary):
(WebCore::LocalDOMWindow::crossDomainAccessErrorMessage):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::debugDescription const):
* Source/WebCore/page/LoggedInStatus.cpp:
(WebCore::LoggedInStatus::create):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::logMemoryStatistics):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::urlForBlankFrame):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::convertMarkToTimestamp const):
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::pageProperty):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::requestStorageAccessAndHandleClick const):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::ResourceUsageOverlay::platformDraw):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportUnsupportedDirective const):
(WebCore::ContentSecurityPolicy::reportDuplicateDirective const):
(WebCore::ContentSecurityPolicy::reportInvalidPluginTypes const):
(WebCore::ContentSecurityPolicy::reportInvalidTrustedTypesPolicy const):
(WebCore::ContentSecurityPolicy::reportInvalidTrustedTypesSinkGroup const):
(WebCore::ContentSecurityPolicy::reportInvalidDirectiveValueCharacter const):
(WebCore::ContentSecurityPolicy::reportInvalidSourceExpression const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::create):
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::threadCPUUsage):
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::debugDescription const):
* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::TimingFunction::createFromCSSText):
(WebCore::TimingFunction::cssText const):
* Source/WebCore/platform/audio/HRTFElevation.cpp:
(WebCore::HRTFElevation::calculateKernelsForAzimuthElevation):
* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::MediaSessionGLib::ensureMprisSessionRegistered):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::create):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::decodeAudioForBusCreation):
* Source/WebCore/platform/cocoa/KeyEventCocoa.mm:
(WebCore::keyIdentifierForCharCode):
* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp:
(WebCore::KeyHandle::idAsString const):
* Source/WebCore/platform/graphics/ColorSerialization.cpp:
(WebCore::serializationUsingColorFunction):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::animationNameForTransition):
* Source/WebCore/platform/graphics/HEVCUtilities.cpp:
(WebCore::createAVCCodecParametersString):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::toDataURL):
* Source/WebCore/platform/graphics/MediaResourceSniffer.cpp:
(WebCore::MediaResourceSniffer::create):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WTF::LogArgument&lt;WebCore::SourceBufferEvictionData&gt;::toString):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::isContentTypeSupported):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::startLoading):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::debugName const):
(WebCore::GraphicsLayerCA::setContentsToSolidColor):
(WebCore::GraphicsLayerCA::setContentsToModel):
(WebCore::GraphicsLayerCA::recursiveCommitChanges):
(WebCore::GraphicsLayerCA::updateContentsImage):
(WebCore::GraphicsLayerCA::updateContentsRects):
(WebCore::GraphicsLayerCA::findOrMakeClone):
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::createTileLayer):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::presentationModifiers):
(WebCore::PlatformCAFilters::setFiltersOnLayer):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encodeToDataURL):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ImageDecoderGStreamer::ImageDecoderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::load):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::AppendPipeline):
(WebCore::AppendPipeline::resetParserState):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::load):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(dumpPipeline):
(webKitMediaSrcEmitStreams):
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper):
* Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp:
(WebCore::PlatformKeyboardEvent::keyIdentifierForGdkKeyCode):
* Source/WebCore/platform/ios/UserAgentIOS.mm:
(WebCore::standardUserAgentWithApplicationName):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::decode):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::create):
(WebCore::LibWebRTCVPXInternalVideoEncoder::encode):
* Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp:
(WebCore::PlatformKeyboardEvent::keyIdentifierForWPEKeyCode):
* Source/WebCore/platform/mac/UserAgentMac.mm:
(WebCore::standardUserAgentWithApplicationName):
* Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm:
(WebCore::CGDisplayStreamScreenCaptureSource::screenCaptureDevices):
(WebCore::CGDisplayStreamScreenCaptureSource::screenCaptureDeviceForMainDisplay):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::sessionFilterDidChange):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::completeDeviceSelection):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::drawText):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::createDataSegment):
* Source/WebCore/platform/network/CredentialBase.cpp:
(WebCore::CredentialBase::serializationForBasicAuthorizationHeader const):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPHeader):
* Source/WebCore/platform/network/ParsedContentRange.cpp:
(WebCore::ParsedContentRange::headerValue const):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::sanitizeSuggestedFilename):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::synthesizedResponseForRange):
* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
(WebCore::CookieJarDB::verifySchemaVersion):
(WebCore::CookieJarDB::hasCookies):
(WebCore::CookieJarDB::searchCookies):
* Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp:
(WebCore::extractBoundary):
* Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp:
(WebCore::protectionSpaceFromSoupAuthAndURL):
* Source/WebCore/platform/playstation/UserAgentPlayStation.cpp:
(WebCore::standardUserAgentStatic):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::unauthorizedSQLFunction):
(WebCore::SQLiteDatabase::setMaximumSize):
(WebCore::SQLiteDatabase::setSynchronous):
(WebCore::SQLiteDatabase::clearAllTables):
* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:
(WebCore::createSharedMemory):
* Source/WebCore/platform/win/KeyEventWin.cpp:
(WebCore::keyIdentifierForWindowsKeyCode):
* Source/WebCore/platform/win/SearchPopupMenuDB.cpp:
(WebCore::SearchPopupMenuDB::verifySchemaVersion):
* Source/WebCore/platform/win/UserAgentWin.cpp:
(WebCore::standardUserAgent):
* Source/WebCore/platform/xr/openxr/OpenXRUtils.h:
(PlatformXR::resultToString):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::debugDescription const):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType):
* Source/WebCore/svg/SVGFitToViewBox.cpp:
(WebCore::SVGFitToViewBox::parseViewBoxGeneric):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::address):
(WebCore::Internals::configurationForViewport):
(WebCore::Internals::createTemporaryFile):
(WebCore::Internals::queueMicroTask):
* Source/WebCore/testing/MockContentFilterSettings.cpp:
(WebCore::MockContentFilterSettings::unblockRequestURL const):
* Source/WebCore/testing/MockPageOverlayClient.cpp:
(WebCore::MockPageOverlayClient::mouseEvent):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::constructJavaScriptMIMETypeError):
(WebCore::WorkerScriptLoader::validateWorkerResponse):
* Source/WebCore/workers/service/FetchEvent.cpp:
(WebCore::FetchEvent::createResponseError):
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::SWClientConnection::startScriptFetchForServer):
* Source/WebCore/workers/service/ServiceWorkerClients.cpp:
(WebCore::ServiceWorkerClients::openWindow):
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
(WebCore::ServiceWorkerJob::notifyFinished):
* Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h:
(WebCore::ServiceWorkerJobDataIdentifier::loggingString const):
* Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp:
(WebCore::ServiceWorkerWindowClient::navigate):
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::databaseFilePath):
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptFetchFinished):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::prepareToSend):
(WebCore::XMLHttpRequest::send):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::openFunc):
* Source/WebDriver/Session.cpp:
(WebDriver::Session::getElementProperty):
(WebDriver::Session::getElementCSSValue):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::deserializeProxy):
(WebDriver::WebDriverService::processCapabilities const):
(WebDriver::WebDriverService::connectToBrowser):
* Source/WebDriver/socket/SessionHostSocket.cpp:
(WebDriver::SessionHost::connectToBrowser):

Canonical link: <a href="https://commits.webkit.org/278671@main">https://commits.webkit.org/278671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cd349d507122c85384a36d09475f0e8df3dc0b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41757 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22875 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1463 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44615 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49157 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48314 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28521 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/63090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7457 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27367 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/63090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->