### PR TITLE
[view-transitions] Mispositioned snapshots on https://codepen.io/bramus/full/mdowgYX

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+body { background: lightpink; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+  addEventListener("scroll", () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  }, { once: true, capture: true });
+  document.documentElement.scrollTop = 500;
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+body { background: lightpink; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+  addEventListener("scroll", () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  }, { once: true, capture: true });
+  document.documentElement.scrollTop = 500;
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-transform-position-fixed-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<script src="../../../../../resources/ui-helper.js"></script>
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+  view-transition-name: target;
+}
+
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  await waitForAtLeastOneFrame();
+
+  /* Scroll the doc, target element's element-to-screen transform should not change */
+  await new Promise((resolve) => {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }, { once: true, capture: true });
+
+    document.documentElement.scrollTop = 500;
+  });
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html >
+<html class="reftest-wait">
 <title>View transitions: capture root element with scrollbar (ref)</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
@@ -25,6 +26,13 @@ body {
 
 <script>
   function scrollContainer() {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document.documentElement.classList.remove("reftest-wait");
+        });
+      });
+    }, { once: true, capture: true });
     document.documentElement.scrollTop = 500;
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html
@@ -25,6 +25,13 @@ body {
 
 <script>
   function scrollContainer() {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document.documentElement.classList.remove("reftest-wait");
+        });
+      });
+    }, { once: true, capture: true });
     document.documentElement.scrollTop = 500;
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background.html
@@ -56,7 +56,13 @@ failIfNot(document.startViewTransition, "Missing document.startViewTransition");
 async function runTest() {
   await waitForAtLeastOneFrame();
 
-  document.documentElement.scrollTop = 500;
+  await new Promise((resolve) => {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }, { once: true, capture: true });
+
+    document.documentElement.scrollTop = 500;
+  });
   document.startViewTransition(() => {
     requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
   });

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1480,6 +1480,16 @@ FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet
     return transformState.lastPlanarPoint();
 }
 
+std::unique_ptr<TransformationMatrix> RenderObject::localToAbsoluteTransform() const
+{
+    TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint { });
+    transformState.setTransformMatrixTracking(TransformState::TrackSVGCTMMatrix);
+    OptionSet<MapCoordinatesMode> mode { UseTransforms, ApplyContainerFlip };
+    mapLocalToContainer(nullptr, transformState, mode, nullptr);
+    transformState.flatten();
+    return transformState.releaseTrackedTransform();
+}
+
 FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, OptionSet<MapCoordinatesMode> mode) const
 {
     TransformState transformState(TransformState::UnapplyInverseTransformDirection, containerPoint);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -821,6 +821,7 @@ public:
 
     // Convert the given local point to absolute coordinates. If OptionSet<MapCoordinatesMode> includes UseTransforms, take transforms into account.
     WEBCORE_EXPORT FloatPoint localToAbsolute(const FloatPoint& localPoint = FloatPoint(), OptionSet<MapCoordinatesMode> = { }, bool* wasFixed = nullptr) const;
+    std::unique_ptr<TransformationMatrix> localToAbsoluteTransform() const;
     FloatPoint absoluteToLocal(const FloatPoint&, OptionSet<MapCoordinatesMode> = { }) const;
 
     // Convert a local quad to absolute coordinates, taking transforms into account.


### PR DESCRIPTION
#### 42b9196ba9be3f57453b1ec5b4e5724cabc965d8
<pre>
[view-transitions] Mispositioned snapshots on <a href="https://codepen.io/bramus/full/mdowgYX">https://codepen.io/bramus/full/mdowgYX</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272185">https://bugs.webkit.org/show_bug.cgi?id=272185</a>
<a href="https://rdar.apple.com/125931829">rdar://125931829</a>

Reviewed by NOBODY (OOPS!).

Original patch by Matt Woodrow.

We were previously unconditionally substracting the scroll position from the transform when positioning the snapshots.
This is incorrect in some cases, like when the element is fixed positioned.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background.html:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::copyElementBaseProperties):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::localToAbsoluteTransform const):
* Source/WebCore/rendering/RenderObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42b9196ba9be3f57453b1ec5b4e5724cabc965d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42364 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54138 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28992 "Found 1 new test failure: http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56910 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49755 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48972 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->