### PR TITLE
Restore constexpr after build fix for 278486@main

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1062,14 +1062,14 @@ void FastStringifier<CharType>::append(JSValue value)
         }
 
         auto charactersCopySameType = [&](auto span, auto* cursor) ALWAYS_INLINE_LAMBDA {
-#if CPU(ARM64) || CPU(X86_64)
+#if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
             constexpr size_t stride = 16 / sizeof(CharType);
             if (span.size() >= stride) {
                 using UnsignedType = std::make_unsigned_t<CharType>;
                 using BulkType = decltype(SIMD::load(static_cast<const UnsignedType*>(nullptr)));
-                const auto quoteMask = SIMD::splat(static_cast<UnsignedType>('"'));
-                const auto escapeMask = SIMD::splat(static_cast<UnsignedType>('\\'));
-                const auto controlMask = SIMD::splat(static_cast<UnsignedType>(' '));
+                constexpr auto quoteMask = SIMD::splat(static_cast<UnsignedType>('"'));
+                constexpr auto escapeMask = SIMD::splat(static_cast<UnsignedType>('\\'));
+                constexpr auto controlMask = SIMD::splat(static_cast<UnsignedType>(' '));
                 const auto* ptr = span.data();
                 const auto* end = ptr + span.size();
                 auto* cursorEnd = cursor + span.size();
@@ -1082,8 +1082,8 @@ void FastStringifier<CharType>::append(JSValue value)
                     auto controls = SIMD::lessThan(input, controlMask);
                     accumulated = SIMD::merge(accumulated, SIMD::merge(quotes, SIMD::merge(escapes, controls)));
                     if constexpr (sizeof(CharType) != 1) {
-                        const auto surrogateMask = SIMD::splat(static_cast<UnsignedType>(0xf800));
-                        const auto surrogateCheckMask = SIMD::splat(static_cast<UnsignedType>(0xd800));
+                        constexpr auto surrogateMask = SIMD::splat(static_cast<UnsignedType>(0xf800));
+                        constexpr auto surrogateCheckMask = SIMD::splat(static_cast<UnsignedType>(0xd800));
                         accumulated = SIMD::merge(accumulated, SIMD::equal(simde_vandq_u16(input, surrogateMask), surrogateCheckMask));
                     }
                 }
@@ -1095,8 +1095,8 @@ void FastStringifier<CharType>::append(JSValue value)
                     auto controls = SIMD::lessThan(input, controlMask);
                     accumulated = SIMD::merge(accumulated, SIMD::merge(quotes, SIMD::merge(escapes, controls)));
                     if constexpr (sizeof(CharType) != 1) {
-                        const auto surrogateMask = SIMD::splat(static_cast<UnsignedType>(0xf800));
-                        const auto surrogateCheckMask = SIMD::splat(static_cast<UnsignedType>(0xd800));
+                        constexpr auto surrogateMask = SIMD::splat(static_cast<UnsignedType>(0xf800));
+                        constexpr auto surrogateCheckMask = SIMD::splat(static_cast<UnsignedType>(0xd800));
                         accumulated = SIMD::merge(accumulated, SIMD::equal(simde_vandq_u16(input, surrogateMask), surrogateCheckMask));
                     }
                 }
@@ -1116,15 +1116,15 @@ void FastStringifier<CharType>::append(JSValue value)
         };
 
         auto charactersCopyUpconvert = [&](std::span<const LChar> span, UChar* cursor) ALWAYS_INLINE_LAMBDA {
-#if CPU(ARM64) || CPU(X86_64)
+#if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
             constexpr size_t stride = 16 / sizeof(LChar);
             if (span.size() >= stride) {
                 using UnsignedType = std::make_unsigned_t<LChar>;
                 using BulkType = decltype(SIMD::load(static_cast<const UnsignedType*>(nullptr)));
-                const auto quoteMask = SIMD::splat(static_cast<UnsignedType>('"'));
-                const auto escapeMask = SIMD::splat(static_cast<UnsignedType>('\\'));
-                const auto controlMask = SIMD::splat(static_cast<UnsignedType>(' '));
-                const auto zeros = SIMD::splat(static_cast<UnsignedType>(0));
+                constexpr auto quoteMask = SIMD::splat(static_cast<UnsignedType>('"'));
+                constexpr auto escapeMask = SIMD::splat(static_cast<UnsignedType>('\\'));
+                constexpr auto controlMask = SIMD::splat(static_cast<UnsignedType>(' '));
+                constexpr auto zeros = SIMD::splat(static_cast<UnsignedType>(0));
                 const auto* ptr = span.data();
                 const auto* end = ptr + span.size();
                 auto* cursorEnd = cursor + span.size();


### PR DESCRIPTION
#### dd78bd9548b7ec75b286a16d21760254bec0f437
<pre>
Restore constexpr after build fix for 278486@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=274096">https://bugs.webkit.org/show_bug.cgi?id=274096</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType&gt;::append):

Canonical link: <a href="https://commits.webkit.org/278737@main">https://commits.webkit.org/278737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e19e3b730b598a83c588f2b946aba958893c044e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1522 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44682 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56194 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50843 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44327 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48398 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11251 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28589 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/63167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27434 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/63167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->