### PR TITLE
[GStreamer][Quirks] playbin flags should be merged among quirks

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
@@ -33,6 +33,7 @@ public:
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
+    unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
 
 private:
     GRefPtr<GstCaps> m_sinkCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -249,14 +249,20 @@ void GStreamerQuirksManager::setHolePunchEnabledForTesting(bool enabled)
 
 unsigned GStreamerQuirksManager::getAdditionalPlaybinFlags() const
 {
+    unsigned flags = 0;
     for (const auto& quirk : m_quirks) {
-        if (auto flags = quirk->getAdditionalPlaybinFlags()) {
-            GST_DEBUG("Quirk %s requests these playbin flags: %u", quirk->identifier(), flags);
-            return flags;
-        }
+        auto quirkFlags = quirk->getAdditionalPlaybinFlags();
+        GST_DEBUG("Quirk %s requests these playbin flags: %u", quirk->identifier(), quirkFlags);
+        flags |= quirkFlags;
     }
-    GST_DEBUG("Quirks didn't request any specific playbin flags.");
-    return getGstPlayFlag("text") | getGstPlayFlag("soft-colorbalance");
+
+    if (flags)
+        GST_DEBUG("Final quirk flags: %u", flags);
+    else {
+        GST_DEBUG("Quirks didn't request any specific playbin flags, returning default text+soft-colorbalance.");
+        flags = getGstPlayFlag("text") | getGstPlayFlag("soft-colorbalance");
+    }
+    return flags;
 }
 
 bool GStreamerQuirksManager::shouldParseIncomingLibWebRTCBitStream() const

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -60,7 +60,7 @@ public:
     virtual std::optional<bool> isHardwareAccelerated(GstElementFactory*) { return std::nullopt; }
     virtual std::optional<GstElementFactoryListType> audioVideoDecoderFactoryListType() const { return std::nullopt; }
     virtual Vector<String> disallowedWebAudioDecoders() const { return { }; }
-    virtual unsigned getAdditionalPlaybinFlags() const { return getGstPlayFlag("text") | getGstPlayFlag("soft-colorbalance"); }
+    virtual unsigned getAdditionalPlaybinFlags() const { return 0; }
     virtual bool shouldParseIncomingLibWebRTCBitStream() const { return true; }
 };
 


### PR DESCRIPTION
#### f6a5f33fe606f204e93f64a6476724a6a07a4b13
<pre>
[GStreamer][Quirks] playbin flags should be merged among quirks
<a href="https://bugs.webkit.org/show_bug.cgi?id=274141">https://bugs.webkit.org/show_bug.cgi?id=274141</a>

Reviewed by Philippe Normand.

Westeros was missing its own flags and also, they need to be merged as we can have more than one quirks working at the
same time.

* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::getAdditionalPlaybinFlags const):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::getAdditionalPlaybinFlags const):

Canonical link: <a href="https://commits.webkit.org/278748@main">https://commits.webkit.org/278748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bede100821f7790defd827f06f1c854a251a2d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25711 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1635 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html (failure)") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56317 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1597 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49298 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44438 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11258 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->