### PR TITLE
Unreviewed. Fix non-unified build

### DIFF
--- a/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
@@ -29,7 +29,9 @@
 
 #include "JSDOMConstructor.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
+#include "JSMessagePort.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -27,6 +27,7 @@
 #include "CSSCalcPrimitiveValueNode.h"
 
 #include "CSSCalcCategoryMapping.h"
+#include "CSSCalcSymbolTable.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CalcExpressionLength.h"

--- a/Source/WebCore/css/calc/CSSCalcSymbolNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcSymbolNode.cpp
@@ -26,8 +26,11 @@
 #include "config.h"
 #include "CSSCalcSymbolNode.h"
 
+#include "CSSCalcCategoryMapping.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSValueKeywords.h"
+#include "CalcExpressionNode.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/color/CSSUnresolvedColorKeyword.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColorKeyword.cpp
@@ -29,6 +29,7 @@
 #include "CSSUnresolvedColorResolutionContext.h"
 #include "CSSValueKeywords.h"
 #include "ColorFromPrimitiveValue.h"
+#include "StyleBuilderState.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/color/CSSUnresolvedColorKeyword.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColorKeyword.h
@@ -33,6 +33,7 @@ namespace Style {
 enum class ForVisitedLink : bool;
 }
 
+class Color;
 class Document;
 class RenderStyle;
 class StyleColor;

--- a/Source/WebCore/css/color/StyleColor.cpp
+++ b/Source/WebCore/css/color/StyleColor.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "StyleColor.h"
 
+#include "CSSUnresolvedColor.h"
 #include "HashTools.h"
 #include "RenderTheme.h"
 #include "StyleColorMix.h"

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -27,11 +27,11 @@
 
 #include "GridPositionsResolver.h"
 #include "LayoutUnit.h"
+#include "RenderBox.h"
 
 namespace WebCore {
 
 enum class ItemPosition : uint8_t;
-class RenderBox;
 class RenderElement;
 class RenderGrid;
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "SVGTextLayoutAttributes.h"
 
+#include "RenderSVGInlineText.h"
 #include <stdio.h>
 #include <wtf/text/CString.h>
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -195,7 +195,7 @@ void RemotePageProxy::didFailProvisionalLoadForFrame(FrameInfoData&& frameInfo, 
     m_page->didFailProvisionalLoadForFrameShared(m_process.copyRef(), *frame, WTFMove(frameInfo), WTFMove(request), navigationID, provisionalURL, error, willContinueLoading, userData, willInternallyHandleFailure);
 }
 
-void RemotePageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
+void RemotePageProxy::didStartProvisionalLoadForFrame(WebCore::FrameIdentifier frameID, FrameInfoData&& frameInfo, WebCore::ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
 {
     if (!m_page)
         return;


### PR DESCRIPTION
#### c0163f6fb69ea55e8b3983dd1824520a182dea39
<pre>
Unreviewed. Fix non-unified build

* Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp:
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
* Source/WebCore/css/calc/CSSCalcSymbolNode.cpp:
* Source/WebCore/css/color/CSSUnresolvedColorKeyword.cpp:
* Source/WebCore/css/color/CSSUnresolvedColorKeyword.h:
* Source/WebCore/css/color/StyleColor.cpp:
* Source/WebCore/rendering/GridLayoutFunctions.h:
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::didStartProvisionalLoadForFrame):

Canonical link: <a href="https://commits.webkit.org/278749@main">https://commits.webkit.org/278749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf0076e64a9a2545bd612aa47d0fb8720e8157d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1834 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53560 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44379 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23028 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1638 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1599 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49302 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44441 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11259 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->