### PR TITLE
[Site Isolation] Begin implementing cross-site redirects to provisional load failures

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -67,7 +67,7 @@ ASCIILiteral NavigatorBeacon::supplementName()
     return "NavigatorBeacon"_s;
 }
 
-void NavigatorBeacon::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void NavigatorBeacon::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     if (!resource.resourceError().isNull())
         logError(resource.resourceError());

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -55,7 +55,7 @@ private:
 
     static ASCIILiteral supplementName();
 
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void logError(const ResourceError&);
 
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -70,7 +70,7 @@ void ArtworkImageLoader::requestImageResource()
         m_cachedImage->addClient(*this);
 }
 
-void ArtworkImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void ArtworkImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, &resource == m_cachedImage);
     if (m_cachedImage->loadFailedOrCanceled() || m_cachedImage->errorOccurred() || !m_cachedImage->image()) {

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -56,7 +56,7 @@ public:
     WEBCORE_EXPORT void requestImageResource();
 
 protected:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
 private:
     Document& m_document;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -230,7 +230,7 @@ void HTMLModelElement::dataReceived(CachedResource& resource, const SharedBuffer
     m_data.append(buffer);
 }
 
-void HTMLModelElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void HTMLModelElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     auto invalidateResourceHandleAndUpdateRenderer = [&] {
         m_resource->removeClient(*this);

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -161,7 +161,7 @@ private:
 
     // CachedRawResourceClient overrides.
     void dataReceived(CachedResource&, const SharedBuffer&) final;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     // ModelPlayerClient overrides.
     void didUpdateLayerHostingContextIdentifier(ModelPlayer&, LayerHostingContextIdentifier) final;

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
@@ -73,7 +73,7 @@ bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL)
     return true;
 }
 
-void CachedModuleScriptLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void CachedModuleScriptLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, &resource == m_cachedScript);
     ASSERT(m_cachedScript);

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -59,7 +59,7 @@ public:
 private:
     CachedModuleScriptLoader(ModuleScriptLoaderClient&, DeferredPromise&, CachedScriptFetcher&, RefPtr<JSC::ScriptFetchParameters>&&);
 
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     CachedResourceHandle<CachedScript> m_cachedScript;
     URL m_sourceURL;

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -85,7 +85,7 @@ bool LoadableNonModuleScriptBase::wasCanceled() const
     return m_cachedScript->wasCanceled();
 }
 
-void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT(m_cachedScript);
     if (resource.resourceError().isAccessControl()) {

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -61,7 +61,7 @@ protected:
     LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
 protected:
     CachedResourceHandle<CachedScript> m_cachedScript { };

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -72,13 +72,13 @@ void HTMLImageLoader::dispatchLoadEvent()
     element().dispatchEvent(Event::create(errorOccurred ? eventNames().errorEvent : eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& metrics)
+void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     ASSERT(image());
     CachedImage& cachedImage = *image();
 
     Ref<Element> protect(element());
-    ImageLoader::notifyFinished(cachedImage, metrics);
+    ImageLoader::notifyFinished(cachedImage, metrics, loadWillContinueInAnotherProcess);
 
     bool loadError = cachedImage.errorOccurred() || cachedImage.response().httpStatusCode() >= 400;
     if (!loadError) {

--- a/Source/WebCore/html/HTMLImageLoader.h
+++ b/Source/WebCore/html/HTMLImageLoader.h
@@ -33,7 +33,7 @@ public:
 
     void dispatchLoadEvent() override;
 
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 };
 
 }

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -119,7 +119,7 @@ std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
     return m_processedManifest;
 }
 
-void ApplicationManifestLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void ApplicationManifestLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
     Ref { m_documentLoader.get() }->finishedLoadingApplicationManifest(*this);

--- a/Source/WebCore/loader/ApplicationManifestLoader.h
+++ b/Source/WebCore/loader/ApplicationManifestLoader.h
@@ -54,7 +54,7 @@ public:
     std::optional<ApplicationManifest>& processManifest();
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&);
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess);
 
     SingleThreadWeakRef<DocumentLoader> m_documentLoader;
     std::optional<ApplicationManifest> m_processedManifest;

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -93,7 +93,7 @@ void CrossOriginPreflightChecker::validatePreflightResponse(DocumentThreadableLo
     loader.preflightSuccess(WTFMove(request));
 }
 
-void CrossOriginPreflightChecker::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void CrossOriginPreflightChecker::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
     Ref loader = m_loader.get();

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.h
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.h
@@ -54,7 +54,7 @@ public:
     void setDefersLoading(bool);
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) final;
 
     static void handleLoadingFailure(DocumentThreadableLoader&, unsigned long, const ResourceError&);

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -40,6 +40,7 @@
 #include "DocumentWriter.h"
 #include "ElementTargetingTypes.h"
 #include "FrameDestructionObserver.h"
+#include "FrameLoaderTypes.h"
 #include "LinkIcon.h"
 #include "NavigationAction.h"
 #include "ResourceError.h"
@@ -329,7 +330,7 @@ public:
     void setMainResourceDataBufferingPolicy(DataBufferingPolicy);
 
     void startLoadingMainResource();
-    WEBCORE_EXPORT void cancelMainResourceLoad(const ResourceError&);
+    WEBCORE_EXPORT void cancelMainResourceLoad(const ResourceError&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     void willContinueMainResourceLoadAfterRedirect(const ResourceRequest&);
 
     bool isLoadingMainResource() const { return m_loadingMainResource; }
@@ -539,11 +540,11 @@ private:
 
     void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     void finishedLoading();
-    void mainReceivedError(const ResourceError&);
+    void mainReceivedError(const ResourceError&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     WEBCORE_EXPORT void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
     WEBCORE_EXPORT void responseReceived(CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
     WEBCORE_EXPORT void dataReceived(CachedResource&, const SharedBuffer&) override;
-    WEBCORE_EXPORT void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+    WEBCORE_EXPORT void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 #if USE(QUICK_LOOK)
     WEBCORE_EXPORT void previewResponseReceived(CachedResource&, const ResourceResponse&) override;
 #endif
@@ -575,7 +576,7 @@ private:
     bool tryLoadingRedirectRequestFromApplicationCache(const ResourceRequest&);
     void continueAfterContentPolicy(PolicyAction);
 
-    void stopLoadingForPolicyChange();
+    void stopLoadingForPolicyChange(LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     ResourceError interruptedForPolicyChangeError() const;
 
     void handleSubstituteDataLoadNow();

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -476,7 +476,7 @@ void DocumentThreadableLoader::finishedTimingForWorkerLoad(const ResourceTiming&
     m_client->didFinishTiming(resourceTiming);
 }
 
-void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics)
+void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess)
 {
     ASSERT(m_client);
     ASSERT_UNUSED(resource, &resource == m_resource);

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -92,7 +92,7 @@ class CachedRawResource;
         void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
         void finishedTimingForWorkerLoad(CachedResource&, const ResourceTiming&) override;
         void finishedTimingForWorkerLoad(const ResourceTiming&);
-        void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+        void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
         void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&);
         void didReceiveData(ResourceLoaderIdentifier, const SharedBuffer&);

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -191,7 +191,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<CFDictionaryRef> connectionProperties(ResourceLoader*);
 #endif
-    void receivedMainResourceError(const ResourceError&);
+    void receivedMainResourceError(const ResourceError&, LoadWillContinueInAnotherProcess);
 
     bool willLoadMediaElementURL(URL&, Node&);
 
@@ -223,7 +223,7 @@ public:
     void loadedResourceFromMemoryCache(CachedResource&, ResourceRequest& newRequest, ResourceError&);
     void tellClientAboutPastMemoryCacheLoads();
 
-    void checkLoadComplete();
+    void checkLoadComplete(LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     WEBCORE_EXPORT void detachFromParent();
     void detachViewsAndDocumentLoader();
 
@@ -394,7 +394,7 @@ private:
     void scrollToFragmentWithParentBoundary(const URL&, bool isNewNavigation = true);
 
     void dispatchDidFailProvisionalLoad(DocumentLoader& provisionalDocumentLoader, const ResourceError&, WillInternallyHandleFailure);
-    void checkLoadCompleteForThisFrame();
+    void checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess);
     void handleLoadFailureRecovery(DocumentLoader&, const ResourceError&, bool);
 
     void setDocumentLoader(RefPtr<DocumentLoader>&&);

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -395,7 +395,7 @@ inline void ImageLoader::rejectDecodePromises(ASCIILiteral message)
     rejectPromises(m_decodingPromises, message);
 }
 
-void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " notifyFinished - hasPendingLoadEvent " << m_hasPendingLoadEvent);
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -104,7 +104,7 @@ public:
 
 protected:
     explicit ImageLoader(Element&);
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
 
 private:
     void resetLazyImageLoading(Document&);

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -91,7 +91,7 @@ void LinkLoader::triggerError()
     m_client->linkLoadingErrored();
 }
 
-void LinkLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void LinkLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, m_cachedLinkResource.get() == &resource);
 

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -84,7 +84,7 @@ public:
     void cancelLoad();
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
     static void preconnectIfNeeded(const LinkLoadParameters&, Document&);
     static std::unique_ptr<LinkPreloadResourceClient> preloadIfNeeded(const LinkLoadParameters&, Document&, LinkLoader*);
     void prefetchIfNeeded(const LinkLoadParameters&, Document&);

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -86,7 +86,7 @@ public:
     }
 
 private:
-    void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&) final { triggerEvents(resource); }
+    void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };
@@ -122,7 +122,7 @@ public:
     }
 
 private:
-    void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&) final { triggerEvents(resource); }
+    void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };
@@ -157,7 +157,7 @@ public:
     }
 
 private:
-    void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&) final { triggerEvents(resource); }
+    void notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final { triggerEvents(resource); }
     void clear() final { clearResource(*this); }
     bool shouldMarkAsReferenced() const final { return false; }
 };

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -304,7 +304,7 @@ void MediaResource::dataReceived(CachedResource& resource, const SharedBuffer& b
         client->dataReceived(*this, buffer);
 }
 
-void MediaResource::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics)
+void MediaResource::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess)
 {
     assertIsMainThread();
 

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -90,7 +90,7 @@ public:
     bool shouldCacheResponse(CachedResource&, const ResourceResponse&) override;
     void dataSent(CachedResource&, unsigned long long, unsigned long long) override;
     void dataReceived(CachedResource&, const SharedBuffer&) override;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
 private:
     Ref<MediaResourceLoader> protectedLoader() const;

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -179,7 +179,7 @@ void NetscapePlugInStreamLoader::willCancel(const ResourceError& error)
         m_client->didFail(this, error);
 }
 
-void NetscapePlugInStreamLoader::didCancel(const ResourceError&)
+void NetscapePlugInStreamLoader::didCancel(LoadWillContinueInAnotherProcess)
 {
     notifyDone();
 }

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.h
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.h
@@ -81,7 +81,7 @@ private:
     NetscapePlugInStreamLoader(LocalFrame&, NetscapePlugInStreamLoaderClient&);
 
     void willCancel(const ResourceError&) override;
-    void didCancel(const ResourceError&) override;
+    void didCancel(LoadWillContinueInAnotherProcess) override;
 
     void notifyDone();
 

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -681,7 +681,7 @@ void ResourceLoader::cancel()
     cancel(ResourceError());
 }
 
-void ResourceLoader::cancel(const ResourceError& error)
+void ResourceLoader::cancel(const ResourceError& error, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     // If the load has already completed - succeeded, failed, or previously cancelled - do nothing.
     if (m_reachedTerminalState)
@@ -724,7 +724,7 @@ void ResourceLoader::cancel(const ResourceError& error)
     if (m_reachedTerminalState)
         return;
 
-    didCancel(nonNullError);
+    didCancel(loadWillContinueInAnotherProcess);
 
     if (m_cancellationStatus == FinishedCancel)
         return;

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "CachedResourceHandle.h"
+#include "FrameLoaderTypes.h"
 #include "ResourceHandleClient.h"
 #include "ResourceLoadTiming.h"
 #include "ResourceLoaderIdentifier.h"
@@ -86,7 +87,7 @@ public:
     const ResourceRequest& originalRequest() const { return m_originalRequest; }
 
     WEBCORE_EXPORT void start();
-    WEBCORE_EXPORT void cancel(const ResourceError&);
+    WEBCORE_EXPORT void cancel(const ResourceError&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     WEBCORE_EXPORT ResourceError cancelledError();
     WEBCORE_EXPORT ResourceError blockedError();
     ResourceError blockedByContentBlockerError();
@@ -197,7 +198,7 @@ protected:
 
 private:
     virtual void willCancel(const ResourceError&) = 0;
-    virtual void didCancel(const ResourceError&) = 0;
+    virtual void didCancel(LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) = 0;
 
     void addBuffer(const FragmentedSharedBuffer&, DataPayloadType);
     void loadDataURL();

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -861,7 +861,7 @@ void SubresourceLoader::willCancel(const ResourceError& error)
     memoryCache.remove(*resource);
 }
 
-void SubresourceLoader::didCancel(const ResourceError&)
+void SubresourceLoader::didCancel(LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     if (m_state == Uninitialized || reachedTerminalState())
         return;
@@ -872,7 +872,7 @@ void SubresourceLoader::didCancel(const ResourceError&)
     if (resource->type() != CachedResource::Type::MainResource)
         tracePoint(SubresourceLoadDidEnd, identifier().toUInt64());
 
-    resource->cancelLoad();
+    resource->cancelLoad(loadWillContinueInAnotherProcess);
     notifyDone(LoadCompletionType::Cancel);
 }
 

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -86,7 +86,7 @@ private:
     void didFinishLoading(const NetworkLoadMetrics&) final;
     void didFail(const ResourceError&) final;
     void willCancel(const ResourceError&) final;
-    void didCancel(const ResourceError&) final;
+    void didCancel(LoadWillContinueInAnotherProcess) final;
     
     void updateReferrerPolicy(const String&);
 

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -115,7 +115,7 @@ void TextTrackLoader::corsPolicyPreventedLoad()
     m_state = Failed;
 }
 
-void TextTrackLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void TextTrackLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, m_resource == &resource);
 

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -78,7 +78,7 @@ public:
 
 private:
     // CachedResourceClient
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void deprecatedDidReceiveCachedResource(CachedResource&) final;
 
     // WebVTTParserClient

--- a/Source/WebCore/loader/appcache/ApplicationCacheResourceLoader.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheResourceLoader.cpp
@@ -87,7 +87,7 @@ void ApplicationCacheResourceLoader::responseReceived(CachedResource& resource, 
     }
 
     if (response.httpStatusCode() == 304) {
-        notifyFinished(*m_resource, { });
+        notifyFinished(*m_resource, { }, LoadWillContinueInAnotherProcess::No);
         return;
     }
 
@@ -117,7 +117,7 @@ void ApplicationCacheResourceLoader::redirectReceived(CachedResource&, ResourceR
     callback(WTFMove(newRequest));
 }
 
-void ApplicationCacheResourceLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void ApplicationCacheResourceLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     Ref protectedThis { *this };
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheResourceLoader.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheResourceLoader.h
@@ -58,7 +58,7 @@ private:
     void responseReceived(CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) final;
     void dataReceived(CachedResource&, const SharedBuffer&) final;
     void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) final;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     unsigned m_type;
     CachedResourceHandle<CachedRawResource> m_resource;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -128,7 +128,7 @@ Ref<TextResourceDecoder> CachedCSSStyleSheet::protectedDecoder() const
     return m_decoder;
 }
 
-void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&)
+void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     if (isLoading())
         return;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "CachedResource.h"
+#include "FrameLoaderTypes.h"
 
 namespace WebCore {
 
@@ -61,7 +62,7 @@ private:
 
     void setBodyDataFrom(const CachedResource&) final;
 
-    void checkNotify(const NetworkLoadMetrics&) final;
+    void checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) final;
 
     Ref<TextResourceDecoder> m_decoder;
     String m_decodedSheetText;

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -210,7 +210,7 @@ void CachedFont::allClientsRemoved()
     m_fontCustomPlatformData = nullptr;
 }
 
-void CachedFont::checkNotify(const NetworkLoadMetrics&)
+void CachedFont::checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     if (isLoading())
         return;

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -28,6 +28,7 @@
 #include "CachedResource.h"
 #include "CachedResourceClient.h"
 #include "Font.h"
+#include "FrameLoaderTypes.h"
 #include "TextFlags.h"
 #include "TrustedFonts.h"
 #include <pal/SessionID.h>
@@ -71,7 +72,7 @@ protected:
 private:
     String calculateItemInCollection() const;
 
-    void checkNotify(const NetworkLoadMetrics&) override;
+    void checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
     bool mayTryReplaceEncodedData() const override;
 
     void load(CachedResourceLoader&) override;

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -321,14 +321,14 @@ void CachedResource::setBodyDataFrom(const CachedResource& resource)
     setEncodedSize(resource.encodedSize());
 }
 
-void CachedResource::checkNotify(const NetworkLoadMetrics& metrics)
+void CachedResource::checkNotify(const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     if (isLoading() || stillNeedsLoad())
         return;
 
     CachedResourceClientWalker<CachedResourceClient> walker(*this);
     while (CachedResourceClient* client = walker.next())
-        client->notifyFinished(*this, metrics);
+        client->notifyFinished(*this, metrics, loadWillContinueInAnotherProcess);
 }
 
 void CachedResource::updateBuffer(const FragmentedSharedBuffer&)
@@ -364,7 +364,7 @@ void CachedResource::clearCachedCryptographicDigests()
     m_cryptographicDigests.fill(std::nullopt);
 }
     
-void CachedResource::cancelLoad()
+void CachedResource::cancelLoad(LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     if (!isLoading() && !stillNeedsLoad())
         return;
@@ -377,7 +377,7 @@ void CachedResource::cancelLoad()
         setStatus(LoadError);
 
     setLoading(false);
-    checkNotify({ });
+    checkNotify({ }, loadWillContinueInAnotherProcess);
 }
 
 void CachedResource::finish()

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -258,7 +258,7 @@ public:
 
     bool isExpired() const;
 
-    void cancelLoad();
+    void cancelLoad(LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     bool wasCanceled() const;
     bool errorOccurred() const { return m_status == LoadError || m_status == DecodeError; }
     bool loadFailedOrCanceled() const;
@@ -344,7 +344,7 @@ private:
 
     void decodedDataDeletionTimerFired();
 
-    virtual void checkNotify(const NetworkLoadMetrics&);
+    virtual void checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     virtual bool mayTryReplaceEncodedData() const { return false; }
 
     Seconds freshnessLifetime(const ResourceResponse&) const;

--- a/Source/WebCore/loader/cache/CachedResourceClient.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceClient.cpp
@@ -48,7 +48,7 @@ void CachedResourceClient::removeAssociatedResource(CachedResource& resource)
 }
 #endif
 
-void CachedResourceClient::notifyFinished(CachedResource&, const NetworkLoadMetrics&)
+void CachedResourceClient::notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
 }
 

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "FrameLoaderTypes.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -56,7 +57,7 @@ public:
 
     virtual ~CachedResourceClient();
 
-    virtual void notifyFinished(CachedResource&, const NetworkLoadMetrics&);
+    virtual void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     virtual void deprecatedDidReceiveCachedResource(CachedResource&);
 
     static CachedResourceClientType expectedType();

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -81,7 +81,7 @@ void CachedXSLStyleSheet::finishLoading(const FragmentedSharedBuffer* data, cons
     checkNotify(metrics);
 }
 
-void CachedXSLStyleSheet::checkNotify(const NetworkLoadMetrics&)
+void CachedXSLStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     if (isLoading())
         return;

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
@@ -41,7 +41,7 @@ public:
     const String& sheet() const { return m_sheet; }
 
 private:
-    void checkNotify(const NetworkLoadMetrics&) final;
+    void checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) final;
     bool mayTryReplaceEncodedData() const final { return true; }
     void didAddClient(CachedResourceClient&) final;
     void setEncoding(const String&) final;

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -66,7 +66,7 @@ void KeepaliveRequestTracker::registerRequest(CachedResource& resource)
     resource.addClient(*this);
 }
 
-void KeepaliveRequestTracker::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void KeepaliveRequestTracker::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     unregisterRequest(resource);
 }

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
@@ -39,7 +39,7 @@ public:
 
 private:
     // CachedRawResourceClient.
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     void registerRequest(CachedResource&);
     void unregisterRequest(CachedResource&);

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -103,7 +103,7 @@ void IconLoader::stopLoading()
         resource->removeClient(*this);
 }
 
-void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
 

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -48,7 +48,7 @@ public:
     void stopLoading();
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     SingleThreadWeakRef<DocumentLoader> m_documentLoader;
     URL m_url;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -65,7 +65,7 @@ private:
     // CachedRawResourceClient
     void responseReceived(CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) final;
     void dataReceived(CachedResource&, const SharedBuffer&) final;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     void fulfillRequestWithResource(CachedResource&);
 
@@ -124,7 +124,7 @@ void CachedResourceMediaLoader::responseReceived(CachedResource& resource, const
     m_parent.responseReceived(response.mimeType(), response.httpStatusCode(), response.contentRange(), response.expectedContentLength());
 }
 
-void CachedResourceMediaLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void CachedResourceMediaLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     if (resource.loadFailedOrCanceled()) {
         m_parent.loadFailed(resource.resourceError());

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1611,7 +1611,7 @@ VisibleInViewportState RenderElement::imageVisibleInViewport(const Document& doc
     return isVisibleInViewport() ? VisibleInViewportState::Yes : VisibleInViewportState::No;
 }
 
-void RenderElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void RenderElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     document().protectedCachedResourceLoader()->notifyFinished(resource);
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -317,7 +317,7 @@ protected:
     void insertedIntoTree() override;
     void willBeRemovedFromTree() override;
     void willBeDestroyed() override;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
     void setHasContinuationChainNode(bool b) { m_hasContinuationChainNode = b; }
 

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -412,7 +412,7 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
     contentChanged(ImageChanged);
 }
 
-void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics)
+void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     if (renderTreeBeingDestroyed())
         return;
@@ -428,7 +428,7 @@ void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetr
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element()))
         page().didFinishLoadingImageForElement(*image);
 
-    RenderReplaced::notifyFinished(newImage, metrics);
+    RenderReplaced::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
 }
 
 void RenderImage::setImageDevicePixelRatio(float factor)

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -126,7 +126,7 @@ private:
 
     LayoutUnit minimumReplacedHeight() const override;
 
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 
     IntSize imageSizeForError(CachedImage*) const;

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -67,7 +67,7 @@ bool RenderLayerFilters::hasSourceImage() const
     return m_targetSwitcher && m_targetSwitcher->hasSourceImage();
 }
 
-void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetrics&)
+void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     // FIXME: This really shouldn't have to invalidate layer composition,
     // but tests like css3/filters/effect-reference-delete.html fail if that doesn't happen.

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -74,7 +74,7 @@ public:
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void resetDirtySourceRect() { m_dirtySourceRect = LayoutRect(); }
 
     RenderLayer& m_layer;

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -326,7 +326,7 @@ void RenderSVGImage::repaintOrMarkForLayout(const IntRect* rect)
         layer()->contentChanged(ImageChanged);
 }
 
-void RenderSVGImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics)
+void RenderSVGImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     if (renderTreeBeingDestroyed())
         return;
@@ -340,7 +340,7 @@ void RenderSVGImage::notifyFinished(CachedResource& newImage, const NetworkLoadM
             layer()->contentChanged(ImageChanged);
     }
 
-    RenderSVGModelObject::notifyFinished(newImage, metrics);
+    RenderSVGModelObject::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
 }
 
 void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -72,7 +72,7 @@ private:
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 
     void repaintOrMarkForLayout(const IntRect* = nullptr);
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     bool bufferForeground(PaintInfo&, const LayoutPoint&);
 
     bool needsHasSVGTransformFlags() const final;

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -161,7 +161,7 @@ void SVGFEImageElement::removedFromAncestor(RemovalType removalType, ContainerNo
         clearResourceReferences();
 }
 
-void SVGFEImageElement::notifyFinished(CachedResource&, const NetworkLoadMetrics&)
+void SVGFEImageElement::notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     if (!isConnected())
         return;

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -48,7 +48,7 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
 
     void didFinishInsertingNode() override;

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -603,7 +603,7 @@ bool SVGUseElement::selfHasRelativeLengths() const
     return targetClone && targetClone->hasRelativeLengths();
 }
 
-void SVGUseElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
+void SVGUseElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
     ASSERT(ScriptDisallowedScope::InMainThread::isScriptAllowed());
     invalidateShadowTree();

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -68,7 +68,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     Path toClipPath() override;
     bool selfHasRelativeLengths() const override;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     Document* externalDocument() const;
     void updateExternalDocument();

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -33,11 +33,10 @@
 
 namespace WebKit {
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess, bool isCrossSiteRedirect)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess)
     : m_frame(frame)
     , m_frameProcess(WTFMove(frameProcess))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
-    , m_isCrossSiteRedirect(isCrossSiteRedirect)
     , m_layerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier::generate())
 {
     process().markProcessAsRecentlyUsed();

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -49,7 +49,7 @@ class WebProcessProxy;
 class ProvisionalFrameProxy : public CanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&, bool isCrossSiteRedirect);
+    ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
     ~ProvisionalFrameProxy();
 
     WebProcessProxy& process() const;
@@ -59,13 +59,10 @@ public:
 
     Ref<FrameProcess> takeFrameProcess();
 
-    bool isCrossSiteRedirect() const { return m_isCrossSiteRedirect; }
-
 private:
     WeakRef<WebFrameProxy> m_frame;
     Ref<FrameProcess> m_frameProcess;
     Ref<VisitedLinkStore> m_visitedLinkStore;
-    bool m_isCrossSiteRedirect;
     WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
 };
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -192,9 +192,6 @@ void RemotePageProxy::didFailProvisionalLoadForFrame(FrameInfoData&& frameInfo, 
     if (!frame)
         return;
 
-    if (auto* provisionalFrame = frame->provisionalFrame(); provisionalFrame && provisionalFrame->isCrossSiteRedirect())
-        return;
-
     m_page->didFailProvisionalLoadForFrameShared(m_process.copyRef(), *frame, WTFMove(frameInfo), WTFMove(request), navigationID, provisionalURL, error, willContinueLoading, userData, willInternallyHandleFailure);
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -444,7 +444,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
         // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
         RegistrableDomain mainFrameDomain(page->mainFrame()->url());
 
-        m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, group.ensureProcessForDomain(navigationDomain, process, page->preferences()), navigation.currentRequestIsCrossSiteRedirect());
+        m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, group.ensureProcessForDomain(navigationDomain, process, page->preferences()));
         page->websiteDataStore().protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [aggregator] { });
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -432,6 +432,7 @@ void WebFrame::destroyProvisionalFrame()
             client->takeFrameInvalidator().release();
         if (RefPtr parent = frame->tree().parent())
             parent->tree().removeChild(*frame);
+        frame->loader().detachFromParent();
         frame->setView(nullptr);
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -2581,7 +2581,17 @@ TEST(SiteIsolation, NavigateIframeToProvisionalNavigationFailure)
     checkProvisionalLoadFailure(@"https://webkit.org/terminate");
     checkProvisionalLoadFailure(@"https://apple.com/terminate");
 
-    // FIXME: Add tests navigating the iframe to each redirect_to_*_terminate.
+    checkProvisionalLoadFailure(@"https://example.com/redirect_to_example_terminate");
+    checkProvisionalLoadFailure(@"https://webkit.org/redirect_to_example_terminate");
+    checkProvisionalLoadFailure(@"https://apple.com/redirect_to_example_terminate");
+
+    checkProvisionalLoadFailure(@"https://example.com/redirect_to_webkit_terminate");
+    checkProvisionalLoadFailure(@"https://webkit.org/redirect_to_webkit_terminate");
+    checkProvisionalLoadFailure(@"https://apple.com/redirect_to_webkit_terminate");
+
+    checkProvisionalLoadFailure(@"https://example.com/redirect_to_apple_terminate");
+    checkProvisionalLoadFailure(@"https://webkit.org/redirect_to_apple_terminate");
+    checkProvisionalLoadFailure(@"https://apple.com/redirect_to_apple_terminate");
 }
 
 TEST(SiteIsolation, CancelProvisionalLoad)


### PR DESCRIPTION
#### acdf944d361b6379c01cd8e66d518a4dfa54f40e
<pre>
[Site Isolation] Begin implementing cross-site redirects to provisional load failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=274104">https://bugs.webkit.org/show_bug.cgi?id=274104</a>
<a href="https://rdar.apple.com/128015329">rdar://128015329</a>

Reviewed by Charlie Wolfe and Sihui Liu.

When NavigationPolicyDecision::LoadWillContinueInAnotherProcess is sent to a web content process,
that web content process calls DocumentLoader::stopLoadingForPolicyChange which calls
WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad which sends IPC to the UI process.
When NavigationPolicyDecision::IgnoreLoad is used, this IPC message is desired, but if the load
is continuing in another process the message is not needed because the UI process already knows,
and it is not desired because receiving and handling such a message would lead to inconsistent
state.  We solved this previously for Process-Swap-On-Navigation by just ignoring most messages
from a previous process, but with site isolation we can&apos;t do this.  I saw four ways to possibly
implement this for site isolation:

1. Pipe a boolean from DocumentLoader::willSendRequest&apos;s call to stopLoadingForPolicyChange all
the way through this stack trace to directly get whether we should send the message:
FrameLoader::dispatchDidFailProvisionalLoad(DocumentLoader&amp;, const ResourceError&amp;, WillInternallyHandleFailure)
FrameLoader::checkLoadCompleteForThisFrame()
FrameLoader::checkLoadComplete()
FrameLoader::receivedMainResourceError(const ResourceError&amp;)
DocumentLoader::mainReceivedError(const ResourceError&amp;)
DocumentLoader::notifyFinished(CachedResource&amp;, const NetworkLoadMetrics&amp;)
CachedResource::checkNotify(const NetworkLoadMetrics&amp;)
CachedResource::cancelLoad()
SubresourceLoader::didCancel(const ResourceError&amp;)
ResourceLoader::cancel(const ResourceError&amp;)
DocumentLoader::cancelMainResourceLoad(const ResourceError&amp;)
DocumentLoader::stopLoadingForPolicyChange()

2. Store a boolean on the CachedResource along with the ResourceError to shortcut all the parts
of 1&apos;s stack where a ResourceError is currently not sent.

3. Create a new ResourceError that is a sentinel value indicating that LoadWillContinueInAnotherProcess
has been used and checking for that sentinel value before sending the message.

4. Store a boolean on the WebFrame when receiving LoadWillContinueInAnotherProcess indicating
that one dispatchDidFailProvisionalLoad should be ignored.

I chose 1 because it is the most direct and complete, even though it adds a lot of false boolean
parameters to code that is used for all loading.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::continueAfterContentPolicy):
(WebCore::DocumentLoader::interruptedForPolicyChangeError const):
(WebCore::DocumentLoader::stopLoadingForPolicyChange):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::interruptedForPolicyChangeError const):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/Shared/API/APIError.h:
* Source/WebKit/Shared/API/c/WKErrorRef.cpp:
(WKErrorGetErrorCode):
* Source/WebKit/Shared/WebErrors.cpp:
(WebKit::interruptedForPolicyChangeError):
* Source/WebKit/Shared/WebErrors.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::interruptedForPolicyChangeError const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::interruptedForPolicyChangeError const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeToProvisionalNavigationFailure)):

Canonical link: <a href="https://commits.webkit.org/278736@main">https://commits.webkit.org/278736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6514fb442d0b82271bd26e41b17ef176a235f1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1803 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1612 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56289 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49274 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44413 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28682 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7493 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->