### PR TITLE
[WPE] WPE Platform: add wpe_keymap_translate_keyboard_state()

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp
@@ -62,6 +62,29 @@ gboolean wpe_keymap_get_entries_for_keyval(WPEKeymap* keymap, guint keyval, WPEK
 }
 
 /**
+ * wpe_keymap_translate_keyboard_state:
+ * @keymap: a #WPEKaymap
+ * @keycode: a hardware keycode
+ * @modifiers: a #WPEModifiers
+ * @group: active keyboard group
+ * @keyval: (out) (optional): return location for keyval
+ * @effective_group: (out) (optional): return location for effective group
+ * @level: (out) (optional): return location for level
+ * @consumed_modifiers: (out) (optional): return location for modifiers that were used to determine the group or level
+ *
+ * Translate @keycode, @modifiers and @group into a keyval, effective group and level.
+ * Modifiers that affected the translation are returned in @consumed_modifiers.
+ *
+ * Returns: %TRUE if there was a keyval bound to keycode, modifiers and group, or %FALSE otherwise
+ */
+gboolean wpe_keymap_translate_keyboard_state(WPEKeymap* keymap, guint keycode, WPEModifiers modifiers, int group, guint* keyval, int* effectiveGroup, int* level, WPEModifiers* consumedModifiers)
+{
+    g_return_val_if_fail(WPE_IS_KEYMAP(keymap), FALSE);
+
+    return WPE_KEYMAP_GET_CLASS(keymap)->translate_keyboard_state(keymap, keycode, modifiers, group, keyval, effectiveGroup, level, consumedModifiers);
+}
+
+/**
  * wpe_keymap_get_modifiers:
  * @keymap: a #WPEKaymap
  *

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymap.h
@@ -68,20 +68,36 @@ struct _WPEKeymapClass
 {
     GObjectClass parent_class;
 
-    gboolean     (* get_entries_for_keyval) (WPEKeymap       *keymap,
-                                             guint            keyval,
-                                             WPEKeymapEntry **entries,
-                                             guint           *n_entries);
-    WPEModifiers (* get_modifiers)          (WPEKeymap       *keymap);
+    gboolean     (* get_entries_for_keyval)   (WPEKeymap       *keymap,
+                                               guint            keyval,
+                                               WPEKeymapEntry **entries,
+                                               guint           *n_entries);
+    gboolean     (* translate_keyboard_state) (WPEKeymap       *keymap,
+                                               guint            keycode,
+                                               WPEModifiers     modifiers,
+                                               int              group,
+                                               guint           *keyval,
+                                               int             *effective_group,
+                                               int             *level,
+                                               WPEModifiers    *consumed_modifiers);
+    WPEModifiers (* get_modifiers)            (WPEKeymap       *keymap);
 
     gpointer padding[32];
 };
 
-WPE_API gboolean     wpe_keymap_get_entries_for_keyval (WPEKeymap       *keymap,
-                                                        guint            keyval,
-                                                        WPEKeymapEntry **entries,
-                                                        guint           *n_entries);
-WPE_API WPEModifiers wpe_keymap_get_modifiers          (WPEKeymap       *keymap);
+WPE_API gboolean     wpe_keymap_get_entries_for_keyval   (WPEKeymap       *keymap,
+                                                          guint            keyval,
+                                                          WPEKeymapEntry **entries,
+                                                          guint           *n_entries);
+WPE_API gboolean     wpe_keymap_translate_keyboard_state (WPEKeymap       *keymap,
+                                                          guint            keycode,
+                                                          WPEModifiers     modifiers,
+                                                          int              group,
+                                                          guint           *keyval,
+                                                          int             *effective_group,
+                                                          int             *level,
+                                                          WPEModifiers    *consumed_modifiers);
+WPE_API WPEModifiers wpe_keymap_get_modifiers            (WPEKeymap       *keymap);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
@@ -87,22 +87,71 @@ static gboolean wpeKeymapXKBGetEntriesForKeyval(WPEKeymap* keymap, guint keyval,
     return FALSE;
 }
 
+static xkb_mod_mask_t xkbModifiersFromWPEModifiers(struct xkb_keymap* xkbKeymap, WPEModifiers modifiers)
+{
+    xkb_mod_mask_t mask = 0;
+    if (modifiers & WPE_MODIFIER_KEYBOARD_CONTROL)
+        mask |= 1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_CTRL);
+    if (modifiers & WPE_MODIFIER_KEYBOARD_SHIFT)
+        mask |= 1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_SHIFT);
+    if (modifiers & WPE_MODIFIER_KEYBOARD_ALT)
+        mask |= 1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_ALT);
+    if (modifiers & WPE_MODIFIER_KEYBOARD_META)
+        mask |= 1 << xkb_keymap_mod_get_index(xkbKeymap, "Meta");
+    if (modifiers & WPE_MODIFIER_KEYBOARD_CAPS_LOCK)
+        mask |= 1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_CAPS);
+    return mask;
+}
+
+static WPEModifiers wpeModifiersFromXKBModifiers(struct xkb_keymap* xkbKeymap, xkb_state* xkbState, xkb_mod_mask_t mask)
+{
+    unsigned modifiers = 0;
+    if (mask & (1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_CTRL)))
+        modifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
+    if (mask & (1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_SHIFT)))
+        modifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
+    if (mask & (1 << xkb_keymap_mod_get_index(xkbKeymap, XKB_MOD_NAME_ALT)))
+        modifiers |= WPE_MODIFIER_KEYBOARD_ALT;
+    if (mask & (1 << xkb_keymap_mod_get_index(xkbKeymap, "Meta")))
+        modifiers |= WPE_MODIFIER_KEYBOARD_META;
+    if (xkb_state_led_name_is_active(xkbState, XKB_LED_NAME_CAPS))
+        modifiers |= WPE_MODIFIER_KEYBOARD_CAPS_LOCK;
+    return static_cast<WPEModifiers>(modifiers);
+}
+
+static gboolean wpeKeymapXKBTranslateKeyboardState(WPEKeymap* keymap, guint keycode, WPEModifiers modifiers, int group, guint* keyval, int* effectiveGroup, int* level, WPEModifiers* consumedModifiers)
+{
+    g_return_val_if_fail(group < 4, FALSE);
+
+    auto* priv = WPE_KEYMAP_XKB(keymap)->priv;
+    auto* xkbState = xkb_state_new(priv->xkbKeymap);
+    xkb_mod_mask_t mask = xkbModifiersFromWPEModifiers(priv->xkbKeymap, modifiers);
+    xkb_state_update_mask(xkbState, mask, 0, 0, group, 0, 0);
+
+    auto keysym = xkb_state_key_get_one_sym(xkbState, keycode);
+    if (keyval)
+        *keyval = keysym;
+    if (effectiveGroup)
+        *effectiveGroup = xkb_state_key_get_layout(xkbState, keycode);
+    if (level) {
+        auto layout = xkb_state_key_get_layout(xkbState, keycode);
+        *level = xkb_state_key_get_level(xkbState, keycode, layout);
+    }
+    if (consumedModifiers) {
+        xkb_mod_mask_t consumed = mask & ~xkb_state_mod_mask_remove_consumed(xkbState, keycode, mask);
+        *consumedModifiers = wpeModifiersFromXKBModifiers(priv->xkbKeymap, xkbState, consumed);
+    }
+
+    xkb_state_unref(xkbState);
+
+    return keysym != XKB_KEY_NoSymbol;
+}
+
 static WPEModifiers wpeKeymapXKBGetModifiers(WPEKeymap* keymap)
 {
     auto* priv = WPE_KEYMAP_XKB(keymap)->priv;
     xkb_mod_mask_t mask = xkb_state_serialize_mods(priv->xkbState, XKB_STATE_MODS_EFFECTIVE);
-    unsigned modifiers = 0;
-    if (mask & (1 << xkb_keymap_mod_get_index(priv->xkbKeymap, XKB_MOD_NAME_CTRL)))
-        modifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
-    if (mask & (1 << xkb_keymap_mod_get_index(priv->xkbKeymap, XKB_MOD_NAME_SHIFT)))
-        modifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
-    if (mask & (1 << xkb_keymap_mod_get_index(priv->xkbKeymap, XKB_MOD_NAME_ALT)))
-        modifiers |= WPE_MODIFIER_KEYBOARD_ALT;
-    if (mask & (1 << xkb_keymap_mod_get_index(priv->xkbKeymap, "Meta")))
-        modifiers |= WPE_MODIFIER_KEYBOARD_META;
-    if (xkb_state_led_name_is_active(priv->xkbState, XKB_LED_NAME_CAPS))
-        modifiers |= WPE_MODIFIER_KEYBOARD_CAPS_LOCK;
-    return static_cast<WPEModifiers>(modifiers);
+    return wpeModifiersFromXKBModifiers(priv->xkbKeymap, priv->xkbState, mask);
 }
 
 static void wpe_keymap_xkb_class_init(WPEKeymapXKBClass* keymapXKBClass)
@@ -112,6 +161,7 @@ static void wpe_keymap_xkb_class_init(WPEKeymapXKBClass* keymapXKBClass)
 
     WPEKeymapClass* keymapClass = WPE_KEYMAP_CLASS(keymapXKBClass);
     keymapClass->get_entries_for_keyval = wpeKeymapXKBGetEntriesForKeyval;
+    keymapClass->translate_keyboard_state = wpeKeymapXKBTranslateKeyboardState;
     keymapClass->get_modifiers = wpeKeymapXKBGetModifiers;
 }
 


### PR DESCRIPTION
#### f873c1671b50a6a75b0879ec961ffb4ad669983d
<pre>
[WPE] WPE Platform: add wpe_keymap_translate_keyboard_state()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274143">https://bugs.webkit.org/show_bug.cgi?id=274143</a>

Reviewed by Alejandro G. Castro.

This will be needed by automation.

* Source/WebKit/WPEPlatform/wpe/WPEKeymap.cpp:
(wpe_keymap_translate_keyboard_state):
* Source/WebKit/WPEPlatform/wpe/WPEKeymap.h:
* Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp:
(xkbModifiersFromWPEModifiers):
(wpeModifiersFromXKBModifiers):
(wpeKeymapXKBTranslateKeyboardState):
(wpeKeymapXKBGetModifiers):
(wpe_keymap_xkb_class_init):

Canonical link: <a href="https://commits.webkit.org/278854@main">https://commits.webkit.org/278854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e912578a111ad6989e0a387d3b7c56406fc2fdb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1836 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41907 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44382 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23031 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25727 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56322 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1602 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49301 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48478 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28715 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7553 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->