### PR TITLE
Web Inspector: Remove unused event parameters in GradientSlider.js

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GradientSlider.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GradientSlider.js
@@ -117,7 +117,7 @@ WI.GradientSlider = class GradientSlider extends WI.Object
         this._updateCanvas();
     }
 
-    knobCanDetach(knob)
+    knobCanDetach()
     {
         return this._knobs.length > 2;
     }
@@ -160,7 +160,7 @@ WI.GradientSlider = class GradientSlider extends WI.Object
         this._updateShadowKnob(event);
     }
 
-    _handleMouseout(event)
+    _handleMouseout()
     {
         if (!this._shadowKnob)
             return;
@@ -420,7 +420,7 @@ WI.GradientSliderKnob = class GradientSliderKnob extends WI.Object
             this.delegate.knobXDidChange(this);
     }
 
-    _handleMouseup(event)
+    _handleMouseup()
     {
         window.removeEventListener("mousemove", this, true);
         window.removeEventListener("mouseup", this, true);
@@ -433,7 +433,7 @@ WI.GradientSliderKnob = class GradientSliderKnob extends WI.Object
             this.selected = !this.selected;
     }
 
-    _handleTransitionEnd(event)
+    _handleTransitionEnd()
     {
         this.element.removeEventListener("transitionend", this);
         this.element.classList.remove(WI.GradientSliderKnob.FadeOutClassName);


### PR DESCRIPTION
#### aa3083b94e5454332686a508734c04e1ab5c9bea
<pre>
Web Inspector: Remove unused event parameters in GradientSlider.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=274105">https://bugs.webkit.org/show_bug.cgi?id=274105</a>

Reviewed by NOBODY (OOPS!).

Remove unused event and knob parameters in GradientSlider.js.

* Source/WebInspectorUI/UserInterface/Views/GradientSlider.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa3083b94e5454332686a508734c04e1ab5c9bea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2047 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41839 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1538 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26474 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44343 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->