### PR TITLE
Unreviewed. Fix JSCOnly build after 278554@main

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -612,9 +612,68 @@ set(WTF_SOURCES
     unicode/icu/ICUHelpers.cpp
 )
 
-if (APPLE)
+if (WIN32)
+    list(APPEND WTF_PUBLIC_HEADERS
+        text/win/WCharStringExtras.h
+
+        win/DbgHelperWin.h
+        win/GDIObject.h
+        win/PathWalker.h
+        win/SoftLinking.h
+        win/Win32Handle.h
+    )
+elseif (APPLE)
     list(APPEND WTF_SOURCES
         darwin/OSLogPrintStream.mm
+    )
+
+    list(APPEND WTF_PUBLIC_HEADERS
+        cf/CFURLExtras.h
+        cf/TypeCastsCF.h
+        cf/VectorCF.h
+
+        cocoa/CrashReporter.h
+        cocoa/Entitlements.h
+        cocoa/NSURLExtras.h
+        cocoa/RuntimeApplicationChecksCocoa.h
+        cocoa/SoftLinking.h
+        cocoa/TollFreeBridging.h
+        cocoa/TypeCastsCocoa.h
+        cocoa/VectorCocoa.h
+
+        darwin/OSLogPrintStream.h
+        darwin/WeakLinking.h
+
+        spi/cf/CFBundleSPI.h
+        spi/cf/CFStringSPI.h
+
+        spi/cocoa/CFXPCBridgeSPI.h
+        spi/cocoa/CrashReporterClientSPI.h
+        spi/cocoa/IOSurfaceSPI.h
+        spi/cocoa/MachVMSPI.h
+        spi/cocoa/NSLocaleSPI.h
+        spi/cocoa/NSObjCRuntimeSPI.h
+        spi/cocoa/SecuritySPI.h
+        spi/cocoa/objcSPI.h
+
+        spi/darwin/AbortWithReasonSPI.h
+        spi/darwin/CodeSignSPI.h
+        spi/darwin/DataVaultSPI.h
+        spi/darwin/OSVariantSPI.h
+        spi/darwin/ProcessMemoryFootprint.h
+        spi/darwin/SandboxSPI.h
+        spi/darwin/XPCSPI.h
+        spi/darwin/dyldSPI.h
+
+        spi/mac/MetadataSPI.h
+
+        text/cf/StringConcatenateCF.h
+        text/cf/TextBreakIteratorCF.h
+    )
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    list(APPEND WTF_PUBLIC_HEADERS
+        linux/CurrentProcessMemoryStatus.h
+        linux/ProcessMemoryFootprint.h
     )
 endif ()
 

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -93,10 +93,6 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
 
         unix/MemoryPressureHandlerUnix.cpp
     )
-    list(APPEND WTF_PUBLIC_HEADERS
-        linux/CurrentProcessMemoryStatus.h
-        linux/ProcessMemoryFootprint.h
-    )
 elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     list(APPEND WTF_SOURCES
         generic/MemoryFootprintGeneric.cpp


### PR DESCRIPTION
#### c540157bf655646e38732e036554b7bfe7d6aaee
<pre>
Unreviewed. Fix JSCOnly build after 278554@main

Bring back missing platform specific headers to CMake file.

* Source/WTF/wtf/PlatformJSCOnly.cmake:

Canonical link: <a href="https://commits.webkit.org/279431@main">https://commits.webkit.org/279431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd4976becb44bdf56015aca01981ceb8e8d96a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4067 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43248 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3394 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2223 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46698 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58216 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52855 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50647 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49982 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30629 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65159 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7873 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29469 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12417 "Found 15 new JSC stress test failures: stress/spread-non-array.js.mini-mode, wasm.yaml/wasm/function-tests/basic-element.js.wasm-eager, wasm.yaml/wasm/function-tests/f32-const.js.wasm-eager, wasm.yaml/wasm/function-tests/f64-const.js.wasm-eager, wasm.yaml/wasm/function-tests/factorial.js.wasm-eager, wasm.yaml/wasm/function-tests/grow-memory-4.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-load-shared.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-store-shared.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-store.js.wasm-eager, wasm.yaml/wasm/js-api/global-mutate.js.wasm-eager ... (failure)") | 
<!--EWS-Status-Bubble-End-->