### PR TITLE
[GStreamer] GL/DMABuf logging improvements

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
@@ -32,30 +32,46 @@
 #undef GST_USE_UNSTABLE_API
 #include <wtf/glib/GUniquePtr.h>
 
-GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
-#define GST_CAT_DEFAULT webkit_media_player_debug
+GST_DEBUG_CATEGORY(webkit_display_debug);
+#define GST_CAT_DEFAULT webkit_display_debug
 
 namespace WebCore {
 
+static void ensureDebugCategoryInitialized()
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_display_debug, "webkitdisplay", 0, "WebKit Display");
+    });
+}
+
 GstGLDisplay* PlatformDisplay::gstGLDisplay() const
 {
+    ensureDebugCategoryInitialized();
     if (!m_gstGLDisplay)
         m_gstGLDisplay = adoptGRef(GST_GL_DISPLAY(gst_gl_display_egl_new_with_egl_display(eglDisplay())));
+    GST_TRACE("Using GL display %" GST_PTR_FORMAT, m_gstGLDisplay.get());
     return m_gstGLDisplay.get();
 }
 
 GstGLContext* PlatformDisplay::gstGLContext() const
 {
+    ensureDebugCategoryInitialized();
+
     if (m_gstGLContext)
         return m_gstGLContext.get();
 
     auto* gstDisplay = gstGLDisplay();
-    if (!gstDisplay)
+    if (!gstDisplay) {
+        GST_ERROR("No GL display");
         return nullptr;
+    }
 
     auto* context = const_cast<PlatformDisplay*>(this)->sharingGLContext();
-    if (!context)
+    if (!context) {
+        GST_ERROR("No sharing GL context");
         return nullptr;
+    }
 
     m_gstGLContext = adoptGRef(gst_gl_context_new_wrapped(gstDisplay, reinterpret_cast<guintptr>(context->platformContext()), GST_GL_PLATFORM_EGL, GST_GL_API_GLES2));
     {
@@ -63,10 +79,11 @@ GstGLContext* PlatformDisplay::gstGLContext() const
         if (gst_gl_context_activate(m_gstGLContext.get(), TRUE)) {
             GUniqueOutPtr<GError> error;
             if (!gst_gl_context_fill_info(m_gstGLContext.get(), &error.outPtr()))
-                GST_WARNING("Failed to fill in GStreamer context: %s", error->message);
+                GST_ERROR("Failed to fill in GStreamer context: %s", error->message);
             gst_gl_context_activate(m_gstGLContext.get(), FALSE);
         }
     }
+    GST_DEBUG("Created GL context %" GST_PTR_FORMAT, m_gstGLContext.get());
     return m_gstGLContext.get();
 }
 
@@ -77,5 +94,7 @@ void PlatformDisplay::clearGStreamerGLState()
 }
 
 } // namespace WebCore
+
+#undef GST_CAT_DEFAULT
 
 #endif // USE(GSTREAMER_GL)


### PR DESCRIPTION
#### ec004d2b24503adb91ec90b2ff441663522f28b7
<pre>
[GStreamer] GL/DMABuf logging improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=274146">https://bugs.webkit.org/show_bug.cgi?id=274146</a>

Reviewed by Xabier Rodriguez-Calvar.

The webkitdisplay GST_DEBUG category can be used to diagnose WebKit/GL errors now. The DMABuf
rendering code path was also instrumented with logs in order to help diagnosing issues.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
(WebCore::ensureDebugCategoryInitialized):
(WebCore::PlatformDisplay::gstGLContext const):

Canonical link: <a href="https://commits.webkit.org/278802@main">https://commits.webkit.org/278802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e50ea87befcd6c7e5023e05bae285d456350197

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41909 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1644 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26585 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1605 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49303 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44447 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48506 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11295 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->