### PR TITLE
[webkitscmpy] Fix BitBucket inline comments for added files

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
@@ -249,7 +249,7 @@ class BitBucket(mocks.Requests):
                     contextLines=3,
                     whitespace='SHOW',
                     diffs=[dict(
-                        source=dict(toString='ChangeLog'),
+                        source=None,
                         destination=dict(toString='ChangeLog'),
                         hunks=[dict(
                             sourceLine=1,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -348,8 +348,8 @@ class BitBucket(Scm):
             relative_to_absolute = defaultdict(lambda: defaultdict(list))
 
             for diff in json_diff.get('diffs', []):
-                destination = diff.get('destination', {}).get('toString')
-                source = diff.get('source', {}).get('toString')
+                destination = (diff.get('destination') or {}).get('toString')
+                source = (diff.get('source') or {}).get('toString')
 
                 count = -1
                 for hunk in diff.get('hunks', []):
@@ -370,11 +370,11 @@ class BitBucket(Scm):
                                 absolute_to_relative['source'][source][source_pos] = count
 
                             if dest_pos:
-                                relative_to_absolute[source][count] = {'to': dest_pos}
+                                relative_to_absolute[destination][count] = {'to': dest_pos}
                             elif source_pos:
                                 relative_to_absolute[source][count] = {'from': source_pos}
                             if segment.get('type'):
-                                relative_to_absolute[source][count]['type'] = segment['type']
+                                relative_to_absolute[source or destination][count]['type'] = segment['type']
 
             return absolute_to_relative, relative_to_absolute
 
@@ -555,8 +555,11 @@ class BitBucket(Scm):
     def json_to_diff(cls, data):
         output = ''
         for diff in data.get('diffs', []):
-            output += '--- a/{}\n'.format(diff['source']['toString'])
-            output += '+++ b/{}\n'.format(diff['destination']['toString'])
+            source = (diff.get('source') or {}).get('toString')
+            destination = (diff.get('destination') or {}).get('toString')
+
+            output += '--- {}\n'.format(('a/' + source) if source else '/dev/null')
+            output += '+++ {}\n'.format(('b/' + destination) if destination else '/dev/null')
             for hunk in diff.get('hunks', []):
                 output += '@@ -{},{} +{},{} @@\n'.format(
                     hunk['sourceLine'], hunk['sourceSpan'],

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -987,7 +987,7 @@ class TestBitBucket(testing.TestCase):
         with mocks.remote.BitBucket():
             repo = remote.BitBucket(self.remote)
             self.assertEqual([
-                '--- a/ChangeLog',
+                '--- /dev/null',
                 '+++ b/ChangeLog',
                 '@@ -1,0 +1,0 @@',
                 '+Patch Series',
@@ -1002,7 +1002,7 @@ class TestBitBucket(testing.TestCase):
                 'Date: {}'.format(datetime.fromtimestamp(1601668000).strftime('%a %b %d %H:%M:%S %Y')),
                 'Subject: [PATCH] 8th commit',
                 '---',
-                '--- a/ChangeLog',
+                '--- /dev/null',
                 '+++ b/ChangeLog',
                 '@@ -1,0 +1,0 @@',
                 '+8th commit',
@@ -1018,7 +1018,7 @@ class TestBitBucket(testing.TestCase):
                 'Date: {}'.format(datetime.fromtimestamp(1601668000).strftime('%a %b %d %H:%M:%S %Y')),
                 'Subject: [PATCH 1/2] 8th commit',
                 '---',
-                '--- a/ChangeLog',
+                '--- /dev/null',
                 '+++ b/ChangeLog',
                 '@@ -1,0 +1,0 @@',
                 '+8th commit',
@@ -1027,7 +1027,7 @@ class TestBitBucket(testing.TestCase):
                 'Date: {}'.format(datetime.fromtimestamp(1601663000).strftime('%a %b %d %H:%M:%S %Y')),
                 'Subject: [PATCH 2/2] 4th commit',
                 '---',
-                '--- a/ChangeLog',
+                '--- /dev/null',
                 '+++ b/ChangeLog',
                 '@@ -1,0 +1,0 @@',
                 '+4th commit',


### PR DESCRIPTION
#### 741a871d17464fde986045793a3c0be5bb40f277
<pre>
[webkitscmpy] Fix BitBucket inline comments for added files
<a href="https://bugs.webkit.org/show_bug.cgi?id=274100">https://bugs.webkit.org/show_bug.cgi?id=274100</a>
<a href="https://rdar.apple.com/128012248">rdar://128012248</a>

Reviewed by Dewei Zhu.

When adding a new file, the &quot;source&quot; file won&apos;t exist in BitBucket&apos;s diff response.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator._position_converters): Handle case where source or destination don&apos;t exist.
(BitBucket.json_to_diff): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/278717@main">https://commits.webkit.org/278717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbd0e4f6fad1acf2e3ea903ff899230df8e2e20f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1716 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22939 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51196 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1535 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56200 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1504 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/51366 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44340 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28600 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7481 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->