### PR TITLE
REGRESSION (278619@main): [iOS] TestWebKitAPI.WKWebExtensionAPICommands.PerformKeyCommand is timing out

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -64,7 +64,7 @@ static auto *commandsManifest = @{
         },
         @"test-command": @{
             @"suggested_key": @{
-                @"default": @"",
+                @"default": @"Command+Alt+Z",
                 @"mac": @"Command+Alt+Z"
             },
             @"description": @"Test Command"
@@ -215,7 +215,7 @@ TEST(WKWebExtensionAPICommands, PerformKeyCommand)
 
     auto *command = filteredCommands.firstObject;
 
-    [command.keyCommand performWithSender:nil target:UIApplication.sharedApplication];
+    [manager.get().context performCommandForKeyCommand:command.keyCommand];
 
     [manager run];
 }


### PR DESCRIPTION
#### c44af016dd217817be2b770dca6a5e81b1771366
<pre>
REGRESSION (278619@main): [iOS] TestWebKitAPI.WKWebExtensionAPICommands.PerformKeyCommand is timing out
<a href="https://rdar.apple.com/127902100">rdar://127902100</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274022">https://bugs.webkit.org/show_bug.cgi?id=274022</a>

Reviewed by Brian Weinstein.

Updated the unit test for performing key command for web extensions.
The key command will never be a firstResponder so it is incorrect
to try to fire the keyCommand object directly. Instead, do what
the client firstResponder would do: invoke -performCommandForKeyCommand:
on the context object.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICommands, PerformKeyCommand)):

Canonical link: <a href="https://commits.webkit.org/278721@main">https://commits.webkit.org/278721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bf30e17a6ca13f4e7cca9924df5827d09028152

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22961 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1563 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56227 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1533 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44368 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11244 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->