### PR TITLE
[WebXR] Implicitly clear WebXROpaqueFramebuffer

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/Framebuffer.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Framebuffer.cpp
@@ -1680,6 +1680,8 @@ angle::Result Framebuffer::discard(const Context *context, size_t count, const G
     // Back-ends might make the contents of the FBO undefined. In WebGL 2.0, invalidate operations
     // can be no-ops, so we should probably do that to ensure consistency.
     // TODO(jmadill): WebGL behaviour, and robust resource init behaviour without WebGL.
+    if (context->isRobustResourceInitEnabled())
+        markDrawAttachmentsNeedInit(count, attachments);
 
     return mImpl->discard(context, count, attachments);
 }
@@ -1691,6 +1693,8 @@ angle::Result Framebuffer::invalidate(const Context *context,
     // Back-ends might make the contents of the FBO undefined. In WebGL 2.0, invalidate operations
     // can be no-ops, so we should probably do that to ensure consistency.
     // TODO(jmadill): WebGL behaviour, and robust resource init behaviour without WebGL.
+    if (context->isRobustResourceInitEnabled())
+        markDrawAttachmentsNeedInit(count, attachments);
 
     return mImpl->invalidate(context, count, attachments);
 }
@@ -2838,5 +2842,57 @@ angle::Result Framebuffer::syncAttachmentState(const Context *context,
     }
 
     return angle::Result::Continue;
+}
+
+void Framebuffer::markDrawAttachmentsNeedInit(size_t count, const GLenum *attachments)
+{
+    bool stateChanged = false;
+    for (size_t attachmentIdx = 0; attachmentIdx < count; attachmentIdx++)
+    {
+        GLenum attachmentBindPoint = attachments[attachmentIdx];
+        switch (attachmentBindPoint)
+        {
+            case GL_DEPTH_ATTACHMENT:
+            case GL_DEPTH_EXT:
+                if (mState.mDepthAttachment.isAttached())
+                {
+                    mDirtyBits.set(DIRTY_BIT_DEPTH_ATTACHMENT);
+                    mState.mResourceNeedsInit.set(DIRTY_BIT_DEPTH_ATTACHMENT);
+                    mState.mDepthAttachment.setInitState(InitState::MayNeedInit);
+                    stateChanged = true;
+                }
+                break;
+            case GL_STENCIL_ATTACHMENT:
+            case GL_STENCIL_EXT:
+                if (mState.mStencilAttachment.isAttached())
+                {
+                    mDirtyBits.set(DIRTY_BIT_STENCIL_ATTACHMENT);
+                    mState.mResourceNeedsInit.set(DIRTY_BIT_STENCIL_ATTACHMENT);
+                    mState.mStencilAttachment.setInitState(InitState::MayNeedInit);
+                    stateChanged = true;
+                }
+                break;
+            default:
+                if (attachmentBindPoint == GL_COLOR_EXT)
+                {
+                    attachmentBindPoint = GL_COLOR_ATTACHMENT0;
+                }
+                int colorDirtyBit = attachmentBindPoint - GL_COLOR_ATTACHMENT0;
+                if (colorDirtyBit >= 0 && colorDirtyBit < IMPLEMENTATION_MAX_DRAW_BUFFERS &&
+                    mState.mColorAttachments[colorDirtyBit].isAttached())
+                {
+                    mDirtyBits.set(colorDirtyBit);
+                    mState.mResourceNeedsInit.set(colorDirtyBit);
+                    mState.mColorAttachments[colorDirtyBit].setInitState(InitState::MayNeedInit);
+                    stateChanged = true;
+                }
+                break;
+        }
+    }
+
+    if (stateChanged)
+    {
+        onStateChange(angle::SubjectMessage::DirtyBitsFlagged);
+    }
 }
 }  // namespace gl

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Framebuffer.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Framebuffer.h
@@ -545,6 +545,8 @@ class Framebuffer final : public angle::ObserverInterface,
                                       Command command,
                                       const FramebufferAttachment *attachment) const;
 
+    void markDrawAttachmentsNeedInit(size_t count, const GLenum *attachments);
+
     FramebufferState mState;
     rx::FramebufferImpl *mImpl;
 

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
@@ -146,7 +146,6 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
     ScopedWebGLRestoreTexture restoreTexture { m_context, textureTarget };
     ScopedWebGLRestoreRenderbuffer restoreRenderBuffer { m_context };
 
-    gl->bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
     // https://immersive-web.github.io/webxr/#opaque-framebuffer
     // The buffers attached to an opaque framebuffer MUST be cleared to the values in the provided table when first created,
     // or prior to the processing of each XR animation frame.
@@ -162,6 +161,10 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
         m_completionSyncEvent = MachSendRight(data.layerSetup->completionSyncEvent);
     }
 
+    gl->bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
+    Vector<GCGLenum, 3> discardAttachments = { GL::COLOR_ATTACHMENT0, GL::DEPTH_ATTACHMENT, GL::STENCIL_ATTACHMENT };
+    gl->framebufferDiscard(GL::FRAMEBUFFER, discardAttachments);
+
     bindCompositorTexturesForDisplay(*gl, data);
     auto displayAttachmentSet = reusableDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
     ASSERT(displayAttachmentSet);
@@ -175,22 +178,6 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
     }
 
     m_renderingFrameIndex = data.renderingFrameIndex;
-
-    // WebXR must always clear for the rAF of the session. Currently we assume content does not do redundant initial clear,
-    // as the spec says the buffer always starts cleared.
-    ScopedDisableRasterizerDiscard disableRasterizerDiscard { m_context };
-    ScopedEnableBackbuffer enableBackBuffer { m_context };
-    ScopedDisableScissorTest disableScissorTest { m_context };
-    ScopedClearColorAndMask zeroClear { m_context, 0.f, 0.f, 0.f, 0.f, true, true, true, true, };
-    ScopedClearDepthAndMask zeroDepth { m_context, 1.0f, true, m_attributes.depth };
-    ScopedClearStencilAndMask zeroStencil { m_context, 0, 0xFFFFFFFF, m_attributes.stencil };
-    GCGLenum clearMask = GL::COLOR_BUFFER_BIT;
-    if (m_attributes.depth)
-        clearMask |= GL::DEPTH_BUFFER_BIT;
-    if (m_attributes.stencil)
-        clearMask |= GL::STENCIL_BUFFER_BIT;
-    gl->bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
-    gl->clear(clearMask);
 }
 
 void WebXROpaqueFramebuffer::endFrame()
@@ -314,8 +301,10 @@ void WebXROpaqueFramebuffer::blitSharedToLayered(GraphicsContextGL& gl)
         gl.blitFramebuffer(xOffset, 0, xOffset + width, height, 0, 0, width, height, buffers, GL::NEAREST);
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=272104 - [WebXR] Compositor expects reverse-Z values
-        gl.clearDepth(FLT_MIN);
-        gl.clear(GL::DEPTH_BUFFER_BIT | GL::STENCIL_BUFFER_BIT);
+        {
+            ScopedClearDepthAndMask minDepth { m_context, FLT_MIN, true, m_attributes.depth };
+            gl.clear(GL::DEPTH_BUFFER_BIT);
+        }
 
         xOffset += width;
         width = m_rightPhysicalSize.width();

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -37,6 +37,7 @@
 #include "HostWindow.h"
 #include "Image.h"
 #include "ImageObserver.h"
+#include "NotImplemented.h"
 #include "PixelBuffer.h"
 #include "VideoFrame.h"
 
@@ -569,6 +570,11 @@ GCGLint GraphicsContextGL::getInternalformati(GCGLenum target, GCGLenum internal
     GCGLint value[1] { };
     getInternalformativ(target, internalformat, pname, value);
     return value[0];
+}
+
+void GraphicsContextGL::framebufferDiscard(GCGLenum, std::span<const GCGLenum>)
+{
+    notImplemented();
 }
 
 void GraphicsContextGL::setDrawingBufferColorSpace(const DestinationColorSpace&)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1618,6 +1618,9 @@ public:
     // GL_EXT_polygon_offset_clamp
     virtual void polygonOffsetClampEXT(GCGLfloat factor, GCGLfloat units, GCGLfloat clamp) = 0;
 
+    // GL_EXT_discard_framebuffer
+    WEBCORE_EXPORT virtual void framebufferDiscard(GCGLenum, std::span<const GCGLenum>);
+
     // ========== Internal use for WebXR on WebGL1 contexts.
     virtual void renderbufferStorageMultisampleANGLE(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height) = 0;
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -91,6 +91,9 @@ public:
 
 #if ENABLE(WEBXR)
     bool enableRequiredWebXRExtensions() final;
+
+    // GL_EXT_discard_framebuffer
+    void framebufferDiscard(GCGLenum, std::span<const GCGLenum>) final;
 #endif
 
     void waitUntilWorkScheduled();

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -730,6 +730,15 @@ void GraphicsContextGLCocoa::disableFoveation()
 #endif
 }
 
+#if ENABLE(WEBXR)
+void GraphicsContextGLCocoa::framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments)
+{
+    if (!makeContextCurrent())
+        return;
+    GL_DiscardFramebufferEXT(target, attachments.size(), attachments.data());
+}
+#endif
+
 RetainPtr<id> GraphicsContextGLCocoa::newSharedEventWithMachPort(mach_port_t sharedEventSendRight)
 {
     return WebCore::newSharedEventWithMachPort(m_displayObj, sharedEventSendRight);
@@ -760,6 +769,7 @@ bool GraphicsContextGLCocoa::enableRequiredWebXRExtensionsImpl()
 {
     return enableExtension("GL_ANGLE_framebuffer_multisample"_s)
         && enableExtension("GL_ANGLE_framebuffer_blit"_s)
+        && enableExtension("GL_EXT_discard_framebuffer"_s)
         && enableExtension("GL_EXT_sRGB"_s)
         && enableExtension("GL_OES_EGL_image"_s)
         && enableExtension("GL_OES_rgb8_rgba8"_s)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -335,6 +335,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     [EnabledIf='webXREnabled()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
     [EnabledIf='webXREnabled()'] void EnableFoveation(uint32_t arg0)
     [EnabledIf='webXREnabled()'] void DisableFoveation()
+    [EnabledIf='webXREnabled()'] void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1709,5 +1709,10 @@
         assertIsCurrent(workQueue());
         m_context->disableFoveation();
     }
+    void framebufferDiscard(uint32_t target, std::span<const uint32_t>&& attachments)
+    {
+        assertIsCurrent(workQueue());
+        m_context->framebufferDiscard(target, attachments);
+    }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -374,6 +374,7 @@ public:
     bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
     void enableFoveation(GCGLuint) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
     void disableFoveation() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
 #endif
     // End of list used by generate-gpup-webgl script.
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -3169,6 +3169,17 @@ void RemoteGraphicsContextGLProxy::disableFoveation()
         return;
     }
 }
+
+void RemoteGraphicsContextGLProxy::framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferDiscard(target, attachments));
+    if (sendResult != IPC::Error::NoError) {
+        markContextLost();
+        return;
+    }
+}
 #endif
 
 }


### PR DESCRIPTION
#### 729393d0741fe040579bf599843215b206d0b6b1
<pre>
[WebXR] Implicitly clear WebXROpaqueFramebuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=274136">https://bugs.webkit.org/show_bug.cgi?id=274136</a>
<a href="https://rdar.apple.com/128041214">rdar://128041214</a>

Reviewed by Kimmo Kinnunen and Mike Wyrzykowski.

The performance panel of GPU debugger shows 3.5ms spent just clearing and
writing render targets at the start of frame due to our explicit glClear to
match the WebXR spec.

This change makes use of the robust resource feature of ANGLE to initialize
render target attachments just before their first use. To achieve this,
framebuffer discard/invalidate now marks attachments as needing initialization
when robust resource init is enabled is ANGLE.

This change adds framebufferDiscard and IPC messages gated on availability of
WebXR for WebXROpaqueFramebuffer to use.

* Source/ThirdParty/ANGLE/src/libANGLE/Framebuffer.cpp:
(gl::Framebuffer::discard):
(gl::Framebuffer::invalidate):
(gl::Framebuffer::markDrawAttachmentsNeedInit):
* Source/ThirdParty/ANGLE/src/libANGLE/Framebuffer.h:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::framebufferDiscard):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::framebufferDiscard):
(WebCore::GraphicsContextGLCocoa::enableRequiredWebXRExtensionsImpl):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(framebufferDiscard):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::framebufferDiscard):

Canonical link: <a href="https://commits.webkit.org/280236@main">https://commits.webkit.org/280236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec9f4040fe6f37991db2784061370761d8180323

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44112 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3349 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51536 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30646 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->