### PR TITLE
Canvas drawImage should not alter the input source or the destination rectangles

### DIFF
--- a/LayoutTests/fast/canvas/canvas-drawImage-negative-coordinate-expected.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-negative-coordinate-expected.html
@@ -1,0 +1,19 @@
+<style>
+    canvas {
+        outline: 1px solid red;
+        aspect-ratio: 1 / 1;
+    }
+</style>
+<body>
+    <canvas id="test"></canvas>
+    <script>
+        const destCanvas = document.querySelector('#test');
+        const destCtx = destCanvas.getContext('2d');
+        destCtx.imageSmoothingEnabled = false;
+
+        destCtx.fillStyle = 'yellow';
+        destCtx.fillRect(70, 70, 150, 150);
+        destCtx.fillStyle = 'green';
+        destCtx.fillRect(95, 95, 100, 60);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-drawImage-negative-coordinate.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-negative-coordinate.html
@@ -1,0 +1,25 @@
+<style>
+    canvas {
+        outline: 1px solid red;
+        aspect-ratio: 1 / 1;
+    }
+</style>
+<body>
+    <canvas id="test"></canvas>
+    <script>
+        const srcCanvas = document.createElement('canvas');
+        const srcCtx = srcCanvas.getContext('2d');
+        srcCanvas.width = 80;
+        srcCanvas.height = 80;
+
+        const destCanvas = document.querySelector('#test');
+        const destCtx = destCanvas.getContext('2d');
+        destCtx.imageSmoothingEnabled = false;
+
+        srcCtx.fillStyle = 'yellow';
+        srcCtx.fillRect(0, 0, 80, 80);
+        srcCtx.fillStyle = 'green';
+        srcCtx.fillRect(10, 10, 40, 40);
+        destCtx.drawImage(srcCanvas, -20, -20, 80, 80, 20, 20, 200, 200);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-drawImage-out-of-bounds-coordinate-expected.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-out-of-bounds-coordinate-expected.html
@@ -1,0 +1,28 @@
+<style>
+    canvas {
+        outline: 1px solid red;
+        aspect-ratio: 1 / 1;
+    }
+</style>
+<body>
+    <canvas id="test1"></canvas>
+    <canvas id="test2"></canvas>
+    <script>
+        function drawRectsToCanvas(destCanvas) {
+            const destCtx = destCanvas.getContext('2d');
+            destCtx.fillStyle = 'green';
+
+            destCtx.fillRect(25, 25, 40, 40);
+            destCtx.fillRect(25, 75, 40, 75);
+
+            destCtx.fillRect(75, 25, 80, 40);
+            destCtx.fillRect(75, 75, 80, 75);
+
+            destCtx.fillRect(175, 25, 40, 40);
+            destCtx.fillRect(175, 75, 40, 75);
+        }
+
+        drawRectsToCanvas(document.querySelector('#test1'));
+        drawRectsToCanvas(document.querySelector('#test2'));
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-drawImage-out-of-bounds-coordinate.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-out-of-bounds-coordinate.html
@@ -1,0 +1,42 @@
+<style>
+    canvas {
+        outline: 1px solid red;
+        aspect-ratio: 1 / 1;
+    }
+</style>
+<body>
+    <canvas id="test1"></canvas>
+    <canvas id="test2"></canvas>
+    <script>
+        function drawImageToCanvas(source, destCanvas) {
+            const destCtx = destCanvas.getContext('2d');
+            destCtx.imageSmoothingEnabled = false;
+
+            destCtx.drawImage(source, -100, -100, 200, 200, -25, -25, 100, 100);
+            destCtx.drawImage(source, -100,    0, 200, 100, -25,  75, 100, 100);
+
+            destCtx.drawImage(source,    0, -100, 100, 200,  75, -25, 100, 100);
+            destCtx.drawImage(source, -100, -100, 300, 300, -25, -25, 300, 300);
+
+            destCtx.drawImage(source,    0, -100, 200, 200, 175, -25, 100, 100);
+            destCtx.drawImage(source,    0,    0, 200, 100, 175,  75, 100, 100);
+        }
+
+        const srcCanvas = document.createElement('canvas');
+        const srcCtx = srcCanvas.getContext('2d');
+        srcCanvas.width = 80;
+        srcCanvas.height = 80;
+
+        srcCtx.fillStyle = 'green';
+        srcCtx.fillRect(0, 0, srcCanvas.width, srcCanvas.height);
+
+        drawImageToCanvas(srcCanvas, document.querySelector('#test1'));
+
+        const dataURL = srcCanvas.toDataURL();
+        const image = new Image();
+        image.src = dataURL;
+        image.onload = () => {
+            drawImageToCanvas(image, document.querySelector('#test2'));
+        };
+    </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas-expected.txt
@@ -149,17 +149,17 @@ PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 99,99 should be red.
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel outside canvas should be transparent black.
 
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,70 should be blue. assert_array_equals: expected property 2 to be 255 but got 0 (expected array [0, 0, 255, 255] got object "0,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,70 should be blue.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be blue.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be blue.
 FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 82,82 should be blue. assert_array_equals: expected property 2 to be 255 but got 0 (expected array [0, 0, 255, 255] got object "0,0,0,255")
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,84 should be black.
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,99 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,84 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,99 should be black.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,84 should be black.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be black.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 0,69 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,0 should be red.
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,69 should be red. assert_array_equals: expected property 0 to be 255 but got 0 (expected array [255, 0, 0, 255] got object "0,0,0,255")
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,69 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel outside canvas should be transparent black.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image-expected.txt
@@ -109,13 +109,13 @@ PASS Test scenario 11: sx = 0, sy = 0, sw = 2048, sh = 2048, dx = 0, dy = 0, dw 
 PASS Test scenario 11: sx = 0, sy = 0, sw = 2048, sh = 2048, dx = 0, dy = 0, dw = 800, dh = 800 --- Pixel outside canvas should be transparent black.
 
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,70 should be light purple.
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be light purple. assert_array_equals: expected property 0 to be 253 but got 255 (expected array [253, 140, 245, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be light purple. assert_array_equals: expected property 0 to be 253 but got 255 (expected array [253, 140, 245, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be light purple. assert_array_equals: expected property 0 to be 253 but got 255 (expected array [253, 140, 245, 255] got object "255,0,0,255")
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be light purple.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be light purple.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be light purple.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 0,0 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 0,99 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,0 should be red.
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,69 should be red. assert_array_equals: expected property 0 to be 255 but got 253 (expected array [255, 0, 0, 255] got object "253,140,245,255")
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,69 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,99 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,69 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel outside canvas should be transparent black.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas-expected.txt
@@ -97,14 +97,14 @@ PASS Test scenario 7: sx = 0, sy = 0, sw = 25, sh = 25, dx = 25, dy = 25, dw = 2
 PASS Test scenario 7: sx = 0, sy = 0, sw = 25, sh = 25, dx = 25, dy = 25, dw = 25, dh = 25 --- Pixel 50,50 should be red.
 PASS Test scenario 7: sx = 0, sy = 0, sw = 25, sh = 25, dx = 25, dy = 25, dw = 25, dh = 25 --- Pixel outside canvas should be transparent black.
 
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,20 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 20,0 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 20,20 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 24,24 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,0 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,19 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 19,0 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 19,19 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,20 should be blue.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 20,0 should be blue.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 20,20 should be blue.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 24,24 should be blue.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,0 should be black.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,19 should be black.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 19,0 should be black.
+PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 19,19 should be black.
 PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,25 should be red.
 PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 25,0 should be red.
 PASS Test scenario 8: sx = 25, sy = 25, sw = 50, sh = 50, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 25,25 should be red.
@@ -115,10 +115,10 @@ PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw =
 PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 50,99 should be blue.
 PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 99,50 should be blue.
 PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 99,99 should be blue.
-FAIL Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 55,55 should be black. assert_array_equals: expected property 2 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "0,0,255,255")
-FAIL Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 55,94 should be black. assert_array_equals: expected property 2 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "0,0,255,255")
-FAIL Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 94,55 should be black. assert_array_equals: expected property 2 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "0,0,255,255")
-FAIL Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 94,94 should be black. assert_array_equals: expected property 2 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "0,0,255,255")
+PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 55,55 should be black.
+PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 55,94 should be black.
+PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 94,55 should be black.
+PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 94,94 should be black.
 PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 0,0 should be red.
 PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 49,49 should be red.
 PASS Test scenario 9: sx = 0, sy = 0, sw = 50, sh = 50, dx = 100, dy = 100, dw = -50, dh = -50 --- Pixel 0,99 should be red.
@@ -135,28 +135,28 @@ PASS Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 20
 PASS Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 99,99 should be black.
 PASS Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel outside canvas should be transparent black.
 
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,0 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 1,1 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 23,23 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 24,24 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 3,3 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 3,21 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 21,3 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 21,21 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,0 should be blue.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 1,1 should be blue.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 23,23 should be blue.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 24,24 should be blue.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 3,3 should be black.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 3,21 should be black.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 21,3 should be black.
+PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 21,21 should be black.
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 0,25 should be red.
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 25,0 should be red.
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 25,25 should be red.
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel 99,99 should be red.
 PASS Test scenario 11: sx = 0, sy = 0, sw = 100, sh = 100, dx = 0, dy = 0, dw = 50, dh = 50 --- Pixel outside canvas should be transparent black.
 
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,70 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 82,82 should be blue. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 255, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,84 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,99 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,84 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
-FAIL Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be black. assert_array_equals: expected property 0 to be 0 but got 255 (expected array [0, 0, 0, 255] got object "255,0,0,255")
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,70 should be blue.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be blue.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be blue.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 82,82 should be blue.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,84 should be black.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,99 should be black.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,84 should be black.
+PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be black.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 0,69 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,0 should be red.
 PASS Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 69,69 should be red.

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1631,25 +1631,6 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CSSStyleImageValue& im
     return result;
 }
 
-static std::pair<FloatRect, FloatRect> normalizeSourceAndDestination(const FloatRect& imageRect, const FloatRect& srcRect, const FloatRect& dstRect)
-{
-    std::pair<FloatRect, FloatRect> srcDstRect { normalizeRect(srcRect), normalizeRect(dstRect) };
-
-    // When the source rectangle is outside the source image, the source rectangle must be clipped
-    // to the source image and the destination rectangle must be clipped in the same proportion.
-    FloatRect originalNormalizedSrcRect = srcDstRect.first;
-    srcDstRect.first.intersect(imageRect);
-    if (srcDstRect.first.isEmpty())
-        return srcDstRect;
-
-    if (srcDstRect.first != originalNormalizedSrcRect) {
-        srcDstRect.second.setWidth(srcDstRect.second.width() * srcDstRect.first.width() / originalNormalizedSrcRect.width());
-        srcDstRect.second.setHeight(srcDstRect.second.height() * srcDstRect.first.height() / originalNormalizedSrcRect.height());
-    }
-
-    return srcDstRect;
-}
-
 #if ENABLE(WEB_CODECS)
 ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(WebCodecsVideoFrame& frame, const FloatRect&, const FloatRect& dstRect)
 {
@@ -1688,9 +1669,8 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
     if (!dstRect.width() || !dstRect.height())
         return { };
 
-    auto normalizedSrcDstRect = normalizeSourceAndDestination(imageRect, srcRect, dstRect);
-    FloatRect normalizedSrcRect = normalizedSrcDstRect.first;
-    FloatRect normalizedDstRect = normalizedSrcDstRect.second;
+    auto normalizedSrcRect = normalizeRect(srcRect);
+    auto normalizedDstRect = normalizeRect(dstRect);
 
     if (normalizedSrcRect.isEmpty())
         return { };
@@ -1778,9 +1758,8 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     if (!srcRect.width() || !srcRect.height())
         return { };
 
-    auto normalizedSrcDstRect = normalizeSourceAndDestination(srcCanvasRect, srcRect, dstRect);
-    FloatRect normalizedSrcRect = normalizedSrcDstRect.first;
-    FloatRect normalizedDstRect = normalizedSrcDstRect.second;
+    auto normalizedSrcRect = normalizeRect(srcRect);
+    auto normalizedDstRect = normalizeRect(dstRect);
 
     if (normalizedSrcRect.isEmpty())
         return { };
@@ -1846,13 +1825,11 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
     if (video.readyState() == HTMLMediaElement::HAVE_NOTHING || video.readyState() == HTMLMediaElement::HAVE_METADATA)
         return { };
 
-    FloatRect videoRect = FloatRect(FloatPoint(), size(video));
     if (!srcRect.width() || !srcRect.height())
         return { };
 
-    auto normalizedSrcDstRect = normalizeSourceAndDestination(videoRect, srcRect, dstRect);
-    FloatRect normalizedSrcRect = normalizedSrcDstRect.first;
-    FloatRect normalizedDstRect = normalizedSrcDstRect.second;
+    auto normalizedSrcRect = normalizeRect(srcRect);
+    auto normalizedDstRect = normalizeRect(dstRect);
 
     if (normalizedSrcRect.isEmpty())
         return { };


### PR DESCRIPTION
#### 5dd01bad437e9caca054e7a6809ccf7281b70f4a
<pre>
Canvas drawImage should not alter the input source or the destination rectangles
<a href="https://bugs.webkit.org/show_bug.cgi?id=202457">https://bugs.webkit.org/show_bug.cgi?id=202457</a>
<a href="https://rdar.apple.com/127982607">rdar://127982607</a>

Reviewed by Kimmo Kinnunen.

The input source rectangle was incorrectly clipped to the image source rectangle.
The specs [1] means copying the pixels from the image should be limited to the
image source rectangle. This clipped is already handled by the drawing SDK.

The input source and the destination rectangles should not be altered because
they are used to scale the image when it is drawn to the canvas.

[1] <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#dom-context-2d-drawimage">http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#dom-context-2d-drawimage</a>

* LayoutTests/fast/canvas/canvas-drawImage-negative-coordinate-expected.html: Added.
* LayoutTests/fast/canvas/canvas-drawImage-negative-coordinate.html: Added.
* LayoutTests/fast/canvas/canvas-drawImage-out-of-bounds-coordinate-expected.html: Added.
* LayoutTests/fast/canvas/canvas-drawImage-out-of-bounds-coordinate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_html_image-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_canvas-expected.txt: Renamed from LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/drawing-images-to-the-canvas/drawimage_canvas-expected.txt.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::normalizeSourceAndDestination): Deleted.

Canonical link: <a href="https://commits.webkit.org/278807@main">https://commits.webkit.org/278807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c52c3a272e6735810ee0f87b2b8f721e560b12f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2296 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42006 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1771 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49404 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44582 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48605 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->