### PR TITLE
[macOS] Add a mechanism to temporarily suppress text indicators during scrolling/resizing/zooming

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1403,6 +1403,9 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
 - (void)setPageZoom:(CGFloat)pageZoom
 {
     THROW_IF_SUSPENDED;
+#if PLATFORM(MAC)
+    _impl->suppressContentRelativeChildViews(WebKit::WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
+#endif
     _page->setPageZoomFactor(pageZoom);
 }
 
@@ -3732,6 +3735,9 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 - (void)_setTextZoomFactor:(double)zoomFactor
 {
     THROW_IF_SUSPENDED;
+#if PLATFORM(MAC)
+    _impl->suppressContentRelativeChildViews(WebKit::WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
+#endif
     _page->setTextZoomFactor(zoomFactor);
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -279,6 +279,11 @@ void WebPageProxy::createSandboxExtensionsIfNeeded(const Vector<String>& files, 
     }
 }
 
+void WebPageProxy::scrollingNodeScrollViewDidScroll(ScrollingNodeID nodeID)
+{
+    protectedPageClient()->scrollingNodeScrollViewDidScroll(nodeID);
+}
+
 bool WebPageProxy::scrollingUpdatesDisabledForTesting()
 {
     return protectedPageClient()->scrollingUpdatesDisabledForTesting();

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -514,6 +514,8 @@ public:
 #if PLATFORM(COCOA)
     virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&) = 0;
     virtual void layerTreeCommitComplete() = 0;
+
+    virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -541,7 +543,6 @@ public:
     virtual double minimumZoomScale() const = 0;
     virtual WebCore::FloatRect documentRect() const = 0;
     virtual void scrollingNodeScrollViewWillStartPanGesture(WebCore::ScrollingNodeID) = 0;
-    virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
     virtual void scrollingNodeScrollWillStartScroll(WebCore::ScrollingNodeID) = 0;
     virtual void scrollingNodeScrollDidEndScroll(WebCore::ScrollingNodeID) = 0;
     virtual Vector<String> mimeTypesWithCustomContentProviders() = 0;
@@ -593,6 +594,9 @@ public:
     virtual void navigationGestureDidEnd() = 0;
     virtual void willRecordNavigationSnapshot(WebBackForwardListItem&) = 0;
     virtual void didRemoveNavigationGestureSnapshot() = 0;
+
+    virtual void willBeginViewGesture() { }
+    virtual void didEndViewGesture() { }
 
     virtual void didFirstVisuallyNonEmptyLayoutForMainFrame() = 0;
     virtual void didFinishNavigation(API::Navigation*) = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -176,9 +176,7 @@ void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll(ScrollingNodeID
     if (m_webPageProxy.scrollingUpdatesDisabledForTesting())
         return;
 
-#if PLATFORM(IOS_FAMILY)
     m_webPageProxy.scrollingNodeScrollViewDidScroll(scrolledNodeID);
-#endif
 
     if (m_scrollingTree->isHandlingProgrammaticScroll())
         return;

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -138,6 +138,8 @@ void ViewGestureController::willBeginGesture(ViewGestureType type)
 
     m_activeGestureType = type;
     m_currentGestureID = takeNextGestureID();
+
+    m_webPageProxy.willBeginViewGesture();
 }
 
 void ViewGestureController::didEndGesture()
@@ -146,6 +148,8 @@ void ViewGestureController::didEndGesture()
 
     m_activeGestureType = ViewGestureType::None;
     m_currentGestureID = 0;
+
+    m_webPageProxy.didEndViewGesture();
 }
 
 void ViewGestureController::setAlternateBackForwardListSourcePage(WebPageProxy* page)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11699,6 +11699,16 @@ void WebPageProxy::navigationGestureSnapshotWasRemoved()
     m_navigationClient->didRemoveNavigationGestureSnapshot(*this);
 }
 
+void WebPageProxy::willBeginViewGesture()
+{
+    protectedPageClient()->willBeginViewGesture();
+}
+
+void WebPageProxy::didEndViewGesture()
+{
+    protectedPageClient()->didEndViewGesture();
+}
+
 void WebPageProxy::isPlayingMediaDidChange(MediaProducerMediaStateFlags newState)
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -941,6 +941,10 @@ public:
         
     void adjustLayersForLayoutViewport(const WebCore::FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale);
 
+#if PLATFORM(COCOA)
+    void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID);
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     void textInputContextsInRect(WebCore::FloatRect, CompletionHandler<void(const Vector<WebCore::ElementContext>&)>&&);
     void focusTextInputContextAndPlaceCaret(const WebCore::ElementContext&, const WebCore::IntPoint&, CompletionHandler<void(bool)>&&);
@@ -963,7 +967,6 @@ public:
     WebCore::FloatRect unconstrainedLayoutViewportRect() const;
 
     void scrollingNodeScrollViewWillStartPanGesture(WebCore::ScrollingNodeID);
-    void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID);
     void scrollingNodeScrollWillStartScroll(std::optional<WebCore::ScrollingNodeID>);
     void scrollingNodeScrollDidEndScroll(std::optional<WebCore::ScrollingNodeID>);
 
@@ -1762,6 +1765,9 @@ public:
     void willRecordNavigationSnapshot(WebBackForwardListItem&);
 
     bool isShowingNavigationGestureSnapshot() const { return m_isShowingNavigationGestureSnapshot; }
+
+    void willBeginViewGesture();
+    void didEndViewGesture();
 
     bool isPlayingAudio() const;
     bool hasMediaStreaming() const;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -259,11 +259,6 @@ void WebPageProxy::scrollingNodeScrollViewWillStartPanGesture(ScrollingNodeID no
     protectedPageClient()->scrollingNodeScrollViewWillStartPanGesture(nodeID);
 }
 
-void WebPageProxy::scrollingNodeScrollViewDidScroll(ScrollingNodeID nodeID)
-{
-    protectedPageClient()->scrollingNodeScrollViewDidScroll(nodeID);
-}
-
 void WebPageProxy::scrollingNodeScrollWillStartScroll(std::optional<ScrollingNodeID> nodeID)
 {
     protectedPageClient()->scrollingNodeScrollWillStartScroll(nodeID.value_or(ScrollingNodeID { }));

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -200,6 +200,8 @@ private:
     void didCommitLayerTree(const RemoteLayerTreeTransaction&) override;
     void layerTreeCommitComplete() override;
 
+    void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) override;
+
     void registerInsertionUndoGrouping() override;
 
     void createPDFHUD(PDFPluginIdentifier, const WebCore::IntRect&) override;
@@ -228,6 +230,9 @@ private:
     void navigationGestureDidEnd() override;
     void willRecordNavigationSnapshot(WebBackForwardListItem&) override;
     void didRemoveNavigationGestureSnapshot() override;
+
+    void willBeginViewGesture() final;
+    void didEndViewGesture() final;
 
     void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&) final;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -763,6 +763,21 @@ void PageClientImpl::layerTreeCommitComplete()
 {
 }
 
+void PageClientImpl::scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID)
+{
+    m_impl->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
+}
+
+void PageClientImpl::willBeginViewGesture()
+{
+    m_impl->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::Remove);
+}
+
+void PageClientImpl::didEndViewGesture()
+{
+    m_impl->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::Restore);
+}
+
 #if ENABLE(FULLSCREEN_API)
 
 WebFullScreenManagerProxyClient& PageClientImpl::fullScreenManagerProxyClient()

--- a/Source/WebKit/UIProcess/mac/WKTextIndicatorStyleManager.h
+++ b/Source/WebKit/UIProcess/mac/WKTextIndicatorStyleManager.h
@@ -43,6 +43,11 @@ class WebViewImpl;
 - (void)addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType;
 - (void)removeTextIndicatorStyleForID:(NSUUID *)uuid;
 
+- (BOOL)hasActiveTextIndicatorStyle;
+
+- (void)suppressTextIndicatorStyle;
+- (void)restoreTextIndicatorStyle;
+
 @end
 
 #endif // ENABLE(UNIFIED_TEXT_REPLACEMENT)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -104,6 +104,11 @@ class Object;
 class PageConfiguration;
 }
 
+namespace PAL {
+class HysteresisActivity;
+enum class HysteresisState : bool;
+}
+
 namespace WebCore {
 class DestinationColorSpace;
 class IntPoint;
@@ -386,6 +391,9 @@ public:
     void changeFontColorFromSender(id);
     bool validateUserInterfaceItem(id <NSValidatedUserInterfaceItem>);
     void setEditableElementIsFocused(bool);
+
+    enum class ContentRelativeChildViewsSuppressionType : uint8_t { Remove, Restore, TemporarilyRemove };
+    void suppressContentRelativeChildViews(ContentRelativeChildViewsSuppressionType);
 
 #if HAVE(REDESIGNED_TEXT_CURSOR)
     void updateCursorAccessoryPlacement();
@@ -754,6 +762,11 @@ private:
     void uninstallImageAnalysisOverlayView();
 #endif
 
+    bool hasContentRelativeChildViews() const;
+
+    void suppressContentRelativeChildViews();
+    void restoreContentRelativeChildViews();
+
     bool m_clientWantsMediaPlaybackControlsView { false };
     bool m_canCreateTouchBars { false };
     bool m_startedListeningToCustomizationEvents { false };
@@ -817,6 +830,8 @@ private:
 #endif
 
     NSTextCheckingTypes getTextCheckingTypes() const;
+
+    void contentRelativeViewsHysteresisTimerFired(PAL::HysteresisState);
 
     void flushPendingMouseEventCallbacks();
 
@@ -891,6 +906,8 @@ private:
     id m_flagsChangedEventMonitor { nullptr };
 
     std::unique_ptr<WebCore::TextIndicatorWindow> m_textIndicatorWindow;
+
+    std::unique_ptr<PAL::HysteresisActivity> m_contentRelativeViewsHysteresis;
 
     RetainPtr<NSColorSpace> m_colorSpace;
 


### PR DESCRIPTION
#### d74204522d48951c10bb31282e991ce3a7df96d7
<pre>
[macOS] Add a mechanism to temporarily suppress text indicators during scrolling/resizing/zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=274071">https://bugs.webkit.org/show_bug.cgi?id=274071</a>
<a href="https://rdar.apple.com/127271298">rdar://127271298</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Modern text indicators are inserted as subviews of `WKWebView`. During scrolling,
resizing, and zooming, text can get displaced from the text indicator. Consequently,
in this scenarios, text indicators should be temporarily suppressed, and restored
when in a stable state.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView setPageZoom:]):
(-[WKWebView _setTextZoomFactor:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::scrollingNodeScrollViewDidScroll):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::willBeginViewGesture):
(WebKit::PageClient::didEndViewGesture):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll):

Remove the platform conditional, so that all types of scrolls can be detected on macOS.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::willBeginGesture):
(WebKit::ViewGestureController::didEndGesture):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::willBeginViewGesture):
(WebKit::WebPageProxy::didEndViewGesture):
* Source/WebKit/UIProcess/WebPageProxy.h:

Introduce `willBeginViewGesture` and `didEndViewGesture` to enable suppression
during magnification and navigation gestures.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::scrollingNodeScrollViewDidScroll): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::scrollingNodeScrollViewDidScroll):
(WebKit::PageClientImpl::willBeginViewGesture):
(WebKit::PageClientImpl::didEndViewGesture):
* Source/WebKit/UIProcess/mac/WKTextIndicatorStyleManager.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
(WebKit::WebViewImpl::renewGState):

Suppress modern text indicators during resizing.

(WebKit::WebViewImpl::hasContentRelativeChildViews const):
(WebKit::WebViewImpl::suppressContentRelativeChildViews):

Use a `HysteresisActivity` to drive suppression. `Remove` / `Restore` are used
to hide views for a longer period of time, such as during a magnification gesture.
Otherwise, `TemporarilyRemove` is used for affecting behaviors which have no
start/end, such as resizing.

(WebKit::WebViewImpl::contentRelativeViewsHysteresisTimerFired):
(WebKit::WebViewImpl::restoreContentRelativeChildViews):
(WebKit::WebViewImpl::setMagnification):

Canonical link: <a href="https://commits.webkit.org/278818@main">https://commits.webkit.org/278818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97bea0bad34f29c340d760449a19231f7b2fa84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2282 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44499 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23122 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (warnings)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25835 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56448 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49393 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48591 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28842 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7531 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->