### PR TITLE
Add a mechanism for tracking whether web pages have "recently" used gamepads

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -374,6 +374,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/gamepad/GamepadEffectParameters.h
     Modules/gamepad/GamepadHapticEffectType.h
+    Modules/gamepad/NavigatorGamepad.h
 
     Modules/geolocation/Geolocation.h
     Modules/geolocation/GeolocationClient.h

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -28,12 +28,15 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "Chrome.h"
+#include "ChromeClient.h"
 #include "Document.h"
 #include "Gamepad.h"
 #include "GamepadManager.h"
 #include "GamepadProvider.h"
 #include "LocalDOMWindow.h"
 #include "Navigator.h"
+#include "Page.h"
 #include "PermissionsPolicy.h"
 #include "PlatformGamepad.h"
 
@@ -89,8 +92,41 @@ ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Naviga
     return NavigatorGamepad::from(navigator)->gamepads();
 }
 
+// The UIProcess tracks when a WebPage has recently used gamepads to configure certain behaviors on the page.
+//
+// Once a WebPage notifies the UIProcess that gamepads have been accessed, the UIProcess starts a timer with
+// a short delay, after which it assumes that WebPage is no longer actively using gamepads.
+//
+// This works because of the polling nature of the gamepad API - If a web page is using gamepads it will be
+// accessing them multiple times per second.
+//
+// WebPages need to continuously tell the UIProcess that gamepads have been used recently, but can do so lazily;
+// As long as a WebPage continuously using gamepads notifies the UIProcess at least once during the UIProcess's
+// timer delay, things will work as expected.
+//
+// So it follows: Web processes have this value initialized to be compatible with the UIProcess timer threshold.
+
+static Seconds s_gamepadsRecentlyAccessedThreshold;
+
+void NavigatorGamepad::setGamepadsRecentlyAccessedThreshold(Seconds threshold)
+{
+    // This value should only initialized once.
+    RELEASE_ASSERT(!s_gamepadsRecentlyAccessedThreshold);
+    s_gamepadsRecentlyAccessedThreshold = threshold;
+}
+
+Seconds NavigatorGamepad::gamepadsRecentlyAccessedThreshold()
+{
+    return s_gamepadsRecentlyAccessedThreshold;
+}
+
 const Vector<RefPtr<Gamepad>>& NavigatorGamepad::gamepads()
 {
+    if (RefPtr frame = m_navigator.frame()) {
+        if (RefPtr page = frame->protectedPage())
+            page->gamepadsRecentlyAccessed();
+    }
+
     if (m_gamepads.isEmpty())
         return m_gamepads;
 

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 
 #include "Supplementable.h"
+#include <wtf/MonotonicTime.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -64,10 +65,14 @@ public:
 
     Ref<Gamepad> gamepadFromPlatformGamepad(PlatformGamepad&);
 
+    WEBCORE_EXPORT static void setGamepadsRecentlyAccessedThreshold(Seconds);
+    static Seconds gamepadsRecentlyAccessedThreshold();
+
 private:
     static ASCIILiteral supplementName();
 
     void gamepadsBecameVisible();
+    void maybeNotifyRecentAccess();
 
     const Vector<RefPtr<Gamepad>>& gamepads();
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -657,6 +657,10 @@ public:
 
     virtual void didAdjustVisibilityWithSelectors(Vector<String>&&) { }
 
+#if ENABLE(GAMEPAD)
+    virtual void gamepadsRecentlyAccessed() { }
+#endif
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -106,6 +106,7 @@
 #include "ModelPlayerProvider.h"
 #include "NavigationScheduler.h"
 #include "Navigator.h"
+#include "NavigatorGamepad.h"
 #include "OpportunisticTaskScheduler.h"
 #include "PageColorSampler.h"
 #include "PageConfiguration.h"
@@ -4797,6 +4798,17 @@ void Page::setDefaultSpatialTrackingLabel(const String& label)
     forEachDocument([&] (Document& document) {
         document.defaultSpatialTrackingLabelChanged(m_defaultSpatialTrackingLabel);
     });
+}
+#endif
+
+#if ENABLE(GAMEPAD)
+void Page::gamepadsRecentlyAccessed()
+{
+    if (MonotonicTime::now() - m_lastAccessNotificationTime < NavigatorGamepad::gamepadsRecentlyAccessedThreshold())
+        return;
+
+    chrome().client().gamepadsRecentlyAccessed();
+    m_lastAccessNotificationTime = MonotonicTime::now();
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1120,6 +1120,10 @@ public:
     const String& defaultSpatialTrackingLabel() const { return m_defaultSpatialTrackingLabel; }
 #endif
 
+#if ENABLE(GAMEPAD)
+    void gamepadsRecentlyAccessed();
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1514,7 +1518,11 @@ private:
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;
 #endif
-};
+
+#if ENABLE(GAMEPAD)
+    MonotonicTime m_lastAccessNotificationTime;
+#endif
+}; // class Page
 
 inline Page* Frame::page() const
 {

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -242,6 +242,11 @@ public:
     virtual void updateClientBadge(WebKit::WebPageProxy&, const WebCore::SecurityOriginData&, std::optional<uint64_t>) { }
 
     virtual void didAdjustVisibilityWithSelectors(WebKit::WebPageProxy&, Vector<WTF::String>&&) { }
+
+#if ENABLE(GAMEPAD)
+    virtual void recentlyAccessedGamepadsForTesting(WebKit::WebPageProxy&) { }
+    virtual void stoppedAccessingGamepadsForTesting(WebKit::WebPageProxy&) { }
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -206,6 +206,9 @@ struct UIEdgeInsets;
 
 - (void)_webView:(WKWebView *)webView didAdjustVisibilityWithSelectors:(NSArray<NSString *> *)selectors WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+- (void)_webViewRecentlyAccessedGamepadsForTesting:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_webViewStoppedAccessingGamepadsForTesting:(WKWebView *)webView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 #if TARGET_OS_IPHONE
 
 - (BOOL)_webView:(WKWebView *)webView shouldIncludeAppLinkActionsForElement:(_WKActivatedElementInfo *)element WK_API_AVAILABLE(ios(9.0));

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -204,6 +204,11 @@ private:
 
         void didAdjustVisibilityWithSelectors(WebPageProxy&, Vector<String>&&) final;
 
+#if ENABLE(GAMEPAD)
+        void recentlyAccessedGamepadsForTesting(WebPageProxy&) final;
+        void stoppedAccessingGamepadsForTesting(WebPageProxy&) final;
+#endif
+
         WeakPtr<UIDelegate> m_uiDelegate;
     };
 
@@ -312,6 +317,11 @@ private:
         bool webViewUpdatedAppBadge : 1;
         bool webViewUpdatedClientBadge : 1;
         bool webViewDidAdjustVisibilityWithSelectors : 1;
+
+#if ENABLE(GAMEPAD)
+        bool webViewRecentlyAccessedGamepadsForTesting : 1;
+        bool webViewStoppedAccessingGamepadsForTesting : 1;
+#endif
     } m_delegateMethods;
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -234,6 +234,11 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
     m_delegateMethods.webViewUpdatedClientBadge = [delegate respondsToSelector:@selector(_webView:updatedClientBadge:fromSecurityOrigin:)];
 
     m_delegateMethods.webViewDidAdjustVisibilityWithSelectors = [delegate respondsToSelector:@selector(_webView:didAdjustVisibilityWithSelectors:)];
+
+#if ENABLE(GAMEPAD)
+    m_delegateMethods.webViewRecentlyAccessedGamepadsForTesting = [delegate respondsToSelector:@selector(_webViewRecentlyAccessedGamepadsForTesting:)];
+    m_delegateMethods.webViewStoppedAccessingGamepadsForTesting = [delegate respondsToSelector:@selector(_webViewStoppedAccessingGamepadsForTesting:)];
+#endif
 }
 
 #if ENABLE(CONTEXT_MENUS)
@@ -1936,6 +1941,38 @@ void UIDelegate::UIClient::didAdjustVisibilityWithSelectors(WebPageProxy&, Vecto
     RetainPtr nsSelectors = createNSArray(WTFMove(selectors));
     [delegate _webView:m_uiDelegate->m_webView.get().get() didAdjustVisibilityWithSelectors:nsSelectors.get()];
 }
+
+#if ENABLE(GAMEPAD)
+void UIDelegate::UIClient::recentlyAccessedGamepadsForTesting(WebPageProxy&)
+{
+    if (!m_uiDelegate)
+        return;
+
+    if (!m_uiDelegate->m_delegateMethods.webViewRecentlyAccessedGamepadsForTesting)
+        return;
+
+    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    if (!delegate)
+        return;
+
+    [delegate _webViewRecentlyAccessedGamepadsForTesting:m_uiDelegate->m_webView.get().get()];
+}
+
+void UIDelegate::UIClient::stoppedAccessingGamepadsForTesting(WebPageProxy&)
+{
+    if (!m_uiDelegate)
+        return;
+
+    if (!m_uiDelegate->m_delegateMethods.webViewStoppedAccessingGamepadsForTesting)
+        return;
+
+    auto delegate = (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    if (!delegate)
+        return;
+
+    [delegate _webViewStoppedAccessingGamepadsForTesting:m_uiDelegate->m_webView.get().get()];
+}
+#endif
 
 #if ENABLE(WEBXR)
 static _WKXRSessionMode toWKXRSessionMode(PlatformXR::SessionMode mode)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -31,6 +31,7 @@
 #include "MessageSender.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NowPlayingMetadataObserver.h>
+#include <pal/HysteresisActivity.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/OptionSet.h>
@@ -1897,7 +1898,10 @@ public:
 #endif
 
 #if ENABLE(GAMEPAD)
+    static constexpr Seconds gamepadsRecentlyAccessedThreshold { 1500_ms };
+
     void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
+    void gamepadsRecentlyAccessed();
 #endif
 
     void isLoadingChanged();
@@ -3049,6 +3053,10 @@ private:
 
     void frameNameChanged(IPC::Connection&, WebCore::FrameIdentifier, const String& frameName);
 
+#if ENABLE(GAMEPAD)
+    void recentGamepadAccessStateChanged(PAL::HysteresisState);
+#endif
+
     struct Internals;
     Internals& internals() { return m_internals; }
     const Internals& internals() const { return m_internals; }
@@ -3581,6 +3589,10 @@ private:
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     bool m_isUnifiedTextReplacementActive { false };
+#endif
+
+#if ENABLE(GAMEPAD)
+    PAL::HysteresisActivity m_recentGamepadAccessHysteresis;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -646,4 +646,8 @@ messages -> WebPageProxy {
     DidAdjustVisibilityWithSelectors(Vector<String> selectors)
 
     FrameNameChanged(WebCore::FrameIdentifier frameID, String frameName)
+
+#if ENABLE(GAMEPAD)
+    GamepadsRecentlyAccessed()
+#endif
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1823,4 +1823,11 @@ void WebChromeClient::didAdjustVisibilityWithSelectors(Vector<String>&& selector
     return protectedPage()->didAdjustVisibilityWithSelectors(WTFMove(selectors));
 }
 
+#if ENABLE(GAMEPAD)
+void WebChromeClient::gamepadsRecentlyAccessed()
+{
+    protectedPage()->gamepadsRecentlyAccessed();
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -502,6 +502,10 @@ private:
 
     void didAdjustVisibilityWithSelectors(Vector<String>&&) final;
 
+#if ENABLE(GAMEPAD)
+    void gamepadsRecentlyAccessed() final;
+#endif
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8102,6 +8102,11 @@ void WebPage::gamepadActivity(const Vector<std::optional<GamepadData>>& gamepadD
     WebGamepadProvider::singleton().gamepadActivity(gamepadDatas, eventVisibilty);
 }
 
+void WebPage::gamepadsRecentlyAccessed()
+{
+    send(Messages::WebPageProxy::GamepadsRecentlyAccessed());
+}
+
 #endif
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1396,6 +1396,7 @@ public:
 
 #if ENABLE(GAMEPAD)
     void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
+    void gamepadsRecentlyAccessed();
 #endif
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -70,6 +70,7 @@
 #include "WebPageCreationParameters.h"
 #include "WebPageGroupProxy.h"
 #include "WebPageInlines.h"
+#include "WebPageProxy.h"
 #include "WebPaymentCoordinator.h"
 #include "WebPermissionController.h"
 #include "WebPlatformStrategies.h"
@@ -117,6 +118,7 @@
 #include <WebCore/MemoryRelease.h>
 #include <WebCore/MessagePort.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
+#include <WebCore/NavigatorGamepad.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageGroup.h>
@@ -628,6 +630,13 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
 
     updateStorageAccessUserAgentStringQuirks(WTFMove(parameters.storageAccessUserAgentStringQuirksData));
     updateDomainsWithStorageAccessQuirks(WTFMove(parameters.storageAccessPromptQuirksDomains));
+
+#if ENABLE(GAMEPAD)
+    // Web processes need to periodically notify the UI process of gamepad access at least as frequently
+    // as the WebPageProxy::gamepadsRecentlyAccessedThreshold value.
+    // 3-times-as-often seems like it will guarantee proper behavior for almost all web pages.
+    WebCore::NavigatorGamepad::setGamepadsRecentlyAccessedThreshold(WebPageProxy::gamepadsRecentlyAccessedThreshold / 3);
+#endif
 
     WEBPROCESS_RELEASE_LOG(Process, "initializeWebProcess: Presenting processPID=%d", WebCore::presentingApplicationPID());
 }


### PR DESCRIPTION
#### b5e71b32c88ce4dfbcb216ab61dea9535727dbfd
<pre>
Add a mechanism for tracking whether web pages have &quot;recently&quot; used gamepads
<a href="https://rdar.apple.com/127892698">rdar://127892698</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274134">https://bugs.webkit.org/show_bug.cgi?id=274134</a>

Reviewed by Sihui Liu.

In some configurations the UIProcess might want to configure specific behaviors based on
whether or not content in a web page has &quot;recently&quot; accessed gamepads via JavaScript.

Do to the polling nature of navigator.getGamepads() we consider a web page to have &quot;recently&quot;
accessed them as long as that function is called periodically during an arbitrary timespan
I have arbitrarily chosen as 1.5 seconds.

This patch adds the behavior and tests it via TestWebKitAPI.
Actually using this behavior to do something interesting will come in a followup.

* Source/WebCore/Headers.cmake:

* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::setGamepadsRecentlyAccessedThreshold):
(WebCore::NavigatorGamepad::maybeNotifyRecentAccess):
(WebCore::NavigatorGamepad::gamepads):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::gamepadsRecentlyAccessed):

* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::recentlyAccessedGamepadsForTesting):
(API::UIClient::stoppedAccessingGamepadsForTesting):

* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:

* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::recentlyAccessedGamepadsForTesting):
(WebKit::UIDelegate::UIClient::stoppedAccessingGamepadsForTesting):

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_recentGamepadAccessHysteresis):
(WebKit::WebPageProxy::recentGamepadAccessStateChanged):
(WebKit::WebPageProxy::gamepadsRecentlyAccessed):
(WebKit::m_browsingContextGroup): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::gamepadsRecentlyAccessed):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::gamepadsRecentlyAccessed):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):

* Tools/TestWebKitAPI/Tests/mac/HIDGamepads.mm:
(-[GamepadUIDelegate _webViewRecentlyAccessedGamepadsForTesting:]):
(-[GamepadUIDelegate _webViewStoppedAccessingGamepadsForTesting:]):
(TestWebKitAPI::(Gamepad, GamepadState)):

Canonical link: <a href="https://commits.webkit.org/278782@main">https://commits.webkit.org/278782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c72cba689be4fb36020dd0e3e59e04bab71b47ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41960 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1708 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1664 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48547 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11279 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->