### PR TITLE
Fill layer pattern for mask-mode is not correctly applied

### DIFF
--- a/LayoutTests/fast/masking/parsing-mask-mode-expected.txt
+++ b/LayoutTests/fast/masking/parsing-mask-mode-expected.txt
@@ -1,5 +1,5 @@
 PASS setProperty("alpha, alpha, alpha, alpha") is "alpha, alpha, alpha, alpha"
-PASS setProperty("luminance, alpha") is "luminance, alpha, match-source, match-source"
+PASS setProperty("luminance, alpha") is "luminance, alpha, luminance, alpha"
 PASS setProperty("luminance, luminance, luminance, luminance") is "luminance, luminance, luminance, luminance"
 PASS setProperty("match-source, alpha, luminance, luminance") is "match-source, alpha, luminance, luminance"
 PASS successfullyParsed is true

--- a/LayoutTests/fast/masking/parsing-mask-mode.html
+++ b/LayoutTests/fast/masking/parsing-mask-mode.html
@@ -24,7 +24,7 @@
             }
 
             test("alpha, alpha, alpha, alpha", "alpha, alpha, alpha, alpha");
-            test("luminance, alpha", "luminance, alpha, match-source, match-source");
+            test("luminance, alpha", "luminance, alpha, luminance, alpha");
             test("luminance, luminance, luminance, luminance", "luminance, luminance, luminance, luminance");
             test("match-source, alpha, luminance, luminance", "match-source, alpha, luminance, luminance");
         </script>

--- a/LayoutTests/fast/masking/parsing-mask-source-type-expected.txt
+++ b/LayoutTests/fast/masking/parsing-mask-source-type-expected.txt
@@ -1,5 +1,5 @@
 PASS setProperty("alpha, alpha, alpha, alpha") is "alpha, alpha, alpha, alpha"
-PASS setProperty("luminance, alpha") is "luminance, alpha, alpha, alpha"
+PASS setProperty("luminance, alpha") is "luminance, alpha, luminance, alpha"
 PASS setProperty("luminance, luminance, luminance, luminance") is "luminance, luminance, luminance, luminance"
 PASS setProperty("auto, alpha, luminance, luminance") is "alpha, alpha, luminance, luminance"
 PASS successfullyParsed is true

--- a/LayoutTests/fast/masking/parsing-mask-source-type.html
+++ b/LayoutTests/fast/masking/parsing-mask-source-type.html
@@ -24,7 +24,7 @@
             }
 
             test("alpha, alpha, alpha, alpha", "alpha, alpha, alpha, alpha");
-            test("luminance, alpha", "luminance, alpha, alpha, alpha");
+            test("luminance, alpha", "luminance, alpha, luminance, alpha");
             test("luminance, luminance, luminance, luminance", "luminance, luminance, luminance, luminance");
             test("auto, alpha, luminance, luminance", "alpha, alpha, luminance, luminance");
         </script>

--- a/Source/WebCore/rendering/style/FillLayer.cpp
+++ b/Source/WebCore/rendering/style/FillLayer.cpp
@@ -287,6 +287,17 @@ void FillLayer::fillUnsetProperties()
                 pattern = this;
         }
     }
+
+    for (curr = this; curr && curr->isMaskModeSet(); curr = curr->next()) { }
+    if (curr && curr != this) {
+        // We need to fill in the remaining values with the pattern specified.
+        for (FillLayer* pattern = this; curr; curr = curr->next()) {
+            curr->m_maskMode = pattern->m_maskMode;
+            pattern = pattern->next();
+            if (pattern == curr || !pattern)
+                pattern = this;
+        }
+    }
 }
 
 void FillLayer::cullEmptyLayers()


### PR DESCRIPTION
#### ec2c8756e6a2051c182e0e8c153490b8037df753
<pre>
Fill layer pattern for mask-mode is not correctly applied
<a href="https://bugs.webkit.org/show_bug.cgi?id=274084">https://bugs.webkit.org/show_bug.cgi?id=274084</a>
<a href="https://rdar.apple.com/127999241">rdar://127999241</a>

Reviewed by Tim Nguyen.

* LayoutTests/fast/masking/parsing-mask-mode.html:
* LayoutTests/fast/masking/parsing-mask-mode-expected.txt:

New results match other browsers.

* LayoutTests/fast/masking/parsing-mask-source-type-expected.txt:
* LayoutTests/fast/masking/parsing-mask-source-type.html:

* Source/WebCore/rendering/style/FillLayer.cpp:
(WebCore::FillLayer::fillUnsetProperties):

Fill unset mask-mode with a pattern similar to other fill layer properties.

Canonical link: <a href="https://commits.webkit.org/278698@main">https://commits.webkit.org/278698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58e1696d2e68ca09762780185cdb46378c2891ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1700 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22927 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1520 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1488 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44325 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48380 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11224 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->