### PR TITLE
IntersectionObserver callback for a visible sentinel node within a container with CSS transform animations is triggered multiple times, but should only be triggered once

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transform-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transform-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An element that already intersects with the viewport does not trigger the observer callback when animating its transform.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transform-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transform-animation.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+#container {
+  width: 200px;
+  height: 200px;
+  background-color: black;
+}
+
+#target {
+  position: relative;
+  top: 100px;
+  width: 100%;
+  height: 1px;
+  background-color: gray;
+}
+
+</style>
+
+<div id="container"><div id="target"></div></div>
+
+<script>
+
+promise_test(async function(t) {
+  let intersections = 0;
+
+  const observer = new IntersectionObserver(entries => ++intersections);
+  observer.observe(document.getElementById("target"));
+
+  await document.getElementById("container").animate({ transform: 'translate(0, 100px)' }, 1000).finished;
+  assert_equals(intersections, 1);
+}, "An element that already intersects with the viewport does not trigger the observer callback when animating its transform.");
+
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2539,9 +2539,9 @@ auto RenderBox::computeVisibleRectsInContainer(const RepaintRects& rects, const 
     // We are now in our parent container's coordinate space. Apply our transform to obtain a bounding box
     // in the parent's coordinate space that encloses us.
     auto position = styleToUse.position();
-    if (hasLayer() && layer()->transform()) {
+    if (hasLayer() && layer()->isTransformed()) {
         context.hasPositionFixedDescendant = position == PositionType::Fixed;
-        adjustedRects.transform(*layer()->transform(), document().deviceScaleFactor());
+        adjustedRects.transform(layer()->currentTransform(), document().deviceScaleFactor());
     } else if (position == PositionType::Fixed)
         context.hasPositionFixedDescendant = true;
 


### PR DESCRIPTION
#### a2fe0bd677be0835629265ce16d45907c52d4228
<pre>
IntersectionObserver callback for a visible sentinel node within a container with CSS transform animations is triggered multiple times, but should only be triggered once
<a href="https://bugs.webkit.org/show_bug.cgi?id=273928">https://bugs.webkit.org/show_bug.cgi?id=273928</a>
<a href="https://rdar.apple.com/127804335">rdar://127804335</a>

Reviewed by Simon Fraser.

Make sure we use RenderLayer::currentTransform() when querying the target&apos;s transform to ensure that it accounts
for accelerated animations. Indeed, RenderLayer::transform() will only account for the transform set on the
`RenderStyle` which does *not* update during the course of an accelerated property animation.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transform-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transform-animation.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeVisibleRectsInContainer const):

Canonical link: <a href="https://commits.webkit.org/278763@main">https://commits.webkit.org/278763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f120e3ac93ac1230d2bc6b8a07a488d1196d460

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41920 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1658 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56337 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49314 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48499 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28730 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7504 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->