### PR TITLE
Web Inspector: get y should return this._y in GradientSlider.js

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GradientSlider.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GradientSlider.js
@@ -317,16 +317,6 @@ WI.GradientSliderKnob = class GradientSliderKnob extends WI.Object
         this._updateTransform();
     }
 
-    get y()
-    {
-        return this._x;
-    }
-
-    set y(y) {
-        this._y = y;
-        this._updateTransform();
-    }
-
     get wellColor()
     {
         return this._wellColor;
@@ -414,9 +404,10 @@ WI.GradientSliderKnob = class GradientSliderKnob extends WI.Object
             x = Math.min(Math.max(0, x), w);
         this.x = x;
 
-        if (this._detaching)
-            this.y = event.pageY - this._startMouseY;
-        else if (this.delegate && typeof this.delegate.knobXDidChange === "function")
+        if (this._detaching) {
+            this._y = event.pageY - this._startMouseY;
+            this._updateTransform();
+        } else if (this.delegate && typeof this.delegate.knobXDidChange === "function")
             this.delegate.knobXDidChange(this);
     }
 


### PR DESCRIPTION
#### 5ab59d6891b5d75313b8356b2ff0cdcf2fb3b710
<pre>
get y should return this._y in GradientSlider.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=274094">https://bugs.webkit.org/show_bug.cgi?id=274094</a>

Reviewed by Devin Rousso.

Delete get y() and set (y).
Add this._updateTransform() in _handleMousemove because set y() was removed where it was originally set.

* Source/WebInspectorUI/UserInterface/Views/GradientSlider.js:
(WI.GradientSliderKnob.prototype._handleMousemove):
(WI.GradientSliderKnob.prototype.get y): Deleted.
(WI.GradientSliderKnob.prototype.set y): Deleted.

Canonical link: <a href="https://commits.webkit.org/278904@main">https://commits.webkit.org/278904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68fb77c576e83b9eec3d3c8b5ae5c79d80defefe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2515 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1965 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56682 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49564 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->