### PR TITLE
REGRESSION(277476@main): [GTK] Crash in WebCore::GIFImageDecoder::haveDecodedRow

### DIFF
--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
@@ -234,8 +234,8 @@ bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned 
     // Write one row's worth of data into the frame.  
     for (int x = xBegin; x < xEnd; ++x) {
         const unsigned char sourceValue = rowBuffer[x - frameContext->xOffset];
-        if ((!frameContext->isTransparent || (sourceValue != frameContext->tpixel)) && (sourceValue < colorMap.size())) {
-            const size_t colorIndex = static_cast<size_t>(sourceValue) * 3;
+        const size_t colorIndex = static_cast<size_t>(sourceValue) * 3;
+        if ((!frameContext->isTransparent || (sourceValue != frameContext->tpixel)) && (colorIndex + 2 < colorMap.size())) {
             buffer.backingStore()->setPixel(currentAddress, colorMap[colorIndex], colorMap[colorIndex + 1], colorMap[colorIndex + 2], 255);
         } else {
             m_currentBufferSawAlpha = true;

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.h
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.h
@@ -156,7 +156,7 @@ public:
     int tpixel; // Index of transparent pixel.
     WebCore::ScalableImageDecoderFrame::DisposalMethod disposalMethod; // Restore to background, leave in place, etc.
     size_t localColormapPosition; // Per-image colormap.
-    int localColormapSize; // Size of local colormap array.
+    int localColormapSize; // Size of local colormap array (in 3-byte units)
     int datasize;
     
     bool isLocalColormapDefined : 1;
@@ -255,12 +255,12 @@ public:
 
     std::span<const uint8_t> globalColormap() const
     {
-        return m_isGlobalColormapDefined ? data(m_globalColormapPosition, m_globalColormapSize) : std::span<const uint8_t> { };
+        return m_isGlobalColormapDefined ? data(m_globalColormapPosition, m_globalColormapSize * 3) : std::span<const uint8_t> { };
     }
 
     std::span<const uint8_t> localColormap(const GIFFrameContext* frame) const
     {
-        return frame->isLocalColormapDefined ? data(frame->localColormapPosition, frame->localColormapSize) : std::span<const uint8_t> { };
+        return frame->isLocalColormapDefined ? data(frame->localColormapPosition, frame->localColormapSize * 3) : std::span<const uint8_t> { };
     }
 
     const GIFFrameContext* frameContext() const
@@ -302,7 +302,7 @@ private:
     unsigned m_screenHeight;
     bool m_isGlobalColormapDefined;
     size_t m_globalColormapPosition; // (3* MAX_COLORS in size) Default colormap if local not supplied, 3 bytes for each color.
-    int m_globalColormapSize; // Size of global colormap array.
+    int m_globalColormapSize; // Size of global colormap array (in 3-byte units)
     int m_loopCount; // Netscape specific extension block to control the number of animation loops a GIF renders.
     
     Vector<std::unique_ptr<GIFFrameContext> > m_frames;


### PR DESCRIPTION
#### cae3dbd2f345116351cbb73fd45950ce01af9168
<pre>
REGRESSION(277476@main): [GTK] Crash in WebCore::GIFImageDecoder::haveDecodedRow
<a href="https://bugs.webkit.org/show_bug.cgi?id=274027">https://bugs.webkit.org/show_bug.cgi?id=274027</a>

Reviewed by Carlos Garcia Campos.

Confusingly, the &quot;size&quot; of the color maps is defined in 3-byte units, so
size in bytes is actually 3x the &quot;size&quot; of the color map. Chris
understandably missed this when converting the code to use std::span.
Now we&apos;re reading off the end of the span. This triggers libstdc++
runtime assertions, but the assertions are disabled by default, so our
EWS bots did not notice. Distros do (or should) enable the assertions
using something like -DCMAKE_CXX_FLAGS=&quot;-Wp,-D_GLIBCXX_ASSERTIONS&quot;.

* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp:
(WebCore::GIFImageDecoder::haveDecodedRow):
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.h:
(GIFImageReader::globalColormap const):
(GIFImageReader::localColormap const):

Canonical link: <a href="https://commits.webkit.org/278739@main">https://commits.webkit.org/278739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d096dff05f3913e6ee20e4a1db56bd3e9dc0a8de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51335 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41813 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1518 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49205 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48382 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28583 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->