### PR TITLE
Unreviewed Internal build fix

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -228,6 +228,8 @@ static String stringForTLSCipherSuite(tls_ciphersuite_t suite)
     case tls_ciphersuite_##cipher: \
         return "" #cipher ""_s
 
+// FIXME: rdar://128061442
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     switch (suite) {
         STRINGIFY_CIPHER(RSA_WITH_3DES_EDE_CBC_SHA);
         STRINGIFY_CIPHER(RSA_WITH_AES_128_CBC_SHA);
@@ -256,6 +258,7 @@ static String stringForTLSCipherSuite(tls_ciphersuite_t suite)
         STRINGIFY_CIPHER(AES_256_GCM_SHA384);
         STRINGIFY_CIPHER(CHACHA20_POLY1305_SHA256);
     }
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     return { };
 
@@ -304,6 +307,8 @@ static String stringForSSLCipher(SSLCipherSuite cipher)
     case cipher: \
         return "" #cipher ""_s
 
+// FIXME: rdar://128061442
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     switch (cipher) {
     STRINGIFY_CIPHER(SSL_RSA_EXPORT_WITH_RC4_40_MD5);
     STRINGIFY_CIPHER(SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5);
@@ -475,6 +480,7 @@ static String stringForSSLCipher(SSLCipherSuite cipher)
         ASSERT_NOT_REACHED();
         return emptyString();
     }
+ALLOW_DEPRECATED_DECLARATIONS_END
 
 #undef STRINGIFY_CIPHER
 }


### PR DESCRIPTION
#### b20a04aa7b405aaf02cebbda8fa73e51e32b1db8
<pre>
Unreviewed Internal build fix
<a href="https://rdar.apple.com/128061442">rdar://128061442</a>

Unreviewed build fix.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(stringForTLSCipherSuite):
(stringForSSLCipher):

Canonical link: <a href="https://commits.webkit.org/278755@main">https://commits.webkit.org/278755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f9fb77a52416705cfe0d31851ceea12ebb449a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3826 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54742 "Hash f1f9fb77 for PR 28535 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2168 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1848 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/54742 "Hash f1f9fb77 for PR 28535 does not build (failure)") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53574 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44393 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/54742 "Hash f1f9fb77 for PR 28535 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26594 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44455 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28727 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7501 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->