### PR TITLE
[WGSL] Constant size for array types should be concretized

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1708,10 +1708,13 @@ void TypeChecker::visit(AST::ArrayTypeExpression& array)
 
         auto value = array.maybeElementCount()->constantValue();
         if (value.has_value()) {
-            auto elementCount = value->integerValue();
-            if (elementCount < 1) {
-                typeError(array.span(), "array count must be greater than 0"_s);
-                return;
+            int64_t elementCount = 0;
+            if (convertValue(array.maybeElementCount()->span(), concretize(elementCountType, m_types), value)) {
+                elementCount = value->integerValue();
+                if (elementCount < 1) {
+                    typeError(array.span(), "array count must be greater than 0"_s);
+                    return;
+                }
             }
             size = { static_cast<unsigned>(elementCount) };
         } else

--- a/Source/WebGPU/WGSL/tests/invalid/array.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/array.wgsl
@@ -3,6 +3,9 @@
 // CHECK-L: 'array' requires at least 1 template argument
 var<private> a:array;
 
+// CHECK-L: value 4294967296 cannot be represented as 'i32'
+@group(0) @binding(0) var<storage, read_write> b: array<u32, (1<<32)>;
+
 fn testArrayLengthMismatch() {
   // CHECK-L: array count must be greater than 0
   let x1 = array<i32, 0>();


### PR DESCRIPTION
#### 6dae8e21c19fb04f9e21abdabce268a95f543508
<pre>
[WGSL] Constant size for array types should be concretized
<a href="https://bugs.webkit.org/show_bug.cgi?id=274149">https://bugs.webkit.org/show_bug.cgi?id=274149</a>
<a href="https://rdar.apple.com/127986684">rdar://127986684</a>

Reviewed by Mike Wyrzykowski.

The size of an array type has to be a concrete integer, but we were using the
constant value without concretizing, so 64-bit integers were allowed.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/array.wgsl:

Canonical link: <a href="https://commits.webkit.org/278761@main">https://commits.webkit.org/278761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86eab1178f9c413c930c524c1c2bde86175e5050

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2163 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41913 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23037 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25722 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56329 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49305 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48485 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11266 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->