### PR TITLE
Regression(278398@main): COG does not build for the first time with meson before 1.1.0

### DIFF
--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -16,6 +16,20 @@ endif ()
 
 if (ENABLE_COG)
     include(ExternalProject)
+    find_program(MESON_EXE NAMES meson)
+    execute_process(
+        COMMAND "${MESON_EXE}" --version
+        OUTPUT_VARIABLE MESON_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+        ERROR_QUIET
+    )
+    if ("${MESON_VERSION}" VERSION_GREATER 1.1.0)
+        set(MESON_RECONFIGURE flag)
+    else ()
+        set(MESON_RECONFIGURE remove)
+    endif ()
+
     if ("${WPE_COG_PLATFORMS}" STREQUAL "")
         set(WPE_COG_PLATFORMS "drm,headless,gtk4,x11,wayland")
     elseif ("${WPE_COG_PLATFORMS}" STREQUAL "none")
@@ -63,7 +77,9 @@ if (ENABLE_COG)
         SOURCE_DIR "${CMAKE_SOURCE_DIR}/Tools/wpe/cog"
         BUILD_IN_SOURCE FALSE
         CONFIGURE_COMMAND
-            meson setup --reconfigure <BINARY_DIR> <SOURCE_DIR>
+            ${CMAKE_SOURCE_DIR}/Tools/wpe/meson-wrapper
+            ${MESON_RECONFIGURE}
+            <BINARY_DIR> <SOURCE_DIR>
             --buildtype ${COG_MESON_BUILDTYPE}
             --pkg-config-path ${WPE_COG_PKG_CONFIG_PATH}
             -Dwpe_api=${WPE_API_VERSION}
@@ -73,4 +89,8 @@ if (ENABLE_COG)
             meson compile -C <BINARY_DIR>
         INSTALL_COMMAND "")
     ExternalProject_Add_StepDependencies(cog build WebKit)
+    ExternalProject_Add_StepDependencies(cog configure
+        "${CMAKE_BINARY_DIR}/cmakeconfig.h"
+        "${WPE_PKGCONFIG_FILE}"
+    )
 endif ()

--- a/Tools/wpe/meson-wrapper
+++ b/Tools/wpe/meson-wrapper
@@ -1,0 +1,14 @@
+#! /usr/bin/env sh
+set -e
+
+reconfigure_mode=$1
+shift
+
+if [ "$reconfigure_mode" = flag ] || [ -r "$1/build.ninja" ] ; then
+    set -- setup --reconfigure "$@"
+else
+    set -- setup "$@"
+fi
+
+echo "MESON: meson $*"
+exec meson "$@"


### PR DESCRIPTION
#### b653500dcfab16a565f9e9c3d00f5fd7061af09a
<pre>
Regression(278398@main): COG does not build for the first time with meson before 1.1.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=273871">https://bugs.webkit.org/show_bug.cgi?id=273871</a>

Reviewed by Adrian Perez de Castro.

With this change &quot;--reconfigure&quot; option is added to meson(COG) only if meson version is
greater than 1.1.0 or if build.ninja exists (which means that COG was previously configured).

* Tools/PlatformWPE.cmake:
* Tools/wpe/meson-wrapper: Added.

Canonical link: <a href="https://commits.webkit.org/278747@main">https://commits.webkit.org/278747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b43cc13d4165fb2a9b38e4488a54d95e8db25be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41789 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22907 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25583 "4 new passes 5 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1496 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56162 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49186 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48354 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11256 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->