### PR TITLE
Unreviewed, reverting 278128@main (eb01eca78d82)

### DIFF
--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -86,16 +86,6 @@ bool screenHasInvertedColors()
 
 double fontDPI()
 {
-#if !USE(GTK4)
-    // The code in this conditionally-compiled block is needed in order to
-    // respect the GDK_DPI_SCALE setting that was present in GTK3 as an
-    // additional font scaling factor.
-    if (auto* display = gdk_display_get_default()) {
-        if (auto* screen = gdk_display_get_default_screen(display))
-            return gdk_screen_get_resolution(screen);
-    }
-#endif
-
     static GtkSettings* gtkSettings = gtk_settings_get_default();
     if (gtkSettings) {
         int gtkXftDpi;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -35,7 +35,6 @@
 #include "DrawingAreaProxyCoordinatedGraphics.h"
 #include "DropTarget.h"
 #include "EditorState.h"
-#include "GtkSettingsManager.h"
 #include "InputMethodFilter.h"
 #include "KeyAutoRepeatHandler.h"
 #include "KeyBindingTranslator.h"
@@ -245,8 +244,6 @@ typedef HashMap<uint32_t, GRefPtr<GdkEvent>> TouchEventsMap;
 struct _WebKitWebViewBasePrivate {
     _WebKitWebViewBasePrivate()
         : updateActivityStateTimer(RunLoop::main(), this, &_WebKitWebViewBasePrivate::updateActivityStateTimerFired)
-        , pageScaleFactor(1.0)
-        , textScaleFactor(1.0)
 #if GTK_CHECK_VERSION(3, 24, 0)
         , releaseEmojiChooserTimer(RunLoop::main(), this, &_WebKitWebViewBasePrivate::releaseEmojiChooserTimerFired)
 #endif
@@ -342,8 +339,6 @@ struct _WebKitWebViewBasePrivate {
     RunLoop::Timer updateActivityStateTimer;
 
     PlatformDisplayID displayID;
-    double pageScaleFactor; // Corrects length of absolute units
-    double textScaleFactor; // Respects GTK font-specific scaling
 
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxy::FullscreenState fullScreenState;
@@ -429,45 +424,6 @@ webkitWebViewBaseAccessibleInterfaceInit(GtkAccessibleInterface* iface)
 }
 #endif
 
-static void refreshInternalScaling(WebKitWebViewBase* self)
-{
-    auto* page = webkitWebViewBaseGetPage(self);
-
-    // Gather the data needed to determine the ideal scale factors
-    auto displayID = self->priv->displayID;
-    if (!displayID)
-        displayID = primaryScreenDisplayID();
-    // Sadly, seems to be necessary always to collect the screen
-    // properties, in case the device rescaled since the last time.
-    ScreenManager::singleton().collectScreenProperties();
-    auto* data = WebCore::screenData(displayID);
-    double screenDPI = data ? data->dpi : 96.;
-    double fontDPI = WebCore::fontDPI();
-
-    // Compute the new ideal scale factors
-    // The following computation should cause a CSS unit of 1in appear
-    // as 1 actual physical inch on the current display:
-    double newPageScale = screenDPI / 96.;
-    // And the following computation should make a 96px font take up the
-    // specified number of device pixels on the screen:
-    double newTextScale = fontDPI / screenDPI;
-    // Note that if the font DPI does not equal the screen DPI, then a 1em
-    // length with respect to a 96px font will not actually measure 1in at
-    // default zoom, as specified by the CSS standard; but we presume it is
-    // better to respect the environment's specific font size request.
-
-    // Finally, adjust the page and text zooms as needed, and update
-    // the internal scale factors. Don't bother with changes under one percent.
-    if (std::abs(newPageScale / self->priv->pageScaleFactor - 1) > 0.01) {
-        page->setPageZoomFactor(page->pageZoomFactor() * newPageScale / self->priv->pageScaleFactor);
-        self->priv->pageScaleFactor = newPageScale;
-    }
-    if (std::abs(newTextScale / self->priv->textScaleFactor - 1) > 0.01) {
-        page->setTextZoomFactor(page->textZoomFactor() * newTextScale / self->priv->textScaleFactor);
-        self->priv->textScaleFactor = newTextScale;
-    }
-}
-
 static void webkitWebViewBaseUpdateDisplayID(WebKitWebViewBase* webViewBase, GdkMonitor* monitor)
 {
     if (!monitor)
@@ -478,7 +434,6 @@ static void webkitWebViewBaseUpdateDisplayID(WebKitWebViewBase* webViewBase, Gdk
         return;
 
     webViewBase->priv->displayID = displayID;
-    refreshInternalScaling(webViewBase);
     if (webViewBase->priv->pageProxy)
         webViewBase->priv->pageProxy->windowScreenDidChange(displayID);
 }
@@ -890,7 +845,6 @@ static void webkitWebViewBaseDispose(GObject* gobject)
         webkitWebViewAccessibleSetWebView(WEBKIT_WEB_VIEW_ACCESSIBLE(webView->priv->accessible.get()), nullptr);
 #endif
 
-    GtkSettingsManager::singleton().removeObserver(webView);
     webkitWebViewBaseSetToplevelOnScreenWindow(webView, nullptr);
 #if GTK_CHECK_VERSION(3, 24, 0)
     webkitWebViewBaseCompleteEmojiChooserRequest(webView, emptyString());
@@ -2601,27 +2555,9 @@ WebPageProxy* webkitWebViewBaseGetPage(WebKitWebViewBase* webkitWebViewBase)
     return webkitWebViewBase->priv->pageProxy.get();
 }
 
-WebKitWebViewBaseScaleFactors webkitWebViewBaseGetScaleFactors(WebKitWebViewBase* webkitWebViewBase)
-{
-    auto* priv = webkitWebViewBase->priv;
-    return WebKitWebViewBaseScaleFactors { priv->pageScaleFactor, priv->textScaleFactor };
-}
-
 static void deviceScaleFactorChanged(WebKitWebViewBase* webkitWebViewBase)
 {
-    auto page = webkitWebViewBase->priv->pageProxy;
-    auto initialScaleFactor = page->deviceScaleFactor();
     webkitWebViewBase->priv->pageProxy->setIntrinsicDeviceScaleFactor(gtk_widget_get_scale_factor(GTK_WIDGET(webkitWebViewBase)));
-    auto scaleRatio = initialScaleFactor / page->deviceScaleFactor();
-    // Re-collecting the screenDPIs and refreshing the scaling was not working
-    // reliably. Maybe there is some kind of race condition with whatever
-    // updates the screen DPI. So instead, update the scaling directly.
-    if (std::abs(scaleRatio - 1) > 0.01) {
-        page->setPageZoomFactor(page->pageZoomFactor() * scaleRatio);
-        webkitWebViewBase->priv->pageScaleFactor *= scaleRatio;
-        page->setTextZoomFactor(page->textZoomFactor() / scaleRatio);
-        webkitWebViewBase->priv->textScaleFactor /= scaleRatio;
-    }
 }
 
 void webkitWebViewBaseCreateWebPage(WebKitWebViewBase* webkitWebViewBase, Ref<API::PageConfiguration>&& configuration)
@@ -2637,15 +2573,8 @@ void webkitWebViewBaseCreateWebPage(WebKitWebViewBase* webkitWebViewBase, Ref<AP
     if (priv->displayID)
         priv->pageProxy->windowScreenDidChange(priv->displayID);
 
-    refreshInternalScaling(webkitWebViewBase);
     // We attach this here, because changes in scale factor are passed directly to the page proxy.
     g_signal_connect(webkitWebViewBase, "notify::scale-factor", G_CALLBACK(deviceScaleFactorChanged), nullptr);
-    // Also watch for changes to xft-dpi
-    GtkSettingsManager::singleton().addObserver([webkitWebViewBase](const GtkSettingsState& state) {
-        if (!state.xftDPI)
-            return;
-        refreshInternalScaling(webkitWebViewBase);
-    }, webkitWebViewBase);
 }
 
 void webkitWebViewBaseSetTooltipText(WebKitWebViewBase* webViewBase, const char* tooltip)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -48,10 +48,6 @@
 
 WebKitWebViewBase* webkitWebViewBaseCreate(const API::PageConfiguration&);
 WebKit::WebPageProxy* webkitWebViewBaseGetPage(WebKitWebViewBase*);
-struct WebKitWebViewBaseScaleFactors {
-    double pageScale, textScale;
-};
-WebKitWebViewBaseScaleFactors webkitWebViewBaseGetScaleFactors(WebKitWebViewBase*);
 void webkitWebViewBaseCreateWebPage(WebKitWebViewBase*, Ref<API::PageConfiguration>&&);
 void webkitWebViewBaseSetTooltipText(WebKitWebViewBase*, const char*);
 void webkitWebViewBaseSetTooltipArea(WebKitWebViewBase*, const WebCore::IntRect&);


### PR DESCRIPTION
#### 37dcbc0d5c4afe2e8cad7d15e9d966464e796ec3
<pre>
Unreviewed, reverting 278128@main (eb01eca78d82)
<a href="https://bugs.webkit.org/show_bug.cgi?id=274075">https://bugs.webkit.org/show_bug.cgi?id=274075</a>

Broke font rendering in some cases.

Reverted changeset:

&quot;[GTK] Correct scaling for DPI.&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=247980">https://bugs.webkit.org/show_bug.cgi?id=247980</a>
<a href="https://commits.webkit.org/278128@main">https://commits.webkit.org/278128@main</a>

* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::fontDPI):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
(webkitWebViewDispose):
(webkit_web_view_set_zoom_level):
(webkit_web_view_get_zoom_level):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(_WebKitWebViewBasePrivate::_WebKitWebViewBasePrivate):
(webkitWebViewBaseUpdateDisplayID):
(webkitWebViewBaseDispose):
(deviceScaleFactorChanged):
(webkitWebViewBaseCreateWebPage):
(refreshInternalScaling): Deleted.
(webkitWebViewBaseGetScaleFactors): Deleted.
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:

Canonical link: <a href="https://commits.webkit.org/278678@main">https://commits.webkit.org/278678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7371f904cbc566abc37bb892123a900af23c7dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1656 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28237 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25562 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47531 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1444 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27645 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28535 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7463 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->