### PR TITLE
[WebGPU] Buffer sizes for pipelines need to be decoupled from the underlying layouts (274098)

### DIFF
--- a/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt
@@ -1,5 +1,5 @@
      0                0
      8                0
-GPUDevice.createBindGroup: entrySize == 0 or entrySize(16) > buffer size(16) or layoutBinding->minBindingSize(1073741820) > entrySize(16)
+buffer length is 16 which is less than required bufferSize of 1073741820
 done
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -176,8 +176,8 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
             return;
         }
         auto& group = *kvp.value.get();
-        if (!validateBindGroup(group)) {
-            makeInvalid(@"buffer is too small");
+        if (NSString* error = errorValidatingBindGroup(group, m_pipeline->minimumBufferSizes(bindGroupIndex))) {
+            makeInvalid(error);
             return;
         }
         [m_computeCommandEncoder setBuffer:group.computeArgumentBuffer() offset:0 atIndex:bindGroupIndex];

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import "BindGroupLayout.h"
+#import "Pipeline.h"
 
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
@@ -47,9 +48,9 @@ class PipelineLayout;
 class ComputePipeline : public WGPUComputePipelineImpl, public RefCounted<ComputePipeline>, public CanMakeWeakPtr<ComputePipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, Ref<PipelineLayout>&& pipelineLayout, MTLSize threadsPerThreadgroup, Device& device)
+    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, Ref<PipelineLayout>&& pipelineLayout, MTLSize threadsPerThreadgroup, BufferBindingSizesForPipeline&& minimumBufferSizes, Device& device)
     {
-        return adoptRef(*new ComputePipeline(computePipelineState, WTFMove(pipelineLayout), threadsPerThreadgroup, device));
+        return adoptRef(*new ComputePipeline(computePipelineState, WTFMove(pipelineLayout), threadsPerThreadgroup, WTFMove(minimumBufferSizes), device));
     }
     static Ref<ComputePipeline> createInvalid(Device& device)
     {
@@ -69,9 +70,10 @@ public:
     MTLSize threadsPerThreadgroup() const { return m_threadsPerThreadgroup; }
 
     PipelineLayout& pipelineLayout() const;
+    const BufferBindingSizesForBindGroup* minimumBufferSizes(uint32_t) const;
 
 private:
-    ComputePipeline(id<MTLComputePipelineState>, Ref<PipelineLayout>&&, MTLSize, Device&);
+    ComputePipeline(id<MTLComputePipelineState>, Ref<PipelineLayout>&&, MTLSize, BufferBindingSizesForPipeline&&, Device&);
     ComputePipeline(Device&);
 
     const id<MTLComputePipelineState> m_computePipelineState { nil };
@@ -79,6 +81,7 @@ private:
     const Ref<Device> m_device;
     const MTLSize m_threadsPerThreadgroup;
     const Ref<PipelineLayout> m_pipelineLayout;
+    const BufferBindingSizesForPipeline m_minimumBufferSizes;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -31,16 +31,19 @@ namespace WebGPU {
 class BindGroup;
 class ShaderModule;
 
+using BufferBindingSizesForBindGroup = HashMap<uint32_t, uint64_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using BufferBindingSizesForPipeline = HashMap<uint32_t, BufferBindingSizesForBindGroup, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+
 struct LibraryCreationResult {
     id<MTLLibrary> library;
     WGSL::Reflection::EntryPointInformation entryPointInformation; // FIXME(PERFORMANCE): This is big. Don't copy this around.
     HashMap<String, WGSL::ConstantValue> wgslConstantValues;
 };
 
-std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, PipelineLayout*, const String& entryPointName, NSString *label, uint32_t constantCount, const WGPUConstantEntry* constants, NSError **);
+std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, PipelineLayout*, const String& entryPointName, NSString *label, uint32_t constantCount, const WGPUConstantEntry* constants, BufferBindingSizesForPipeline&, NSError **);
 
 id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, NSString *label);
 
-bool validateBindGroup(BindGroup&);
+NSString* errorValidatingBindGroup(const BindGroup&, const BufferBindingSizesForBindGroup*);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -453,8 +453,8 @@ bool RenderPassEncoder::executePreDrawCommands(const Buffer* indirectBuffer)
             return false;
         }
         auto& group = *weakBindGroup.get();
-        if (!validateBindGroup(group)) {
-            makeInvalid(@"buffer is too small");
+        if (NSString* error = errorValidatingBindGroup(group, m_pipeline->minimumBufferSizes(groupIndex))) {
+            makeInvalid(error);
             return false;
         }
         [m_renderCommandEncoder setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:m_device->vertexBufferIndexForBindGroup(groupIndex)];

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "Pipeline.h"
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
 #import <wtf/HashTraits.h>
@@ -53,9 +54,9 @@ public:
     };
     using RequiredBufferIndicesContainer = HashMap<uint32_t, BufferData, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthClipMode depthClipMode, MTLDepthStencilDescriptor *depthStencilDescriptor, Ref<PipelineLayout>&& pipelineLayout, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, uint32_t sampleMask, MTLRenderPipelineDescriptor* renderPipelineDescriptor, uint32_t colorAttachmentCount, const WGPURenderPipelineDescriptor& descriptor, RequiredBufferIndicesContainer&& requiredBufferIndices, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthClipMode depthClipMode, MTLDepthStencilDescriptor *depthStencilDescriptor, Ref<PipelineLayout>&& pipelineLayout, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, uint32_t sampleMask, MTLRenderPipelineDescriptor* renderPipelineDescriptor, uint32_t colorAttachmentCount, const WGPURenderPipelineDescriptor& descriptor, RequiredBufferIndicesContainer&& requiredBufferIndices, BufferBindingSizesForPipeline&& minimumBufferSizes, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthClipMode, depthStencilDescriptor, WTFMove(pipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, sampleMask, renderPipelineDescriptor, colorAttachmentCount, descriptor, WTFMove(requiredBufferIndices), device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthClipMode, depthStencilDescriptor, WTFMove(pipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, sampleMask, renderPipelineDescriptor, colorAttachmentCount, descriptor, WTFMove(requiredBufferIndices), WTFMove(minimumBufferSizes), device));
     }
 
     static Ref<RenderPipeline> createInvalid(Device& device)
@@ -94,9 +95,10 @@ public:
     WGPUPrimitiveTopology primitiveTopology() const;
     MTLIndexType stripIndexFormat() const;
     size_t vertexStageInBufferCount() const;
+    const BufferBindingSizesForBindGroup* minimumBufferSizes(uint32_t) const;
 
 private:
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthClipMode, MTLDepthStencilDescriptor *, Ref<PipelineLayout>&&, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, uint32_t sampleMask, MTLRenderPipelineDescriptor*, uint32_t colorAttachmentCount, const WGPURenderPipelineDescriptor&, RequiredBufferIndicesContainer&&, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthClipMode, MTLDepthStencilDescriptor *, Ref<PipelineLayout>&&, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, uint32_t sampleMask, MTLRenderPipelineDescriptor*, uint32_t colorAttachmentCount, const WGPURenderPipelineDescriptor&, RequiredBufferIndicesContainer&&, BufferBindingSizesForPipeline&&, Device&);
     RenderPipeline(Device&);
     bool colorTargetsMatch(MTLRenderPassDescriptor*, uint32_t) const;
     bool depthAttachmentMatches(MTLRenderPassDepthAttachmentDescriptor*) const;
@@ -124,6 +126,7 @@ private:
     WGPUDepthStencilState m_descriptorDepthStencil;
     WGPUFragmentState m_descriptorFragment;
     Vector<WGPUColorTargetState> m_descriptorTargets;
+    const BufferBindingSizesForPipeline m_minimumBufferSizes;
     bool m_writesStencil { false };
 };
 


### PR DESCRIPTION
#### f27603377e0a3151445d1d0f986f5f3dee6b05a9
<pre>
[WebGPU] Buffer sizes for pipelines need to be decoupled from the underlying layouts (274098)
<a href="https://bugs.webkit.org/show_bug.cgi?id=274098">https://bugs.webkit.org/show_bug.cgi?id=274098</a>
&lt;radar://128011723&gt;

Reviewed by Tadeu Zagallo.

The same bind group layout can be used in multiple pipelines,
so we should store the information for buffer sizes in the pipeline
and not the layout itself.

* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/ComputePipeline.h:
(WebGPU::ComputePipeline::create):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::ComputePipeline):
(WebGPU::ComputePipeline::bufferSizes const):
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
(WebGPU::errorValidatingBindGroup):
(WebGPU::validateBindGroup): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::create):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::RenderPipeline):
(WebGPU::m_bufferSizes):
(WebGPU::RenderPipeline::bufferSizes const):

Canonical link: <a href="https://commits.webkit.org/278794@main">https://commits.webkit.org/278794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03b5067d4a32aa2eed0e9571cc2647319e68cd08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2250 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1722 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56416 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49369 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11287 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->