### PR TITLE
[GStreamer][WebRTC] Caps negotiation failure when ssrc-audio-level RTP extension is requested

### DIFF
--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -51,6 +51,7 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=extmap:5 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt
@@ -26,6 +26,7 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=extmap:5 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
 a=rtpmap:9 G722/8000
 a=rtcp-fb:9 transport-cc
@@ -74,6 +75,7 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=extmap:5 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
 a=rtpmap:9 G722/8000
 a=rtcp-fb:9 transport-cc

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -179,25 +179,26 @@ private:
     void fillAudioRtpCapabilities(Configuration, RTCRtpCapabilities&);
     void fillVideoRtpCapabilities(Configuration, RTCRtpCapabilities&);
 
+#define WEBRTC_EXPERIMENTS_HDREXT "http://www.webrtc.org/experiments/rtp-hdrext/"
     Vector<const char*> m_commonRtpExtensions {
         "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
-        "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+        WEBRTC_EXPERIMENTS_HDREXT "abs-send-time",
         GST_RTP_HDREXT_BASE "sdes:mid",
         GST_RTP_HDREXT_BASE "sdes:repaired-rtp-stream-id",
         GST_RTP_HDREXT_BASE "sdes:rtp-stream-id",
         GST_RTP_HDREXT_BASE "toffset"
     };
     Vector<const char*> m_allAudioRtpExtensions {
-        // This extension triggers caps negotiation issues. See https://bugs.webkit.org/show_bug.cgi?id=271519.
-        // "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
+        GST_RTP_HDREXT_BASE "ssrc-audio-level"
     };
     Vector<const char*> m_allVideoRtpExtensions {
-        "http://www.webrtc.org/experiments/rtp-hdrext/color-space",
-        "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay",
-        "http://www.webrtc.org/experiments/rtp-hdrext/video-content-type",
-        "http://www.webrtc.org/experiments/rtp-hdrext/video-timing",
+        WEBRTC_EXPERIMENTS_HDREXT "color-space",
+        WEBRTC_EXPERIMENTS_HDREXT "playout-delay",
+        WEBRTC_EXPERIMENTS_HDREXT "video-content-type",
+        WEBRTC_EXPERIMENTS_HDREXT "video-timing",
         "urn:3gpp:video-orientation"
     };
+#undef WEBRTC_EXPERIMENTS_HDREXT
 
     std::optional<Vector<RTCRtpCapabilities::HeaderExtensionCapability>> m_audioRtpExtensions;
     std::optional<Vector<RTCRtpCapabilities::HeaderExtensionCapability>> m_videoRtpExtensions;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -143,6 +143,42 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
     }
 
     auto rtpCaps = adoptGRef(gst_caps_new_empty());
+
+    // When not present in caps, the vad support of the ssrc-audio-level extension should be
+    // enabled. In order to prevent caps negotiation issues with downstream, explicitely set it.
+    unsigned totalFields = gst_structure_n_fields(structure.get());
+    for (unsigned i = 0; i < totalFields; i++) {
+        auto fieldName = makeString(gst_structure_nth_field_name(structure.get(), i));
+        if (!fieldName.startsWith("extmap-"_s))
+            continue;
+
+        const auto value = gst_structure_get_value(structure.get(), fieldName.ascii().data());
+        if (!G_VALUE_HOLDS_STRING(value))
+            continue;
+
+        const char* uri = g_value_get_string(value);
+        if (!g_str_equal(uri, GST_RTP_HDREXT_BASE "ssrc-audio-level"))
+            continue;
+
+        GValue arrayValue G_VALUE_INIT;
+        gst_value_array_init(&arrayValue, 3);
+
+        GValue stringValue G_VALUE_INIT;
+        g_value_init(&stringValue, G_TYPE_STRING);
+
+        g_value_set_static_string(&stringValue, "");
+        gst_value_array_append_value(&arrayValue, &stringValue);
+
+        g_value_set_string(&stringValue, uri);
+        gst_value_array_append_value(&arrayValue, &stringValue);
+
+        g_value_set_static_string(&stringValue, "vad=on");
+        gst_value_array_append_and_take_value(&arrayValue, &stringValue);
+
+        gst_structure_remove_field(structure.get(), fieldName.ascii().data());
+        gst_structure_take_value(structure.get(), fieldName.ascii().data(), &arrayValue);
+    }
+
     gst_caps_append_structure(rtpCaps.get(), structure.release());
 
     g_object_set(m_inputCapsFilter.get(), "caps", m_inputCaps.get(), nullptr);


### PR DESCRIPTION
#### d6d7f3edf374504363fece083b65e38793b27df0
<pre>
[GStreamer][WebRTC] Caps negotiation failure when ssrc-audio-level RTP extension is requested
<a href="https://bugs.webkit.org/show_bug.cgi?id=271519">https://bugs.webkit.org/show_bug.cgi?id=271519</a>

Reviewed by Xabier Rodriguez-Calvar.

When not present in caps, the vad support of the ssrc-audio-level extension should be enabled. In
order to prevent caps negotiation issues with downstream, explicitely set it.

* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/278738@main">https://commits.webkit.org/278738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d0e43a9aaf93ea65cd51798a100c81c0e170b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2004 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41792 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22910 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1500 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44655 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56167 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50816 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49191 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44305 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48376 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->