### PR TITLE
Update FragmentedSharedBuffer::copyTo() to taken in a std::span

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -385,17 +385,16 @@ Vector<uint8_t> FragmentedSharedBuffer::read(size_t offset, size_t length) const
     return data;
 }
 
-void FragmentedSharedBuffer::copyTo(void* destination, size_t length) const
+void FragmentedSharedBuffer::copyTo(std::span<uint8_t> destination) const
 {
-    return copyTo(destination, 0, length);
+    return copyTo(destination, 0);
 }
 
-void FragmentedSharedBuffer::copyTo(void* destination, size_t offset, size_t length) const
+void FragmentedSharedBuffer::copyTo(std::span<uint8_t> destination, size_t offset) const
 {
-    ASSERT(length + offset <= size());
     if (offset >= size())
         return;
-    auto remaining = std::min(length, size() - offset);
+    auto remaining = std::min(destination.size(), size() - offset);
     if (!remaining)
         return;
 
@@ -407,7 +406,7 @@ void FragmentedSharedBuffer::copyTo(void* destination, size_t offset, size_t len
         segment = std::upper_bound(segment, end(), offset, comparator);
         segment--; // std::upper_bound gives a pointer to the segment that is greater than offset. We want the segment just before that.
     }
-    auto destinationPtr = static_cast<uint8_t*>(destination);
+    auto destinationPtr = destination.data();
 
     size_t positionInSegment = offset - segment->beginPosition;
     size_t amountToCopyThisTime = std::min(remaining, segment->segment->size() - positionInSegment);

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -203,8 +203,8 @@ public:
     bool isContiguous() const { return m_contiguous; }
 
     WEBCORE_EXPORT Ref<FragmentedSharedBuffer> copy() const;
-    WEBCORE_EXPORT void copyTo(void* destination, size_t length) const;
-    WEBCORE_EXPORT void copyTo(void* destination, size_t offset, size_t length) const;
+    WEBCORE_EXPORT void copyTo(std::span<uint8_t> destination) const;
+    WEBCORE_EXPORT void copyTo(std::span<uint8_t> destination, size_t offset) const;
 
     WEBCORE_EXPORT void forEachSegment(const Function<void(std::span<const uint8_t>)>&) const;
     WEBCORE_EXPORT bool startsWith(std::span<const uint8_t> prefix) const;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -80,7 +80,7 @@ public:
         enum class ReadError { EndOfFile, FatalError };
         using ReadResult = Expected<size_t, ReadError>;
 
-        ReadResult read(size_t position, size_t, uint8_t* destination) const;
+        ReadResult read(std::span<uint8_t> destination, size_t position = 0) const;
 
     private:
         std::variant<

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -281,7 +281,7 @@ public:
                 continue;
             }
 
-            auto readResult = currentSegment.read(m_positionWithinSegment, numToRead, outputBuffer);
+            auto readResult = currentSegment.read({ outputBuffer, numToRead }, m_positionWithinSegment);
             if (!readResult.has_value())
                 return segmentReadErrorToWebmStatus(readResult.error());
             auto lastRead = readResult.value();
@@ -360,7 +360,7 @@ public:
                 if (!buffer.tryReserveInitialCapacity(numToRead))
                     return Status(Status::kNotEnoughMemory);
                 buffer.grow(numToRead);
-                auto readResult = currentSegment.read(m_positionWithinSegment, numToRead, buffer.data());
+                auto readResult = currentSegment.read(buffer.mutableSpan(), m_positionWithinSegment);
                 if (!readResult.has_value())
                     return segmentReadErrorToWebmStatus(readResult.error());
                 buffer.shrink(readResult.value());


### PR DESCRIPTION
#### cf3a68471419260d95533438ec46208adef11ca8
<pre>
Update FragmentedSharedBuffer::copyTo() to taken in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=274067">https://bugs.webkit.org/show_bug.cgi?id=274067</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::copyTo const):
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp:
(WebCore::SourceBufferParser::Segment::read const):
(WebCore::SourceBufferParser::Segment::takeSharedBuffer):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:

Canonical link: <a href="https://commits.webkit.org/278720@main">https://commits.webkit.org/278720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df50e2c3a92e1956d0d5b08884b0ce9c5ba344e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22989 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1593 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1555 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44394 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7483 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->