### PR TITLE
Support nested currentcolor resolution for canvas

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.colormix.currentcolor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.colormix.currentcolor-expected.txt
@@ -2,5 +2,5 @@
 color-mix works as color input with currentcolor
 Actual output:
 
-FAIL color-mix works as color input with currentcolor assert_equals: ctx.fillStyle === 'color(srgb 0.5 0 0.5)' (got #000000[string], expected color(srgb 0.5 0 0.5)[string]) expected "color(srgb 0.5 0 0.5)" but got "#000000"
+PASS color-mix works as color input with currentcolor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.system-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.system-expected.txt
@@ -1,5 +1,5 @@
 2d.fillStyle.parse.system
 
 
-FAIL OffscreenCanvas test: 2d.fillStyle.parse.system assert_regexp_match: expected object "/^#(?!(FF0000|ff0000|f00)$)/" but got "#ff0000"
+PASS OffscreenCanvas test: 2d.fillStyle.parse.system
 

--- a/Source/WebCore/css/color/CSSUnresolvedColorKeyword.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColorKeyword.cpp
@@ -52,15 +52,15 @@ Color createColor(const CSSUnresolvedColorKeyword& unresolved, const CSSUnresolv
 {
     switch (unresolved.valueID) {
     case CSSValueInternalDocumentTextColor:
-        return context.internalDocumentTextColor;
+        return context.internalDocumentTextColor();
     case CSSValueWebkitLink:
-        return context.forVisitedLink == Style::ForVisitedLink::Yes ? context.webkitLinkVisited : context.webkitLink;
+        return context.forVisitedLink == Style::ForVisitedLink::Yes ? context.webkitLinkVisited() : context.webkitLink();
     case CSSValueWebkitActivelink:
-        return context.webkitActiveLink;
+        return context.webkitActiveLink();
     case CSSValueWebkitFocusRingColor:
-        return context.webkitFocusRingColor;
+        return context.webkitFocusRingColor();
     case CSSValueCurrentcolor:
-        return context.currentColor;
+        return context.currentColor();
     default:
         return StyleColor::colorFromKeyword(unresolved.valueID, context.keywordOptions);
     }

--- a/Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.cpp
@@ -26,15 +26,8 @@
 #include "config.h"
 #include "CSSUnresolvedColorResolutionContext.h"
 
-#include "StyleBuilderState.h"
-
 namespace WebCore {
 
-CSSUnresolvedColorResolutionContext::CSSUnresolvedColorResolutionContext()
-    : forVisitedLink { Style::ForVisitedLink::No }
-{
-}
-
-CSSUnresolvedColorResolutionContext::~CSSUnresolvedColorResolutionContext() = default;
+CSSUnresolvedColorResolutionDelegate::~CSSUnresolvedColorResolutionDelegate() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasGradient.cpp
+++ b/Source/WebCore/html/canvas/CanvasGradient.cpp
@@ -68,20 +68,12 @@ Ref<CanvasGradient> CanvasGradient::create(const FloatPoint& centerPoint, float 
 
 CanvasGradient::~CanvasGradient() = default;
 
-ExceptionOr<void> CanvasGradient::addColorStop(double value, const String& colorString)
+ExceptionOr<void> CanvasGradient::addColorStop(ScriptExecutionContext& scriptExecutionContext, double value, const String& colorString)
 {
     if (!(value >= 0 && value <= 1))
         return Exception { ExceptionCode::IndexSizeError };
 
-    // Treat currentColor as black, as required by the standard.
-    Color color;
-    if (isCurrentColorString(colorString))
-        color = Color::black;
-    else if (m_context)
-        color = parseColor(colorString, m_context->canvasBase());
-    else
-        color = parseColor(colorString);
-
+    auto color = parseColor(colorString, scriptExecutionContext);
     if (!color.isValid())
         return Exception { ExceptionCode::SyntaxError };
 

--- a/Source/WebCore/html/canvas/CanvasGradient.h
+++ b/Source/WebCore/html/canvas/CanvasGradient.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class CanvasRenderingContext;
 class Gradient;
+class ScriptExecutionContext;
 
 class CanvasGradient : public RefCounted<CanvasGradient> {
 public:
@@ -44,7 +45,7 @@ public:
     Gradient& gradient() { return m_gradient; }
     const Gradient& gradient() const { return m_gradient; }
 
-    ExceptionOr<void> addColorStop(double value, const String& color);
+    ExceptionOr<void> addColorStop(ScriptExecutionContext&, double value, const String& color);
 
 private:
     CanvasGradient(const FloatPoint& p0, const FloatPoint& p1, CanvasRenderingContext&);

--- a/Source/WebCore/html/canvas/CanvasGradient.idl
+++ b/Source/WebCore/html/canvas/CanvasGradient.idl
@@ -28,5 +28,5 @@
     Exposed=(Window,Worker),
 ] interface CanvasGradient {
     // opaque object
-    undefined addColorStop(double offset, DOMString color);
+    [CallWith=CurrentScriptExecutionContext] undefined addColorStop(double offset, DOMString color);
 };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -402,7 +402,9 @@ private:
     void realizeSavesLoop();
 
     void setStrokeStyle(CanvasStyle);
+    void setStrokeStyle(std::optional<CanvasStyle>);
     void setFillStyle(CanvasStyle);
+    void setFillStyle(std::optional<CanvasStyle>);
 
     ExceptionOr<RefPtr<CanvasPattern>> createPattern(CachedImage&, RenderElement*, bool repeatX, bool repeatY);
     ExceptionOr<RefPtr<CanvasPattern>> createPattern(HTMLImageElement&, bool repeatX, bool repeatY);


### PR DESCRIPTION
#### b6495ee90abb854c0e3acd2f103835436ddf7db3
<pre>
Support nested currentcolor resolution for canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=274120">https://bugs.webkit.org/show_bug.cgi?id=274120</a>

Reviewed by Darin Adler.

Support for &apos;currentcolor&apos; in canvas was previously hardcoded
to look for the explicit string, which made any nested usage,
such as in `color-mix()` broken.

To resolve this, we remove all special casing of `currentcolor`
in the canvas code (simplifying CanvasStyle considerably) and
use the CSSUnresolvedColorResolutionContext and its delegate
to resolve it at any nesting level.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.colormix.currentcolor-expected.txt:
    - Update results now that we pass.

* Source/WebCore/css/color/CSSUnresolvedColorKeyword.cpp:
(WebCore::createColor):
    - Call the context&apos;s getter functions to allow lazy
      lookup of the color values.

* Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.cpp:
* Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.h:
    - Re-work the resolution context to contain a delegate that allows
      the client to only compute color values if they are needed.
      The client is still able to use the context without a delegate,
      and explicitly set color values before hand if they want to.
      The keyword lookup code now calls the functions on the context,
      which check for the memoized value and then call the delegate
      if available and necessary.

* Source/WebCore/html/canvas/CanvasGradient.idl:
* Source/WebCore/html/canvas/CanvasGradient.cpp:
(WebCore::CanvasGradient::addColorStop):
    - Remove special casing of `currentcolor`, instead relying on
      the elementless `parseColor()` function doing the right thing
      by specifying `Color::black` for the resolved value. This also
      now more closely follows the spec text.
    - Update IDL to pass in a ScriptExecutionContext, which is now
      needed by the elementless `parseColor()` function.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::setStrokeStyle):
(WebCore::CanvasRenderingContext2DBase::setFillStyle):
    - With CanvasStyle no longer having its own invalid state,
      setStrokeStyle/setFillStyle get an additional overload
      with an std::optional&lt;CanvasStyle&gt;, which takes the place
      of the invalid state.
    - We also remove all the special casing of `currentcolor`
      that is no longer needed.

(WebCore::CanvasRenderingContext2DBase::setShadowColor):
(WebCore::CanvasRenderingContext2DBase::setShadow):
    - We can call the standard `parseColor()` now, as it
      supports `currentcolor`.

(WebCore::toStyleVariant):
    - Use the new `CanvasStyle.visit(...)` function rather
      than checking each type one at a time.

* Source/WebCore/html/canvas/CanvasStyle.h:
    - Removes the Invalid and CurrentColor states. CurrentColor is
      handled by the Color state now. Invalid was only used briefly
      by rendering context and has been replaced by a std::optional
      result from the create functions. By removing these states,
      the switchOn statements can now have all their states handled
      without ASSERT_NOT_REACHED(). The RefPtrs have also been
      replaced by Refs, as these are known non-null.

(WebCore::CanvasStyle::visit): Added.
    - Added a helper to switch over the different internal states,
      eagerly converting to a String for color, as that is what is
      expected by the canvas rendering context code.

(WebCore::CanvasStyle::color):
    - Add check that Color is the alternative held by the variant.
      Previously, this function was only called when all the other
      types had been ruled out, but could easily have caused a crash
      if misused.

(WebCore::CanvasStyle::isCurrentColor const): Deleted.
(WebCore::CanvasStyle::overrideAlpha const): Deleted.
(WebCore::CanvasStyle::CanvasStyle): Deleted.
(WebCore::CanvasStyle::srgbaColor const): Deleted.
    - Remove a bunch of unused functions.

* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::CanvasStyleColorResolutionDelegate::CanvasStyleColorResolutionDelegate):
    - Implement a simple delegate for color resolution, moving the
      existing code for resolving `currentcolor` from below.

(WebCore::parseColor):
    - Bottleneck color parsing in two parse functions, one taking
      a CanvasBase, one a ScriptExecutionContext. The one taking
      a CanvasBase further refines itself based on whether the
      CanvasBase is a canvas element, in which case, it creates
      a resolution delegate for resolving `currentcolor` based
      on the element style.

      All other canvases are treated as elementless, getting a
      hardcoded `Color::black` for `currentcolor` and utilizing
      the execution context to determine if system colors are
      supported.

(WebCore::CanvasStyle::createFromString):
(WebCore::CanvasStyle::createFromStringWithOverrideAlpha):
    - Remove special casing for `currentcolor`, calling through to the
      shared `parseColor()` function.

(WebCore::CanvasStyle::applyStrokeColor const):
(WebCore::CanvasStyle::applyFillColor const):
    - Update switchOns for Ref use and removed states.

(WebCore::isCurrentColorString): Deleted.
(WebCore::currentColor): Deleted.
(WebCore::parseColorOrCurrentColor): Deleted.
    - Remove now unused functions.

Canonical link: <a href="https://commits.webkit.org/279017@main">https://commits.webkit.org/279017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/695d39cd8dfd2991c8a8b2384d272486cf0bcf4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52206 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42489 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57076 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49879 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49117 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29477 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/7894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->