### PR TITLE
ScreenCaptureKitCaptureSource should not reconfigure if video effect is on but overlay rect is not filled

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -522,7 +522,7 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
     double contentScale = 1;
     double scaleFactor = 1;
     FloatRect contentRect;
-    auto hasLargePresenterOverlay = false;
+    bool shouldDisallowReconfiguration = false;
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     auto canCheckForOverlayMode = PAL::canLoad_ScreenCaptureKit_SCStreamFrameInfoPresenterOverlayContentRect();
 #endif
@@ -544,7 +544,7 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
             if (auto overlayRectDictionary = (CFDictionaryRef)attachment[SCStreamFrameInfoPresenterOverlayContentRect]) {
                 CGRect overlayRect;
                 if (CGRectMakeWithDictionaryRepresentation(overlayRectDictionary, &overlayRect))
-                    hasLargePresenterOverlay = overlayRect.origin.x > 0 && overlayRect.origin.x != std::numeric_limits<double>::infinity() && overlayRect.origin.y > 0 && overlayRect.origin.y != std::numeric_limits<double>::infinity();
+                    shouldDisallowReconfiguration = overlayRect.origin.x && overlayRect.origin.y;
             }
         }
 #endif
@@ -578,7 +578,7 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
 
     // FIXME: for now we will rely on cropping to handle large presenter overlay.
     // We might further want to reduce calling updateStreamConfiguration once we crop when user is resizing.
-    if (m_contentSize != scaledContentRect.size() && !hasLargePresenterOverlay) {
+    if (m_contentSize != scaledContentRect.size() && !shouldDisallowReconfiguration) {
         m_contentSize = scaledContentRect.size();
         m_streamConfiguration = nullptr;
         updateStreamConfiguration();


### PR DESCRIPTION
#### ec6f4da2341ed9b831b175e61003eafe53b10c92
<pre>
ScreenCaptureKitCaptureSource should not reconfigure if video effect is on but overlay rect is not filled
<a href="https://rdar.apple.com/127882407">rdar://127882407</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274076">https://bugs.webkit.org/show_bug.cgi?id=274076</a>

Reviewed by Eric Carlson and Jean-Yves Avenard.

In <a href="https://rdar.apple.com/125925090">rdar://125925090</a>, <a href="https://commits.webkit.org/278390@main">https://commits.webkit.org/278390@main</a>, we started detecting presenter overlay mode by looking at SCStreamFrameInfoPresenterOverlayContentRect.
We were checking whether the origin was not (0, 0) and not (Inf, Inf).
(0, 0) is to ensure we are not in small overlay mode.
(Inf, Inf) was to ensure there was some overlay.

When starting large presenter overlay mode, (Inf, Inf) may be used for a couple of video frames, in particular when going from small to large overlay mode.
This triggered sometimes reconfiguration, which was further delaying a correct overlay, ending in a loop of reconfiguration.

To prevent this, we only allow reconfiguration when we are sure we are in small presenter overlay mode, thus origin is (0, 0).
We rename hasLargePresenterOverlay to shouldDisallowReconfiguration as this is more consistent.
Manually tested.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/278685@main">https://commits.webkit.org/278685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/234c2f4db5e39e6682b31d70b6b72b5db18bfc6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41778 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1483 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56147 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49175 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48337 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->