### PR TITLE
[WebGPU] waitUntilCompleted call will fail when Queue is invalid

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2119,6 +2119,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273585.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274270.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274270.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274161.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274161.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274161-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274161-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274161.html
+++ b/LayoutTests/fast/webgpu/fuzz-274161.html
@@ -1,0 +1,19178 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let promise0 = adapter0.requestDevice({
+  label: '\u2a6d\u0597\u25a4\u3c5a\u1ae6',
+  defaultQueue: {label: '\u3efa\uae64\u15e6\u00ce\u0178\u025e\u0cd9\u9f1c\ucda6\u{1f683}'},
+  requiredFeatures: ['depth32float-stencil8', 'texture-compression-etc2', 'bgra8unorm-storage'],
+});
+let promise1 = navigator.gpu.requestAdapter();
+let promise2 = navigator.gpu.requestAdapter();
+let adapter1 = await promise1;
+let device0 = await adapter1.requestDevice({
+  label: '\u327e\u{1f891}\u3a70',
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxColorAttachmentBytesPerSample: 32,
+    maxVertexAttributes: 27,
+    maxVertexBufferArrayStride: 60078,
+    maxStorageTexturesPerShaderStage: 8,
+    maxStorageBuffersPerShaderStage: 23,
+    maxDynamicStorageBuffersPerPipelineLayout: 8344,
+    maxDynamicUniformBuffersPerPipelineLayout: 7018,
+    maxBindingsPerBindGroup: 4262,
+    maxTextureArrayLayers: 797,
+    maxTextureDimension1D: 14364,
+    maxTextureDimension2D: 12652,
+    maxVertexBuffers: 8,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 257916003,
+    maxUniformBuffersPerShaderStage: 21,
+    maxSampledTexturesPerShaderStage: 26,
+    maxInterStageShaderVariables: 110,
+    maxInterStageShaderComponents: 99,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let texture0 = device0.createTexture({
+  label: '\u5cfd\u01a5\ue0a5\u{1fa08}\ue590\u03b0\u89ad\u0454\u0068\u8db9\u4862',
+  size: [320],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u9ca5\u34cd\u0fb0\u51e7\uad98\uab04',
+  entries: [
+    {
+      binding: 582,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 86, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 643,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({label: '\ua39a\udc3e\u005e\u{1f808}', type: 'occlusion', count: 433});
+let textureView0 = texture0.createView({});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(64)), /* required buffer size: 813 */
+{offset: 397}, {width: 26, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({label: '\ua9bc\u{1f836}\u088e\ua4a5', bindGroupLayouts: []});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u05a8\u{1fbac}\u0dcd\u4d6f\ue67c\u919d\u064b\uc4ee\ue699\u0fcd\u8a8c'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u3930\u{1fe31}\u245c\u15ff\u0234\u{1f747}\u0ddd',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  stencilReadOnly: true,
+});
+gc();
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture1 = device0.createTexture({
+  label: '\u{1f70a}\ue5bc\u{1f757}\ue2a7\ua884\u0818',
+  size: {width: 3072},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderBundleEncoder0.setVertexBuffer(2634, undefined, 144170557);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(778, 198);
+try {
+device0.label = '\u0409\u0c4c\u0671\ua7a3\u1e76\u{1fe52}\uf712\ua3b8';
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({label: '\u087f\u626b\u{1f854}\u01e9\u0185\uae84\u7865\u321a', entries: []});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1836});
+let textureView1 = texture0.createView({label: '\udab9\u54f9\u2c16\u8a71\u63d1\u5c0c\u01b8\uc745'});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\ud686\u075b\u1395\u{1f9a1}\u8645\u{1f92e}\u4977\u9ef6\u25f7'});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u2e0d\uc005\u1d4f\udfc6\u84b0\u4430\u0b22\ude34\ub1dc\u22a9\ub856'});
+let sampler0 = device0.createSampler({
+  label: '\uf960\uad51\u9c6e\u5f9b\u39f0\u2f99\u038a\u3f09\ud686',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.58,
+  lodMaxClamp: 74.54,
+});
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView2 = texture0.createView({label: '\u610c\u85d4\u043a\u{1ff4d}\u300e\u2226\u3363'});
+let computePassEncoder1 = commandEncoder0.beginComputePass();
+let imageBitmap0 = await createImageBitmap(offscreenCanvas0);
+let computePassEncoder2 = commandEncoder2.beginComputePass({label: '\u07e2\u0c2c\ub904\u0d3a'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u7c83\u2e1b',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 449 */
+{offset: 449, bytesPerRow: 4566, rowsPerImage: 237}, {width: 279, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer0 = device0.createBuffer({
+  label: '\uc2a6\u2574\u8876\uaff6\u00fc\u2f42',
+  size: 675693,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder3 = device0.createCommandEncoder({label: '\ua164\u5ef6\u3ea8\u0ef4\u094c\u09d3\u01d7\u{1fc00}\u3f7c\u{1f7b6}'});
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let commandEncoder4 = device0.createCommandEncoder({label: '\u3912\u{1ff3a}\u89f9\u7d57\ua5e2\u44d9\u0975\uc8c8\u1496\u11f0'});
+let textureView3 = texture0.createView({label: '\u1dd7\ua68b', dimension: '1d'});
+let computePassEncoder3 = commandEncoder4.beginComputePass();
+let sampler1 = device0.createSampler({
+  label: '\u097c\ud68c\u00d1\u4ab3',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 85.96,
+  lodMaxClamp: 96.22,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(56)), /* required buffer size: 693 */
+{offset: 693, bytesPerRow: 3613}, {width: 222, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer1 = device0.createBuffer({
+  size: 566293,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView4 = texture0.createView({
+  label: '\u{1fed4}\u07ec\uf664\u{1f77a}\u7db5\u6278\u1ae6\ud9e3\u8451\u{1fa4b}\u17e5',
+  dimension: '1d',
+});
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 3408 widthInBlocks: 213 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 10592 */
+  offset: 7184,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 213, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(24)), /* required buffer size: 447 */
+{offset: 447}, {width: 68, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView5 = texture1.createView({});
+let sampler2 = device0.createSampler({
+  label: '\u0224\ua4cc\ud590\u{1fd04}\uc4ce\u51dc\u4ccc',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.99,
+  lodMaxClamp: 70.66,
+  compare: 'greater-equal',
+  maxAnisotropy: 4,
+});
+let buffer2 = device0.createBuffer({
+  label: '\u0760\u{1fa5a}',
+  size: 194796,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\ube08\ua47a\u222d'});
+let querySet2 = device0.createQuerySet({label: '\u873e\u29dc\u08a6\uf9ca\u05f2\ubf0e\u0677\uf7f7', type: 'occlusion', count: 2674});
+let canvas0 = document.createElement('canvas');
+let offscreenCanvas1 = new OffscreenCanvas(101, 624);
+let texture2 = device0.createTexture({
+  label: '\u0bf7\ua574\u{1f9e2}\uf332\u{1f916}\u{1fb1b}',
+  size: {width: 384, height: 1, depthOrArrayLayers: 186},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let computePassEncoder4 = commandEncoder3.beginComputePass({label: '\u{1f82b}\u098a'});
+try {
+querySet1.destroy();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup0 = device0.createBindGroup({label: '\u8d80\u{1fdd4}\u3f01\uac1f\u3ba7\u7f72', layout: bindGroupLayout1, entries: []});
+let commandEncoder6 = device0.createCommandEncoder();
+let textureView6 = texture2.createView({baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\uc30b\u{1fcd8}\u6cdb\u{1fabe}\u0a86\u0276\u5921',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder1.setBindGroup(7, bindGroup0);
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+document.body.prepend(canvas0);
+gc();
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u08d3\ua4ed\u6c84\u03e5\u075f\u03f1\u5d56\u025b',
+  entries: [
+    {
+      binding: 4109,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 4138,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture3 = device0.createTexture({
+  label: '\u1b0a\u{1fd64}\u0a6c\u9f01\u0bb5\u0250',
+  size: [768],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder5.beginComputePass({label: '\u06f5\u8da3\u{1fbde}\u04e8'});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 3057});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({label: '\uf1fd\u494b\u2709\u0326\ue41b', colorFormats: ['rgba32float', undefined, 'rgba8unorm']});
+let texture4 = device0.createTexture({
+  size: [864],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let textureView7 = texture1.createView({label: '\u736b\udf84\u08a7', baseArrayLayer: 0});
+try {
+renderBundleEncoder2.setBindGroup(7, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(5, bindGroup0, new Uint32Array(4021), 1675, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4680, undefined, 0, 1889238268);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 205, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 43, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\uefa8\uf742\u6e7d\u02f5',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout2, bindGroupLayout0, bindGroupLayout2, bindGroupLayout1],
+});
+let querySet4 = device0.createQuerySet({label: '\u3ac9\u288b\u{1fb5e}\u9f43\u7c26\u00a4\u05bb', type: 'occlusion', count: 2218});
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 346, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 5744 widthInBlocks: 359 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 29424 */
+  offset: 29424,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 359, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 651 */
+{offset: 651, bytesPerRow: 3974}, {width: 247, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView8 = texture3.createView({label: '\u{1f63a}\u5426\u02b2\u{1f685}\u1e0c\u0cf7\u{1fabe}'});
+try {
+computePassEncoder5.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(6, bindGroup0, new Uint32Array(7662), 1073, 0);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({label: '\u2f7f\ue2cc\ufc08\u9ec3\u06d1\u0eb4\uf8e6', entries: []});
+let commandBuffer0 = commandEncoder6.finish({label: '\uf808\ub697'});
+try {
+computePassEncoder0.pushDebugGroup('\udfdc');
+} catch {}
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+offscreenCanvas1.width = 149;
+let buffer3 = device0.createBuffer({
+  label: '\u0de9\ue118\u0cf0\u1ef6\u{1f6f7}\u524f\u2034\u02de',
+  size: 296338,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let texture5 = device0.createTexture({
+  label: '\uc3bc\u{1ffab}\u{1ffa3}\u{1f708}\uc31c\u08c4\u{1fc88}\u{1f83b}\ubc4a',
+  size: [384, 1, 116],
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler3 = device0.createSampler({
+  label: '\u0bbb\u{1f975}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.25,
+  maxAnisotropy: 17,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 226, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 111 */
+{offset: 111}, {width: 322, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture6 = device0.createTexture({
+  label: '\u04aa\u0775\u0593\u33a6\u049f\u06c5\u15df\uda86\u{1f8e2}\uffb6',
+  size: {width: 3072},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+});
+let renderBundle1 = renderBundleEncoder3.finish({label: '\u4da4\u8409\u4974\u{1fac5}\u0c69\u0466\u23c7\u3caa\u0f0b\u0aab'});
+let sampler4 = device0.createSampler({
+  label: '\u45f2\ua188\u{1fbad}\u{1f634}\u0d0b\ufed4\u30d0\u8dd4',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 66.27,
+  maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(2, buffer1, 112292, 77479);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({label: '\uda15\u05f8\u{1fe69}\u{1f881}\u{1fa12}'});
+let textureView9 = texture0.createView({
+  label: '\u0315\u02ac\ubcb5\u0fbe\uc5cf\u0e6a\ue53e\ucf09\u8eed\u0f78',
+  dimension: '1d',
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(1, buffer1, 0, 213348);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+let imageData0 = new ImageData(112, 68);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\ufa86\ud3e5\u480c\u{1fdfa}\u0933\u0aae\ue739\ucec7',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  sampleCount: 1,
+});
+let sampler5 = device0.createSampler({
+  label: '\u71a6\u0939\u{1fa34}\u{1fb31}\u0d2e\u{1f7f8}\ubb24\u3e4c\u5acb\u149e',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.88,
+  maxAnisotropy: 4,
+});
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(2248), 607, 0);
+} catch {}
+try {
+commandEncoder1.label = '\u{1fb54}\u7194';
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u775c\uf817\ufd30\u{1ff94}\u0bb2\u9558\u5bdc\u0fd3\uf674\ucf76\u0620'});
+let texture7 = device0.createTexture({
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let textureView10 = texture5.createView({label: '\u06e6\uca85\u975e\u88e8\u0d3b\u7cd5\u{1f771}\u7c3b', aspect: 'all', format: 'rgba8unorm'});
+let sampler6 = device0.createSampler({
+  label: '\u0131\u0a63',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.75,
+  lodMaxClamp: 95.09,
+  maxAnisotropy: 14,
+});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(42, 714);
+let bindGroup1 = device0.createBindGroup({label: '\u48f4\u0e00\u0e20\u0026\u55b4\u0fc4\u{1fbea}', layout: bindGroupLayout3, entries: []});
+let textureView11 = texture7.createView({
+  label: '\u7d74\u0950\ucb5c\u16c2\ubea4\u8e06\u{1ffcb}\u1962\u8ca1\u{1f95c}\u{1fcf8}',
+  baseArrayLayer: 0,
+});
+let computePassEncoder6 = commandEncoder8.beginComputePass({label: '\u4174\uc058\u{1f8c9}\u{1f932}\udd4d\u6935\u1d68\u0a79\ud427'});
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let video0 = await videoWithData();
+let sampler7 = device0.createSampler({
+  label: '\u0351\u26cb\u{1fbd6}\u03e2\u548c\u4354',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 95.15,
+});
+try {
+renderBundleEncoder2.setBindGroup(4, bindGroup0, new Uint32Array(440), 40, 0);
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas2.getContext('webgpu');
+let querySet5 = device0.createQuerySet({label: '\uc947\u0a71', type: 'occlusion', count: 3955});
+let textureView12 = texture2.createView({label: '\u480b\uf912\u0485\u48f2\u767d\u{1fdbf}\u062f', baseMipLevel: 2, arrayLayerCount: 1});
+let computePassEncoder7 = commandEncoder7.beginComputePass({});
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+gc();
+let querySet6 = device0.createQuerySet({label: '\uffae\u{1f608}\u{1fa78}\ufd60\u6855\ua66a\uc81d\u{1f903}', type: 'occlusion', count: 2883});
+let textureView13 = texture7.createView({label: '\u0974\u0422\u052f\ua6f9\u00d7\u0e11\ubac2\u{1f684}\u4878\ue0e7'});
+let externalTexture0 = device0.importExternalTexture({
+  label: '\uc6a2\u0dd1\u0cd7\u4954\u{1fe46}\u{1fc2e}\ucaa2\u6518\u0c37\u2aea\u0ce8',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+let bindGroupLayout4 = device0.createBindGroupLayout({label: '\u{1ff41}\u0873', entries: []});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 1028});
+let textureView14 = texture3.createView({label: '\ue9ca\u0e46\u031e\u08c5\u2f14\u{1f9f6}'});
+let sampler8 = device0.createSampler({
+  label: '\u0dcb\u1aec\u0c14\u09fa\u0cf1\u5922\u7d7c\u05b3',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 49.41,
+  lodMaxClamp: 78.63,
+});
+try {
+computePassEncoder1.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint16', 370544, 39754);
+} catch {}
+video0.width = 52;
+let shaderModule0 = device0.createShaderModule({
+  label: '\u{1f80f}\u{1fc66}\u{1ff8f}\ufa5d\u6265\u{1fa91}',
+  code: `@group(3) @binding(643)
+var<storage, read_write> global0: array<u32>;
+@group(3) @binding(86)
+var<storage, read_write> parameter0: array<u32>;
+@group(2) @binding(4138)
+var<storage, read_write> n0: array<u32>;
+@group(4) @binding(4138)
+var<storage, read_write> global1: array<u32>;
+@group(3) @binding(582)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(8, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(14) f0: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec3<f16>, a1: S0, @builtin(instance_index) a2: u32, @location(15) a3: f32, @location(8) a4: vec2<i32>, @location(18) a5: vec2<u32>, @location(17) a6: vec2<f32>, @location(1) a7: vec4<f16>, @location(9) a8: vec4<i32>, @location(2) a9: vec4<f32>, @location(10) a10: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup2 = device0.createBindGroup({label: '\u0f27\udc68', layout: bindGroupLayout4, entries: []});
+let commandEncoder9 = device0.createCommandEncoder({label: '\ub661\u9e75\u81ed\u0b99\u06bb\ub944\u{1fc48}\u0169\u0da5\u1b6d'});
+let querySet8 = device0.createQuerySet({label: '\u0280\u01f0\u9e3d', type: 'occlusion', count: 39});
+let textureView15 = texture6.createView({label: '\u6d2f\u2f44\u{1f6ca}\u8b31\u9ec3\u0ef6\u3fc3', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundle2 = renderBundleEncoder2.finish();
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 4852 widthInBlocks: 1213 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 55724 */
+  offset: 50872,
+  bytesPerRow: 4864,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 503, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1213, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder9.insertDebugMarker('\u3a11');
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(608, 244);
+let imageBitmap1 = await createImageBitmap(imageBitmap0);
+try {
+offscreenCanvas3.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0cc2\u6491\u0858\ue34e\u{1f8df}\u{1fb1d}\u6017\uea96\u{1fa36}'});
+let texture8 = device0.createTexture({
+  label: '\u986a\ubfb7\udcf2\u0816\u0f74\u{1fc6e}',
+  size: {width: 160},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let sampler9 = device0.createSampler({
+  label: '\u09c4\uce59\u66da\u9f8d\ud1f7\u983c\u086d\u5e48\u07be\u3369',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.66,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder1.setBindGroup(6, bindGroup2);
+} catch {}
+let promise3 = buffer3.mapAsync(GPUMapMode.READ, 0, 128928);
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 9328 widthInBlocks: 583 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 32272 */
+  offset: 22944,
+  rowsPerImage: 122,
+  buffer: buffer2,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 583, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 94, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 141, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 163, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'dst'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 51464,
+        attributes: [
+          {format: 'uint32x3', offset: 4448, shaderLocation: 18},
+          {format: 'uint8x4', offset: 1132, shaderLocation: 14},
+          {format: 'sint16x2', offset: 38132, shaderLocation: 8},
+          {format: 'sint8x2', offset: 2436, shaderLocation: 9},
+          {format: 'float16x4', offset: 7368, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 17396, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 3932, shaderLocation: 15},
+          {format: 'float32x3', offset: 51452, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 5880, attributes: []},
+      {
+        arrayStride: 9088,
+        attributes: [
+          {format: 'float16x4', offset: 516, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 3140, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let commandBuffer1 = commandEncoder9.finish({label: '\u1f96\u{1fa58}'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u{1faab}\u01e0\ue251\u0a98\uc15c',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 541, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 51, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let buffer4 = device0.createBuffer({label: '\u00ed\u3274\u0201', size: 137762, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder11 = device0.createCommandEncoder({label: '\u{1f6d1}\ufc16\u0266\u0fbb'});
+let textureView16 = texture8.createView({format: 'rgba8unorm-srgb'});
+let externalTexture1 = device0.importExternalTexture({label: '\u4172\ucf7e\u0118\uf8c7\udfe7', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup0, new Uint32Array(5681), 2819, 0);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 3347537381,
+    stencilWriteMask: 947454629,
+    depthBias: -1608610118,
+    depthBiasClamp: 527.814992640049,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 384, shaderLocation: 14},
+          {format: 'sint32x2', offset: 2744, shaderLocation: 9},
+          {format: 'uint32', offset: 264, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 416, shaderLocation: 21},
+          {format: 'float32x3', offset: 1680, shaderLocation: 10},
+          {format: 'sint32x4', offset: 2432, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 398, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 962, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 7756,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 1022, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 1092, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw'},
+});
+let shaderModule1 = device0.createShaderModule({
+  label: '\u01b9\u032c\u{1fc60}\uc2dd\u{1f99b}\u0003\u059d\u0f7f\u5644\u86da\ub25a',
+  code: `@group(4) @binding(4138)
+var<storage, read_write> local0: array<u32>;
+@group(2) @binding(4138)
+var<storage, read_write> type0: array<u32>;
+@group(3) @binding(86)
+var<storage, read_write> n1: array<u32>;
+@group(2) @binding(4109)
+var<storage, read_write> parameter1: array<u32>;
+@group(3) @binding(643)
+var<storage, read_write> global2: array<u32>;
+@group(4) @binding(4109)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(1, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(13) f0: vec4<f32>,
+  @location(24) f1: vec4<u32>,
+  @location(109) f2: vec3<f32>,
+  @location(37) f3: vec4<f32>,
+  @location(54) f4: vec3<f16>,
+  @location(39) f5: vec4<f16>,
+  @location(14) f6: vec3<i32>,
+  @location(10) f7: vec4<u32>,
+  @location(9) f8: vec4<u32>,
+  @location(0) f9: f32,
+  @location(23) f10: vec2<u32>,
+  @location(44) f11: vec2<u32>,
+  @builtin(position) f12: vec4<f32>,
+  @location(26) f13: u32,
+  @location(74) f14: vec3<u32>,
+  @builtin(sample_index) f15: u32,
+  @location(61) f16: vec4<f16>,
+  @location(104) f17: u32,
+  @location(17) f18: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(72) a0: i32, @location(79) a1: i32, a2: S1, @location(22) a3: u32, @location(18) a4: vec3<f32>, @location(84) a5: vec3<f16>, @location(80) a6: vec3<f16>, @location(20) a7: f16, @location(108) a8: vec2<f32>, @location(66) a9: f16, @location(33) a10: vec2<f16>, @location(11) a11: f32, @location(2) a12: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(61) f0: vec4<f16>,
+  @location(26) f1: u32,
+  @location(0) f2: f32,
+  @builtin(position) f3: vec4<f32>,
+  @location(38) f4: f32,
+  @location(20) f5: f16,
+  @location(18) f6: vec3<f32>,
+  @location(17) f7: vec2<f32>,
+  @location(53) f8: vec2<f16>,
+  @location(31) f9: vec4<u32>,
+  @location(24) f10: vec4<u32>,
+  @location(83) f11: f16,
+  @location(33) f12: vec2<f16>,
+  @location(11) f13: f32,
+  @location(13) f14: vec4<f32>,
+  @location(80) f15: vec3<f16>,
+  @location(54) f16: vec3<f16>,
+  @location(10) f17: vec4<u32>,
+  @location(104) f18: u32,
+  @location(22) f19: u32,
+  @location(50) f20: i32,
+  @location(55) f21: vec3<f16>,
+  @location(74) f22: vec3<u32>,
+  @location(79) f23: i32,
+  @location(63) f24: vec3<i32>,
+  @location(14) f25: vec3<i32>,
+  @location(9) f26: vec4<u32>,
+  @location(39) f27: vec4<f16>,
+  @location(66) f28: f16,
+  @location(2) f29: vec4<f32>,
+  @location(23) f30: vec2<u32>,
+  @location(37) f31: vec4<f32>,
+  @location(44) f32: vec2<u32>,
+  @location(84) f33: vec3<f16>,
+  @location(108) f34: vec2<f32>,
+  @location(72) f35: i32,
+  @location(88) f36: vec4<f32>,
+  @location(69) f37: vec4<f16>,
+  @location(51) f38: vec4<f16>,
+  @location(109) f39: vec3<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(16) a1: vec3<u32>, @location(4) a2: vec4<f16>, @location(21) a3: vec2<i32>, @location(5) a4: vec3<f16>, @location(25) a5: vec4<i32>, @location(20) a6: i32, @builtin(vertex_index) a7: u32, @location(3) a8: f32, @location(10) a9: vec3<f32>, @location(19) a10: vec2<f32>, @location(22) a11: f32, @location(8) a12: vec4<f32>, @location(18) a13: vec3<f32>, @location(6) a14: vec4<u32>, @location(9) a15: u32, @location(12) a16: vec2<f32>, @location(0) a17: vec2<i32>, @location(7) a18: vec2<u32>, @location(15) a19: vec4<i32>, @location(1) a20: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 398,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 3920,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 3959, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let buffer5 = device0.createBuffer({
+  label: '\u0f47\u{1fdb4}\ueb5c\u4f3a\u0a33\uf6d7\u456c\u09eb\u0a49\u05bb',
+  size: 81999,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u0fc3\ub27b\u0037\u6ef6\u3612\u{1fa26}\u1065\udc5e\uc490\u03ba\u98e5'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f650}\u80aa\u5f8b\uffcf\u{1f717}\u006a\u8e9e',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer1, 0, 445481);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.READ, 0, 15520);
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer5, 47616, 34108);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 10192, new Float32Array(8637), 8296, 84);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder8 = commandEncoder11.beginComputePass();
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\ue003\u0085\u0416\u{1fa67}',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+let sampler10 = device0.createSampler({
+  label: '\u{1f77e}\u6b4b\u{1fa14}\u8db8\u1739\ubdc5',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.572,
+  lodMaxClamp: 26.81,
+  maxAnisotropy: 2,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u3f0f\u{1f80b}\u{1fe42}\u0721\u8b12', source: video0, colorSpace: 'srgb'});
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(56)), /* required buffer size: 620 */
+{offset: 620}, {width: 155, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  label: '\u02d3\u0a23',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xc41231df},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 2403333375,
+    stencilWriteMask: 1355762565,
+    depthBias: 1618727136,
+    depthBiasClamp: 994.2450800182191,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 53672,
+        attributes: [
+          {format: 'snorm8x2', offset: 14476, shaderLocation: 2},
+          {format: 'float32x4', offset: 1176, shaderLocation: 10},
+          {format: 'uint32x2', offset: 3272, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 24796, shaderLocation: 15},
+          {format: 'sint32', offset: 2264, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint8x2', offset: 26840, shaderLocation: 18}]},
+      {
+        arrayStride: 19044,
+        attributes: [
+          {format: 'snorm16x2', offset: 2252, shaderLocation: 1},
+          {format: 'float16x4', offset: 2316, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 13588, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 19532, attributes: [{format: 'sint8x2', offset: 352, shaderLocation: 9}]},
+      {arrayStride: 31028, attributes: []},
+      {arrayStride: 8584, attributes: [{format: 'snorm16x2', offset: 264, shaderLocation: 17}]},
+    ],
+  },
+});
+let offscreenCanvas4 = new OffscreenCanvas(32, 838);
+let texture9 = device0.createTexture({
+  label: '\u70eb\u{1fbc1}',
+  size: [720, 60, 1],
+  mipLevelCount: 5,
+  format: 'astc-12x12-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-12x12-unorm-srgb'],
+});
+let computePassEncoder9 = commandEncoder10.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u0225\uc078\uab72\ua5a8\u{1f837}\u6832\ue4a0\u9719',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+});
+let sampler11 = device0.createSampler({
+  label: '\u0a96\u68ea\u0a6b\u3765\u{1f988}',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 76.68,
+});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer1, 'uint16', 502250, 26558);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 483, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 567, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(526, 648);
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u{1fa79}\u2be3\u07bb\u07ac',
+  entries: [
+    {
+      binding: 1012,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let textureView17 = texture1.createView({label: '\u1e05\u0239\u{1fc3e}\u{1fcb3}\uf2c9\u0aaf\u1aa2'});
+let sampler12 = device0.createSampler({
+  label: '\u3414\u8b81\u013d\u1eac\u{1fd4b}\u01a5\u3ec0',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.15,
+  lodMaxClamp: 94.95,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer0, 524344, buffer5, 55640, 18628);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3888 widthInBlocks: 243 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8992 */
+  offset: 8992,
+  buffer: buffer5,
+}, {width: 243, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 186, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView18 = texture6.createView({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\ua251\u{1fe5e}\ube43\u4575\ubc87\u0ec3',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler13 = device0.createSampler({
+  label: '\u3ad4\u085c\ubdd8\u183b\u479a\ued1a\u{1fe32}\u{1fe41}\u0d15',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.34,
+  lodMaxClamp: 97.03,
+  maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder7.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder6.pushDebugGroup('\u041e');
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+  label: '\ub8fe\udb4f\uba5a\u9f66',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 0, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 20, shaderLocation: 2},
+          {format: 'float32x3', offset: 32, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 23052,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 380, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 3492, shaderLocation: 1},
+          {format: 'sint16x2', offset: 7352, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 5704, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 21116,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm16x4', offset: 3296, shaderLocation: 21}],
+      },
+      {
+        arrayStride: 1072,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 156, shaderLocation: 10}],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 1968, stepMode: 'instance', attributes: []},
+      {arrayStride: 2024, attributes: []},
+      {arrayStride: 11364, attributes: [{format: 'uint8x4', offset: 488, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+gc();
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let textureView19 = texture2.createView({label: '\u7bd2\u3816\u4987\u06ca\uc2e4', baseMipLevel: 3});
+try {
+device0.queue.writeBuffer(buffer5, 10804, new DataView(new ArrayBuffer(26654)), 5084, 1244);
+} catch {}
+gc();
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 3179});
+let textureView20 = texture6.createView({label: '\u{1f611}\u{1f6fe}\u{1fcb9}'});
+let externalTexture3 = device0.importExternalTexture({label: '\ua05f\u0d80\u5b96', source: videoFrame0});
+try {
+renderBundleEncoder8.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer0 = buffer4.getMappedRange(0, 8668);
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 768 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 13632 */
+  offset: 13632,
+  buffer: buffer2,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  label: '\ub00f\u11cd\u175b\u039d\ue245\u091d\u9d15\u{1fb35}\u31ba\u48e4\uc437',
+  layout: pipelineLayout2,
+  multisample: {mask: 0x38b752af},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 1722652218,
+    depthBias: -765671226,
+    depthBiasClamp: 606.5800849958033,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 24796,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 1120, shaderLocation: 17},
+          {format: 'sint32x3', offset: 4916, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 12096, shaderLocation: 10},
+          {format: 'sint8x2', offset: 6846, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 3420, shaderLocation: 21},
+          {format: 'uint16x4', offset: 3344, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 944, shaderLocation: 15},
+          {format: 'float32x4', offset: 2812, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 4688, shaderLocation: 2},
+          {format: 'uint32', offset: 2448, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({label: '\ue6d8\u8d17\u0431\u{1fd49}\u{1fc78}\u73be'});
+let texture10 = device0.createTexture({
+  label: '\u01ba\u{1fa80}',
+  size: [3072, 1, 1],
+  mipLevelCount: 12,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+let computePassEncoder10 = commandEncoder12.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(1, bindGroup0, new Uint32Array(1087), 538, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(4, bindGroup0, new Uint32Array(768), 768, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer0, 214444, buffer5, 27004, 17108);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 9408 widthInBlocks: 588 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 47888 */
+  offset: 38480,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 588, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 542, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 559 */
+{offset: 559}, {width: 1511, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas4.getContext('webgpu');
+let texture11 = device0.createTexture({
+  label: '\u0328\u967b\ud4ce\ue8a7\u6779\u06e7\ubf78\u08af\u{1fd7f}',
+  size: [160, 1, 131],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+});
+let textureView21 = texture2.createView({label: '\u{1f67b}\ua104\u9435\uf202', baseMipLevel: 4});
+try {
+renderBundleEncoder6.popDebugGroup();
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\u{1f931}\u61cb\u0dc4\u3b9e\u3547\u6001\u7e2d\ub488\u07e8\u006d'});
+let texture12 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 3024 widthInBlocks: 189 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 19232 */
+  offset: 19232,
+  bytesPerRow: 3072,
+  buffer: buffer2,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 189, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder8.insertDebugMarker('\ua771');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 3, y: 281 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device0.createComputePipelineAsync({
+  label: '\ua96f\uc88d\u{1fd6a}\u0cb8\u{1fa3b}\u339e\ude5b\u0ed3\u46ff\u0e47',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u0fb0\u12dc'});
+let texture13 = device0.createTexture({
+  label: '\u7994\ue309\u{1f759}\u0e7a\ufea3\u3bfa\u0d81\u0805\u8629',
+  size: {width: 432},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView22 = texture5.createView({label: '\u36c4\u2608\u04a2\u31d4\u{1fa7b}\u3533'});
+let computePassEncoder11 = commandEncoder4.beginComputePass({label: '\u{1f9da}\u1c6d\u834a'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float', undefined, 'rgba8unorm'], depthReadOnly: true});
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup0, new Uint32Array(9502), 3444, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer0, 457860, buffer4, 120400, 6944);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 1172 widthInBlocks: 293 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8676 */
+  offset: 8676,
+  buffer: buffer2,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 293, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 19, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u8c43');
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({
+  label: '\u0073\u7c42\u595e\uce1e\u{1fd4b}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let texture14 = device0.createTexture({
+  label: '\u0cf5\u5ad4\u{1fff2}',
+  size: [108],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler14 = device0.createSampler({
+  label: '\u{1fddf}\u4d8a\u{1fedd}\u664d\u4347\u8d59\u{1f924}\udf6d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.87,
+  lodMaxClamp: 55.12,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 153, y: 84 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({label: '\u66d9\u0b3d\u05a4\u0c8e\u{1fcda}'});
+let texture15 = device0.createTexture({
+  size: [320],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView23 = texture4.createView({label: '\u5b0b\ucd48\u0561', mipLevelCount: 1});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup2, new Uint32Array(1636), 695, 0);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 115560, buffer5, 69392, 5072);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 3824 widthInBlocks: 239 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 13280 */
+  offset: 9456,
+  rowsPerImage: 177,
+  buffer: buffer2,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 97, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 239, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder();
+let sampler15 = device0.createSampler({
+  label: '\uda58\u2661\ue3b0\u0e08\u010d',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.53,
+});
+try {
+computePassEncoder9.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(4, bindGroup1, new Uint32Array(6847), 3280, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer5, 7016, 38212);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 319, y: 20 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 1, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let imageData1 = new ImageData(32, 120);
+let commandEncoder18 = device0.createCommandEncoder({label: '\u0689\u0fde\u0d14\uc8f4\u{1f7c5}\u{1ff37}\u5a4b\u1bee\u{1fb2a}\u0f92\u4ca6'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\ua082\ud55a\u0f58\u{1fa55}\ua628', colorFormats: ['rgba32float', undefined, 'rgba8unorm']});
+try {
+commandEncoder17.clearBuffer(buffer5, 66876, 1520);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 283, y: 66 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4, bindGroupLayout7]});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u03a9\u{1fa95}\u{1fcba}\u0e66\u39a5\u397a\ub9af\u0b1e'});
+let textureView24 = texture0.createView({label: '\u4e2f\u0db0\ue7b8\u0f71\u013f\ube0b\u2b57\u{1f701}\u5eb6\uab17\u472a', baseArrayLayer: 0});
+let computePassEncoder12 = commandEncoder14.beginComputePass();
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup1);
+} catch {}
+let gpuCanvasContext5 = canvas1.getContext('webgpu');
+let commandEncoder20 = device0.createCommandEncoder({label: '\u3dd8\u0777'});
+let textureView25 = texture5.createView({label: '\u0b00\ub23d\u0963'});
+let computePassEncoder13 = commandEncoder19.beginComputePass();
+try {
+commandEncoder18.clearBuffer(buffer4, 86272, 33668);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(558, 541);
+let video1 = await videoWithData();
+let commandEncoder21 = device0.createCommandEncoder({label: '\u995d\uac9c\u152b\uc6c3'});
+let computePassEncoder14 = commandEncoder17.beginComputePass({label: '\u07d0\u{1f6aa}\ua36e\u{1f67c}\u{1fb8c}\ua345\ucba6\u8703'});
+try {
+computePassEncoder4.setBindGroup(4, bindGroup1, new Uint32Array(4920), 1241, 0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 266, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2084 widthInBlocks: 521 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2660 */
+  offset: 576,
+  buffer: buffer5,
+}, {width: 521, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 48, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\uea2a\u{1f893}\u007d\u5ad0\u0637\ubcd4\u69f2\u9e35\u{1faa3}\u037f\u{1fcf2}',
+  code: `
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(75) f0: f16,
+  @location(30) f1: vec4<u32>,
+  @location(76) f2: u32,
+  @builtin(front_facing) f3: bool,
+  @location(36) f4: vec2<f16>,
+  @location(44) f5: i32,
+  @location(8) f6: vec4<f16>,
+  @location(83) f7: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(85) a0: vec3<f16>, @location(79) a1: vec4<f32>, a2: S3, @location(50) a3: vec2<u32>, @location(91) a4: vec4<i32>, @location(1) a5: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(13) f0: vec2<f16>,
+  @location(4) f1: f32,
+  @location(16) f2: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(72) f40: vec3<f16>,
+  @location(45) f41: vec3<f32>,
+  @location(37) f42: i32,
+  @location(90) f43: vec2<f32>,
+  @location(36) f44: vec2<f16>,
+  @location(30) f45: vec4<u32>,
+  @location(20) f46: vec4<f32>,
+  @location(3) f47: vec3<i32>,
+  @location(38) f48: vec3<i32>,
+  @location(41) f49: vec2<i32>,
+  @location(108) f50: f32,
+  @location(5) f51: vec4<i32>,
+  @location(83) f52: vec2<f32>,
+  @location(98) f53: vec3<f16>,
+  @location(91) f54: vec4<i32>,
+  @location(69) f55: vec4<f32>,
+  @location(97) f56: i32,
+  @location(85) f57: vec3<f16>,
+  @location(82) f58: i32,
+  @location(76) f59: u32,
+  @location(58) f60: f16,
+  @location(89) f61: vec4<i32>,
+  @location(44) f62: i32,
+  @location(79) f63: vec4<f32>,
+  @location(27) f64: vec3<f32>,
+  @location(1) f65: vec3<f32>,
+  @location(75) f66: f16,
+  @location(2) f67: vec2<i32>,
+  @location(8) f68: vec4<f16>,
+  @location(50) f69: vec2<u32>,
+  @builtin(position) f70: vec4<f32>,
+  @location(14) f71: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec3<u32>, @location(23) a1: vec3<f16>, @location(1) a2: vec3<u32>, @location(26) a3: vec2<f16>, @location(15) a4: vec4<u32>, @builtin(vertex_index) a5: u32, @location(5) a6: vec3<f16>, @builtin(instance_index) a7: u32, @location(3) a8: i32, @location(11) a9: vec2<i32>, @location(14) a10: vec3<f32>, @location(8) a11: vec4<f32>, @location(18) a12: i32, @location(21) a13: vec4<u32>, @location(24) a14: vec4<f32>, @location(2) a15: vec4<i32>, @location(12) a16: vec4<f16>, @location(20) a17: vec4<f32>, @location(10) a18: vec2<f16>, @location(7) a19: vec2<f32>, @location(6) a20: vec3<i32>, a21: S2, @location(9) a22: vec3<u32>, @location(19) a23: f16, @location(0) a24: vec4<f32>, @location(17) a25: u32, @location(25) a26: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u{1f6b1}\u63cc\u6eb7\u{1fce4}\u{1f7fd}\u{1f94b}\u{1fbfc}\u9692\u6cd8',
+  entries: [
+    {
+      binding: 1054,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 2041,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 1465, visibility: 0, sampler: { type: 'non-filtering' }},
+  ],
+});
+let buffer6 = device0.createBuffer({label: '\u1525\uda73', size: 119758, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder22 = device0.createCommandEncoder();
+let textureView26 = texture14.createView({label: '\u3c6e\u053c\uba7c\u06e5\u6874\udced\u0f40\u{1fe5a}\u750c\u9292', arrayLayerCount: 1});
+let renderBundle3 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup2, new Uint32Array(2439), 434, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer2, 102176, buffer5, 59828, 13480);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 828 widthInBlocks: 207 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28364 */
+  offset: 28364,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 207, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 5239 */
+{offset: 55}, {width: 324, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet10 = device0.createQuerySet({label: '\u{1ffb4}\u{1fcb5}\ub8bf\u02a5\u0e5d', type: 'occlusion', count: 812});
+try {
+computePassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer4, 124636, 1640);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+  label: '\u7a74\u04f0\u0308\u{1fa44}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext6 = offscreenCanvas6.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(video1);
+try {
+adapter1.label = '\u0416\uf222\u541b\u943e';
+} catch {}
+let texture16 = device0.createTexture({
+  label: '\u{1fc98}\u08ff\ucbd9\u{1fd48}\u{1f909}',
+  size: [3072],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+});
+let computePassEncoder15 = commandEncoder15.beginComputePass({label: '\u0757\u120c'});
+let sampler16 = device0.createSampler({
+  label: '\u{1fe2e}\u0547\u062c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 63.75,
+  lodMaxClamp: 93.29,
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(7, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer1, 430348, 99983);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer0, 26448, buffer6, 109492, 9192);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 578 */
+{offset: 578}, {width: 252, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = videoFrame0.clone();
+let textureView27 = texture16.createView({label: '\u17be\u0036\u1a63\u{1fdbe}', format: 'rgba8unorm-srgb'});
+let renderBundle4 = renderBundleEncoder8.finish({label: '\u52f9\u06db\u{1f781}\u8a2c\u0f79\u{1f8d7}\uc948\u9009\udd10\u{1fef5}'});
+let externalTexture5 = device0.importExternalTexture({label: '\ue128\u0ed1\ud935', source: video1, colorSpace: 'srgb'});
+let pipeline7 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule1, entryPoint: 'compute0'}});
+let pipeline8 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32x2', offset: 30244, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 3462, shaderLocation: 19},
+          {format: 'sint16x4', offset: 3656, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 21944, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 31132, shaderLocation: 12},
+          {format: 'float32', offset: 21556, shaderLocation: 20},
+          {format: 'uint8x2', offset: 1064, shaderLocation: 1},
+          {format: 'float32x2', offset: 2380, shaderLocation: 8},
+          {format: 'sint16x4', offset: 156, shaderLocation: 18},
+          {format: 'float32x4', offset: 4444, shaderLocation: 10},
+          {format: 'float32x2', offset: 7464, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 21488, shaderLocation: 13},
+          {format: 'sint8x2', offset: 19668, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 30576, shaderLocation: 25},
+          {format: 'uint16x4', offset: 21184, shaderLocation: 21},
+          {format: 'snorm8x4', offset: 10960, shaderLocation: 4},
+          {format: 'sint8x4', offset: 9648, shaderLocation: 2},
+          {format: 'float32', offset: 380, shaderLocation: 24},
+          {format: 'unorm8x2', offset: 21200, shaderLocation: 16},
+          {format: 'float32', offset: 44932, shaderLocation: 26},
+          {format: 'sint32x2', offset: 7880, shaderLocation: 3},
+          {format: 'float32x4', offset: 24692, shaderLocation: 7},
+          {format: 'uint8x2', offset: 3448, shaderLocation: 22},
+          {format: 'float16x4', offset: 7952, shaderLocation: 23},
+          {format: 'uint32', offset: 14556, shaderLocation: 9},
+          {format: 'float32', offset: 880, shaderLocation: 0},
+          {format: 'uint32x2', offset: 17436, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+offscreenCanvas4.width = 640;
+let offscreenCanvas7 = new OffscreenCanvas(38, 77);
+let pipelineLayout4 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout8, bindGroupLayout3, bindGroupLayout5, bindGroupLayout6, bindGroupLayout8],
+});
+let querySet11 = device0.createQuerySet({label: '\u2171\u07e6\u0e7f\u08e6\u382a\ue5c4\u{1f86c}\u{1f8ed}\ucc22', type: 'occlusion', count: 866});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\ua961\u3f81\u8fbf\u485e\u26d5\u02d3\u957c\uf802\u23b4\ue60c',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer1, 'uint16', 52068, 123141);
+} catch {}
+try {
+commandEncoder21.insertDebugMarker('\u9547');
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas7.getContext('webgpu');
+document.body.prepend(canvas0);
+let canvas2 = document.createElement('canvas');
+let img0 = await imageWithData(129, 226, '#2563ea01', '#653d69a3');
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u623f\u7b22\u0c12\u{1f8b2}\u1b3b\u{1fa17}'});
+let commandBuffer2 = commandEncoder13.finish({label: '\u05b5\u8a3e\ub393\u0530'});
+let renderBundle5 = renderBundleEncoder4.finish();
+try {
+commandEncoder18.copyBufferToBuffer(buffer0, 96160, buffer6, 89660, 24832);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 904 widthInBlocks: 226 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20564 */
+  offset: 19660,
+  rowsPerImage: 78,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 226, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 60, y: 121 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync({
+  label: '\u97fa\u{1fab5}\u6303\uddd5\u{1ffed}\u9535\u701b',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {depthFailOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 1802500123,
+    stencilWriteMask: 3233278484,
+    depthBias: -1207148881,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x2', offset: 5090, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 8548, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 14556,
+        attributes: [
+          {format: 'float32x4', offset: 1252, shaderLocation: 5},
+          {format: 'float32x4', offset: 408, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 4704, shaderLocation: 8},
+          {format: 'sint32x4', offset: 6160, shaderLocation: 6},
+          {format: 'float16x4', offset: 5568, shaderLocation: 26},
+          {format: 'float32x3', offset: 2980, shaderLocation: 7},
+          {format: 'sint32x2', offset: 1020, shaderLocation: 18},
+          {format: 'uint16x2', offset: 2896, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 2524, shaderLocation: 14},
+          {format: 'uint32x4', offset: 3956, shaderLocation: 1},
+          {format: 'float32x2', offset: 1036, shaderLocation: 12},
+          {format: 'sint8x2', offset: 1452, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 364, shaderLocation: 20},
+          {format: 'uint16x2', offset: 6192, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 1096,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 96, shaderLocation: 13},
+          {format: 'uint32x2', offset: 160, shaderLocation: 22},
+          {format: 'uint8x2', offset: 152, shaderLocation: 9},
+          {format: 'float16x4', offset: 388, shaderLocation: 24},
+          {format: 'snorm8x2', offset: 1046, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 16488,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1396, shaderLocation: 25},
+          {format: 'snorm8x2', offset: 1238, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 5832, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 7656,
+        attributes: [
+          {format: 'sint8x2', offset: 1638, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 23},
+          {format: 'uint32', offset: 372, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame2 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u05ca\u{1fcf8}\uc7e8\u07d3'});
+let texture17 = device0.createTexture({
+  label: '\u{1fbb2}\u51ea\u003a\u3df5\ud9af\u6daa',
+  size: {width: 80},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView28 = texture7.createView({label: '\u{1ff85}\u8a8d\u0886\u{1ff7e}\u{1ffd9}\u0680\ua00d\u{1fb9c}\u0197\u027b'});
+let sampler17 = device0.createSampler({
+  label: '\u9454\u{1f6f6}\u{1fce7}\u0cdb\u0a33\uac9d',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 26.41,
+  lodMaxClamp: 85.88,
+  compare: 'less',
+});
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer1, 0);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer2, 115424, buffer4, 97496, 576);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 252, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 1040, new DataView(new ArrayBuffer(2673)), 1311, 212);
+} catch {}
+let pipeline10 = device0.createRenderPipeline({
+  label: '\u0a1f\u02b4\u8e3a\u0791\u{1f693}\uc900\ud61c\u01ac\u{1ff81}',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x42d8e137},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x2', offset: 30888, shaderLocation: 8},
+          {format: 'uint32x3', offset: 7028, shaderLocation: 14},
+          {format: 'float32x3', offset: 4380, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 17340,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 48, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 634, shaderLocation: 15},
+          {format: 'float16x2', offset: 1548, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 4096, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 2312,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 1560, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 34096,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 2668, shaderLocation: 21},
+          {format: 'sint16x4', offset: 3648, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let video2 = await videoWithData();
+let bindGroupLayout9 = device0.createBindGroupLayout({label: '\u58f8\u{1fd1d}\u{1fce4}\u0842\u8d03', entries: []});
+let commandEncoder25 = device0.createCommandEncoder({label: '\uac23\u{1f7ac}\u9b99\u9ad0\u1923\ud82d\u630d\u0f60\u0068\u0fca'});
+let textureView29 = texture5.createView({label: '\u0372\u0c51\ued4a\u1470\u4e32\u5402\u{1fbc6}', dimension: '3d', baseMipLevel: 0});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u4aa4\u0092\ua0a0\u0f5a\u0997\u5f55\u0c82\u09d8',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler18 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 94.79,
+  lodMaxClamp: 95.17,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 5344 widthInBlocks: 334 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6704 */
+  offset: 6704,
+  buffer: buffer0,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 334, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView30 = texture13.createView({label: '\u{1f946}\ud15b\u2257\uea8f\u0367', dimension: '1d'});
+let computePassEncoder16 = commandEncoder25.beginComputePass({label: '\u{1fb34}\u4e76\u3b94\ua546\u49bc\ua417'});
+let renderBundle6 = renderBundleEncoder10.finish({label: '\ue828\u7580\u{1fb4a}\u2df7\ua2cf\u0a4a\u{1feef}\u5fae\u{1fd84}\u64ee'});
+let sampler19 = device0.createSampler({
+  label: '\u1945\u0d8c\uc521\u286a',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 47.41,
+  lodMaxClamp: 65.72,
+  compare: 'always',
+});
+try {
+renderBundleEncoder6.setVertexBuffer(7, buffer1, 0, 335260);
+} catch {}
+let gpuCanvasContext8 = canvas2.getContext('webgpu');
+let imageData2 = new ImageData(20, 240);
+let bindGroup3 = device0.createBindGroup({label: '\u99a8\u{1fed5}', layout: bindGroupLayout1, entries: []});
+let texture18 = device0.createTexture({
+  label: '\u{1fb17}\u0279\u044e\u0066\u30a1',
+  size: {width: 216, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm'],
+});
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer1, 229880);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2976 widthInBlocks: 186 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 23744 */
+  offset: 23744,
+  buffer: buffer6,
+}, {width: 186, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer6, 45996, 20848);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 96 */
+{offset: 96}, {width: 414, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video0.height = 45;
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u03e3\u0a7c\u{1f862}',
+  entries: [
+    {
+      binding: 402,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let querySet12 = device0.createQuerySet({label: '\u2de6\udc47\u0aec\u4d72\u{1fb32}', type: 'occlusion', count: 3618});
+let texture19 = device0.createTexture({
+  label: '\u{1fa84}\u0c93\u7b3c\u3426',
+  size: [2880, 240, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView31 = texture1.createView({label: '\u0437\ueb8a\u{1fc9f}\uf9db\u6c8c\u51a7'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1fcda}\u055c\u28dc\u{1fbf6}\u09a4\uc4de\u06b7',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle7 = renderBundleEncoder7.finish({label: '\u0e6d\u0066\u0730\u90f8\u844b\u209c\u{1fe8a}\u79f3'});
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup3, new Uint32Array(8377), 120, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  label: '\ufa8a\u{1f95d}\u8f7c\u51c2\u498c\u0c3d\u084f\uc6fc\u{1f9da}\u02f2\u7ead',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x6b01a694},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.RED}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 40048,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 5864, shaderLocation: 21},
+          {format: 'float16x2', offset: 220, shaderLocation: 3},
+          {format: 'uint32', offset: 2108, shaderLocation: 16},
+          {format: 'uint16x4', offset: 84, shaderLocation: 6},
+          {format: 'uint8x4', offset: 24628, shaderLocation: 7},
+          {format: 'float16x2', offset: 4248, shaderLocation: 5},
+          {format: 'float32x3', offset: 14596, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 2236, shaderLocation: 18},
+          {format: 'sint32x2', offset: 772, shaderLocation: 20},
+          {format: 'uint32x3', offset: 4004, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 2320, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 3876,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 312, shaderLocation: 4},
+          {format: 'sint32x4', offset: 556, shaderLocation: 25},
+          {format: 'uint8x2', offset: 470, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 1096, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 428, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 9544,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 7660, shaderLocation: 12},
+          {format: 'sint16x4', offset: 7040, shaderLocation: 15},
+          {format: 'sint32', offset: 2408, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder26 = device0.createCommandEncoder();
+let commandBuffer3 = commandEncoder23.finish({label: '\u0d4a\u71a1\u5bd2\u90d5\u{1fca3}\u2bdb\u{1fa24}\u{1fbd5}\u6518'});
+let externalTexture7 = device0.importExternalTexture({label: '\u2b76\u06f9\u039d\u01a9\u9092\u08d5', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer2, 68792, buffer4, 124820, 6048);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10348 */
+  offset: 10348,
+  rowsPerImage: 158,
+  buffer: buffer0,
+}, {
+  texture: texture18,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2900 widthInBlocks: 725 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 57660 */
+  offset: 57660,
+  buffer: buffer6,
+}, {width: 725, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 324, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 350, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(8)), /* required buffer size: 153 */
+{offset: 153, rowsPerImage: 176}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `@group(3) @binding(3920)
+var<storage, read_write> type1: array<u32>;
+@group(4) @binding(1012)
+var<storage, read_write> function0: array<u32>;
+@group(5) @binding(1054)
+var<storage, read_write> n2: array<u32>;
+@group(5) @binding(2041)
+var<storage, read_write> n3: array<u32>;
+@group(1) @binding(2041)
+var<storage, read_write> local2: array<u32>;
+@group(5) @binding(1465)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(1465)
+var<storage, read_write> global3: array<u32>;
+@group(1) @binding(1054)
+var<storage, read_write> type2: array<u32>;
+@group(3) @binding(3959)
+var<storage, read_write> local3: array<u32>;
+@group(3) @binding(398)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(6) f0: vec4<f16>,
+  @location(43) f1: vec2<f32>,
+  @location(37) f2: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(6) f2: i32
+}
+
+@fragment
+fn fragment0(@location(57) a0: vec2<u32>, @location(17) a1: vec2<u32>, @location(24) a2: vec4<f16>, @location(33) a3: vec2<u32>, @location(91) a4: vec2<f32>, @location(86) a5: vec4<u32>, @location(51) a6: vec4<f32>, @location(75) a7: vec2<f16>, @location(49) a8: f32, @builtin(front_facing) a9: bool, @location(35) a10: vec2<i32>, @location(23) a11: vec4<i32>, @location(77) a12: vec2<u32>, @location(20) a13: i32, @location(108) a14: u32, @location(65) a15: vec3<i32>, @builtin(sample_index) a16: u32, @location(79) a17: vec2<f32>, @location(62) a18: vec4<i32>, a19: S5, @location(13) a20: i32, @location(69) a21: f32, @location(92) a22: vec4<f16>, @location(7) a23: vec3<f16>, @location(88) a24: vec4<f32>, @location(29) a25: vec3<f32>, @location(47) a26: vec2<f32>, @location(101) a27: vec3<u32>, @location(36) a28: vec4<i32>, @location(81) a29: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(0) f0: vec2<f32>,
+  @location(17) f1: u32,
+  @location(20) f2: vec2<f16>,
+  @location(13) f3: vec2<f32>,
+  @location(5) f4: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(88) f72: vec4<f32>,
+  @location(33) f73: vec2<u32>,
+  @location(108) f74: u32,
+  @location(81) f75: vec4<i32>,
+  @location(72) f76: vec2<i32>,
+  @location(20) f77: i32,
+  @location(29) f78: vec3<f32>,
+  @location(77) f79: vec2<u32>,
+  @location(92) f80: vec4<f16>,
+  @location(23) f81: vec4<i32>,
+  @location(6) f82: vec4<f16>,
+  @location(21) f83: u32,
+  @location(103) f84: f32,
+  @location(4) f85: vec4<f32>,
+  @location(47) f86: vec2<f32>,
+  @location(65) f87: vec3<i32>,
+  @location(57) f88: vec2<u32>,
+  @location(36) f89: vec4<i32>,
+  @location(51) f90: vec4<f32>,
+  @location(79) f91: vec2<f32>,
+  @location(24) f92: vec4<f16>,
+  @location(13) f93: i32,
+  @location(66) f94: vec3<u32>,
+  @location(40) f95: vec2<i32>,
+  @builtin(position) f96: vec4<f32>,
+  @location(35) f97: vec2<i32>,
+  @location(7) f98: vec3<f16>,
+  @location(49) f99: f32,
+  @location(91) f100: vec2<f32>,
+  @location(75) f101: vec2<f16>,
+  @location(101) f102: vec3<u32>,
+  @location(62) f103: vec4<i32>,
+  @location(43) f104: vec2<f32>,
+  @location(17) f105: vec2<u32>,
+  @location(86) f106: vec4<u32>,
+  @location(18) f107: vec2<i32>,
+  @location(80) f108: vec2<i32>,
+  @location(37) f109: vec3<i32>,
+  @location(69) f110: f32,
+  @location(64) f111: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: u32, @location(23) a1: vec4<f32>, @location(21) a2: i32, @location(9) a3: vec4<i32>, a4: S4, @location(1) a5: vec4<i32>, @location(22) a6: vec2<f16>, @location(26) a7: f16, @location(14) a8: vec2<u32>, @location(4) a9: vec2<i32>, @location(18) a10: vec3<f16>, @location(3) a11: i32, @location(12) a12: vec3<u32>, @location(16) a13: u32, @location(8) a14: vec4<i32>, @location(15) a15: vec3<i32>, @location(24) a16: vec3<f32>, @location(11) a17: vec2<f16>, @location(25) a18: vec4<i32>, @builtin(vertex_index) a19: u32, @location(10) a20: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let querySet13 = device0.createQuerySet({
+  label: '\u4552\u0a9e\u099e\ucae7\u0dd1\u5fc3\u1f7f\u910f\u0f80\u2002\u0a08',
+  type: 'occlusion',
+  count: 1460,
+});
+let commandBuffer4 = commandEncoder4.finish({label: '\u3975\ubea0\ub585\u{1f842}\u026b\u{1f7a7}\u6184\u0fc4'});
+let textureView32 = texture0.createView({label: '\u288c\u{1fafe}\ue39f\uc603\u0eef\u4bd0\u60fb\u{1fa9f}', dimension: '1d', baseArrayLayer: 0});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\ucc9d\u782a\u{1fbfe}\uae4f\u0f52\uf91d\ud6dc',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(4, buffer1, 553736, 6198);
+} catch {}
+let img1 = await imageWithData(261, 83, '#e9081d13', '#7320f228');
+let commandEncoder27 = device0.createCommandEncoder();
+let commandBuffer5 = commandEncoder21.finish({label: '\u07e1\ud32b\uf483\uc7c3\ufdf3\u0ff4\uaa56\u22e4\u{1fa6d}\u003f'});
+let textureView33 = texture7.createView({label: '\u0ab0\ud569\u0790\ube48\u53bf\u{1fcf9}\u02ac', aspect: 'all'});
+let computePassEncoder17 = commandEncoder18.beginComputePass();
+try {
+computePassEncoder16.setBindGroup(7, bindGroup3, new Uint32Array(3491), 217, 0);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline11);
+} catch {}
+let arrayBuffer1 = buffer3.getMappedRange(6880, 73116);
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18704 */
+  offset: 18680,
+  buffer: buffer0,
+}, {
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline12 = device0.createComputePipeline({
+  label: '\u0499\ua113',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let img2 = await imageWithData(39, 81, '#52a8f511', '#d3da2170');
+let buffer7 = device0.createBuffer({size: 109436, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX, mappedAtCreation: true});
+let commandEncoder28 = device0.createCommandEncoder({label: '\u588b\ubffa'});
+let commandBuffer6 = commandEncoder22.finish({});
+let computePassEncoder18 = commandEncoder16.beginComputePass({label: '\u{1f914}\u{1f656}\u6007\u0596'});
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 38, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 87, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(568, 903);
+let video3 = await videoWithData();
+let videoFrame3 = new VideoFrame(videoFrame2, {timestamp: 0});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.READ, 0, 56972);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer2, 129872, buffer4, 54880, 6104);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({entries: []});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u{1fc38}\u263b\u9884\u612b\u079d\u09ac\u02ec\u5555\u0426\u5378'});
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(2139), 33, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer1, 341416, 178129);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 11096 widthInBlocks: 2774 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11692 */
+  offset: 11692,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2774, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer6, 15808, 100184);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 10, y: 52 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 26},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+  label: '\ua3bf\ubd77\u{1fea6}\u0cad',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline14 = device0.createRenderPipeline({
+  label: '\u04d0\u{1fcb4}\u9b2a',
+  layout: pipelineLayout4,
+  multisample: {count: 1, mask: 0x246eeac1},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilWriteMask: 1792612508,
+    depthBias: -1785092149,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10640,
+        attributes: [
+          {format: 'sint8x4', offset: 780, shaderLocation: 1},
+          {format: 'float16x2', offset: 4156, shaderLocation: 13},
+          {format: 'uint16x2', offset: 3328, shaderLocation: 6},
+          {format: 'sint8x4', offset: 508, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 564, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 2996, shaderLocation: 24},
+          {format: 'sint8x4', offset: 124, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 3600, shaderLocation: 20},
+          {format: 'uint32', offset: 184, shaderLocation: 12},
+          {format: 'float32', offset: 1628, shaderLocation: 23},
+          {format: 'unorm8x4', offset: 5604, shaderLocation: 5},
+          {format: 'sint8x4', offset: 1444, shaderLocation: 15},
+          {format: 'uint16x4', offset: 2296, shaderLocation: 14},
+          {format: 'sint32x2', offset: 196, shaderLocation: 25},
+          {format: 'snorm16x4', offset: 872, shaderLocation: 11},
+          {format: 'uint16x4', offset: 4392, shaderLocation: 16},
+          {format: 'float16x2', offset: 900, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 16180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 3504, shaderLocation: 0},
+          {format: 'float32', offset: 15648, shaderLocation: 26},
+          {format: 'sint32x3', offset: 2688, shaderLocation: 4},
+          {format: 'sint16x4', offset: 3364, shaderLocation: 3},
+          {format: 'sint32x4', offset: 8124, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 1080, shaderLocation: 18},
+          {format: 'uint16x2', offset: 6516, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise5;
+} catch {}
+let canvas3 = document.createElement('canvas');
+let textureView34 = texture7.createView({label: '\u{1feb5}\u{1faa9}'});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer2, 91400, buffer6, 23204, 26792);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: canvas1,
+  origin: { x: 12, y: 37 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\u0c46\u0822\u0940\u{1f8bd}\u0806\u0210\u0a64\u7025\u560b\u0625\u05d3',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let img3 = await imageWithData(260, 195, '#b1f3d0f3', '#2437b6e3');
+try {
+offscreenCanvas8.getContext('bitmaprenderer');
+} catch {}
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 1062});
+let commandBuffer7 = commandEncoder24.finish();
+let texture20 = device0.createTexture({
+  size: [216, 12, 569],
+  mipLevelCount: 8,
+  dimension: '2d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView35 = texture14.createView({label: '\u{1fdc3}\u472b', baseArrayLayer: 0, arrayLayerCount: 1});
+let sampler20 = device0.createSampler({
+  label: '\u0186\ud9be\u871f\u6285\u{1f75c}\u1736',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.91,
+  lodMaxClamp: 86.74,
+});
+try {
+renderBundleEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer2, 49900, buffer5, 3536, 40432);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let gpuCanvasContext9 = canvas3.getContext('webgpu');
+let imageData3 = new ImageData(104, 216);
+let videoFrame4 = new VideoFrame(img0, {timestamp: 0});
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u0bcd\ua7ee\u{1f9b4}\u4f83', bindGroupLayouts: []});
+let renderBundle8 = renderBundleEncoder13.finish({});
+let sampler21 = device0.createSampler({
+  label: '\u68f6\u0848',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 67.17,
+  lodMaxClamp: 83.73,
+});
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+let arrayBuffer2 = buffer7.getMappedRange(102576);
+try {
+commandEncoder7.copyBufferToBuffer(buffer0, 348060, buffer6, 61384, 53412);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 964 widthInBlocks: 241 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 66812 */
+  offset: 65848,
+  rowsPerImage: 263,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 386, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 241, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u0c5e');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: video0,
+  origin: { x: 5, y: 1 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet15 = device0.createQuerySet({label: '\u092a\u1bca\uaefc\u63f7\ub9a9\u{1fe9a}\u0f06\u{1feb7}', type: 'occlusion', count: 512});
+let textureView36 = texture13.createView({label: '\u0d7a\u0557\u0e96\uc2cb\u1934\u{1fe9a}'});
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer1, 301688, 232558);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u6125');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 2336, new BigUint64Array(30481), 13824, 156);
+} catch {}
+let querySet16 = device0.createQuerySet({label: '\u0a6b\u{1fa20}\u22c3\u3920', type: 'occlusion', count: 2626});
+let texture21 = device0.createTexture({
+  label: '\u8f3d\u034e\u4b44\u4c9f\u151b\u089f\u{1f9a5}\u672a\u025a\ue8ca',
+  size: {width: 1440},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u{1f9a0}\u55ed\u8893\ub019\u079b\u1377',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  stencilReadOnly: true,
+});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\u{1fa5d}\u05a6\u7b9e\ua57f\ue754\u7a7c\u7eb9\ubed4\u869e',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer4, 3432, 18264);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u0fed\u6a07\u3fb6'});
+let textureView37 = texture20.createView({label: '\u880e\uad5a\u0db9\u{1fa62}\u0a29', dimension: '2d', mipLevelCount: 3, baseArrayLayer: 451});
+let renderBundle9 = renderBundleEncoder3.finish();
+let externalTexture9 = device0.importExternalTexture({
+  label: '\u4f48\u9b0f\uf0b9\u{1faf4}\u085f\u0edb\u0855\uc0d1',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 296 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7832 */
+  offset: 7536,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 74, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 137, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10736 */
+  offset: 10736,
+  buffer: buffer5,
+}, {width: 22, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let commandBuffer8 = commandEncoder27.finish({});
+let textureView38 = texture20.createView({
+  label: '\u0f70\u9a97\u0f83',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+  baseArrayLayer: 449,
+  arrayLayerCount: 118,
+});
+try {
+computePassEncoder1.setBindGroup(5, bindGroup1, new Uint32Array(7263), 192, 0);
+} catch {}
+try {
+computePassEncoder9.dispatchWorkgroups(4, 1, 4);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer2, 133664, buffer4, 104400, 6644);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 26808, new BigUint64Array(56742), 20284, 2416);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  label: '\u{1f84b}\ueef9\uc4a8',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float'}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 68, attributes: []},
+      {
+        arrayStride: 5960,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x2', offset: 1434, shaderLocation: 21},
+          {format: 'sint8x4', offset: 5096, shaderLocation: 9},
+          {format: 'sint32', offset: 2904, shaderLocation: 8},
+          {format: 'uint32x2', offset: 236, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 3776,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 232, shaderLocation: 17}],
+      },
+      {arrayStride: 17144, attributes: []},
+      {
+        arrayStride: 2048,
+        attributes: [
+          {format: 'snorm8x2', offset: 90, shaderLocation: 1},
+          {format: 'float16x2', offset: 104, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 35932,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 12512, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 6188, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 2416,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32', offset: 176, shaderLocation: 18}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let promise6 = adapter0.requestAdapterInfo();
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer1, 0, 417160);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 304 widthInBlocks: 76 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6628 */
+  offset: 6628,
+  rowsPerImage: 253,
+  buffer: buffer5,
+}, {width: 76, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 118, y: 32 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = await promise4;
+let commandBuffer9 = commandEncoder7.finish({label: '\ub7fa\ufdd3\ue46a\u{1f6b8}\uc88a\u0c8c\u3d29\u04ef\u87ad\u9e8f'});
+let renderBundle10 = renderBundleEncoder5.finish({label: '\u29c0\u{1fcf9}'});
+let sampler22 = device0.createSampler({
+  label: '\u0715\u{1fcec}\u00e2\uab64\u0c24\u4e1b\u4c13',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 90.22,
+  lodMaxClamp: 93.35,
+});
+try {
+computePassEncoder8.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup3, new Uint32Array(2765), 1538, 0);
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u0c0a');
+} catch {}
+let pipeline18 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let img4 = await imageWithData(250, 103, '#5d21eeee', '#09668939');
+let videoFrame5 = new VideoFrame(video1, {timestamp: 0});
+let pipelineLayout6 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout10, bindGroupLayout4, bindGroupLayout1, bindGroupLayout3, bindGroupLayout3, bindGroupLayout3, bindGroupLayout10],
+});
+let textureView39 = texture17.createView({label: '\u861f\u{1f8ec}\u3b6f\u{1ff4d}\u8b0e'});
+let sampler23 = device0.createSampler({
+  label: '\u0199\u{1f743}\u6f88\u049b\u{1ff38}\u{1fb46}\u8b56\ua864\u0df2',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.61,
+  lodMaxClamp: 61.83,
+});
+try {
+renderBundleEncoder14.setBindGroup(6, bindGroup0, new Uint32Array(3839), 1458, 0);
+} catch {}
+let arrayBuffer3 = buffer7.getMappedRange(0, 70512);
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 4,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 118, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 916 */
+{offset: 916}, {width: 3007, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+  label: '\u14f1\u{1fa28}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline20 = device0.createRenderPipeline({
+  label: '\ucad6\ua32c\u0b7a\u0037\u{1f83b}\u06ed',
+  layout: pipelineLayout2,
+  multisample: {mask: 0xabb59eb9},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    depthBiasClamp: 200.64746068592063,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x3', offset: 19932, shaderLocation: 26},
+          {format: 'float32x4', offset: 14320, shaderLocation: 23},
+          {format: 'unorm8x4', offset: 10372, shaderLocation: 0},
+          {format: 'uint16x4', offset: 14196, shaderLocation: 6},
+          {format: 'sint32', offset: 17812, shaderLocation: 9},
+          {format: 'sint32x3', offset: 412, shaderLocation: 8},
+          {format: 'float32x2', offset: 38228, shaderLocation: 10},
+          {format: 'sint32x2', offset: 3556, shaderLocation: 21},
+          {format: 'float16x2', offset: 4300, shaderLocation: 13},
+          {format: 'uint32x2', offset: 25508, shaderLocation: 12},
+          {format: 'sint32x3', offset: 5708, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 11616, shaderLocation: 24},
+          {format: 'float32', offset: 19392, shaderLocation: 11},
+          {format: 'sint8x2', offset: 8442, shaderLocation: 25},
+        ],
+      },
+      {arrayStride: 7888, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 24944,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 4716, shaderLocation: 5},
+          {format: 'uint32x3', offset: 1152, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 5400, shaderLocation: 20},
+          {format: 'uint32x4', offset: 4128, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 31628,
+        attributes: [
+          {format: 'sint32x3', offset: 1032, shaderLocation: 15},
+          {format: 'float32', offset: 3008, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 10396,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 3604, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 3508,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 856, shaderLocation: 18},
+          {format: 'sint8x4', offset: 124, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 19320, shaderLocation: 17}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let externalTexture10 = device0.importExternalTexture({
+  label: '\u{1f716}\u08b8\uaf91\u{1f678}\u0630\u4133\u{1fb8a}\uf0bf',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer5, 32628, 34836);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 16376, new Float32Array(30101), 26751, 1084);
+} catch {}
+let buffer8 = device0.createBuffer({
+  label: '\uc17e\ue7de\uebba\u0330\uf305\u0d8f\u38d4\u{1f62b}\u{1fae7}',
+  size: 574276,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\ue919\u6b57'});
+let textureView40 = texture20.createView({
+  label: '\u98f2\ue09a\u33a4\u0dd2\u394a\u3ed8\u0ea0\u7db6',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 6,
+  baseArrayLayer: 54,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({label: '\u1629\uff7b\u02ef', colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint']});
+try {
+renderBundleEncoder1.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12724 */
+  offset: 12684,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 101, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2800 widthInBlocks: 700 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10432 */
+  offset: 7632,
+  bytesPerRow: 2816,
+  buffer: buffer5,
+}, {width: 700, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer5, 36968, 30068);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder();
+let computePassEncoder19 = commandEncoder20.beginComputePass({label: '\ud5fa\ucf83'});
+let sampler24 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 19.31});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 54, y: 141 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({
+  label: '\u08a3\ub875\u06f5\u45fc\u{1f9b0}\u{1f8c4}\u98d4\u04a9\u{1f94b}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+document.body.prepend(img2);
+let canvas4 = document.createElement('canvas');
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u9c81\u{1f8f7}\u{1f79a}\ub7e7\u{1f6dd}\u{1fb79}\u{1fdd3}\u10d2',
+  bindGroupLayouts: [bindGroupLayout5],
+});
+let textureView41 = texture3.createView({baseMipLevel: 0});
+let computePassEncoder20 = commandEncoder31.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u{1fddb}\u{1feed}\u1644\ub084\u{1fae6}\uf632\u3e23',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle11 = renderBundleEncoder13.finish();
+let externalTexture11 = device0.importExternalTexture({label: '\u9c59\u8f01\u4930\u0a4c\u0096\u1223\u{1f79c}\u0e3a\u{1f961}\uc333', source: video3});
+try {
+renderBundleEncoder15.setVertexBuffer(7, buffer1);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer7, 96516, buffer5, 71912, 5744);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 336 widthInBlocks: 84 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6880 */
+  offset: 6880,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 84, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 200 widthInBlocks: 50 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32556 */
+  offset: 32556,
+  rowsPerImage: 43,
+  buffer: buffer5,
+}, {width: 50, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 666, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1471, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 102, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\u{1ff25}\u0b92\u6d27\u1584\u06ba',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let querySet17 = device0.createQuerySet({label: '\ua125\u60f6', type: 'occlusion', count: 2885});
+let textureView42 = texture0.createView({label: '\u00e3\u0fa8\u7fc9', arrayLayerCount: 1});
+let renderBundle12 = renderBundleEncoder10.finish({label: '\u926c\u12fb\u126d\u041c\ua378'});
+try {
+computePassEncoder9.dispatchWorkgroups(2, 3, 1);
+} catch {}
+try {
+commandEncoder32.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 940 widthInBlocks: 235 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3000 */
+  offset: 3000,
+  bytesPerRow: 1280,
+  buffer: buffer5,
+}, {width: 235, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer6, 9416, 63736);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4, commandBuffer7, commandBuffer5, commandBuffer6]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 249, y: 38 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder();
+let commandBuffer10 = commandEncoder32.finish({label: '\u199e\ud3a9\u3707\u4f0b\u0055\u497c\u0180\u0885\uc5a0'});
+try {
+computePassEncoder9.dispatchWorkgroups(3, 2);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(4, bindGroup1, new Uint32Array(823), 395, 0);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(7, buffer1, 498392);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4224 widthInBlocks: 264 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 7248 */
+  offset: 7248,
+  rowsPerImage: 7,
+  buffer: buffer5,
+}, {width: 264, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 215, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer5, 48892, 5304);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder2.insertDebugMarker('\ub4cc');
+} catch {}
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\ud756\ua3ed\u845f\ub327\u8eb1\u4d27\u6f7b\uc962\u{1fbd2}',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer5, 60284, 13724);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+  label: '\u0316\u{1fe27}\uaae9\u3175\u9217\u05b5\ua186',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\u9c4a\u2e59\u{1f929}\u0478'});
+let texture22 = device0.createTexture({
+  label: '\u71b6\u657a\ub540\u{1f910}\u0a3c\u6693\u03b6',
+  size: {width: 216, height: 12, depthOrArrayLayers: 93},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let externalTexture12 = device0.importExternalTexture({label: '\u0e5f\u{1f62e}\u06de\u{1fb31}\ud268\u05c4', source: video1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder18.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 1728, new Float32Array(12456), 2315, 4492);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 541 */
+{offset: 541, bytesPerRow: 303, rowsPerImage: 175}, {width: 73, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 33},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video4 = await videoWithData();
+try {
+device0.label = '\ube1b\u639d\ud481\u{1fbff}\u{1f7e4}\u04fa\u5172';
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\u{1f642}\u065e\u87df\ue556\ud2ea\u0f64\u0a82\u8a29'});
+let textureView43 = texture20.createView({
+  label: '\u7d63\u02af\u4677\u564d\u6bd7\u01de\ue5d4\u126a\uf818',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 52,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder9.dispatchWorkgroups(1, 3, 4);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer6, 90996, 10316);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 14164, new Int16Array(15063), 12993, 408);
+} catch {}
+let img5 = await imageWithData(226, 163, '#4da8475a', '#5f3b4f1d');
+let commandEncoder36 = device0.createCommandEncoder({label: '\u{1ffc4}\u6ea7\u331d\u{1fc29}'});
+let texture23 = device0.createTexture({
+  label: '\u06a0\u{1f798}\u09cf\uc0e8\ub130\u0b55\ude9d\u{1ff50}\u0cfa\ub8c8',
+  size: [320, 1, 35],
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let renderBundle13 = renderBundleEncoder15.finish({label: '\u{1ff13}\u0058'});
+let sampler25 = device0.createSampler({
+  label: '\u6d9f\u{1f6f8}\uca6c\u{1f60f}\uc526\uc710\ubf61\u3a1d\u242a\ub974',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.90,
+  lodMaxClamp: 73.05,
+  maxAnisotropy: 8,
+});
+try {
+commandEncoder2.copyBufferToBuffer(buffer7, 75912, buffer6, 17420, 8716);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 964, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3804 widthInBlocks: 951 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4960 */
+  offset: 4960,
+  buffer: buffer5,
+}, {width: 951, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline24 = await device0.createComputePipelineAsync({
+  label: '\u4af8\ua094\u{1fee4}\u3fe1\u71d1\uf6d5\u5786\u{1ff1d}',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter0.label = '\u{1f91c}\u834e';
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({label: '\u1ab8\u4602\u03b8\ucdfb\u38ef\u025b', entries: []});
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline11);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 1844 widthInBlocks: 461 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9352 */
+  offset: 7508,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 461, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 223, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 53, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture24 = device0.createTexture({
+  size: [720, 60, 1],
+  mipLevelCount: 6,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm'],
+});
+let renderBundle14 = renderBundleEncoder8.finish({label: '\u035d\u{1f8ff}\u16b1\u0a8c\u4432\u{1f78b}\u04a0\u0b56'});
+let sampler26 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.73,
+  lodMaxClamp: 88.86,
+});
+try {
+computePassEncoder9.dispatchWorkgroups(5);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer2, 146632, buffer4, 56252, 22456);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1823, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+  label: '\u{1ff55}\u9bb9\uf753\u06c0\u0187\u5ce1\u{1fe01}\u0880\u7aa3\u{1fa73}\u4023',
+  layout: pipelineLayout5,
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'keep', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilReadMask: 3482122016,
+    stencilWriteMask: 4137003439,
+    depthBiasClamp: 896.3165224796084,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1548,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 34, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 60076,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x2', offset: 3480, shaderLocation: 8},
+          {format: 'sint8x2', offset: 25860, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 3988, shaderLocation: 23},
+          {format: 'uint32', offset: 13912, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 20944, shaderLocation: 10},
+          {format: 'float16x4', offset: 4236, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 34432, shaderLocation: 0},
+          {format: 'sint32x2', offset: 9652, shaderLocation: 21},
+          {format: 'float32x3', offset: 35592, shaderLocation: 26},
+        ],
+      },
+      {
+        arrayStride: 11608,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 5112, shaderLocation: 3},
+          {format: 'sint32x4', offset: 64, shaderLocation: 15},
+          {format: 'uint32x2', offset: 196, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 3320, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 8294, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 50436, shaderLocation: 20},
+          {format: 'uint32x4', offset: 57628, shaderLocation: 6},
+          {format: 'float32', offset: 48828, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 140,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x2', offset: 68, shaderLocation: 24},
+          {format: 'sint16x4', offset: 24, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 60076, attributes: []},
+      {
+        arrayStride: 15360,
+        attributes: [
+          {format: 'sint32', offset: 44, shaderLocation: 25},
+          {format: 'sint32x3', offset: 3652, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 34096,
+        attributes: [
+          {format: 'float32', offset: 13244, shaderLocation: 22},
+          {format: 'uint8x4', offset: 10748, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'front'},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u0fba\u{1fc9c}\u8280\u016a\u243e\u6fb5\u92e9\u74a5',
+  entries: [
+    {
+      binding: 3487,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 2930,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 4216,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u{1f937}\u7c93\uff0e\ube5f\u{1fe05}\u009d\u01ba\uebe1\u9a7d'});
+let texture25 = gpuCanvasContext4.getCurrentTexture();
+let renderBundle15 = renderBundleEncoder13.finish({label: '\u42ee\u030c'});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 50540, new Int16Array(36579), 599, 5360);
+} catch {}
+document.body.prepend(img1);
+let textureView44 = texture24.createView({label: '\uea5a\u{1fdaf}\u3032\u03c1\uff75\u62da\u{1f96b}', baseMipLevel: 3});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\u{1f8ff}\u6513\ub0f0\uc5e8\u7aee\u01ec\u698b\u1131\ucf3f\ub792\u2697',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder9.dispatchWorkgroups(5, 5, 2);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer1, 'uint32');
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer1, 510272, 31824);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer6, 12672, 79852);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: video1,
+  origin: { x: 5, y: 3 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: bindGroupLayout9, entries: []});
+let querySet18 = device0.createQuerySet({
+  label: '\u{1f86f}\u79ef\u{1f81a}\uc477\u8228\u3c1d\u39c8\u{1faef}\u34f0\u0502\u079d',
+  type: 'occlusion',
+  count: 3804,
+});
+let texture26 = device0.createTexture({
+  label: '\u1299\ufd15\uacd4\u0d77\u0ab6\u{1fa1f}\u{1ffc3}\u{1f621}\ub3f6\u{1fb30}\u{1fb48}',
+  size: [1440, 120, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView45 = texture9.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle16 = renderBundleEncoder11.finish({label: '\u0438\u0e45\ubc82\u0401'});
+let sampler27 = device0.createSampler({
+  label: '\ub076\u{1ffc2}\u86f0\u3a73',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 99.72,
+  compare: 'greater',
+});
+try {
+computePassEncoder18.setBindGroup(7, bindGroup2, new Uint32Array(2172), 1735, 0);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer4 = buffer2.getMappedRange(0, 27964);
+try {
+commandEncoder29.copyBufferToBuffer(buffer2, 191596, buffer6, 119712, 16);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 54472, new Int16Array(15307), 10780, 3396);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({label: '\u3b90\u{1fd35}\uddd6\u06c4\uad85\u0fdd\u9aaf\u627d\u9d33\u{1fe61}\u017a'});
+try {
+computePassEncoder4.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6, buffer1, 498456, 30595);
+} catch {}
+try {
+texture6.destroy();
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer7, 47012, buffer6, 114452, 900);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u0614');
+} catch {}
+let textureView46 = texture10.createView({
+  label: '\u0bf8\u4e60\u{1fc0c}\u4ce4\u064e\u{1f69b}\u1e36\u58a5\u03ab\u0447',
+  dimension: '2d-array',
+  baseMipLevel: 10,
+  mipLevelCount: 2,
+});
+let computePassEncoder21 = commandEncoder29.beginComputePass({label: '\u{1fc4d}\u{1f941}\u0fb4\u07af\u3541\u{1fd37}\u{1f7ef}\u9c86\u9474'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\ua34c\u0083\u0859\ua434\u0b10',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: true,
+});
+let externalTexture14 = device0.importExternalTexture({
+  label: '\u8e3b\u111c\u{1f8b2}\u{1fd4f}\ueedb\ua452\ub7ad\u03fa\uaf82\u5712\u020a',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder9.dispatchWorkgroupsIndirect(buffer8, 73856);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 362, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 81996, new DataView(new ArrayBuffer(24933)), 11435, 0);
+} catch {}
+let pipeline26 = device0.createRenderPipeline({
+  label: '\u845b\u0505\u{1f786}\u1d3a\u0cbb\u2171\u17e6\ue216\u0ce2\u09a9',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp'},
+    stencilReadMask: 2903395999,
+    stencilWriteMask: 3806719739,
+    depthBiasSlopeScale: 556.4193001123584,
+    depthBiasClamp: 551.4580611017714,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17536,
+        attributes: [
+          {format: 'sint32x3', offset: 964, shaderLocation: 9},
+          {format: 'uint32x4', offset: 7568, shaderLocation: 18},
+          {format: 'uint8x2', offset: 8772, shaderLocation: 14},
+          {format: 'float16x2', offset: 13024, shaderLocation: 17},
+          {format: 'float32x4', offset: 13160, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 14476,
+        attributes: [
+          {format: 'float16x2', offset: 5392, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 1620, shaderLocation: 15},
+          {format: 'float32', offset: 14472, shaderLocation: 21},
+          {format: 'sint32', offset: 3256, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 956, attributes: []},
+      {arrayStride: 28432, stepMode: 'instance', attributes: []},
+      {arrayStride: 22560, attributes: [{format: 'float32x4', offset: 2408, shaderLocation: 1}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise6;
+} catch {}
+let imageData4 = new ImageData(224, 24);
+let textureView47 = texture5.createView({label: '\ubf06\ufe85\u0b21\u0f30\u60b3\u{1fe77}\u64f1\u99f0\u82ac', mipLevelCount: 1});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({label: '\u1107\u7130', colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint']});
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer7, 109056, buffer5, 55308, 336);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 12, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer3), /* required buffer size: 841 */
+{offset: 841, bytesPerRow: 279}, {width: 32, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u0104\u0cb6\ua367\u0c33\u5cdb\u0783\u66d3\uc53b',
+  entries: [
+    {
+      binding: 3245,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 185, visibility: 0, sampler: { type: 'filtering' }},
+    {
+      binding: 3290,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder39 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({
+  label: '\u36fa\uf2ed\u1fce\u05cd\u{1f6ab}\u983d\u7cb8\u4580\uce19\uf6f2\ucbc1',
+  type: 'occlusion',
+  count: 755,
+});
+let sampler28 = device0.createSampler({
+  label: '\u790d\u08d2\ua877\u87d1\u6e41\u0f8f\u04c5\u{1f861}\u{1f9bb}\u9a02\u{1f6b6}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.56,
+  lodMaxClamp: 88.06,
+  maxAnisotropy: 5,
+});
+try {
+canvas4.getContext('webgpu');
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  label: '\ub991\u0562\u668b\u47ff\u{1fb01}\ufef5\u0422\u3ceb\u{1f8ba}\u05d2',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\u0e2e\u{1feae}\u{1ffe8}\uf316\u0a30\u5881\u0c09\u0e9b\u056c\u0f27'});
+let texture27 = device0.createTexture({
+  label: '\uac54\u0fbf\u0877\u069d\u{1fea8}\ud9cb\u3dfb\u03bb\u4f35\u454a',
+  size: {width: 80, height: 1, depthOrArrayLayers: 54},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let computePassEncoder22 = commandEncoder28.beginComputePass({label: '\u6286\u0b45\u5ee2\u0f16\u0617\u031b\u0336\ub95f\u7ade'});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u0235\u0ed1\ue60e\u0e9e\u4a3d',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle17 = renderBundleEncoder16.finish({label: '\u{1fc00}\ua02c\u434b\u{1f654}\u{1f632}\u4cf9\u421f\ubc16\u{1fccd}'});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 1488 widthInBlocks: 372 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3988 */
+  offset: 3988,
+  buffer: buffer0,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 372, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 38},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 159, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 299, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer4, 127984, 9068);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 2016, new Float32Array(41044), 30640, 7744);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 413, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 927 */
+{offset: 799, bytesPerRow: 262, rowsPerImage: 97}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet20 = device0.createQuerySet({label: '\u{1fcd0}\ucc3d\ud28a\u8c1b\ubffb\u9c45', type: 'occlusion', count: 1864});
+let textureView48 = texture21.createView({label: '\u3531\u{1fada}\u1197\u066b\u0a94\u{1f6ea}'});
+try {
+computePassEncoder16.setBindGroup(6, bindGroup2, new Uint32Array(7157), 6437, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 4352 widthInBlocks: 272 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 42112 */
+  offset: 42112,
+  buffer: buffer0,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 272, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer4, 78284, 23216);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 28, y: 283 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  label: '\u7d44\u7802',
+  layout: 'auto',
+  multisample: {mask: 0xe33abb15},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float'}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2232,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 808, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 10068,
+        attributes: [
+          {format: 'float32', offset: 820, shaderLocation: 17},
+          {format: 'float32', offset: 2976, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 6184,
+        attributes: [
+          {format: 'uint16x2', offset: 652, shaderLocation: 18},
+          {format: 'float32x2', offset: 984, shaderLocation: 10},
+          {format: 'uint16x2', offset: 1520, shaderLocation: 14},
+          {format: 'float32x2', offset: 3592, shaderLocation: 21},
+          {format: 'sint32x3', offset: 1784, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 21404, shaderLocation: 1},
+          {format: 'float32x2', offset: 25452, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let buffer9 = device0.createBuffer({
+  label: '\u73a0\u088a\u{1fbb1}\u8249\u8ac3',
+  size: 144916,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView49 = texture4.createView({label: '\u0b02\u544b\u0638', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder23 = commandEncoder33.beginComputePass();
+try {
+computePassEncoder5.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(4, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(7, buffer1, 0, 130865);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer7, 82824, buffer5, 17200, 9844);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 324704 */
+  offset: 32012,
+  bytesPerRow: 256,
+  rowsPerImage: 114,
+  buffer: buffer0,
+}, {
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 6},
+  aspect: 'all',
+}, {width: 21, height: 4, depthOrArrayLayers: 11});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 229, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1897, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker('\uf74c');
+} catch {}
+gc();
+let shaderModule4 = device0.createShaderModule({
+  label: '\u{1fa38}\uff8d\u0de4\u{1f85a}\u01bd\u3cef\u7068\u7081\u0dd5',
+  code: `@group(3) @binding(582)
+var<storage, read_write> function1: array<u32>;
+@group(2) @binding(4138)
+var<storage, read_write> function2: array<u32>;
+@group(4) @binding(4109)
+var<storage, read_write> type3: array<u32>;
+@group(4) @binding(4138)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(643)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(4109)
+var<storage, read_write> n4: array<u32>;
+
+@compute @workgroup_size(5, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(104) f0: vec3<f16>,
+  @location(58) f1: vec3<f16>,
+  @location(31) f2: vec4<f16>,
+  @location(64) f3: f32,
+  @location(27) f4: vec3<f16>,
+  @location(46) f5: vec3<u32>,
+  @location(73) f6: f16,
+  @location(17) f7: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec4<i32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(80) a0: vec3<f32>, @location(24) a1: vec2<f32>, @location(19) a2: i32, @location(94) a3: vec3<u32>, @location(30) a4: vec2<f32>, @location(106) a5: f32, a6: S7, @location(14) a7: vec2<f16>, @location(105) a8: vec2<u32>, @builtin(front_facing) a9: bool, @location(49) a10: vec3<i32>, @location(59) a11: f16, @builtin(position) a12: vec4<f32>, @builtin(sample_mask) a13: u32, @builtin(sample_index) a14: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(17) f0: vec4<i32>,
+  @location(8) f1: vec3<f16>,
+  @location(22) f2: vec3<f32>,
+  @location(5) f3: i32
+}
+struct VertexOutput0 {
+  @location(31) f112: vec4<f16>,
+  @location(104) f113: vec3<f16>,
+  @location(105) f114: vec2<u32>,
+  @location(73) f115: f16,
+  @location(58) f116: vec3<f16>,
+  @location(46) f117: vec3<u32>,
+  @location(59) f118: f16,
+  @location(30) f119: vec2<f32>,
+  @location(14) f120: vec2<f16>,
+  @location(64) f121: f32,
+  @location(19) f122: i32,
+  @location(27) f123: vec3<f16>,
+  @location(49) f124: vec3<i32>,
+  @location(94) f125: vec3<u32>,
+  @location(80) f126: vec3<f32>,
+  @location(17) f127: vec2<u32>,
+  @location(24) f128: vec2<f32>,
+  @location(106) f129: f32,
+  @builtin(position) f130: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: f32, @location(20) a1: vec2<f32>, @location(1) a2: u32, @location(0) a3: vec4<u32>, @location(18) a4: vec4<i32>, @location(21) a5: i32, @location(19) a6: i32, @location(9) a7: i32, @builtin(vertex_index) a8: u32, @location(3) a9: vec2<f16>, @location(15) a10: vec3<u32>, @location(7) a11: vec3<f32>, @location(10) a12: u32, a13: S6, @location(4) a14: vec2<i32>, @location(24) a15: vec2<f32>, @location(23) a16: vec4<f16>, @builtin(instance_index) a17: u32, @location(2) a18: vec4<i32>, @location(14) a19: vec4<i32>, @location(13) a20: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+try {
+renderBundleEncoder6.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 208 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 25884 */
+  offset: 25884,
+  buffer: buffer0,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 52, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync({
+  label: '\u{1fb92}\u6572\u184a\u0211\ucc69\ubf49\u0f24\u275d\u8003',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer11 = commandEncoder39.finish();
+let texture28 = device0.createTexture({
+  label: '\u0caf\u4b5b\u23c8',
+  size: [768],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView50 = texture8.createView({
+  label: '\ua7b4\u2855\uea8a\u0dfd\ub91c\u4495\u0e1f\ub9ec',
+  aspect: 'all',
+  format: 'rgba8unorm-srgb',
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer1, 363552);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1964 widthInBlocks: 491 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32700 */
+  offset: 32700,
+  buffer: buffer5,
+}, {width: 491, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 123, y: 0, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 15});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer5, 19960, 14600);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img4,
+  origin: { x: 39, y: 8 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise7 = device0.createComputePipelineAsync({
+  label: '\u85ff\u1fe1\ufabc\u0a10\u{1f8ba}\u5b9e\u087e',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let img6 = await imageWithData(298, 69, '#0f51dd65', '#57380922');
+let commandEncoder41 = device0.createCommandEncoder();
+let textureView51 = texture27.createView({dimension: '3d', baseMipLevel: 1});
+try {
+computePassEncoder23.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 8592 widthInBlocks: 537 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 25968 */
+  offset: 25968,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 537, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 180, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 708 widthInBlocks: 177 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17824 */
+  offset: 17824,
+  bytesPerRow: 768,
+  rowsPerImage: 195,
+  buffer: buffer5,
+}, {width: 177, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 169, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 216, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let texture29 = device0.createTexture({
+  label: '\ufc11\ud713\u0a2a\u79d6\u91bc\uf60c',
+  size: {width: 3072, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView52 = texture27.createView({label: '\u0d2e\u{1f717}\u7d26\u7db1\u1d1e\ud6dd\u008a', baseMipLevel: 2});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'], depthReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(7, bindGroup0);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({label: '\u7bfb\u38ae\u5003', bindGroupLayouts: [bindGroupLayout1, bindGroupLayout4]});
+let commandEncoder42 = device0.createCommandEncoder({label: '\ua281\ud114\u0c85\u2dd5\u0ac4\u{1facd}'});
+try {
+computePassEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 29308, new BigUint64Array(9102));
+} catch {}
+let buffer10 = device0.createBuffer({
+  label: '\u5a4d\u0064\u31e3\u{1fdfd}\u1572\u8d18\u{1f6ad}',
+  size: 69835,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture30 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder22.setPipeline(pipeline21);
+} catch {}
+let arrayBuffer5 = buffer6.getMappedRange(47968, 8032);
+try {
+commandEncoder37.clearBuffer(buffer10, 53552, 10784);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer1), /* required buffer size: 110512 */
+{offset: 68, bytesPerRow: 437, rowsPerImage: 6}, {width: 80, height: 1, depthOrArrayLayers: 43});
+} catch {}
+let canvas5 = document.createElement('canvas');
+let imageBitmap2 = await createImageBitmap(img5);
+let commandEncoder43 = device0.createCommandEncoder({});
+let externalTexture15 = device0.importExternalTexture({source: video4});
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer0, 142360, buffer10, 45108, 4976);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 193513 */
+{offset: 809, bytesPerRow: 124, rowsPerImage: 259}, {width: 2, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u{1fd25}\u{1fd64}',
+  code: `@group(1) @binding(402)
+var<storage, read_write> function3: array<u32>;
+@group(0) @binding(4109)
+var<storage, read_write> function4: array<u32>;
+@group(0) @binding(4138)
+var<storage, read_write> n5: array<u32>;
+@group(7) @binding(402)
+var<storage, read_write> global4: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(3) f1: vec2<u32>,
+  @location(2) f2: vec4<f32>,
+  @location(0) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(16) f0: vec4<f32>,
+  @location(22) f1: f16
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, @location(5) a1: f16, @location(4) a2: vec4<f32>, @location(11) a3: f16, @builtin(vertex_index) a4: u32, @location(19) a5: vec2<f32>, @builtin(instance_index) a6: u32, @location(18) a7: i32, @location(3) a8: vec3<f32>, @location(2) a9: vec4<f16>, a10: S8, @location(10) a11: vec3<u32>, @location(26) a12: f16, @location(20) a13: vec2<f16>, @location(0) a14: i32, @location(9) a15: vec4<f16>, @location(14) a16: vec2<f32>, @location(15) a17: vec2<f16>, @location(1) a18: vec4<i32>, @location(7) a19: vec2<i32>, @location(23) a20: vec4<i32>, @location(17) a21: i32, @location(21) a22: u32, @location(24) a23: i32, @location(12) a24: u32, @location(13) a25: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup6 = device0.createBindGroup({
+  label: '\u60e0\ufa03\u0079\u0eb6\u{1fbef}\u08c0\u5e1b\u{1f79b}\u91ad\u18ba',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u968a\u{1fc65}\u03e7\u0de2\u33a8\u{1fefa}\u013a\u{1ff90}\u132b\u03de\u6ffb',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout13],
+});
+try {
+computePassEncoder10.setBindGroup(7, bindGroup5, new Uint32Array(9609), 1784, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(5, bindGroup4, new Uint32Array(580), 269, 0);
+} catch {}
+let img7 = await imageWithData(168, 35, '#b0bc570c', '#59c425c4');
+let bindGroup7 = device0.createBindGroup({label: '\ua55c\u1ed0\uf2fc\u8d47\u97f1\u4a81\u1c2c', layout: bindGroupLayout4, entries: []});
+let commandEncoder44 = device0.createCommandEncoder();
+let querySet21 = device0.createQuerySet({label: '\u0f8b\ub368\ucdbf\u766d\u2bfb\u{1f745}', type: 'occlusion', count: 1431});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\ua12b\uc2bf\u0e77\u{1fe14}',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder8.setBindGroup(7, bindGroup7, new Uint32Array(828), 260, 0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder();
+let sampler29 = device0.createSampler({
+  label: '\u0ca8\ue72d\u0832\u604f\u4712\uec16\ubbc5\u96bf',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 11.24,
+  lodMaxClamp: 98.26,
+});
+try {
+computePassEncoder16.setBindGroup(5, bindGroup4);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer0, 387060, buffer9, 107152, 28704);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer10, 8736, 54264);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 31952, new Float32Array(5443), 2172, 192);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: canvas2,
+  origin: { x: 14, y: 28 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video1.width = 129;
+let offscreenCanvas9 = new OffscreenCanvas(956, 566);
+let commandEncoder46 = device0.createCommandEncoder({label: '\u{1f6a3}\u6a7e\u042d\u08c6'});
+let texture31 = device0.createTexture({
+  label: '\u0875\u1899\u7a74\u00fe\ue069\u03f1\ue324\ub4fb\ua037\ud088\u455e',
+  size: {width: 864, height: 48, depthOrArrayLayers: 373},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle18 = renderBundleEncoder4.finish({});
+let sampler30 = device0.createSampler({
+  label: '\u98a6\u0f7b\uf0f9\u9d3f\u{1ffd2}\u08a8\u0ef7\ud3fb\u{1ff1c}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.61,
+  lodMaxClamp: 89.87,
+});
+let externalTexture16 = device0.importExternalTexture({label: '\u0243\u006f', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder5.dispatchWorkgroups(5, 3);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+offscreenCanvas9.getContext('2d');
+} catch {}
+let texture32 = device0.createTexture({
+  label: '\u{1f9c1}\u{1f8e3}\u040c\u0cf0\u{1f8b5}\u{1f7c3}\u{1fa88}',
+  size: [768, 1, 1158],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView53 = texture31.createView({label: '\u07ee\u{1fa51}\ubdd1\u7c39\u{1fb66}\u{1f942}', baseMipLevel: 7, mipLevelCount: 1});
+let renderBundle19 = renderBundleEncoder7.finish({label: '\u{1f930}\u347b\u{1fe1a}\u82ce\u62ee\u01a0'});
+let externalTexture17 = device0.importExternalTexture({label: '\u0c99\u{1fbea}\u62be', source: videoFrame3});
+try {
+renderBundleEncoder1.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer1, 0, 563459);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14092 */
+  offset: 14092,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 149, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\ud8ec\u632e\u{1f730}\u854c',
+  entries: [
+    {
+      binding: 358,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let computePassEncoder24 = commandEncoder40.beginComputePass();
+let externalTexture18 = device0.importExternalTexture({label: '\u4501\ubf29\uce2a\u733a\u7ad1\u4c05\u03ca\u077d', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder21.pushDebugGroup('\u0ae1');
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync({
+  label: '\u04c9\u024e\uab2b\ue58a\u2b07\uaae9',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let pipeline30 = await device0.createRenderPipelineAsync({
+  label: '\u331d\uf28d\u06f0\u{1ff7a}\u80ae\u47b9\u{1fee8}\u0a0b\u01f6',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xf796ab27},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.RED}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10972,
+        attributes: [
+          {format: 'unorm16x2', offset: 4004, shaderLocation: 1},
+          {format: 'float32x4', offset: 1472, shaderLocation: 15},
+          {format: 'sint16x2', offset: 2544, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1884,
+        attributes: [
+          {format: 'snorm16x2', offset: 972, shaderLocation: 10},
+          {format: 'sint32', offset: 1880, shaderLocation: 9},
+          {format: 'float32x2', offset: 448, shaderLocation: 17},
+          {format: 'uint32x4', offset: 652, shaderLocation: 18},
+          {format: 'uint16x2', offset: 980, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm16x4', offset: 104, shaderLocation: 21},
+          {format: 'float16x2', offset: 7904, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas4);
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\u05ce\u0bc9\u09bb\u{1fa41}\u0ea2\u03df\u{1fec7}\u{1fe44}\u{1fbf8}\u8451',
+  entries: [
+    {
+      binding: 2899,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let textureView54 = texture1.createView({label: '\u02be\u0f2f\ufbef\u093d', dimension: '1d', mipLevelCount: 1});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float', undefined, 'rgba8unorm']});
+let sampler31 = device0.createSampler({
+  label: '\u{1fa3c}\ucd90\ub7f8\u0cfa\udcbe\ua6e1\ufdc8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.02,
+  lodMaxClamp: 90.49,
+  compare: 'less-equal',
+  maxAnisotropy: 9,
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+texture19.destroy();
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u{1fecf}');
+} catch {}
+let texture33 = device0.createTexture({
+  label: '\u{1fbe0}\u09c0\u04e0\u{1ffb9}\u4d47\u73a6\u{1fb28}',
+  size: [80],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView55 = texture28.createView({label: '\u2aa0\u{1f83d}\u09f6\u0c4e\u002f\ubcfb\u{1fc55}', dimension: '1d', aspect: 'all'});
+let sampler32 = device0.createSampler({
+  label: '\u0f81\u{1f739}\u{1f6fa}\u0ae1\u127f\u{1f98f}\u796b\u045c',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.00,
+  lodMaxClamp: 92.23,
+});
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: img4,
+  origin: { x: 24, y: 19 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(232, 68);
+let bindGroup8 = device0.createBindGroup({
+  label: '\u306e\ud94e\u0213\u{1f798}\u0ac8\u22f4\u0b22\ua103\u0bf1',
+  layout: bindGroupLayout1,
+  entries: [],
+});
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1f780}\uddff\u0281\u9c10\u0c46'});
+let renderBundle20 = renderBundleEncoder25.finish({label: '\u06b1\ue45e\u0480\uda6f\u704e'});
+try {
+renderBundleEncoder12.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24592 */
+  offset: 24592,
+  buffer: buffer10,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+let buffer11 = device0.createBuffer({
+  label: '\u33b6\u9226\u{1ff33}\u5235\u35ca\u6baa\u{1f752}',
+  size: 405636,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({label: '\u08e2\u8cf5\u{1faed}', type: 'occlusion', count: 3320});
+let externalTexture19 = device0.importExternalTexture({
+  label: '\u{1f7d0}\u0224\u{1fbc2}\u4517\u63d7\ue217\u{1f885}\u3b04',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder18.setBindGroup(7, bindGroup5);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let pipeline31 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'never', failOp: 'keep', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 2440386954,
+    stencilWriteMask: 1036977095,
+    depthBias: 1658441615,
+    depthBiasSlopeScale: 544.9013267221524,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18636,
+        attributes: [
+          {format: 'snorm16x2', offset: 6852, shaderLocation: 14},
+          {format: 'float32x3', offset: 12588, shaderLocation: 7},
+          {format: 'float16x2', offset: 3672, shaderLocation: 19},
+          {format: 'float32', offset: 6964, shaderLocation: 24},
+          {format: 'snorm8x4', offset: 3336, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 4652, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 5968, shaderLocation: 8},
+          {format: 'sint16x4', offset: 964, shaderLocation: 2},
+          {format: 'sint8x2', offset: 358, shaderLocation: 3},
+          {format: 'uint16x2', offset: 18632, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 264, shaderLocation: 4},
+          {format: 'sint32x2', offset: 7380, shaderLocation: 11},
+          {format: 'uint16x2', offset: 6036, shaderLocation: 17},
+          {format: 'sint32', offset: 3008, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 3120, shaderLocation: 16},
+          {format: 'uint32x2', offset: 592, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 1952, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 852, shaderLocation: 23},
+          {format: 'sint8x4', offset: 5220, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 9064, shaderLocation: 0},
+          {format: 'uint16x2', offset: 3396, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 8220,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x2', offset: 2440, shaderLocation: 26}],
+      },
+      {
+        arrayStride: 6600,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 3276, shaderLocation: 20}],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 624, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 60076, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 22872, attributes: []},
+      {arrayStride: 20000, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6864,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 2040, shaderLocation: 15},
+          {format: 'uint8x4', offset: 172, shaderLocation: 21},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas10 = new OffscreenCanvas(719, 319);
+try {
+canvas5.getContext('webgpu');
+} catch {}
+let texture34 = device0.createTexture({
+  label: '\u{1fbc1}\u6e1e\ua0de\uca10\u07b0',
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder25 = commandEncoder45.beginComputePass({label: '\u{1f9c9}\u0f9a\u744e\u75c4'});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder22.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer1, 'uint32', 275028, 93193);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 488 widthInBlocks: 122 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8304 */
+  offset: 8304,
+  bytesPerRow: 512,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 122, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer5, 21556, 27380);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout17 = device0.createBindGroupLayout({label: '\u02d5\u78ff\u912a\u08c0', entries: [{binding: 163, visibility: 0, externalTexture: {}}]});
+let bindGroup9 = device0.createBindGroup({
+  label: '\u{1f950}\u{1fdc0}\u513d\u065c\ua930\u5581\u{1f89f}\u3de0\u6ff5',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 141});
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30748 */
+  offset: 30596,
+  rowsPerImage: 194,
+  buffer: buffer0,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+renderBundleEncoder19.insertDebugMarker('\uf97f');
+} catch {}
+try {
+  await promise9;
+} catch {}
+let video5 = await videoWithData();
+let bindGroup10 = device0.createBindGroup({label: '\u03dd\u{1ff2c}\u{1f84b}\u9196\u{1fd28}\u2ab0', layout: bindGroupLayout3, entries: []});
+let commandEncoder50 = device0.createCommandEncoder({label: '\u0e5e\u0ede\u6879\u{1fe38}\ue928\udb03\u0c12\u{1f8e9}\ue08d\u08bf'});
+let querySet24 = device0.createQuerySet({label: '\ueffc\u0c7d\u4038\ue5eb\u138e\u01ae', type: 'occlusion', count: 496});
+let computePassEncoder26 = commandEncoder46.beginComputePass({label: '\u7468\u020f\u{1f7e4}\u046d\u018a\uff47\u{1fe43}\ud6ba\u{1f6c7}\uc156\u0208'});
+try {
+computePassEncoder5.dispatchWorkgroups(1, 4, 1);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer2, 183424, buffer10, 13196, 11240);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 17380, new Int16Array(5885), 5774, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer5), /* required buffer size: 6194 */
+{offset: 834, bytesPerRow: 148, rowsPerImage: 36}, {width: 8, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandEncoder51 = device0.createCommandEncoder();
+let texture35 = device0.createTexture({
+  size: {width: 720, height: 60, depthOrArrayLayers: 253},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+let textureView56 = texture6.createView({baseMipLevel: 0});
+try {
+computePassEncoder22.dispatchWorkgroups(5, 1, 3);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 7844 widthInBlocks: 1961 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38884 */
+  offset: 38884,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 627, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1961, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 151, y: 91 },
+  flipY: true,
+}, {
+  texture: texture34,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(canvas4, {timestamp: 0});
+try {
+adapter1.label = '\u0820\u{1f7a8}';
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u008d\u{1ff7e}\uf12d\u2d59\u0ff4\u{1fbe5}\u89a2\u09ed\ue7f9\u{1f828}',
+  size: 171203,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder22.setBindGroup(5, bindGroup5, new Uint32Array(3369), 2853, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer1, 0, 264725);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30716 */
+  offset: 30716,
+  buffer: buffer10,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 17416, new Int16Array(19018), 11848, 1264);
+} catch {}
+let textureView57 = texture24.createView({format: 'rgba8unorm', baseMipLevel: 3, mipLevelCount: 1});
+let externalTexture20 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer1, 0, 54227);
+} catch {}
+let pipeline32 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule3, entryPoint: 'compute0'}});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let img8 = await imageWithData(266, 59, '#44ade3ae', '#0541bb27');
+let imageBitmap3 = await createImageBitmap(videoFrame4);
+try {
+adapter1.label = '\u06f2\u{1fd85}\uc695';
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 3328 widthInBlocks: 208 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 26880 */
+  offset: 23552,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 142, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 208, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 46, y: 117 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+let bindGroup11 = device0.createBindGroup({layout: bindGroupLayout11, entries: []});
+let commandEncoder52 = device0.createCommandEncoder({label: '\uce81\u0449\u{1f6fc}'});
+let textureView58 = texture28.createView({label: '\u39bb\uda6e\u06fb\u1bb0\u0769', aspect: 'all'});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u05f7\u0fca\u096b\u{1f882}\u7512',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+});
+let sampler33 = device0.createSampler({
+  label: '\ue03a\u{1fc9d}',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 16.48,
+  lodMaxClamp: 59.17,
+});
+let externalTexture21 = device0.importExternalTexture({
+  label: '\u28b3\u{1ff29}\ubfa3\u8774\u3fa4\u04cb\u498f\uf8c3\ue8d1',
+  source: videoFrame4,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder13.dispatchWorkgroupsIndirect(buffer8, 524528);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer0, 475072, buffer11, 262424, 110792);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 171, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5540 widthInBlocks: 1385 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48460 */
+  offset: 48460,
+  bytesPerRow: 5632,
+  buffer: buffer12,
+}, {width: 1385, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 337, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 15, y: 120 },
+  flipY: true,
+}, {
+  texture: texture34,
+  mipLevel: 6,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = device0.createRenderPipeline({
+  label: '\u0394\ua4c4\u0ce4\u5013',
+  layout: pipelineLayout3,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: 0}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 2944759422,
+    stencilWriteMask: 529635887,
+    depthBias: -1362944793,
+    depthBiasSlopeScale: 171.7593973258027,
+    depthBiasClamp: 883.0290081552442,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15996,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 7588, shaderLocation: 5}],
+      },
+      {
+        arrayStride: 6692,
+        attributes: [
+          {format: 'sint8x4', offset: 16, shaderLocation: 2},
+          {format: 'uint32x4', offset: 436, shaderLocation: 15},
+          {format: 'sint32', offset: 808, shaderLocation: 4},
+          {format: 'uint8x4', offset: 964, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 5776,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 892, shaderLocation: 14},
+          {format: 'uint32x4', offset: 1588, shaderLocation: 13},
+          {format: 'sint16x4', offset: 1416, shaderLocation: 21},
+          {format: 'sint8x4', offset: 896, shaderLocation: 17},
+          {format: 'uint16x2', offset: 1700, shaderLocation: 10},
+          {format: 'sint8x2', offset: 5206, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 734, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 480, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 1068, shaderLocation: 3},
+          {format: 'sint32', offset: 2692, shaderLocation: 9},
+          {format: 'uint32', offset: 204, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 4568, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 1614, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 212, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 624, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 24332, stepMode: 'instance', attributes: []},
+      {arrayStride: 7704, stepMode: 'instance', attributes: []},
+      {arrayStride: 22996, attributes: [{format: 'unorm16x4', offset: 2352, shaderLocation: 8}]},
+      {arrayStride: 31504, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 15204,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 1336, shaderLocation: 18}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+video2.height = 1;
+let bindGroupLayout18 = device0.createBindGroupLayout({label: '\u8222\u753f', entries: []});
+let commandEncoder53 = device0.createCommandEncoder({label: '\ub399\uc3df\u9795\ue603'});
+let computePassEncoder27 = commandEncoder52.beginComputePass({label: '\u{1fa3d}\u{1fa3c}\ub700\u{1fb45}\u05d1\uaf56\u01ca'});
+let arrayBuffer6 = buffer2.getMappedRange(27968, 8336);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 5, y: 76 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 20, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline34 = device0.createComputePipeline({
+  label: '\u7aa3\uf937\u{1fba2}\u03a1\u3f53\u0250\u5432',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter1.label = '\u8ed9\u{1fdb0}\u2dea\u29ac\u0cb2\u0d2c\u{1fe93}\u7d42\uc8fc';
+} catch {}
+try {
+canvas6.getContext('webgl2');
+} catch {}
+let textureView59 = texture22.createView({format: 'rgb10a2unorm', baseMipLevel: 1, arrayLayerCount: 1});
+let renderBundle21 = renderBundleEncoder20.finish({label: '\u0900\u0676\u6705'});
+let externalTexture22 = device0.importExternalTexture({label: '\u9d78\u0e85\ud4d7\u{1fc7e}', source: videoFrame4, colorSpace: 'display-p3'});
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 79, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer6, 25272, 38736);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+computePassEncoder21.popDebugGroup();
+} catch {}
+try {
+commandEncoder36.insertDebugMarker('\u7122');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1167 */
+{offset: 559}, {width: 38, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({label: '\u{1f716}\u1457\u{1f796}\ue9a5\uc9b2\u4022\u1a5a'});
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 568 widthInBlocks: 142 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4108 */
+  offset: 3540,
+  bytesPerRow: 768,
+  buffer: buffer0,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 138, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 142, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer10, 54304, 13316);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let pipeline35 = device0.createRenderPipeline({
+  label: '\u{1fee7}\u0163\u{1feec}\u8c8a',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: 0,
+}, {format: 'r16uint'}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 34696,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 11568, shaderLocation: 10},
+          {format: 'sint8x4', offset: 3044, shaderLocation: 24},
+          {format: 'sint32x2', offset: 21992, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 25344, shaderLocation: 3},
+          {format: 'sint8x2', offset: 2160, shaderLocation: 18},
+          {format: 'sint32x4', offset: 17352, shaderLocation: 1},
+          {format: 'sint32x4', offset: 4816, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 5156, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 10944, shaderLocation: 11},
+          {format: 'uint8x2', offset: 10240, shaderLocation: 12},
+          {format: 'sint32x2', offset: 2636, shaderLocation: 0},
+          {format: 'float16x2', offset: 3632, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 24604, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 568,
+        attributes: [
+          {format: 'uint16x4', offset: 96, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 260, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 188, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 176, shaderLocation: 9},
+          {format: 'sint8x4', offset: 184, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 248, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 56, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 4320,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x4', offset: 1332, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 2188, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 1552, shaderLocation: 26},
+          {format: 'snorm16x4', offset: 3900, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(video3);
+gc();
+let buffer13 = device0.createBuffer({size: 538081, usage: GPUBufferUsage.COPY_DST});
+let externalTexture23 = device0.importExternalTexture({label: '\u24f8\u{1faf1}\uc789\u0c0c\u0810\u{1fa32}', source: videoFrame4});
+try {
+renderBundleEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20 */
+  offset: 20,
+  buffer: buffer9,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 1261 */
+{offset: 965}, {width: 74, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 42, y: 151 },
+  flipY: false,
+}, {
+  texture: texture34,
+  mipLevel: 6,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\u69a8\u{1f776}\ube33\u4f40\u0cfe\uf009\uadf1\ub7be\u02ae\u{1fd42}\udf17',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout14, bindGroupLayout6, bindGroupLayout3],
+});
+let querySet25 = device0.createQuerySet({label: '\u{1fff6}\u5c3d', type: 'occlusion', count: 2747});
+let textureView60 = texture35.createView({
+  label: '\u{1faaa}\ua0ab\u39cd\u009c\u24c9\ub959\u8765\u091d\u0d3e\uc416',
+  dimension: '3d',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u782e\ud7fd\u73c8\u838a\u{1f91b}\u406e\uc66d\u{1fa48}\uf06f',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: false,
+});
+try {
+commandEncoder47.clearBuffer(buffer12, 41440, 92344);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: canvas6,
+  origin: { x: 84, y: 83 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img9 = await imageWithData(156, 82, '#580c4fb9', '#8c48e52d');
+let externalTexture24 = device0.importExternalTexture({label: '\u84a7\u{1f9a2}\u02a7\ue4c0', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder27.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(7, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup11, new Uint32Array(9847), 1550, 0);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 404 widthInBlocks: 101 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 29252 */
+  offset: 29252,
+  buffer: buffer0,
+}, {
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 101, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer13, 4236, 288716);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 67},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 1360378 */
+{offset: 54, bytesPerRow: 78, rowsPerImage: 109}, {width: 1, height: 1, depthOrArrayLayers: 161});
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({label: '\ud763\ue4c0\u08c0\u6bb9\u569f\uac53\u0b2c\u0014\u8a34\u00c6\u7dce'});
+let computePassEncoder28 = commandEncoder41.beginComputePass({label: '\uf0bd\ucc39\uc5c6\uacfe\u09c8'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u01cc\u1718\u0317\u3997\u02b0\u0095',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+});
+let renderBundle22 = renderBundleEncoder23.finish({label: '\u4349\u11f7\ud1b1\u1fbc\u93e9\u9c36\u0e00'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder9.dispatchWorkgroups(2, 3, 2);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer1, 286176, 11627);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer12, 12344, 4564);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(5018608), /* required buffer size: 5018608 */
+{offset: 928, bytesPerRow: 303, rowsPerImage: 30}, {width: 2, height: 0, depthOrArrayLayers: 553});
+} catch {}
+gc();
+let textureView61 = texture32.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer0, 41860, buffer4, 42124, 62832);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28076 */
+  offset: 28076,
+  bytesPerRow: 512,
+  buffer: buffer0,
+}, {
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 3, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 69, y: 12, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 255, y: 39, z: 0},
+  aspect: 'all',
+},
+{width: 548, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer13, 211636, 173024);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 185},
+  aspect: 'all',
+}, new ArrayBuffer(7264030), /* required buffer size: 7264030 */
+{offset: 86, bytesPerRow: 145, rowsPerImage: 248}, {width: 6, height: 1, depthOrArrayLayers: 203});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: img3,
+  origin: { x: 14, y: 65 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = device0.createRenderPipeline({
+  label: '\u{1fd80}\u{1f7a0}\u{1fe35}\u{1fc4e}\u{1f973}',
+  layout: pipelineLayout6,
+  multisample: {mask: 0xbe45ddd7},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 3783116784,
+    stencilWriteMask: 1430031444,
+    depthBiasSlopeScale: 370.6022938513494,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7676,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 7664, shaderLocation: 14},
+          {format: 'float16x2', offset: 1268, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 464, shaderLocation: 20},
+          {format: 'float32x4', offset: 5560, shaderLocation: 5},
+          {format: 'uint8x2', offset: 3838, shaderLocation: 6},
+          {format: 'uint16x4', offset: 584, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 1708, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 6472,
+        attributes: [
+          {format: 'unorm16x4', offset: 696, shaderLocation: 26},
+          {format: 'sint32x2', offset: 1260, shaderLocation: 25},
+          {format: 'sint32x4', offset: 924, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 1032, shaderLocation: 18},
+          {format: 'uint8x4', offset: 152, shaderLocation: 12},
+          {format: 'sint32x3', offset: 1844, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 208, shaderLocation: 13},
+          {format: 'sint32x2', offset: 1280, shaderLocation: 21},
+          {format: 'sint16x2', offset: 736, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 6468, shaderLocation: 10},
+          {format: 'sint8x2', offset: 2432, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 10160, attributes: []},
+      {arrayStride: 2656, attributes: [{format: 'sint32x2', offset: 68, shaderLocation: 4}]},
+      {arrayStride: 3564, attributes: []},
+      {
+        arrayStride: 14796,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 4316, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 11752,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 1292, shaderLocation: 24},
+          {format: 'sint32x3', offset: 1048, shaderLocation: 8},
+          {format: 'uint8x4', offset: 4424, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 20428,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 386, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', cullMode: 'front'},
+});
+canvas0.height = 2560;
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\u174a\u0551\u0821\u761b\u04aa\u072b\u545e\u40a5\u5627',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout2, bindGroupLayout4, bindGroupLayout5, bindGroupLayout7, bindGroupLayout5],
+});
+let textureView62 = texture14.createView({});
+let externalTexture25 = device0.importExternalTexture({label: '\u{1fe97}\uafdc\u{1fffb}\u002a\u{1fd61}\u2b0d\u{1f6f8}\u3691\u{1ffcc}\u4d71', source: video5});
+try {
+commandEncoder38.copyBufferToBuffer(buffer2, 71840, buffer11, 204180, 93404);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 45 */
+{offset: 45}, {width: 66, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 32, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 19836 */
+  offset: 19740,
+  buffer: buffer0,
+}, {
+  texture: texture34,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer12, 47756, 41144);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img7,
+  origin: { x: 30, y: 0 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 44},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture26 = device0.importExternalTexture({label: '\u8dac\u99ac\u15a0', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder16.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(6, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer1);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 119, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline37 = device0.createComputePipeline({
+  label: '\u9828\u6aa1\uee7a\u0b66\uce16',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let pipeline38 = device0.createRenderPipeline({
+  label: '\u06c4\u4434\u{1fe7c}\u05c7\u04f6\u{1fbd1}\u75ca\u5301\u{1f6f2}\u96d2\u0174',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 27684,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 7348, shaderLocation: 15}],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm16x2', offset: 13700, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 13728, shaderLocation: 10},
+          {format: 'uint32x3', offset: 13588, shaderLocation: 14},
+          {format: 'sint32x4', offset: 11876, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 4884,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 1184, shaderLocation: 18},
+          {format: 'sint16x2', offset: 1512, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 3264, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 912,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 16, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 4524,
+        attributes: [
+          {format: 'unorm8x4', offset: 148, shaderLocation: 1},
+          {format: 'float16x2', offset: 72, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let video6 = await videoWithData();
+let bindGroupLayout19 = pipeline12.getBindGroupLayout(0);
+let querySet26 = device0.createQuerySet({label: '\ueeb1\u0a02\uf2c4', type: 'occlusion', count: 2003});
+let textureView63 = texture25.createView({
+  label: '\u0337\u066a\u{1fbca}\u087b\u0d00\u{1f9ef}\u023d\u8acb\u0a83',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+let sampler34 = device0.createSampler({
+  label: '\u0280\u0aed',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.16,
+  lodMaxClamp: 39.08,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup3, new Uint32Array(3529), 95, 0);
+} catch {}
+try {
+computePassEncoder12.dispatchWorkgroups(3, 3, 3);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, buffer1, 0, 554301);
+} catch {}
+try {
+commandEncoder55.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 10120 widthInBlocks: 2530 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 19880 */
+  offset: 19880,
+  rowsPerImage: 110,
+  buffer: buffer5,
+}, {width: 2530, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 191, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = device0.createRenderPipeline({
+  label: '\ua8df\u5d57\u2672\u029b\u64ed\u{1f6e6}\u0617\u0d5f\ub30a\u8064\u7269',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 23148,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 3792, shaderLocation: 1},
+          {format: 'sint32x3', offset: 3244, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 2844, shaderLocation: 10},
+          {format: 'uint16x4', offset: 4504, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 3388, attributes: []},
+      {
+        arrayStride: 5072,
+        attributes: [
+          {format: 'sint32x3', offset: 672, shaderLocation: 9},
+          {format: 'uint16x2', offset: 1388, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 2444, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 12236,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 2856, shaderLocation: 2},
+          {format: 'float32x4', offset: 3036, shaderLocation: 21},
+          {format: 'float32x4', offset: 1680, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+});
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u8cf7\u{1fb61}\u{1f79f}\u{1fbd8}\u0dd3\u0b17\u2ca3\u{1f893}\u{1f711}\ue44b\u0cc9',
+  entries: [
+    {binding: 3570, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 850,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder56 = device0.createCommandEncoder({label: '\u{1ff69}\udd80\uf8d0\u35e5'});
+try {
+computePassEncoder28.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5108 */
+  offset: 5108,
+  buffer: buffer0,
+}, {
+  texture: texture18,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 72, y: 143 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 33},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img8);
+let bindGroup12 = device0.createBindGroup({label: '\u3036\u07b1\ufc09\ue22c\u42b0\u2945\uf3e7\u0f66', layout: bindGroupLayout18, entries: []});
+let texture36 = device0.createTexture({
+  label: '\ue854\u32cb\ub312\u{1fcc0}',
+  size: [1440, 120, 1633],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let textureView64 = texture24.createView({label: '\u3b49\u{1fec1}\uad31\u{1fd0f}', baseMipLevel: 1, mipLevelCount: 3});
+let sampler35 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.31,
+  lodMaxClamp: 29.98,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder13.dispatchWorkgroups(5, 1);
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer13, 122360, 321932);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 279, y: 255 },
+  flipY: false,
+}, {
+  texture: texture34,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\u7a5a\u4455\u0e86\u2e79\u7013\uf5b9\u0397\u0285\u{1fd17}\u9806\uba44',
+  code: `@group(1) @binding(3487)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(2930)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @builtin(sample_index) f0: u32,
+  @location(77) f1: vec4<u32>,
+  @location(39) f2: vec2<f16>,
+  @location(106) f3: vec2<i32>,
+  @location(38) f4: vec2<f16>,
+  @location(103) f5: f32,
+  @location(0) f6: vec2<f16>,
+  @location(85) f7: vec3<i32>,
+  @location(68) f8: vec4<i32>,
+  @location(84) f9: f32,
+  @location(92) f10: vec4<i32>,
+  @location(86) f11: vec2<i32>,
+  @location(94) f12: vec4<i32>,
+  @location(102) f13: f16,
+  @location(34) f14: vec4<f16>,
+  @location(79) f15: vec4<f16>,
+  @location(2) f16: vec3<i32>,
+  @location(27) f17: vec4<u32>,
+  @location(49) f18: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(7) f1: f32,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec3<f32>, @location(65) a1: vec4<u32>, @builtin(front_facing) a2: bool, @location(8) a3: i32, a4: S9, @location(61) a5: vec4<f32>, @location(37) a6: vec3<u32>, @location(74) a7: vec4<i32>, @location(10) a8: vec4<f16>, @location(105) a9: f32, @builtin(position) a10: vec4<f32>, @location(50) a11: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(39) f131: vec2<f16>,
+  @location(21) f132: vec2<u32>,
+  @location(92) f133: vec4<i32>,
+  @location(0) f134: vec2<f16>,
+  @location(61) f135: vec4<f32>,
+  @location(79) f136: vec4<f16>,
+  @location(49) f137: vec2<f16>,
+  @location(68) f138: vec4<i32>,
+  @location(37) f139: vec3<u32>,
+  @location(103) f140: f32,
+  @location(83) f141: vec2<f16>,
+  @location(77) f142: vec4<u32>,
+  @location(75) f143: vec4<f32>,
+  @location(108) f144: f16,
+  @location(50) f145: f32,
+  @location(74) f146: vec4<i32>,
+  @location(36) f147: vec3<f32>,
+  @location(38) f148: vec2<f16>,
+  @location(48) f149: vec2<f16>,
+  @location(106) f150: vec2<i32>,
+  @location(2) f151: vec3<i32>,
+  @location(89) f152: vec4<f16>,
+  @location(85) f153: vec3<i32>,
+  @location(17) f154: vec4<f16>,
+  @location(84) f155: f32,
+  @location(94) f156: vec4<i32>,
+  @location(65) f157: vec4<u32>,
+  @location(97) f158: vec2<i32>,
+  @location(8) f159: i32,
+  @location(102) f160: f16,
+  @location(27) f161: vec4<u32>,
+  @location(52) f162: vec4<i32>,
+  @location(10) f163: vec4<f16>,
+  @location(34) f164: vec4<f16>,
+  @location(86) f165: vec2<i32>,
+  @location(105) f166: f32,
+  @builtin(position) f167: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec4<u32>, @location(14) a1: vec4<f16>, @location(18) a2: vec4<f32>, @location(3) a3: vec4<u32>, @location(26) a4: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup6, new Uint32Array(8243), 5040, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer7, 93732, buffer6, 21280, 8104);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 27, y: 31, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 964 widthInBlocks: 241 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15104 */
+  offset: 4924,
+  bytesPerRow: 1024,
+  buffer: buffer12,
+}, {width: 241, height: 10, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 1,
+  origin: {x: 102, y: 3, z: 99},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer5, 512, 60792);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6616, new Float32Array(42982), 18094, 3832);
+} catch {}
+gc();
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1f643}\u0119'});
+let commandBuffer12 = commandEncoder47.finish({label: '\ufe33\u0f6e\u4ecd\u1b36\u566f\ubf0b\u0147\u00f3'});
+let texture37 = device0.createTexture({
+  label: '\u3363\u{1f935}\u00c7\u05f7\u052f\ud49a\u078a\u02d6\u0f5c\u3a1f\u09ee',
+  size: [160, 1, 240],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundle23 = renderBundleEncoder8.finish();
+try {
+computePassEncoder15.setBindGroup(6, bindGroup12, new Uint32Array(5836), 3170, 0);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 160804 */
+  offset: 30244,
+  bytesPerRow: 256,
+  rowsPerImage: 85,
+  buffer: buffer0,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 7});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30852 */
+  offset: 30852,
+  buffer: buffer9,
+}, {width: 39, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline40 = device0.createRenderPipeline({
+  label: '\u131c\u07a9\u003d\u9873',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x9c56de90},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20888,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 6580, shaderLocation: 19},
+          {format: 'sint8x2', offset: 404, shaderLocation: 17},
+          {format: 'uint16x2', offset: 4108, shaderLocation: 12},
+          {format: 'float32', offset: 7056, shaderLocation: 16},
+          {format: 'float32x2', offset: 20880, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 11712, shaderLocation: 6},
+          {format: 'sint32x3', offset: 5452, shaderLocation: 23},
+          {format: 'float32', offset: 1792, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 5396, shaderLocation: 20},
+          {format: 'uint32x4', offset: 1428, shaderLocation: 10},
+          {format: 'sint32x3', offset: 8956, shaderLocation: 18},
+          {format: 'float32x4', offset: 2996, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 2488, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 1040, shaderLocation: 14},
+          {format: 'sint32x4', offset: 11904, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 892, shaderLocation: 3},
+          {format: 'float32x2', offset: 2052, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 200, shaderLocation: 15},
+          {format: 'sint32x4', offset: 1208, shaderLocation: 13},
+          {format: 'uint16x2', offset: 2500, shaderLocation: 21},
+          {format: 'sint16x4', offset: 2892, shaderLocation: 24},
+          {format: 'sint32', offset: 9564, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 19784, shaderLocation: 26},
+          {format: 'sint32x4', offset: 1476, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 22516, attributes: []},
+      {arrayStride: 2268, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 11024, attributes: []},
+      {arrayStride: 300, attributes: [{format: 'float16x4', offset: 32, shaderLocation: 5}]},
+    ],
+  },
+});
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5, bindGroupLayout6, bindGroupLayout16]});
+let buffer14 = device0.createBuffer({
+  label: '\u{1fd56}\u{1f852}\u099c\ucce6\u3e55\uc5cd',
+  size: 2278,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u044f\u413b\u29c3\u031f\u5703\u{1fa9c}\u7adb\u3ff2\u0890\u04ea',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+let sampler36 = device0.createSampler({
+  label: '\u2e7f\ue38e\u0738\u{1fa57}\u1e37\u6ca0\ub131\ud64d\u9606\ubd0d',
+  addressModeU: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.74,
+  lodMaxClamp: 95.07,
+});
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer1, 0, 391329);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet1, 676, 73, buffer14, 0);
+} catch {}
+let video7 = await videoWithData();
+let commandEncoder58 = device0.createCommandEncoder();
+let texture38 = device0.createTexture({
+  label: '\u202b\u0a36\u5db5\u92d3\ud6ac\u7787\u0b30\u0527\ua05c\u3185',
+  size: {width: 80, height: 1, depthOrArrayLayers: 947},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView65 = texture13.createView({label: '\u1a1f\u1dc3\u00d4\u611c\u013b\u{1fc1b}\uf950\u0382'});
+let renderBundle24 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup9, new Uint32Array(3425), 1055, 0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 5632 widthInBlocks: 352 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 21440 */
+  offset: 21440,
+  bytesPerRow: 5632,
+  buffer: buffer0,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 352, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({label: '\u8b5c\u831c\u{1fad7}\u0dc3\u0375'});
+let texture39 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder29 = commandEncoder38.beginComputePass({label: '\u5c22\u09e7'});
+let sampler37 = device0.createSampler({
+  label: '\u7f5a\u{1ff77}\u{1fa04}\ud5ac\ub8d1\u2370',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.91,
+  lodMaxClamp: 58.99,
+  maxAnisotropy: 3,
+});
+let externalTexture27 = device0.importExternalTexture({label: '\u3b49\ufba8\u471c\u05d8\uac30', source: videoFrame4});
+try {
+computePassEncoder0.setBindGroup(7, bindGroup5);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer1, 0, 376111);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer14, 1596, buffer10, 38124, 44);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 138, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 10060 widthInBlocks: 2515 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21272 */
+  offset: 21272,
+  buffer: buffer13,
+}, {width: 2515, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder51.insertDebugMarker('\u{1fe8e}');
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let canvas7 = document.createElement('canvas');
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u92a2\u055f\u05d9',
+  entries: [
+    {
+      binding: 4188,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 1371,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 3062,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup4);
+} catch {}
+let promise10 = device0.popErrorScope();
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 249, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 363, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 11456739 */
+{offset: 851, bytesPerRow: 588, rowsPerImage: 102}, {width: 118, height: 1, depthOrArrayLayers: 192});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let imageData6 = new ImageData(120, 20);
+let commandEncoder60 = device0.createCommandEncoder({});
+let querySet27 = device0.createQuerySet({label: '\u{1fbdf}\u2953\u0369\u{1fb6e}\u8e7e\u8644\u499a\u11b7\u0c61', type: 'occlusion', count: 3920});
+let textureView66 = texture25.createView({});
+let computePassEncoder30 = commandEncoder48.beginComputePass({label: '\u{1fb26}\u4d67\uc898\u{1f873}\u{1f8fc}\ueca1\u69a3\ufd5c\u4062'});
+let externalTexture28 = device0.importExternalTexture({
+  label: '\ub5b7\ue2ea\u50f5\u1d79\u{1fd76}\u{1fddf}\u6a30\u{1feb6}\u{1fe6d}\u2103\u{1fe74}',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer7, 'uint16', 1742, 50956);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 196 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 66272 */
+  offset: 66076,
+  buffer: buffer0,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet11, 277, 142, buffer14, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 2, y: 4 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({label: '\u{1f97f}\u47ea\uc20b\uf0b7'});
+let textureView67 = texture30.createView({label: '\u0d19\u0d70\u38fd\u6ffb\ufce3\u9448\u7a53\u0587\u{1f992}\u{1fd22}'});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.75,
+  lodMaxClamp: 51.28,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer5, 'uint32');
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(3, buffer1, 0, 180081);
+} catch {}
+try {
+computePassEncoder19.pushDebugGroup('\u2480');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6396, new DataView(new ArrayBuffer(31943)), 13560, 2344);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(6634), /* required buffer size: 6634 */
+{offset: 218, bytesPerRow: 668}, {width: 101, height: 10, depthOrArrayLayers: 1});
+} catch {}
+let promise11 = device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let canvas8 = document.createElement('canvas');
+let imageData7 = new ImageData(128, 200);
+try {
+canvas8.getContext('2d');
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({
+  label: '\u{1f9e6}\u3033\u0a9f\u087b\u05fd\u95c2\u{1ffcd}\u2da8\u26ed\u74c9\ub26d',
+  bindGroupLayouts: [bindGroupLayout5],
+});
+let texture40 = gpuCanvasContext1.getCurrentTexture();
+let textureView68 = texture1.createView({label: '\u0bcc\uf4d3\ub9f0\u{1f981}\u9221\ufd00\ud708'});
+let sampler39 = device0.createSampler({
+  label: '\u0346\u1313\uf311\ube9d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 44.77,
+  lodMaxClamp: 98.64,
+});
+let externalTexture29 = device0.importExternalTexture({label: '\u82a1\u0f22\u{1fb7a}\ua943\u3313\u{1f969}', source: video1, colorSpace: 'srgb'});
+try {
+device0.queue.submit([commandBuffer8, commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 43},
+  aspect: 'all',
+}, new ArrayBuffer(1101155), /* required buffer size: 1101155 */
+{offset: 771, bytesPerRow: 279, rowsPerImage: 136}, {width: 2, height: 1, depthOrArrayLayers: 30});
+} catch {}
+try {
+canvas7.getContext('webgl');
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder();
+let computePassEncoder31 = commandEncoder61.beginComputePass({label: '\ue4ad\ufb51\ue13a'});
+let sampler40 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.39,
+  lodMaxClamp: 65.02,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer1, 0, 251398);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer14, 1840, buffer10, 55868, 328);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 61876, new DataView(new ArrayBuffer(14999)), 4852, 3080);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 66, y: 59 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u0db4\ua494\uff45\u{1fb32}\u{1f775}\u0097',
+  size: 114280,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let commandEncoder63 = device0.createCommandEncoder({label: '\u079b\uf26e\u0eab\ude58\u{1f65b}\u86df\u9736\u8f48\u0efd'});
+let textureView69 = texture19.createView({
+  label: '\u7fa1\u94ec\u{1ff54}\u0197\u{1f6d4}\u2f22',
+  dimension: '2d-array',
+  format: 'rgba8unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let externalTexture30 = device0.importExternalTexture({label: '\u2934\ua951', source: video2, colorSpace: 'display-p3'});
+try {
+commandEncoder43.resolveQuerySet(querySet9, 805, 211, buffer14, 256);
+} catch {}
+try {
+computePassEncoder19.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: img4,
+  origin: { x: 8, y: 9 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas5.width = 681;
+let bindGroup13 = device0.createBindGroup({
+  label: '\uaa50\u684b\u06a9\u06a2\u09e5\uc5e3\u0ffa\u5b6e\u941a\u{1f830}\u6367',
+  layout: bindGroupLayout10,
+  entries: [{binding: 402, resource: sampler2}],
+});
+try {
+commandEncoder1.copyBufferToBuffer(buffer0, 253980, buffer5, 41496, 20600);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder55.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1780 */
+  offset: 1780,
+  bytesPerRow: 256,
+  rowsPerImage: 224,
+  buffer: buffer13,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline41 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 4164831477,
+    stencilWriteMask: 2162135408,
+    depthBias: 1690805692,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1076,
+        attributes: [
+          {format: 'uint32x4', offset: 616, shaderLocation: 21},
+          {format: 'sint32x3', offset: 96, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 656, shaderLocation: 26},
+          {format: 'sint16x4', offset: 232, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 316, shaderLocation: 23},
+          {format: 'unorm8x4', offset: 180, shaderLocation: 5},
+          {format: 'sint16x2', offset: 800, shaderLocation: 18},
+          {format: 'float16x4', offset: 0, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 150, shaderLocation: 14},
+          {format: 'uint32x3', offset: 172, shaderLocation: 9},
+          {format: 'uint32', offset: 124, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 200, shaderLocation: 20},
+          {format: 'snorm16x4', offset: 424, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 108, shaderLocation: 13},
+          {format: 'float32x3', offset: 192, shaderLocation: 8},
+          {format: 'sint32', offset: 36, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 204, shaderLocation: 0},
+          {format: 'uint32', offset: 288, shaderLocation: 17},
+          {format: 'sint32x3', offset: 88, shaderLocation: 3},
+          {format: 'float16x2', offset: 420, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 920,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x4', offset: 0, shaderLocation: 22}],
+      },
+      {
+        arrayStride: 11188,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 744, shaderLocation: 25},
+          {format: 'uint16x4', offset: 416, shaderLocation: 1},
+          {format: 'float32', offset: 3840, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 11172, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 1504, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 268, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let texture41 = device0.createTexture({
+  label: '\ud426\u{1f752}\u3e18\u1dff\u8d2b\u0488\u{1ff32}',
+  size: {width: 720, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  dimension: '2d',
+  format: 'astc-4x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView70 = texture20.createView({dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 4, baseArrayLayer: 21, arrayLayerCount: 18});
+let renderBundle25 = renderBundleEncoder3.finish({});
+let externalTexture31 = device0.importExternalTexture({
+  label: '\ube55\u{1ffce}\u{1f792}\u893e\u0f30\u{1faa6}\u0d6a\u{1fb37}\u4b78\u1ebb\u35e6',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer1, 0, 514859);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet14, 833, 205, buffer14, 256);
+} catch {}
+try {
+commandEncoder50.insertDebugMarker('\u0ee2');
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder();
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float', undefined, 'rgba8unorm'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle26 = renderBundleEncoder0.finish({label: '\ueab1\u0189\u{1f82d}'});
+try {
+renderBundleEncoder24.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer7, 22264, buffer10, 49860, 17172);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 509204 */
+  offset: 276,
+  bytesPerRow: 256,
+  rowsPerImage: 284,
+  buffer: buffer0,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 8});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6512, new BigUint64Array(475));
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({label: '\ud4d2\u0b8e\uc9fb\u6cbb\u022b\uf359\u0f8d\u0f84\udd9e'});
+let textureView71 = texture22.createView({label: '\u0084\u3c28\u{1fc3e}\u0707\ube43\u25d3', baseMipLevel: 1});
+let renderBundle27 = renderBundleEncoder11.finish({label: '\ub139\u1255\u781a\u{1ffe6}\u1396\ub4bc\u0a76\ub0af'});
+try {
+computePassEncoder15.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 5692 widthInBlocks: 1423 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 35524 */
+  offset: 35524,
+  bytesPerRow: 5888,
+  rowsPerImage: 93,
+  buffer: buffer0,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 249, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1423, height: 27, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder62.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 389, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 4,
+  origin: {x: 59, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline42 = device0.createComputePipeline({
+  label: '\u{1fb40}\u97c2',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise10;
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout6, bindGroupLayout20, bindGroupLayout3, bindGroupLayout10, bindGroupLayout7, bindGroupLayout17, bindGroupLayout13],
+});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u18a9\u0801\u5bf2\u8c93\u0bd8\u4a1d\u2c58\ube88'});
+let textureView72 = texture27.createView({baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\u{1f723}\u4920',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder22.setVertexBuffer(3, buffer1, 0, 351748);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer14, 1564, buffer12, 21076, 232);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet1, 415, 105, buffer14, 1024);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 7380, new Int16Array(12829), 12786, 4);
+} catch {}
+document.body.prepend(canvas8);
+let commandEncoder67 = device0.createCommandEncoder({});
+let textureView73 = texture35.createView({baseMipLevel: 5, mipLevelCount: 1});
+let renderBundle28 = renderBundleEncoder25.finish();
+try {
+computePassEncoder26.setBindGroup(1, bindGroup6, new Uint32Array(1427), 1163, 0);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 1040 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 9616 */
+  offset: 9616,
+  bytesPerRow: 1280,
+  rowsPerImage: 194,
+  buffer: buffer0,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 195, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 65, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 209, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7256 widthInBlocks: 1814 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 37840 */
+  offset: 37840,
+  bytesPerRow: 7424,
+  buffer: buffer13,
+}, {width: 1814, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer10, 30608, 12516);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 5260, new DataView(new ArrayBuffer(56936)), 50804, 932);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 6, y: 47 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({label: '\u{1fa1f}\ub550\u8b07\u6863\ubb8a\u17cb\u{1fe50}'});
+let externalTexture32 = device0.importExternalTexture({label: '\ua611\u62e1\u4f18\u01f8\u0c28\u7ae1\ue813', source: video4, colorSpace: 'srgb'});
+try {
+renderBundleEncoder18.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline43 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7768,
+        attributes: [
+          {format: 'snorm8x4', offset: 732, shaderLocation: 18},
+          {format: 'uint32x2', offset: 2752, shaderLocation: 3},
+          {format: 'sint8x4', offset: 1584, shaderLocation: 26},
+          {format: 'uint16x2', offset: 2232, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 1680, attributes: []},
+      {arrayStride: 10424, attributes: []},
+      {arrayStride: 10596, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 26700,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 1968, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw'},
+});
+let offscreenCanvas11 = new OffscreenCanvas(636, 877);
+let bindGroup14 = device0.createBindGroup({label: '\u{1f855}\u4c56\u5c6b\u{1fc01}\u846c\u0cd0', layout: bindGroupLayout12, entries: []});
+let pipelineLayout15 = device0.createPipelineLayout({
+  label: '\ufffa\u1320\u{1fa63}\ua686\u05bd\u0caf\u{1fa86}\u6f28\u{1f70c}',
+  bindGroupLayouts: [bindGroupLayout20],
+});
+let textureView74 = texture31.createView({
+  label: '\u3443\u094d\u{1fb33}\uf011\u05b8\u0760\u9e45',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let externalTexture33 = device0.importExternalTexture({label: '\u0f31\u00c4\u{1fc14}', source: videoFrame6, colorSpace: 'display-p3'});
+try {
+computePassEncoder9.dispatchWorkgroupsIndirect(buffer8, 199532);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(7, bindGroup2, new Uint32Array(4766), 3987, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({label: '\u08c0\u1612\u4de8\u{1fc3a}\ufd1e\u{1fb76}\u{1fc0a}\ub1a2'});
+let sampler41 = device0.createSampler({
+  label: '\u{1fad5}\u{1fd60}\ud6a3\u0edc\ucbee',
+  addressModeU: 'clamp-to-edge',
+  lodMinClamp: 22.19,
+  lodMaxClamp: 75.65,
+});
+try {
+computePassEncoder6.dispatchWorkgroups(3, 5, 3);
+} catch {}
+try {
+computePassEncoder12.dispatchWorkgroupsIndirect(buffer14, 1576);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer5, 'uint16', 64542, 15393);
+} catch {}
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 31, y: 18, z: 152},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8016 widthInBlocks: 501 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4928 */
+  offset: 4928,
+  bytesPerRow: 8192,
+  buffer: buffer9,
+}, {width: 501, height: 23, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 888, y: 24, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 912 */
+{offset: 912, bytesPerRow: 736}, {width: 168, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img10 = await imageWithData(215, 257, '#32633642', '#d91447ce');
+let bindGroupLayout22 = device0.createBindGroupLayout({label: '\ud78e\u018c\u0266\u710d\u64bb\u{1fbf3}\u4f3d\u0598\u10fa\u{1f7ff}\u{1fe68}', entries: []});
+let texture42 = device0.createTexture({
+  label: '\u1255\u4ab4\u8717',
+  size: {width: 1536},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+let textureView75 = texture4.createView({label: '\u46f6\u080f\ud96e\u{1ff82}\u656a\u0e25\u05dc\u{1fca4}\u0c48'});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u2000\u0d76\u{1f983}\u{1f7b8}\u0989\u65cc\u81f3\ua277\ud1c3',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+let sampler42 = device0.createSampler({
+  label: '\u39a7\u0ff8\udea4\u{1fbf5}\u031c\u0d6b\u986f',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 83.77,
+  lodMaxClamp: 98.33,
+});
+try {
+renderBundleEncoder28.setBindGroup(5, bindGroup14, new Uint32Array(7658), 5128, 0);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 81196 */
+  offset: 36372,
+  bytesPerRow: 256,
+  rowsPerImage: 85,
+  buffer: buffer0,
+}, {
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 7},
+  aspect: 'all',
+}, {width: 6, height: 6, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 70},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 39, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({label: '\ub75a\u{1f9e5}\u68ec\u{1f88e}'});
+let textureView76 = texture36.createView({baseMipLevel: 3, mipLevelCount: 1});
+let computePassEncoder32 = commandEncoder54.beginComputePass({});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\u{1fa14}\u0f18\u01bf\u0849\u4f39\u8dca',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  stencilReadOnly: false,
+});
+let renderBundle29 = renderBundleEncoder12.finish({label: '\uc569\u{1ffeb}'});
+let externalTexture34 = device0.importExternalTexture({label: '\u47aa\uec30', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder49.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 76 */
+  offset: 4,
+  rowsPerImage: 230,
+  buffer: buffer14,
+}, {
+  texture: texture34,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet20, 753, 59, buffer14, 1024);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(909, 600);
+let renderBundle30 = renderBundleEncoder6.finish({label: '\u9ea7\u8b1d\u886d\u08d1\uf208\ue79d\u{1ffd0}\u{1ffde}'});
+let externalTexture35 = device0.importExternalTexture({label: '\u{1fbb9}\u01f6', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder13.setBindGroup(7, bindGroup10);
+} catch {}
+try {
+computePassEncoder13.dispatchWorkgroups(2, 3, 1);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer14, 816, 668);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 18876, new BigUint64Array(56839), 53141, 52);
+} catch {}
+let pipeline44 = device0.createComputePipeline({
+  label: '\u077e\u0c21\u0261',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let shaderModule7 = device0.createShaderModule({
+  label: '\uc7ea\ub5e0\ua225\ua5ff\u297e\u2ae3\u04ba',
+  code: `@group(0) @binding(3959)
+var<storage, read_write> field4: array<u32>;
+@group(0) @binding(398)
+var<storage, read_write> parameter3: array<u32>;
+@group(0) @binding(3920)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(76) f0: vec3<f32>,
+  @location(44) f1: vec2<f16>,
+  @location(90) f2: vec3<u32>,
+  @location(42) f3: f16,
+  @location(14) f4: f32,
+  @builtin(sample_mask) f5: u32,
+  @location(3) f6: vec2<f16>,
+  @location(71) f7: vec2<f16>,
+  @location(20) f8: i32,
+  @location(11) f9: vec3<f32>,
+  @location(9) f10: vec4<f32>,
+  @builtin(position) f11: vec4<f32>,
+  @location(74) f12: vec3<f32>,
+  @location(96) f13: u32,
+  @location(49) f14: vec4<f32>,
+  @location(39) f15: vec4<f16>,
+  @location(31) f16: vec4<f32>,
+  @location(1) f17: vec4<u32>,
+  @location(45) f18: vec2<i32>,
+  @location(17) f19: vec4<u32>,
+  @location(89) f20: u32,
+  @location(69) f21: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec3<f32>,
+  @location(0) f1: vec2<i32>,
+  @location(1) f2: vec4<f32>,
+  @location(3) f3: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(68) a0: vec2<f32>, @location(8) a1: vec2<i32>, a2: S10, @location(54) a3: u32, @location(2) a4: vec2<u32>, @location(34) a5: vec4<f32>, @location(105) a6: u32, @location(102) a7: vec4<f32>, @location(33) a8: vec3<f32>, @location(106) a9: vec2<f32>, @location(87) a10: vec2<f16>, @location(41) a11: vec4<f16>, @location(94) a12: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(33) f168: vec3<f32>,
+  @builtin(position) f169: vec4<f32>,
+  @location(20) f170: i32,
+  @location(17) f171: vec4<u32>,
+  @location(41) f172: vec4<f16>,
+  @location(71) f173: vec2<f16>,
+  @location(31) f174: vec4<f32>,
+  @location(1) f175: vec4<u32>,
+  @location(61) f176: vec3<u32>,
+  @location(74) f177: vec3<f32>,
+  @location(54) f178: u32,
+  @location(42) f179: f16,
+  @location(3) f180: vec2<f16>,
+  @location(93) f181: vec2<u32>,
+  @location(94) f182: vec2<u32>,
+  @location(14) f183: f32,
+  @location(19) f184: vec3<i32>,
+  @location(68) f185: vec2<f32>,
+  @location(49) f186: vec4<f32>,
+  @location(34) f187: vec4<f32>,
+  @location(45) f188: vec2<i32>,
+  @location(2) f189: vec2<u32>,
+  @location(87) f190: vec2<f16>,
+  @location(9) f191: vec4<f32>,
+  @location(106) f192: vec2<f32>,
+  @location(91) f193: vec2<u32>,
+  @location(76) f194: vec3<f32>,
+  @location(90) f195: vec3<u32>,
+  @location(88) f196: vec3<f16>,
+  @location(11) f197: vec3<f32>,
+  @location(35) f198: f16,
+  @location(96) f199: u32,
+  @location(102) f200: vec4<f32>,
+  @location(69) f201: vec2<i32>,
+  @location(105) f202: u32,
+  @location(89) f203: u32,
+  @location(75) f204: vec2<f32>,
+  @location(39) f205: vec4<f16>,
+  @location(62) f206: vec3<u32>,
+  @location(44) f207: vec2<f16>,
+  @location(8) f208: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture43 = device0.createTexture({
+  size: [1536, 1, 266],
+  mipLevelCount: 9,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture36 = device0.importExternalTexture({label: '\u1dd3\u{1f726}\u0739\u{1fbb1}', source: video6, colorSpace: 'display-p3'});
+try {
+computePassEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 637, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 10736, new Float32Array(21185));
+} catch {}
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u02cf\uebd9\uebb6',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder12.dispatchWorkgroups(2, 1);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer1, 'uint16', 518760, 17903);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(7, buffer1, 0, 456818);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 86872);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet14, 864, 100, buffer14, 1024);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 332, new Int16Array(29973), 7818, 4);
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame2);
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+let textureView77 = texture26.createView({
+  label: '\u{1ffe0}\u1169\ube0b\ufe99\u0de4\u0988\u347a\u059d\u0980',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+});
+let renderBundle31 = renderBundleEncoder6.finish({label: '\u0fc4\u7bcb\uf984\uc5b9'});
+let sampler43 = device0.createSampler({
+  label: '\u0daf\u0468\u{1fa4f}\u9e57\u6a56\uca25\ua8e8\u349c\u7bcf\u13ea',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.39,
+  lodMaxClamp: 57.59,
+  maxAnisotropy: 11,
+});
+let externalTexture37 = device0.importExternalTexture({label: '\u0670\u{1f70e}\u88c0\u{1f78e}', source: videoFrame1});
+try {
+commandEncoder2.copyBufferToBuffer(buffer14, 268, buffer11, 28680, 1828);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder62.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 187, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1248 widthInBlocks: 312 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14476 */
+  offset: 14476,
+  buffer: buffer5,
+}, {width: 312, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+  label: '\u0bbf\u1895\u54d5\u{1f743}\ub5fd\u05df\u0301\u{1fd12}\uc98a',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({label: '\u6ca1\ue346\u35a2\u0048\u00e0\u0aa3'});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 2097});
+let textureView78 = texture10.createView({
+  label: '\u5612\u46da\u{1f919}\u04c2\u7fbf\uf7d5\u{1fc76}\u000d\u3194',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderBundle32 = renderBundleEncoder20.finish({label: '\u080f\ud538\ud43b\uc13b\ud5c9\u25b5\ua509\u{1fec2}'});
+let sampler44 = device0.createSampler({
+  label: '\u0add\u7621\u{1fed7}\u053c\u0b2d\u7fe1\u{1fd48}\u0cea\u{1fa0c}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 42.61,
+  lodMaxClamp: 48.83,
+});
+let externalTexture38 = device0.importExternalTexture({label: '\u7c42\u0bf1', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder28.setBindGroup(7, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.dispatchWorkgroups(1, 3, 1);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer0, 85044, buffer12, 17088, 28160);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 84, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2128 widthInBlocks: 133 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1136 */
+  offset: 1136,
+  buffer: buffer5,
+}, {width: 133, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 182, y: 19, z: 87},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer5, 80880, 912);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet23, 67, 67, buffer14, 1280);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1, commandBuffer9]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline46 = device0.createRenderPipeline({
+  label: '\u7bba\u45d5\u0d0d\u2dd7',
+  layout: pipelineLayout8,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 27856,
+        attributes: [
+          {format: 'snorm8x4', offset: 2204, shaderLocation: 22},
+          {format: 'uint16x2', offset: 7624, shaderLocation: 6},
+          {format: 'uint8x2', offset: 2936, shaderLocation: 7},
+          {format: 'float32', offset: 5776, shaderLocation: 8},
+          {format: 'uint32x4', offset: 7224, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 2152, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 4666, shaderLocation: 18},
+          {format: 'float32', offset: 4408, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 2828, shaderLocation: 4},
+          {format: 'float32', offset: 4872, shaderLocation: 3},
+          {format: 'sint16x4', offset: 6688, shaderLocation: 25},
+          {format: 'float16x4', offset: 8480, shaderLocation: 19},
+          {format: 'sint16x4', offset: 1524, shaderLocation: 0},
+          {format: 'sint32x3', offset: 6324, shaderLocation: 15},
+          {format: 'uint16x4', offset: 3868, shaderLocation: 1},
+          {format: 'sint32x4', offset: 4940, shaderLocation: 20},
+          {format: 'uint8x4', offset: 7824, shaderLocation: 16},
+          {format: 'sint32x3', offset: 3396, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 4404, attributes: []},
+      {arrayStride: 18948, attributes: []},
+      {arrayStride: 2300, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 19616,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 2336, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+document.body.prepend(video1);
+let commandEncoder72 = device0.createCommandEncoder({label: '\u0c30\u1331\u8987\u6ecb\u9e41\u0fd2\u0712\u{1f773}\uf084\u{1f615}'});
+let textureView79 = texture39.createView({label: '\ude55\u1369\uace7\u{1fac4}\u0d27', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle33 = renderBundleEncoder26.finish({});
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 336},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer12, 129176, 22468);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 496, new BigUint64Array(45673), 9739, 28);
+} catch {}
+let textureView80 = texture43.createView({dimension: '2d', baseMipLevel: 4, mipLevelCount: 4, baseArrayLayer: 21, arrayLayerCount: 1});
+let renderBundle34 = renderBundleEncoder26.finish();
+try {
+renderBundleEncoder1.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 3632 widthInBlocks: 227 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 41808 */
+  offset: 41808,
+  bytesPerRow: 3840,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 227, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder67.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 584, y: 36, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4848 */
+  offset: 2688,
+  bytesPerRow: 256,
+  rowsPerImage: 176,
+  buffer: buffer5,
+}, {width: 28, height: 36, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline47 = device0.createComputePipeline({
+  label: '\u{1f817}\u5a4e\u810e\u48c6\u1462\u{1f892}\ue795\u2318\u8a82\u0cb7\u585c',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let offscreenCanvas13 = new OffscreenCanvas(750, 412);
+let querySet29 = device0.createQuerySet({label: '\u748b\u869d', type: 'occlusion', count: 495});
+let texture44 = device0.createTexture({
+  label: '\u{1f668}\ub80a\u952a\u04ed\uf5c1\u{1f989}',
+  size: {width: 1440, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-6x5-unorm'],
+});
+let textureView81 = texture22.createView({label: '\u9876\u0a61\u51a0\u0cb9\u{1f882}\u{1ff9a}'});
+let computePassEncoder33 = commandEncoder42.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer7, 'uint32', 38752, 24411);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer1);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.READ, 0, 5240);
+} catch {}
+try {
+commandEncoder1.clearBuffer(buffer6, 111952, 1236);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet20, 341, 167, buffer14, 256);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 480, new BigUint64Array(49016), 23843, 12);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let texture45 = device0.createTexture({
+  label: '\u882b\u{1f7b0}\uee8a\u{1f808}\u19c3\u06a4',
+  size: {width: 108, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView82 = texture26.createView({label: '\u1164\u4a01\u1dcb\u257e\u{1fa72}\u9f35', baseMipLevel: 2, baseArrayLayer: 0});
+let externalTexture39 = device0.importExternalTexture({
+  label: '\u0a08\ud19c\u0814\u2e2b\ue74a\udf29\u0efc\ud176\u{1fc8d}\uf219\ufe06',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder36.setIndexBuffer(buffer1, 'uint32', 503616, 52621);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline35);
+} catch {}
+let pipeline48 = device0.createRenderPipeline({
+  label: '\u2825\u06e5\u{1f84d}\u{1fa37}\u5ba8\u64be\u3ef1\u9227\u{1fb95}\u0b40',
+  layout: pipelineLayout15,
+  multisample: {mask: 0x3cdcd2b2},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 300, shaderLocation: 17},
+          {format: 'uint32x2', offset: 1308, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 856,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 840, shaderLocation: 4},
+          {format: 'sint16x4', offset: 24, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 340, shaderLocation: 7},
+          {format: 'float16x2', offset: 268, shaderLocation: 24},
+          {format: 'sint16x2', offset: 116, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 204, shaderLocation: 22},
+          {format: 'sint16x2', offset: 296, shaderLocation: 5},
+          {format: 'float32x3', offset: 256, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 52, shaderLocation: 20},
+          {format: 'uint16x4', offset: 12, shaderLocation: 15},
+          {format: 'uint8x4', offset: 284, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 120, shaderLocation: 11},
+          {format: 'sint16x4', offset: 168, shaderLocation: 2},
+          {format: 'sint16x2', offset: 216, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 3},
+          {format: 'uint32x4', offset: 492, shaderLocation: 10},
+          {format: 'sint16x2', offset: 184, shaderLocation: 21},
+          {format: 'uint8x2', offset: 208, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 208, shaderLocation: 23},
+          {format: 'sint32x2', offset: 108, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  label: '\u5bf2\u7c91\u56cd',
+  code: `@group(1) @binding(402)
+var<storage, read_write> field5: array<u32>;
+@group(0) @binding(4109)
+var<storage, read_write> n6: array<u32>;
+@group(0) @binding(4138)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(4) f1: u32,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(50) a0: vec2<i32>, @location(101) a1: vec3<u32>, @builtin(sample_mask) a2: u32, @location(16) a3: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(24) f0: f16,
+  @location(19) f1: vec3<u32>,
+  @location(18) f2: vec4<i32>,
+  @location(10) f3: f32,
+  @builtin(instance_index) f4: u32
+}
+struct VertexOutput0 {
+  @location(53) f209: i32,
+  @location(26) f210: vec4<f32>,
+  @location(60) f211: vec3<f32>,
+  @location(51) f212: vec2<f32>,
+  @location(22) f213: vec2<i32>,
+  @location(11) f214: vec4<i32>,
+  @location(50) f215: vec2<i32>,
+  @location(7) f216: vec2<u32>,
+  @location(61) f217: vec4<i32>,
+  @location(12) f218: vec3<i32>,
+  @location(56) f219: u32,
+  @builtin(position) f220: vec4<f32>,
+  @location(104) f221: vec2<f16>,
+  @location(101) f222: vec3<u32>,
+  @location(96) f223: f32,
+  @location(82) f224: u32,
+  @location(16) f225: vec4<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(23) a1: vec4<u32>, @location(2) a2: vec3<u32>, @location(22) a3: vec4<u32>, @location(4) a4: vec2<u32>, @location(11) a5: vec2<f32>, @location(9) a6: vec4<f16>, a7: S11, @location(21) a8: vec2<f16>, @location(15) a9: u32, @location(26) a10: vec3<f32>, @location(13) a11: vec3<f16>, @location(12) a12: f16, @location(20) a13: vec4<f16>, @location(25) a14: vec4<f16>, @location(1) a15: u32, @location(6) a16: f32, @location(7) a17: vec2<f32>, @location(5) a18: f32, @location(8) a19: vec4<f16>, @location(16) a20: u32, @location(0) a21: vec4<f32>, @location(17) a22: vec2<f16>, @location(3) a23: u32, @location(14) a24: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView83 = texture3.createView({label: '\u8ef9\uacbe\u4561\ud53e\ue7c5\u3c23', mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder37.beginComputePass({label: '\uc1ba\ue24c\u{1f9be}\u0aca\u3be9'});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\u6f5a\ud47b\u0296\u0c8a\u0ec1\u{1fab9}\u9392\u011e',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder22.setBindGroup(5, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer1, 0, 347595);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer13, 68136, 63716);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(querySet20, 153, 207, buffer14, 512);
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker('\u4b7c');
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder();
+let textureView84 = texture21.createView({label: '\u{1fa60}\u{1f9c1}\u0572\u0225\u4afe\u0837\u9ce8\ubd2f\u3ec3\u0510'});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({label: '\u0465\u{1f75c}\u3030\u0a1c', colorFormats: ['rgba32float', undefined, 'rgba8unorm']});
+let renderBundle35 = renderBundleEncoder38.finish({label: '\u2c40\u05bf\u0939\u09b0\ua051\ubd24\u269f\u{1ff60}\u297a\u0713\ud7b5'});
+try {
+computePassEncoder20.setBindGroup(5, bindGroup4);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(6, bindGroup14, new Uint32Array(2802), 735, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup10, new Uint32Array(7529), 3010, 0);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer2, 130612, buffer6, 79272, 18188);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer4, 1840, 5768);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(799, 1);
+let bindGroupLayout23 = device0.createBindGroupLayout({label: '\u8fda\ufc2f\ue68c\u723c\u{1f77b}\u{1fa32}\u{1fee0}\u72a0\u{1fcd7}\u07d0', entries: []});
+let textureView85 = texture19.createView({
+  label: '\u{1fb49}\u0025\u{1fffd}\u0490\u35ee\u{1fff2}\u06fd',
+  dimension: '2d-array',
+  format: 'rgba8unorm-srgb',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder24.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer1, 444588, 51264);
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u{1ff0c}\u0f75\u44b3\ua868\ubd59\ua930',
+  entries: [{binding: 1688, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let textureView86 = texture36.createView({
+  label: '\u0b37\u4f6e\u039f\u013a\u72b7\u717c\ud44b\u4037\u8bf8\u{1f6eb}',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let computePassEncoder35 = commandEncoder44.beginComputePass({label: '\uf073\u95ec'});
+let externalTexture40 = device0.importExternalTexture({label: '\u0bad\u0d40\u0e1c\u9bbe\u0e02\u03cf\u6ac6', source: video4});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup12, new Uint32Array(1732), 71, 0);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 575, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8336 widthInBlocks: 2084 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36452 */
+  offset: 36452,
+  bytesPerRow: 8448,
+  buffer: buffer12,
+}, {width: 2084, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 79},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer0), /* required buffer size: 895 */
+{offset: 895, rowsPerImage: 228}, {width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline49 = device0.createRenderPipeline({
+  label: '\ude90\u2cfa\u0cfb\u0a86\u0561\ub1d8\u9961',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17748,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 3196, shaderLocation: 24},
+          {format: 'uint16x4', offset: 2132, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 2944, shaderLocation: 25},
+          {format: 'unorm10-10-10-2', offset: 5792, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 340, shaderLocation: 19},
+          {format: 'float16x4', offset: 4676, shaderLocation: 10},
+          {format: 'sint32x3', offset: 3392, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 9358, shaderLocation: 26},
+          {format: 'uint8x4', offset: 580, shaderLocation: 1},
+          {format: 'uint16x2', offset: 1704, shaderLocation: 17},
+          {format: 'sint8x2', offset: 5940, shaderLocation: 6},
+          {format: 'float16x2', offset: 2104, shaderLocation: 13},
+          {format: 'sint8x4', offset: 4204, shaderLocation: 2},
+          {format: 'uint32x3', offset: 2064, shaderLocation: 22},
+          {format: 'sint32', offset: 5168, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 5138, shaderLocation: 12},
+          {format: 'float32', offset: 280, shaderLocation: 16},
+          {format: 'float32x2', offset: 2960, shaderLocation: 23},
+          {format: 'uint8x2', offset: 12458, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 2420,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 1364, shaderLocation: 8},
+          {format: 'float32x4', offset: 364, shaderLocation: 20},
+          {format: 'uint32x3', offset: 192, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 13032,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x2', offset: 5272, shaderLocation: 7},
+          {format: 'float16x2', offset: 528, shaderLocation: 4},
+          {format: 'sint32x4', offset: 1708, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 1960, shaderLocation: 0},
+          {format: 'float16x4', offset: 9532, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+offscreenCanvas5.width = 567;
+let commandEncoder74 = device0.createCommandEncoder();
+let texture46 = gpuCanvasContext5.getCurrentTexture();
+let textureView87 = texture27.createView({baseMipLevel: 1});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup1, new Uint32Array(5701), 4778, 0);
+} catch {}
+try {
+commandEncoder49.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 241, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2084 widthInBlocks: 521 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3292 */
+  offset: 3292,
+  buffer: buffer13,
+}, {width: 521, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+let querySet30 = device0.createQuerySet({
+  label: '\u{1fe7f}\u0582\u2be0\u7dc8\u9a92\u50a5\uad8d\u07d9\ubc3c\u000d\u0c24',
+  type: 'occlusion',
+  count: 1403,
+});
+let textureView88 = texture27.createView({label: '\u9a9a\uf980\u0df8', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder36 = commandEncoder73.beginComputePass({label: '\u4593\u1a5b\u4311\u4912\ucf13\u6f27\u09c6\u3c98'});
+try {
+computePassEncoder14.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(4, bindGroup12);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 106, y: 8, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 107, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 144, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: canvas6,
+  origin: { x: 83, y: 25 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture30.label;
+} catch {}
+try {
+computePassEncoder12.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+commandEncoder57.insertDebugMarker('\u{1f6ee}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 768, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 2, y: 10 },
+  flipY: true,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas13.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(191, 288);
+let shaderModule9 = device0.createShaderModule({
+  code: `@group(1) @binding(4216)
+var<storage, read_write> parameter5: array<u32>;
+@group(1) @binding(2930)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(45) f0: vec2<f32>,
+  @location(33) f1: vec2<u32>,
+  @location(61) f2: vec4<u32>,
+  @location(94) f3: vec3<u32>,
+  @location(21) f4: vec4<f16>,
+  @location(31) f5: vec4<f32>,
+  @location(59) f6: vec3<i32>,
+  @location(107) f7: f32,
+  @location(36) f8: vec4<u32>,
+  @location(76) f9: vec4<f32>,
+  @location(49) f10: vec3<i32>,
+  @location(29) f11: vec3<f32>,
+  @location(14) f12: vec3<u32>,
+  @location(65) f13: i32
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec2<i32>,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: f16, @location(34) a1: vec2<i32>, @location(108) a2: f16, @location(8) a3: vec2<f16>, @location(37) a4: vec4<i32>, @location(87) a5: vec2<i32>, @location(1) a6: vec2<i32>, @location(55) a7: i32, @location(70) a8: vec2<i32>, @location(38) a9: f32, @location(35) a10: vec3<f32>, @location(77) a11: u32, @location(75) a12: vec2<f32>, a13: S13, @location(71) a14: u32, @location(100) a15: vec4<f16>, @location(63) a16: f16, @location(4) a17: vec3<f32>, @location(101) a18: vec4<u32>, @location(57) a19: u32, @location(22) a20: vec4<f32>, @location(30) a21: i32, @location(56) a22: f32, @location(69) a23: vec2<f32>, @location(17) a24: vec4<i32>, @builtin(sample_mask) a25: u32, @location(48) a26: f32, @location(11) a27: vec4<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(12) f0: vec4<f16>,
+  @location(23) f1: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(45) f226: vec2<f32>,
+  @location(29) f227: vec3<f32>,
+  @location(49) f228: vec3<i32>,
+  @location(76) f229: vec4<f32>,
+  @location(87) f230: vec2<i32>,
+  @location(55) f231: i32,
+  @location(57) f232: u32,
+  @location(36) f233: vec4<u32>,
+  @location(21) f234: vec4<f16>,
+  @location(108) f235: f16,
+  @location(11) f236: vec4<u32>,
+  @location(71) f237: u32,
+  @location(3) f238: f16,
+  @location(107) f239: f32,
+  @location(70) f240: vec2<i32>,
+  @location(75) f241: vec2<f32>,
+  @location(48) f242: f32,
+  @location(4) f243: vec3<f32>,
+  @location(56) f244: f32,
+  @builtin(position) f245: vec4<f32>,
+  @location(37) f246: vec4<i32>,
+  @location(7) f247: vec3<u32>,
+  @location(22) f248: vec4<f32>,
+  @location(63) f249: f16,
+  @location(38) f250: f32,
+  @location(101) f251: vec4<u32>,
+  @location(30) f252: i32,
+  @location(17) f253: vec4<i32>,
+  @location(14) f254: vec3<u32>,
+  @location(94) f255: vec3<u32>,
+  @location(61) f256: vec4<u32>,
+  @location(65) f257: i32,
+  @location(100) f258: vec4<f16>,
+  @location(69) f259: vec2<f32>,
+  @location(77) f260: u32,
+  @location(8) f261: vec2<f16>,
+  @location(34) f262: vec2<i32>,
+  @location(59) f263: vec3<i32>,
+  @location(35) f264: vec3<f32>,
+  @location(33) f265: vec2<u32>,
+  @location(1) f266: vec2<i32>,
+  @location(31) f267: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(26) a1: vec4<i32>, @location(6) a2: vec4<f32>, @location(1) a3: vec3<f32>, @location(15) a4: f16, @location(8) a5: vec2<f16>, a6: S12, @location(5) a7: vec2<i32>, @location(4) a8: vec4<u32>, @location(19) a9: vec3<u32>, @location(17) a10: vec4<u32>, @location(11) a11: vec3<i32>, @location(10) a12: vec3<f16>, @location(13) a13: i32, @location(3) a14: vec2<u32>, @location(24) a15: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+try {
+renderBundleEncoder32.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer1, 0);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer0, 20852, buffer6, 119480, 188);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet5, 1115, 166, buffer14, 512);
+} catch {}
+let img11 = await imageWithData(105, 51, '#13b8aa1c', '#9525e1b7');
+let commandEncoder75 = device0.createCommandEncoder();
+let texture47 = device0.createTexture({
+  size: [108],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+try {
+computePassEncoder33.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder14.draw(87667444, 321559216, 77129542, 742466201);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(834728660, 211177607, 240486559, 50254926, 1213421521);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexedIndirect(buffer14, 152);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer1, 'uint16', 477284, 29486);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(0, buffer1, 0, 63768);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer2, 165116, buffer6, 107624, 7776);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet17, 1423, 226, buffer14, 0);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\ufeb9\u0e88\u07ce\ufb8f\u0346\u{1f77c}\u063f\u0419',
+  code: `@group(5) @binding(1465)
+var<storage, read_write> local5: array<u32>;
+@group(1) @binding(1465)
+var<storage, read_write> field6: array<u32>;
+@group(3) @binding(3920)
+var<storage, read_write> local6: array<u32>;
+@group(3) @binding(3959)
+var<storage, read_write> field7: array<u32>;
+@group(4) @binding(1012)
+var<storage, read_write> n7: array<u32>;
+@group(5) @binding(1054)
+var<storage, read_write> global5: array<u32>;
+@group(1) @binding(2041)
+var<storage, read_write> function6: array<u32>;
+@group(3) @binding(398)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(8, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(97) f0: vec2<i32>,
+  @location(76) f1: i32,
+  @location(22) f2: vec2<f16>,
+  @builtin(sample_mask) f3: u32,
+  @location(107) f4: vec3<i32>,
+  @location(33) f5: vec4<u32>,
+  @builtin(front_facing) f6: bool,
+  @location(82) f7: f32,
+  @location(18) f8: vec3<f32>,
+  @location(51) f9: u32,
+  @location(63) f10: u32,
+  @location(20) f11: u32,
+  @location(0) f12: vec3<f32>,
+  @location(105) f13: vec3<f32>,
+  @location(55) f14: f32,
+  @location(59) f15: vec3<u32>,
+  @location(1) f16: i32,
+  @location(99) f17: i32,
+  @location(6) f18: vec4<u32>,
+  @builtin(sample_index) f19: u32,
+  @location(68) f20: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(26) a0: vec4<f32>, @location(102) a1: f16, @location(2) a2: vec4<f16>, @location(92) a3: vec4<f16>, @builtin(position) a4: vec4<f32>, @location(73) a5: vec3<i32>, a6: S15, @location(104) a7: vec3<f16>, @location(37) a8: vec4<f32>, @location(47) a9: vec3<u32>, @location(56) a10: vec3<f32>, @location(46) a11: vec4<f16>, @location(67) a12: vec3<f16>, @location(25) a13: f16, @location(91) a14: vec3<f32>, @location(62) a15: vec4<f16>, @location(12) a16: i32, @location(64) a17: vec3<f32>, @location(101) a18: vec3<u32>, @location(54) a19: vec4<i32>, @location(94) a20: vec2<f32>, @location(48) a21: vec3<f32>, @location(84) a22: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(24) f0: vec2<i32>,
+  @location(18) f1: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(73) f268: vec3<i32>,
+  @location(104) f269: vec3<f16>,
+  @location(22) f270: vec2<f16>,
+  @location(33) f271: vec4<u32>,
+  @location(12) f272: i32,
+  @location(62) f273: vec4<f16>,
+  @location(51) f274: u32,
+  @location(97) f275: vec2<i32>,
+  @location(48) f276: vec3<f32>,
+  @builtin(position) f277: vec4<f32>,
+  @location(82) f278: f32,
+  @location(46) f279: vec4<f16>,
+  @location(105) f280: vec3<f32>,
+  @location(54) f281: vec4<i32>,
+  @location(47) f282: vec3<u32>,
+  @location(1) f283: i32,
+  @location(59) f284: vec3<u32>,
+  @location(64) f285: vec3<f32>,
+  @location(63) f286: u32,
+  @location(76) f287: i32,
+  @location(56) f288: vec3<f32>,
+  @location(67) f289: vec3<f16>,
+  @location(101) f290: vec3<u32>,
+  @location(6) f291: vec4<u32>,
+  @location(18) f292: vec3<f32>,
+  @location(25) f293: f16,
+  @location(55) f294: f32,
+  @location(92) f295: vec4<f16>,
+  @location(2) f296: vec4<f16>,
+  @location(107) f297: vec3<i32>,
+  @location(26) f298: vec4<f32>,
+  @location(20) f299: u32,
+  @location(37) f300: vec4<f32>,
+  @location(99) f301: i32,
+  @location(68) f302: vec3<f16>,
+  @location(84) f303: f32,
+  @location(102) f304: f16,
+  @location(0) f305: vec3<f32>,
+  @location(94) f306: vec2<f32>,
+  @location(91) f307: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: f16, @location(26) a1: vec2<f16>, @builtin(instance_index) a2: u32, @location(17) a3: vec3<u32>, @location(7) a4: f16, @builtin(vertex_index) a5: u32, @location(1) a6: vec3<u32>, @location(10) a7: vec4<i32>, @location(21) a8: vec4<f16>, @location(23) a9: f16, @location(13) a10: vec4<i32>, @location(4) a11: vec4<f32>, @location(20) a12: vec3<f16>, @location(5) a13: vec3<f16>, @location(25) a14: vec4<f32>, @location(12) a15: vec3<i32>, @location(3) a16: u32, @location(2) a17: vec2<i32>, @location(19) a18: vec2<i32>, a19: S14, @location(9) a20: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder76 = device0.createCommandEncoder({label: '\u{1f7ce}\u5e78\u7bf6\u16b3\u{1f6d0}\u8e76\u1235\u0832'});
+let textureView89 = texture29.createView({label: '\ud80d\ua8e0\uffa3\u0fa3\u4282\u094c', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle36 = renderBundleEncoder33.finish({label: '\u0424\u0b0a\u12c8\u716e\u8cae\uc649\u7694\u05c6\uef91'});
+let externalTexture41 = device0.importExternalTexture({label: '\u3fc1\u063d', source: videoFrame5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder14.setBindGroup(4, bindGroup12, []);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer1, 0, 178785);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 10148834 */
+{offset: 146, bytesPerRow: 149, rowsPerImage: 132}, {width: 6, height: 0, depthOrArrayLayers: 517});
+} catch {}
+offscreenCanvas4.height = 1583;
+let img12 = await imageWithData(218, 157, '#3de6e7cc', '#b20e71a5');
+let textureView90 = texture36.createView({label: '\u7630\u0801\u{1fe2d}\u8401\u44f5\u{1fb4a}', baseMipLevel: 7});
+let sampler45 = device0.createSampler({
+  label: '\u{1fc9b}\ueb5c\u3d6e\u{1f7c8}\uec57\ue633\u0026\u027e\u15e2\u{1fd91}\u9719',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.81,
+  lodMaxClamp: 54.80,
+});
+try {
+renderBundleEncoder14.drawIndexed(485046304);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 292 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48516 */
+  offset: 48516,
+  rowsPerImage: 39,
+  buffer: buffer0,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 73, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+renderBundleEncoder19.pushDebugGroup('\u8173');
+} catch {}
+offscreenCanvas0.height = 130;
+let texture48 = device0.createTexture({
+  label: '\uaa26\u1d97\u2b0d',
+  size: {width: 360, height: 30, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u1274\ua323\u14d1\u0c84\u2286\uc302\u0eb6\ucf0d\u{1f751}\u0f6b',
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle37 = renderBundleEncoder29.finish({label: '\u{1fe06}\u07fc\u000c'});
+try {
+renderBundleEncoder9.setBindGroup(6, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder14.draw(34007791);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(548384240, 530053091, 873249018);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexedIndirect(buffer14, 724);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer14, 528, buffer6, 19316, 812);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 94, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 79, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet25, 2139, 96, buffer14, 1024);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 534 */
+{offset: 534}, {width: 357, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img13 = await imageWithData(44, 286, '#fcbc74f8', '#65f8d46e');
+let imageBitmap5 = await createImageBitmap(img5);
+try {
+adapter1.label = '\uf680\u{1f93d}\u4465\uf803\u08ac\u0885\ub677\u4576';
+} catch {}
+let textureView91 = texture4.createView({label: '\u01e0\u6f97\u0fb1\u5e91', dimension: '1d'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u{1ff3a}\u688f\u07a4\u1408\ufd25\u0c2c\u5d31\u06bc\u4b0f\uf2c9',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+});
+let renderBundle38 = renderBundleEncoder20.finish();
+try {
+computePassEncoder17.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(2, buffer1, 0);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 1040 widthInBlocks: 260 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 52044 */
+  offset: 52044,
+  rowsPerImage: 260,
+  buffer: buffer0,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 260, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let textureView92 = texture20.createView({dimension: '2d', aspect: 'all', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 255});
+try {
+renderBundleEncoder18.setPipeline(pipeline43);
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({label: '\u2c4a\u0208'});
+let querySet31 = device0.createQuerySet({label: '\u{1fa6e}\u04c9\u09f4\ud9c1\ud16a\u000f\u{1fc6a}\u4d35', type: 'occlusion', count: 1133});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u{1f637}\u{1fc90}\u1a6c\u0e84\u0f03\u3602\ub9b7\u0fa0\u0858\u1af0',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture42 = device0.importExternalTexture({label: '\u846e\u03f2\uaf3b\u1363', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder14.draw(1205638116, 99804568, 710387620, 813349714);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer4, 4480, 7988);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline50 = device0.createComputePipeline({
+  label: '\u{1fb54}\u7804\u23f0\u{1f97a}\ub6ea\u0438\u489f',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let offscreenCanvas16 = new OffscreenCanvas(131, 905);
+let buffer16 = device0.createBuffer({size: 22149, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture49 = device0.createTexture({
+  label: '\u1655\u3abb\u009d\u9679\u{1f6a8}\u{1fc04}',
+  size: {width: 432, height: 24, depthOrArrayLayers: 186},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView93 = texture35.createView({label: '\udfe8\ueef1\u0eeb\u{1f81b}\u0a91\u{1fdcb}\u0360', baseMipLevel: 4, mipLevelCount: 3});
+try {
+renderBundleEncoder41.setBindGroup(4, bindGroup6, new Uint32Array(4961), 4617, 0);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(262026273, 900065701, 203012180, -901083639, 993881458);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer5, 'uint32', 42000, 35368);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\u{1fb11}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 295104, new DataView(new ArrayBuffer(44301)), 3802, 14052);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 908 */
+{offset: 908, rowsPerImage: 99}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\u0a60\ub0f8\u{1fd9b}\uec2d\u0ff7\uff84\u{1fcfd}\u0ed7',
+  layout: bindGroupLayout17,
+  entries: [{binding: 163, resource: externalTexture36}],
+});
+let querySet32 = device0.createQuerySet({label: '\u27ff\u861b\u04fd\u0fc3\uf91b\u657a\u{1f786}', type: 'occlusion', count: 1706});
+let texture50 = device0.createTexture({
+  label: '\ua22c\u77e7\u067b\u0513\ue3ea',
+  size: {width: 1536, height: 1, depthOrArrayLayers: 164},
+  mipLevelCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView94 = texture12.createView({label: '\u0621\u03eb\u0c7b\u44f3\u076c\u7606\u14eb\u6904\u0013\ua41b\u0134'});
+try {
+computePassEncoder6.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(5, buffer1, 71372, 381296);
+} catch {}
+try {
+renderBundleEncoder19.popDebugGroup();
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  label: '\u9465\u0be2',
+  layout: 'auto',
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 21552,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 11308, shaderLocation: 5},
+          {format: 'uint8x4', offset: 6044, shaderLocation: 1},
+          {format: 'sint8x2', offset: 12538, shaderLocation: 20},
+          {format: 'uint32', offset: 21548, shaderLocation: 9},
+          {format: 'sint16x4', offset: 1744, shaderLocation: 21},
+          {format: 'uint32x4', offset: 9000, shaderLocation: 7},
+          {format: 'sint32x4', offset: 1872, shaderLocation: 25},
+          {format: 'float16x2', offset: 804, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 6496, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 14748, shaderLocation: 4},
+          {format: 'uint8x2', offset: 11120, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 3112, shaderLocation: 18},
+          {format: 'uint32x3', offset: 11252, shaderLocation: 16},
+          {format: 'sint32x4', offset: 2208, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 292, shaderLocation: 22},
+          {format: 'sint8x4', offset: 3780, shaderLocation: 0},
+          {format: 'float32', offset: 7676, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 6224, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x2', offset: 9076, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+let texture51 = device0.createTexture({
+  label: '\u55e9\uc98e\u5cd7\u{1f710}\u0dae\u05f8',
+  size: {width: 3072},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView95 = texture10.createView({label: '\u4a83\udc60', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle39 = renderBundleEncoder24.finish({label: '\u0604\u9a45\u{1fc5b}\u{1fd60}'});
+try {
+computePassEncoder26.dispatchWorkgroups(1, 4, 1);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(659629305, 934677509, 403281913);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer1, 365484, 73727);
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({label: '\u0d0c\u0ab4\u0f31'});
+let querySet33 = device0.createQuerySet({label: '\u{1f6d5}\u1838\u0f30\u9dff\u0113\u{1f74c}\ubcda', type: 'occlusion', count: 2369});
+let texture52 = device0.createTexture({
+  label: '\u0931\u{1fa4d}\u{1faca}\u8cf9\u0027\u04a3\u0d84',
+  size: {width: 320},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba32float'],
+});
+let textureView96 = texture47.createView({label: '\u4ed2\uaece', mipLevelCount: 1});
+let externalTexture43 = device0.importExternalTexture({label: '\ua998\u{1f6ea}\u0e0e\u0f2f\ub011\u0987\u{1fd37}', source: video6});
+try {
+computePassEncoder12.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderBundleEncoder14.draw(328046380, 1011895818, 128595782, 356261107);
+} catch {}
+try {
+renderBundleEncoder14.drawIndirect(buffer14, 376);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 4,
+  origin: {x: 7, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({label: '\u093b\u3142\u990b\u{1fc81}'});
+let textureView97 = texture8.createView({label: '\u075e\uf9e2\u0fe5', format: 'rgba8unorm-srgb', arrayLayerCount: 1});
+let sampler46 = device0.createSampler({
+  label: '\u3167\u0482\u0cf3\u082a\u{1f763}\u5424\u{1f9eb}\u80ec\u6ae5\uac7e',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.47,
+  lodMaxClamp: 83.05,
+  maxAnisotropy: 5,
+});
+let externalTexture44 = device0.importExternalTexture({label: '\u{1f86b}\u03c6\ua10d\u024e\ue2d6\u0905\u01df', source: video5, colorSpace: 'display-p3'});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer1, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer7, 81280, buffer11, 366252, 360);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet9, 1065, 248, buffer14, 0);
+} catch {}
+let promise12 = device0.createRenderPipelineAsync({
+  label: '\uc001\u0ff5\u04c8\u0179\u0bd7\u01b6\u{1f8fb}\udab8',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0x9d3da0df},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'r16uint'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 2438215193,
+    stencilWriteMask: 2381956861,
+    depthBiasSlopeScale: 298.2990901248091,
+    depthBiasClamp: 956.9081835313873,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7252,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 2008, shaderLocation: 14},
+          {format: 'float32x2', offset: 780, shaderLocation: 2},
+          {format: 'sint32x4', offset: 1476, shaderLocation: 23},
+          {format: 'uint8x2', offset: 2544, shaderLocation: 21},
+          {format: 'float16x2', offset: 3172, shaderLocation: 19},
+          {format: 'sint32', offset: 948, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 1708, shaderLocation: 15},
+          {format: 'float32', offset: 836, shaderLocation: 16},
+          {format: 'float16x4', offset: 3448, shaderLocation: 6},
+          {format: 'float32x3', offset: 880, shaderLocation: 26},
+          {format: 'uint8x2', offset: 6086, shaderLocation: 12},
+          {format: 'sint16x4', offset: 1892, shaderLocation: 1},
+          {format: 'sint8x4', offset: 1572, shaderLocation: 7},
+          {format: 'sint32x2', offset: 636, shaderLocation: 13},
+          {format: 'float32x3', offset: 20, shaderLocation: 9},
+          {format: 'sint32x4', offset: 16, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 15264,
+        attributes: [
+          {format: 'snorm16x4', offset: 1880, shaderLocation: 4},
+          {format: 'float32x4', offset: 6780, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 1992, shaderLocation: 22},
+          {format: 'unorm16x4', offset: 1724, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 7824, shaderLocation: 11},
+          {format: 'uint32', offset: 3580, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 2140, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 14908,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32', offset: 4968, shaderLocation: 18}],
+      },
+      {arrayStride: 53724, stepMode: 'instance', attributes: []},
+      {arrayStride: 26844, attributes: []},
+      {
+        arrayStride: 12724,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x4', offset: 1492, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+canvas7.width = 2996;
+let shaderModule11 = device0.createShaderModule({
+  label: '\u0763\u9db2\u4a1a\uc3b5\ufa1b\u2c3f\ucb79\u9b67\ufb88\u03c4',
+  code: `@group(0) @binding(3920)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(398)
+var<storage, read_write> type6: array<u32>;
+@group(0) @binding(3959)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(24) f0: vec3<f16>,
+  @builtin(instance_index) f1: u32,
+  @location(9) f2: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(19) a0: i32, @location(15) a1: f16, @location(1) a2: f32, @location(7) a3: u32, @location(23) a4: vec4<f16>, @builtin(vertex_index) a5: u32, a6: S16, @location(11) a7: vec3<f16>, @location(14) a8: vec3<i32>, @location(13) a9: i32, @location(25) a10: vec3<u32>, @location(8) a11: vec4<f32>, @location(10) a12: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout25 = pipeline36.getBindGroupLayout(0);
+let commandEncoder81 = device0.createCommandEncoder({label: '\u0ec8\u{1f881}\u0729\u2675\u0f61\u3740\u0b65\u7f0f\u0f5c\u{1ff92}\u443f'});
+let textureView98 = texture27.createView({label: '\u97b3\u0251\ub734\uca0f\udabe\u4fcf\u{1fd37}\u{1f7f5}\u0538', aspect: 'all'});
+try {
+renderBundleEncoder14.drawIndexed(549356822, 526936260, 426546019, -94381536, 733426528);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexedIndirect(buffer8, 241808);
+} catch {}
+try {
+renderBundleEncoder14.drawIndirect(buffer14, 276);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer12, 58384, 48108);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet30, 15, 178, buffer14, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 40, y: 209 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let canvas9 = document.createElement('canvas');
+let imageData8 = new ImageData(212, 92);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+gc();
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 256, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 1712, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder82 = device0.createCommandEncoder({label: '\u0c36\ud6af\ubf6a\ue138\u309f\u01d8'});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 873});
+let texture53 = device0.createTexture({
+  label: '\ucb12\u{1f99e}\u{1fa9d}\uc8a9\u{1fbb6}\u0b39\u{1f615}',
+  size: [864, 48, 1],
+  mipLevelCount: 9,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+try {
+renderBundleEncoder35.setBindGroup(4, bindGroup10, new Uint32Array(9566), 6535, 0);
+} catch {}
+try {
+renderBundleEncoder14.draw(1207742761, 1101941515, 907803297);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(1032895509, 1031983820, 361993443, 16585690, 102363779);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexedIndirect(buffer14, 1052);
+} catch {}
+try {
+renderBundleEncoder32.setIndexBuffer(buffer7, 'uint32', 44356, 47853);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 148, y: 12, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 1084, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 356, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let canvas10 = document.createElement('canvas');
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+try {
+externalTexture36.label = '\u3857\ua58b\u15bb\u043f\u8f6e';
+} catch {}
+let imageData9 = new ImageData(176, 96);
+document.body.prepend(video5);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+let offscreenCanvas17 = new OffscreenCanvas(127, 524);
+let promise13 = adapter3.requestAdapterInfo();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise13;
+} catch {}
+try {
+canvas10.getContext('webgpu');
+} catch {}
+let canvas11 = document.createElement('canvas');
+offscreenCanvas11.width = 1048;
+let gpuCanvasContext11 = offscreenCanvas12.getContext('webgpu');
+let adapter4 = await navigator.gpu.requestAdapter({});
+let img14 = await imageWithData(206, 185, '#478189d5', '#19d120a7');
+let img15 = await imageWithData(177, 16, '#8b1d397e', '#48742506');
+let imageData10 = new ImageData(124, 36);
+let videoFrame7 = new VideoFrame(img7, {timestamp: 0});
+let videoFrame8 = new VideoFrame(img8, {timestamp: 0});
+try {
+textureView59.label = '\u06db\u39cf';
+} catch {}
+let img16 = await imageWithData(217, 41, '#31b9f9bd', '#e77cd3c5');
+let promise14 = adapter2.requestAdapterInfo();
+let textureView99 = texture44.createView({label: '\u{1f9af}\u640b\u034a\ufeaa\ua632', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+try {
+renderBundleEncoder32.setPipeline(pipeline39);
+} catch {}
+let promise15 = buffer16.mapAsync(GPUMapMode.WRITE, 816, 17724);
+try {
+commandEncoder53.clearBuffer(buffer10, 12580, 31312);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 5319 */
+{offset: 951, rowsPerImage: 227}, {width: 273, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline52 = device0.createComputePipeline({
+  label: '\u{1fc3e}\u7008\u9132\u0b61\ue05c\u0484',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+let pipeline53 = await promise12;
+let video8 = await videoWithData();
+document.body.prepend(img2);
+try {
+offscreenCanvas16.getContext('webgl2');
+} catch {}
+let videoFrame9 = new VideoFrame(canvas5, {timestamp: 0});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let canvas12 = document.createElement('canvas');
+let videoFrame10 = new VideoFrame(img4, {timestamp: 0});
+let offscreenCanvas18 = new OffscreenCanvas(945, 815);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let video9 = await videoWithData();
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+try {
+  await promise15;
+} catch {}
+video1.width = 267;
+let videoFrame11 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+  await promise14;
+} catch {}
+try {
+window.someLabel = textureView17.label;
+} catch {}
+try {
+canvas11.getContext('webgpu');
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(965, 849);
+let promise16 = adapter0.requestAdapterInfo();
+try {
+  await promise16;
+} catch {}
+let canvas13 = document.createElement('canvas');
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(889, 964);
+try {
+offscreenCanvas19.getContext('webgpu');
+} catch {}
+document.body.prepend(video5);
+let offscreenCanvas21 = new OffscreenCanvas(703, 162);
+let imageData11 = new ImageData(172, 44);
+let img17 = await imageWithData(230, 199, '#9f611e6b', '#58f84076');
+try {
+offscreenCanvas15.getContext('2d');
+} catch {}
+try {
+offscreenCanvas18.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let video10 = await videoWithData();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let gpuCanvasContext12 = canvas9.getContext('webgpu');
+gc();
+let imageBitmap6 = await createImageBitmap(offscreenCanvas7);
+let textureView100 = texture37.createView({label: '\ub199\u99c5\u0e36\u4b55\u774b\ud73e', mipLevelCount: 1});
+let renderBundle40 = renderBundleEncoder16.finish({label: '\ue810\u0012\u55bf\u5e6f\u15cf\u7482\ud9be\u43ab\u0cef\ucb9d'});
+try {
+computePassEncoder17.dispatchWorkgroups(1, 5, 2);
+} catch {}
+try {
+renderBundleEncoder14.drawIndirect(buffer8, 10572);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer15, 'uint32', 89696, 8721);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+canvas13.getContext('webgl');
+} catch {}
+let imageData12 = new ImageData(148, 44);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+offscreenCanvas14.getContext('webgl2');
+} catch {}
+gc();
+let video11 = await videoWithData();
+try {
+offscreenCanvas17.getContext('bitmaprenderer');
+} catch {}
+document.body.prepend(img17);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(494, 784);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let adapter5 = await promise2;
+try {
+externalTexture10.label = '\u{1fa58}\u7052\uec54\u0634\u{1fcb8}\uf685\u9eb9\uf43c\u84fa';
+} catch {}
+let imageBitmap7 = await createImageBitmap(canvas2);
+let gpuCanvasContext13 = canvas12.getContext('webgpu');
+let offscreenCanvas23 = new OffscreenCanvas(877, 172);
+try {
+device0.queue.label = '\u0c2a\u6e98';
+} catch {}
+let imageBitmap8 = await createImageBitmap(offscreenCanvas4);
+let querySet35 = device0.createQuerySet({label: '\u{1fc96}\u9335\u{1fe97}\u{1f732}\u34bb\uaeb8', type: 'occlusion', count: 856});
+let textureView101 = texture41.createView({label: '\u0e64\u2313\u4007\u1e5a', baseMipLevel: 6, mipLevelCount: 2});
+try {
+commandEncoder79.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 57, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 664, new BigUint64Array(1138), 427, 80);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 280 */
+{offset: 280}, {width: 221, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas22.getContext('webgpu');
+let bindGroup16 = device0.createBindGroup({layout: bindGroupLayout12, entries: []});
+let computePassEncoder37 = commandEncoder53.beginComputePass({label: '\uf98c\u{1fcb8}'});
+let renderBundle41 = renderBundleEncoder32.finish({label: '\u7959\u9ea9\uefb9\ud6a1'});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup16, new Uint32Array(5009), 4072, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 38},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 1503568 */
+{offset: 136, bytesPerRow: 471, rowsPerImage: 152}, {width: 67, height: 0, depthOrArrayLayers: 22});
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas23.getContext('webgpu');
+gc();
+let gpuCanvasContext16 = offscreenCanvas20.getContext('webgpu');
+let gpuCanvasContext17 = offscreenCanvas21.getContext('webgpu');
+let videoFrame12 = new VideoFrame(video8, {timestamp: 0});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\u7d56\u{1f647}',
+  colorFormats: ['rgba32float', undefined, 'rgba8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let externalTexture45 = device0.importExternalTexture({label: '\u{1fb00}\u{1f606}\u05df\u0e31', source: videoFrame4, colorSpace: 'srgb'});
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 3568 widthInBlocks: 223 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16992 */
+  offset: 13424,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 230, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 223, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 147544, new BigUint64Array(64713), 56142, 2740);
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  label: '\u256a\u0211\u09ae\ud4ce\u0bfb\ucb5e\u05e4',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, undefined, {format: 'rgba8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'always', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilWriteMask: 3007720761,
+    depthBias: 1895327907,
+    depthBiasSlopeScale: 752.3032903878005,
+    depthBiasClamp: 462.8382087344271,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 21728,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 10104, shaderLocation: 12},
+          {format: 'uint32x3', offset: 1612, shaderLocation: 1},
+          {format: 'sint8x4', offset: 3104, shaderLocation: 24},
+          {format: 'sint8x4', offset: 72, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 3864, shaderLocation: 5},
+          {format: 'float32x4', offset: 1388, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 5852, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 760, shaderLocation: 23},
+          {format: 'float32x2', offset: 2580, shaderLocation: 20},
+          {format: 'unorm16x4', offset: 12804, shaderLocation: 21},
+          {format: 'uint16x2', offset: 3100, shaderLocation: 3},
+          {format: 'sint32x3', offset: 12108, shaderLocation: 19},
+          {format: 'float32', offset: 5992, shaderLocation: 26},
+          {format: 'uint16x4', offset: 9252, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 2040,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 626, shaderLocation: 10},
+          {format: 'float32x3', offset: 240, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 7380,
+        attributes: [
+          {format: 'float16x2', offset: 768, shaderLocation: 15},
+          {format: 'float32x4', offset: 656, shaderLocation: 7},
+          {format: 'sint16x4', offset: 532, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 1144, shaderLocation: 25},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', unclippedDepth: true},
+});
+offscreenCanvas5.width = 690;
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+offscreenCanvas10.height = 160;
+let imageData13 = new ImageData(172, 240);
+let imageData14 = new ImageData(40, 68);
+let canvas14 = document.createElement('canvas');
+let offscreenCanvas24 = new OffscreenCanvas(152, 681);
+try {
+offscreenCanvas24.getContext('webgl');
+} catch {}
+let videoFrame13 = new VideoFrame(img4, {timestamp: 0});
+offscreenCanvas21.width = 526;
+let canvas15 = document.createElement('canvas');
+let videoFrame14 = new VideoFrame(videoFrame12, {timestamp: 0});
+try {
+adapter5.label = '\u453d\ucd12\u2a71\uc8db';
+} catch {}
+let imageBitmap9 = await createImageBitmap(offscreenCanvas21);
+offscreenCanvas7.width = 78;
+let imageBitmap10 = await createImageBitmap(video5);
+let img18 = await imageWithData(29, 207, '#8df56ba4', '#347082e5');
+let img19 = await imageWithData(50, 161, '#15a90748', '#d43951e8');
+let gpuCanvasContext18 = canvas14.getContext('webgpu');
+let canvas16 = document.createElement('canvas');
+try {
+canvas16.getContext('webgpu');
+} catch {}
+let video12 = await videoWithData();
+canvas4.height = 642;
+let canvas17 = document.createElement('canvas');
+let videoFrame15 = new VideoFrame(canvas17, {timestamp: 0});
+let img20 = await imageWithData(35, 300, '#6ec84915', '#f9e93770');
+let imageData15 = new ImageData(88, 208);
+try {
+canvas15.getContext('webgl2');
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  label: '\u6d6f\u057d\u{1fba5}\u7265\u2ca5\u2fe9\u0b64',
+  code: `@group(1) @binding(402)
+var<storage, read_write> local7: array<u32>;
+@group(0) @binding(4138)
+var<storage, read_write> type7: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<f32>,
+  @location(0) f1: vec2<i32>,
+  @location(3) f2: vec3<u32>,
+  @location(1) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup17 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 402, resource: sampler19}]});
+let pipelineLayout16 = device0.createPipelineLayout({label: '\u5501\ucba1\u59a5\u039e\u{1fcd3}\udc8f\uec5c\u992e\u{1fe3c}', bindGroupLayouts: []});
+let querySet36 = device0.createQuerySet({label: '\uc25a\u{1fb92}\u{1fdc0}\u0fdd\ue1c1\ufd63\u03bf', type: 'occlusion', count: 432});
+let textureView102 = texture7.createView({label: '\u6076\u09a8\uc466\u6f25', dimension: '1d'});
+try {
+renderBundleEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder81.resolveQuerySet(querySet10, 741, 67, buffer14, 512);
+} catch {}
+try {
+canvas17.getContext('webgl');
+} catch {}
+let buffer17 = device0.createBuffer({
+  label: '\u964d\u08f0\u{1fa7d}\u0f24\u0031\u0f84\u0142\u{1f757}',
+  size: 239965,
+  usage: GPUBufferUsage.MAP_WRITE,
+});
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 1854});
+let texture54 = device0.createTexture({
+  label: '\u{1f868}\u77c8\u{1fdf8}\u53a9\ue470',
+  size: [320],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm'],
+});
+let textureView103 = texture6.createView({label: '\u0ca7\ud71d\u1998\u66a4\u07d1\u0365\u727a\u0ab2\ubaab'});
+let renderBundle42 = renderBundleEncoder33.finish();
+try {
+computePassEncoder9.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5116 */
+  offset: 3068,
+  bytesPerRow: 512,
+  rowsPerImage: 4,
+  buffer: buffer0,
+}, {
+  texture: texture31,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer0);
+} catch {}
+gc();
+let offscreenCanvas25 = new OffscreenCanvas(389, 265);
+try {
+offscreenCanvas25.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+document.body.prepend(video9);
+let img21 = await imageWithData(167, 188, '#e50a10ed', '#33905b61');
+let videoFrame16 = new VideoFrame(img20, {timestamp: 0});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+window.someLabel = renderBundle19.label;
+} catch {}
+gc();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+gc();
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+gc();
+gc();
+let texture55 = device0.createTexture({
+  label: '\u1e2e\u0eaf\u{1fa1e}\u{1fda5}',
+  size: [80],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder13.setBindGroup(5, bindGroup8, new Uint32Array(6660), 5438, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer1, 0, 455335);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer5, 55976, 2628);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 50844, new BigUint64Array(26083), 3113, 476);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let canvas18 = document.createElement('canvas');
+let imageBitmap11 = await createImageBitmap(offscreenCanvas24);
+let imageBitmap12 = await createImageBitmap(img3);
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let img22 = await imageWithData(205, 197, '#28842988', '#0b3442e8');
+let canvas19 = document.createElement('canvas');
+gc();
+try {
+canvas18.getContext('webgpu');
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(636, 924);
+try {
+window.someLabel = renderBundleEncoder14.label;
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+canvas7.width = 2927;
+try {
+window.someLabel = externalTexture15.label;
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(242, 402);
+try {
+offscreenCanvas26.getContext('webgpu');
+} catch {}
+canvas7.width = 2521;
+let img23 = await imageWithData(137, 226, '#4ce4b19b', '#b6bab009');
+let imageData16 = new ImageData(180, 40);
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let imageData17 = new ImageData(4, 100);
+let img24 = await imageWithData(101, 177, '#02f2b50d', '#25afae35');
+try {
+canvas19.getContext('2d');
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+canvas20.getContext('webgl');
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(197, 753);
+let video13 = await videoWithData();
+let videoFrame17 = new VideoFrame(img9, {timestamp: 0});
+let imageData18 = new ImageData(20, 56);
+let offscreenCanvas29 = new OffscreenCanvas(432, 398);
+let img25 = await imageWithData(141, 248, '#8cbf3d89', '#dd83bc2a');
+try {
+adapter2.label = '\u06b4\udecb';
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+offscreenCanvas3.height = 46;
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+offscreenCanvas22.width = 1672;
+offscreenCanvas24.width = 1633;
+let imageBitmap13 = await createImageBitmap(videoFrame5);
+let imageData19 = new ImageData(256, 112);
+let gpuCanvasContext19 = offscreenCanvas29.getContext('webgpu');
+let canvas21 = document.createElement('canvas');
+try {
+pipelineLayout3.label = '\uee4c\u{1f9dd}\uf325\u5abc\u{1fb20}\u{1f738}';
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(1001, 618);
+try {
+offscreenCanvas28.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let promise17 = navigator.gpu.requestAdapter({});
+try {
+canvas21.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let canvas22 = document.createElement('canvas');
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let videoFrame18 = new VideoFrame(imageBitmap6, {timestamp: 0});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas23 = document.createElement('canvas');
+let gpuCanvasContext20 = offscreenCanvas27.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+canvas23.getContext('webgl');
+} catch {}
+video0.height = 88;
+let img26 = await imageWithData(235, 183, '#80d68ec8', '#a5a728df');
+let imageBitmap14 = await createImageBitmap(img9);
+let gpuCanvasContext21 = offscreenCanvas30.getContext('webgpu');
+document.body.prepend(canvas7);
+gc();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+document.body.prepend(img18);
+let gpuCanvasContext22 = canvas22.getContext('webgpu');
+offscreenCanvas3.height = 6578;
+document.body.prepend(video8);
+try {
+window.someLabel = commandEncoder36.label;
+} catch {}
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend(video7);
+let videoFrame19 = new VideoFrame(img1, {timestamp: 0});
+let imageData20 = new ImageData(152, 204);
+let videoFrame20 = new VideoFrame(canvas10, {timestamp: 0});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+canvas22.width = 396;
+gc();
+let offscreenCanvas31 = new OffscreenCanvas(266, 44);
+let video14 = await videoWithData();
+let videoFrame21 = new VideoFrame(canvas11, {timestamp: 0});
+try {
+offscreenCanvas31.getContext('webgpu');
+} catch {}
+canvas16.height = 2734;
+let canvas24 = document.createElement('canvas');
+let gpuCanvasContext23 = canvas24.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let promise18 = adapter4.requestAdapterInfo();
+try {
+  await promise18;
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u3286\u{1ff72}\u0f3f\u{1f7c8}\u0eca\u{1fd54}\ub340',
+  code: `@group(4) @binding(4109)
+var<storage, read_write> field9: array<u32>;
+@group(3) @binding(86)
+var<storage, read_write> global6: array<u32>;
+@group(2) @binding(4109)
+var<storage, read_write> parameter6: array<u32>;
+@group(3) @binding(582)
+var<storage, read_write> global7: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(2) f2: vec2<f32>,
+  @location(0) f3: vec3<i32>,
+  @location(3) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(0) f0: vec3<f16>,
+  @location(22) f1: vec4<f32>,
+  @location(20) f2: vec3<u32>,
+  @location(11) f3: vec3<f32>,
+  @location(7) f4: vec4<f32>,
+  @location(15) f5: f16,
+  @location(3) f6: vec4<f16>,
+  @location(1) f7: vec2<i32>,
+  @location(18) f8: vec3<u32>,
+  @location(24) f9: f16,
+  @location(17) f10: i32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f32>, @location(12) a1: vec2<u32>, @location(14) a2: i32, @location(23) a3: vec2<i32>, @location(13) a4: vec2<f16>, @location(19) a5: f32, @location(2) a6: f32, a7: S17, @location(25) a8: vec4<f16>, @location(16) a9: vec3<u32>, @builtin(vertex_index) a10: u32, @location(4) a11: vec4<i32>, @location(6) a12: f32, @location(9) a13: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup18 = device0.createBindGroup({label: '\uccf3\u9a6a', layout: bindGroupLayout10, entries: [{binding: 402, resource: sampler31}]});
+let texture56 = device0.createTexture({
+  label: '\u2852\u1b4c',
+  size: {width: 80, height: 1, depthOrArrayLayers: 2036},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView104 = texture33.createView({label: '\u5b9b\u09a2\u929b'});
+let computePassEncoder38 = commandEncoder66.beginComputePass({});
+let renderBundle43 = renderBundleEncoder21.finish({label: '\ucbf3\uf37f\udd51\u8fc9\ue903\u9ff4\uf0c8\ubf94'});
+try {
+computePassEncoder25.dispatchWorkgroups(2, 5);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer14, 84);
+} catch {}
+let promise19 = adapter4.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 62,
+    maxVertexAttributes: 23,
+    maxVertexBufferArrayStride: 13299,
+    maxStorageTexturesPerShaderStage: 21,
+    maxStorageBuffersPerShaderStage: 24,
+    maxDynamicStorageBuffersPerPipelineLayout: 42978,
+    maxDynamicUniformBuffersPerPipelineLayout: 35198,
+    maxBindingsPerBindGroup: 3060,
+    maxTextureArrayLayers: 1754,
+    maxTextureDimension1D: 16266,
+    maxTextureDimension2D: 15156,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 98125755,
+    maxUniformBuffersPerShaderStage: 18,
+    maxSampledTexturesPerShaderStage: 21,
+    maxInterStageShaderVariables: 28,
+    maxInterStageShaderComponents: 81,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas1);
+try {
+commandEncoder33.label = '\u{1fba6}\u0167\u0091\u{1fbf4}\u{1fc16}';
+} catch {}
+try {
+adapter5.label = '\u855f\u0597';
+} catch {}
+let img27 = await imageWithData(115, 167, '#095bae04', '#c5b5e199');
+let video15 = await videoWithData();
+try {
+bindGroup3.label = '\u{1fd4a}\u{1f8f0}\ue938';
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(988, 505);
+let video16 = await videoWithData();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas32.getContext('webgpu');
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(480, 723);
+let imageBitmap15 = await createImageBitmap(imageBitmap2);
+let promise20 = adapter0.requestAdapterInfo();
+try {
+externalTexture10.label = '\u4cb1\u{1ffc9}\u6c7e';
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas33.getContext('webgpu');
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+gc();
+let video17 = await videoWithData();
+let promise21 = navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+try {
+  await promise20;
+} catch {}
+let canvas25 = document.createElement('canvas');
+let video18 = await videoWithData();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let img28 = await imageWithData(4, 141, '#c07f0fe6', '#d8eca6ee');
+let promise22 = adapter3.requestAdapterInfo();
+try {
+externalTexture26.label = '\uc636\uea4f\uce8b\u0e8c\u{1f85c}';
+} catch {}
+let canvas26 = document.createElement('canvas');
+let video19 = await videoWithData();
+try {
+canvas26.getContext('webgpu');
+} catch {}
+let gpuCanvasContext25 = canvas25.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let buffer18 = device0.createBuffer({
+  label: '\u{1fa3e}\u14f4\ua23d\ud71b\u0209\uc958\u0634',
+  size: 173420,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let textureView105 = texture44.createView({
+  label: '\u{1f638}\u03de\uc7f9\u53c4\u8cd6',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle44 = renderBundleEncoder12.finish({label: '\u0532\u4428\ua13d\u9a32\ud90b\u0693\uec4c\uf297\uc26a\u75bb'});
+try {
+computePassEncoder34.setPipeline(pipeline42);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(1107757075, 781092507, 923831231);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer14, 592);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(5, buffer1, 0, 384816);
+} catch {}
+offscreenCanvas32.height = 490;
+let video20 = await videoWithData();
+document.body.prepend(canvas10);
+try {
+renderBundleEncoder9.draw(408807715, 202182241, 475738470, 1152713393);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(638714238, 766580772, 850645732, -1017040121, 842508352);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer14, 344);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer5, 'uint32', 35716, 18525);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(2, buffer1, 57820, 168147);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer7, 34572, buffer11, 113052, 42788);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder75.clearBuffer(buffer6, 92228, 4968);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline55 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}}});
+document.body.prepend(canvas7);
+gc();
+let video21 = await videoWithData();
+document.body.prepend(canvas24);
+gc();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let imageData21 = new ImageData(48, 168);
+let promise23 = adapter4.requestAdapterInfo();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video7);
+try {
+window.someLabel = buffer18.label;
+} catch {}
+video7.height = 88;
+video15.height = 43;
+canvas24.height = 22;
+let canvas27 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+try {
+  await promise22;
+} catch {}
+gc();
+let canvas28 = document.createElement('canvas');
+let imageBitmap16 = await createImageBitmap(img23);
+document.body.prepend(video0);
+video21.height = 166;
+let img29 = await imageWithData(93, 83, '#06d28218', '#1610aca7');
+let gpuCanvasContext26 = canvas28.getContext('webgpu');
+gc();
+let texture57 = device0.createTexture({
+  label: '\u0928\u0834\ua163\u070a\u04b5\u0266\u11e2',
+  size: [720, 60, 1],
+  mipLevelCount: 10,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+let textureView106 = texture29.createView({label: '\u{1f978}\u{1f6c9}\u{1f8dc}\u2fdb\u74f4\ub8a2', dimension: '2d-array', baseMipLevel: 2});
+let sampler47 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.69,
+  maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(5, buffer1, 450848, 39080);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5256 */
+  offset: 5256,
+  buffer: buffer0,
+}, {
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1536, height: 1, depthOrArrayLayers: 164}
+*/
+{
+  source: img15,
+  origin: { x: 6, y: 4 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap17 = await createImageBitmap(imageData9);
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+window.someLabel = commandEncoder69.label;
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas27.getContext('webgpu');
+} catch {}
+gc();
+let device1 = await promise19;
+let video22 = await videoWithData();
+let videoFrame22 = new VideoFrame(canvas11, {timestamp: 0});
+let imageData22 = new ImageData(168, 12);
+let texture58 = device1.createTexture({
+  label: '\u{1f625}\u{1fd41}\u0e6c\u0afd\u95f2',
+  size: [704, 64, 1290],
+  format: 'eac-rg11snorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView107 = texture58.createView({
+  label: '\u5f72\u87e5\u{1fd32}\u{1fad2}',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'eac-rg11snorm',
+  baseMipLevel: 0,
+  baseArrayLayer: 1181,
+  arrayLayerCount: 1,
+});
+try {
+  await promise23;
+} catch {}
+let commandEncoder83 = device1.createCommandEncoder();
+let textureView108 = texture58.createView({label: '\u1e8e\u0ff3\u0122\u9a2c\u0f92\u0f67', baseArrayLayer: 1112, arrayLayerCount: 152});
+let renderBundleEncoder43 = device1.createRenderBundleEncoder({
+  label: '\u0067\u2333\u18d6\u49f9',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle45 = renderBundleEncoder43.finish({});
+let adapter6 = await navigator.gpu.requestAdapter({});
+let querySet38 = device0.createQuerySet({label: '\u0ce9\u03d7\u4a28', type: 'occlusion', count: 3471});
+let commandBuffer13 = commandEncoder56.finish({label: '\u0f0c\u8d1d\ubb3f\u{1f8c5}\u03c2\u{1f81b}\u04b6\ube04'});
+let texture59 = device0.createTexture({
+  label: '\u074c\u4d88\u0792\u08eb\u0286\u4256',
+  size: {width: 768},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler48 = device0.createSampler({
+  label: '\u{1fe08}\u0871\ub8de\u56b1\u{1fa5e}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 37.13,
+  lodMaxClamp: 58.92,
+});
+try {
+renderBundleEncoder9.drawIndexed(315744664, 945457643, 334349347, -669315183, 1167658917);
+} catch {}
+let arrayBuffer7 = buffer9.getMappedRange(126696, 304);
+try {
+commandEncoder75.resolveQuerySet(querySet33, 1297, 157, buffer14, 256);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 120}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 271, y: 7 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet39 = device1.createQuerySet({label: '\u3375\u609c\uf333\u08f7', type: 'occlusion', count: 3158});
+let commandBuffer14 = commandEncoder83.finish();
+let textureView109 = texture58.createView({label: '\uf776\u8031\u64c7\u0807\u{1f95c}\u{1fea0}\u6cd8\ude87', dimension: '2d', baseArrayLayer: 690});
+let externalTexture46 = device1.importExternalTexture({source: video9, colorSpace: 'srgb'});
+let texture60 = device1.createTexture({
+  label: '\u0f09\u079b\u0682\u4463\ue702\u0d45\u{1ff6b}',
+  size: {width: 176, height: 16, depthOrArrayLayers: 1246},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView110 = texture60.createView({label: '\ucd92\u6d36\u{1fdc5}\udbcf\ua267', baseMipLevel: 1, mipLevelCount: 1});
+let textureView111 = texture58.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 491});
+let renderBundle46 = renderBundleEncoder43.finish({});
+let externalTexture47 = device1.importExternalTexture({source: video19, colorSpace: 'srgb'});
+offscreenCanvas32.width = 31;
+let sampler49 = device1.createSampler({
+  label: '\u87d0\ufbd7\u033f\u7155\u7252',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.92,
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let querySet40 = device1.createQuerySet({label: '\u803d\u{1f9a9}\u{1f8f1}\u04e8\u8356\u09e1\u4109\u0453\u0be6', type: 'occlusion', count: 2993});
+let canvas29 = document.createElement('canvas');
+let promise24 = adapter3.requestAdapterInfo();
+let commandEncoder84 = device1.createCommandEncoder({label: '\u{1fee7}\u4c63\u{1f7a2}\u9420\u63cd\u0678'});
+let renderBundle47 = renderBundleEncoder43.finish();
+try {
+commandEncoder84.pushDebugGroup('\u{1f7ce}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 24},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(24)), /* required buffer size: 13709344 */
+{offset: 402, bytesPerRow: 257, rowsPerImage: 254}, {width: 24, height: 3, depthOrArrayLayers: 211});
+} catch {}
+let canvas30 = document.createElement('canvas');
+let video23 = await videoWithData();
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let textureView112 = texture60.createView({label: '\u24cb\u00e9', format: 'r16sint', baseMipLevel: 1});
+let renderBundle48 = renderBundleEncoder43.finish({label: '\ufe06\u090a\u229d\ua60e\u5523'});
+let sampler50 = device1.createSampler({
+  label: '\u{1fd9b}\u0a49\u3d35\u0c82\uca2c\uddde\u{1f7bf}\u6063\u38a7\u0e9a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 66.31,
+  lodMaxClamp: 83.36,
+  compare: 'greater',
+});
+let externalTexture48 = device1.importExternalTexture({label: '\u2e4c\u{1fa87}\u94e9\u0481', source: videoFrame15, colorSpace: 'srgb'});
+let gpuCanvasContext27 = canvas30.getContext('webgpu');
+let video24 = await videoWithData();
+let imageBitmap18 = await createImageBitmap(canvas7);
+try {
+adapter2.label = '\u0ab1\u0bd4';
+} catch {}
+let texture61 = device1.createTexture({
+  label: '\u{1f723}\ubbb0\u{1f64b}\u9c77\u{1fee9}\uc224\u{1fd46}\u0f3b\u{1fdd5}\uff19\u49e5',
+  size: [1389, 1, 17],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+try {
+commandEncoder84.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 43},
+  aspect: 'all',
+}, new ArrayBuffer(6055974), /* required buffer size: 6055974 */
+{offset: 461, bytesPerRow: 155, rowsPerImage: 279}, {width: 64, height: 8, depthOrArrayLayers: 141});
+} catch {}
+try {
+canvas29.getContext('webgpu');
+} catch {}
+let imageData23 = new ImageData(36, 108);
+let commandEncoder85 = device1.createCommandEncoder({label: '\u63d1\u54c5\u7588\uf15b\u{1fd6b}\u{1f6b8}\u{1f7b3}\u8d4e\u662b'});
+let texture62 = device1.createTexture({
+  label: '\ud7ec\u{1f9cf}\u084e\u7d52\u79a0\u0dbf\ue76b\u3be0\u0872',
+  size: [176, 16, 2021],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let textureView113 = texture61.createView({label: '\u12e5\u0f65\u0f39\u0ee1\u2255\u{1fff1}\u210a', aspect: 'all'});
+let renderBundle49 = renderBundleEncoder43.finish({label: '\ufcc8\u{1f898}\ub8ef\u0419\u7ede\u111c'});
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder86 = device1.createCommandEncoder({});
+let textureView114 = texture62.createView({
+  label: '\u8545\u77e9\ue4e9\u04d3\ud9f3\u9091\u{1fc1e}\u{1f759}\uf7f1\ubdcd',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let computePassEncoder39 = commandEncoder84.beginComputePass({label: '\uf7e9\u0eed\u0f53\u03ff\u54d0'});
+let querySet41 = device1.createQuerySet({type: 'occlusion', count: 681});
+let texture63 = device1.createTexture({
+  label: '\u{1f85b}\u0da4\ue4b3\ueb6d\ud04a\u4560\u02e8\u72bf\u{1f9fe}\u0a0f\u0498',
+  size: {width: 2778, height: 3, depthOrArrayLayers: 189},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let video25 = await videoWithData();
+let texture64 = device1.createTexture({
+  label: '\ufc09\u5ed0\u{1f745}',
+  size: [5556],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder44 = device1.createRenderBundleEncoder({
+  label: '\u0e32\u0dd3\u096e\u0e40\ue45c\u064c\u0819\u5c02\u0e99\u1bcd\u{1fcca}',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler51 = device1.createSampler({
+  label: '\u437b\u{1f753}\ua1de',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.96,
+  lodMaxClamp: 18.96,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder44.setVertexBuffer(6963, undefined, 0, 3933970451);
+} catch {}
+try {
+adapter5.label = '\u9a6c\u123a\u05e8\u8f22';
+} catch {}
+let buffer19 = device1.createBuffer({label: '\u{1f9fc}\ueac0\u6866\u437f', size: 225822, usage: GPUBufferUsage.COPY_SRC});
+let querySet42 = device1.createQuerySet({label: '\u0257\u09f1', type: 'occlusion', count: 3254});
+let texture65 = device1.createTexture({
+  label: '\u0d0a\u{1ff9b}\u{1fec9}',
+  size: {width: 704, height: 64, depthOrArrayLayers: 86},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView115 = texture61.createView({label: '\u051f\u2d20\u0ebb\ud003\uac0a\ub487\u{1ff6b}\u4f45', baseMipLevel: 1});
+document.body.prepend(canvas23);
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+document.body.prepend(video10);
+let commandEncoder87 = device1.createCommandEncoder({});
+let querySet43 = device1.createQuerySet({label: '\u1c60\u0e14\u123d', type: 'occlusion', count: 1705});
+let texture66 = device1.createTexture({
+  size: {width: 694},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let renderBundle50 = renderBundleEncoder44.finish({label: '\u05aa\ua8b3\u1ba8\u0865'});
+try {
+  await promise24;
+} catch {}
+let buffer20 = device1.createBuffer({label: '\u8ec2\u0b7a', size: 352589, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder88 = device1.createCommandEncoder({});
+let texture67 = device1.createTexture({
+  label: '\u{1fb7b}\u4126\u029c\u{1f60e}\u{1fac2}\u0891\u0213\u5fe5\u0d8a',
+  size: [352, 32, 733],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let textureView116 = texture64.createView({label: '\u31e2\u0d33\u5802\u1689\uf9b2\ue334', aspect: 'all', baseArrayLayer: 0});
+let sampler52 = device1.createSampler({
+  label: '\u0334\u{1fc90}\u0210\u856f\u0d0a\u{1f7bf}\u{1f7f2}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.10,
+  lodMaxClamp: 98.24,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder39.end();
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageBitmap4);
+let commandEncoder89 = device1.createCommandEncoder({label: '\u0ece\u1727\udf7f\u8d03\u0c7f'});
+let textureView117 = texture58.createView({label: '\u{1f645}\u{1fce8}\u{1fc20}\ua44c\u{1ff7a}', baseArrayLayer: 1168, arrayLayerCount: 88});
+let computePassEncoder40 = commandEncoder86.beginComputePass({label: '\u727d\u0dc7\u0603'});
+let sampler53 = device1.createSampler({
+  label: '\u{1ffa7}\u4bfe',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 53.50,
+  lodMaxClamp: 80.66,
+});
+let externalTexture49 = device1.importExternalTexture({
+  label: '\u{1fbda}\u{1f74c}\u7292\u{1fc08}\u648d\u0dfb\u0f8d\ub39f\u{1f871}',
+  source: video25,
+  colorSpace: 'srgb',
+});
+try {
+device1.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 11},
+  aspect: 'all',
+}, new ArrayBuffer(1548914), /* required buffer size: 1548914 */
+{offset: 278, bytesPerRow: 186, rowsPerImage: 29}, {width: 0, height: 4, depthOrArrayLayers: 288});
+} catch {}
+try {
+window.someLabel = renderBundleEncoder43.label;
+} catch {}
+let commandEncoder90 = device1.createCommandEncoder({label: '\uacab\u{1f871}\ufa42\u77bb\u0152\u0e1e\ue33f\u0007\u0c8f\uda43\uebc5'});
+let textureView118 = texture67.createView({dimension: '3d', baseMipLevel: 1, mipLevelCount: 3, arrayLayerCount: 1});
+let sampler54 = device1.createSampler({
+  label: '\u2e8d\u090b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 34.13,
+  lodMaxClamp: 40.95,
+  compare: 'never',
+});
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 444, y: 1, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 221, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 41, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+textureView107.label = '\u00ef\ufb98\u{1ff60}\u7202\ud162\u0e2b';
+} catch {}
+let commandEncoder91 = device1.createCommandEncoder({});
+let textureView119 = texture58.createView({label: '\u0085\u0e12\u2848\u642f\u4a21', dimension: '2d', baseArrayLayer: 314});
+let computePassEncoder41 = commandEncoder85.beginComputePass({});
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 0, y: 9, z: 40},
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 165, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 234, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 414 */
+{offset: 414}, {width: 3728, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas31 = document.createElement('canvas');
+let video26 = await videoWithData();
+let texture68 = device1.createTexture({
+  label: '\u418d\u78f9\u04a0',
+  size: [2778],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16sint'],
+});
+let textureView120 = texture60.createView({label: '\u30dc\ua4fc\u06c8\u6bfc\u{1fb35}\ucbfd\u0756\u0f2c\ua09b'});
+try {
+device1.queue.submit([commandBuffer14]);
+} catch {}
+let querySet44 = device1.createQuerySet({
+  label: '\u{1fa97}\ue714\u077d\u0574\uaba6\u7328\ud55a\u178d\u6335\uf850\u842f',
+  type: 'occlusion',
+  count: 1052,
+});
+let texture69 = device1.createTexture({
+  label: '\u{1f808}\u8791\u{1f713}',
+  size: {width: 176, height: 16, depthOrArrayLayers: 143},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView121 = texture61.createView({label: '\u3027\ue7b4', dimension: '3d', mipLevelCount: 1});
+let externalTexture50 = device1.importExternalTexture({source: videoFrame13, colorSpace: 'display-p3'});
+try {
+querySet41.destroy();
+} catch {}
+let imageData24 = new ImageData(116, 152);
+let gpuCanvasContext28 = canvas31.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let querySet45 = device1.createQuerySet({label: '\u9a18\u0f9f\u7177\uece5\u91f8\u0afe\ucc1f', type: 'occlusion', count: 2970});
+let textureView122 = texture64.createView({label: '\u96d7\ub995\u{1f839}\u0fb9\u{1f8b8}\u{1fab5}\u0057\u7752\u{1f7a1}\u53ee\u0e7f'});
+let externalTexture51 = device1.importExternalTexture({
+  label: '\u06ae\u949d\u{1fc05}\u{1f73c}\u0ea3\u95b8\u053e',
+  source: videoFrame14,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 2520 widthInBlocks: 315 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 38368 */
+  offset: 38368,
+  bytesPerRow: 2816,
+  rowsPerImage: 300,
+  buffer: buffer19,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 315, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+let querySet46 = device1.createQuerySet({type: 'occlusion', count: 3125});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 110, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 21, y: 0, z: 27},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+video11.width = 28;
+offscreenCanvas29.width = 242;
+let bindGroup19 = device0.createBindGroup({
+  label: '\u0d6f\ud447\u0928\uf040',
+  layout: bindGroupLayout16,
+  entries: [{binding: 2899, resource: sampler19}],
+});
+let querySet47 = device0.createQuerySet({label: '\u01a8\u0f7a\u0932', type: 'occlusion', count: 4041});
+let textureView123 = texture3.createView({label: '\u452e\u02f3\u04e2\u0f32\u1ff5', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder42 = commandEncoder72.beginComputePass({label: '\u1b72\u153b\u3894'});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer8, 346684);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer8, 284460);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 1572 widthInBlocks: 393 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 81276 */
+  offset: 25944,
+  bytesPerRow: 1792,
+  buffer: buffer0,
+}, {
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 269, y: 40, z: 0},
+  aspect: 'all',
+}, {width: 393, height: 31, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 180, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 224, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup('\u0ce4');
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+  label: '\ua084\u{1f693}\u0bc6\u5ef6',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg16float'}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 10380, attributes: []},
+      {arrayStride: 208, attributes: []},
+      {arrayStride: 55748, attributes: [{format: 'unorm8x2', offset: 5506, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+let img30 = await imageWithData(154, 278, '#9df2d664', '#b211dfc5');
+canvas30.height = 329;
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView124 = texture63.createView({label: '\u2c33\u016f\u0351', baseMipLevel: 1, baseArrayLayer: 12, arrayLayerCount: 84});
+let renderBundle51 = renderBundleEncoder43.finish({});
+let externalTexture52 = device1.importExternalTexture({label: '\udbcc\u0db3\u614e', source: video10, colorSpace: 'srgb'});
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 5344 widthInBlocks: 668 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3328 */
+  offset: 3328,
+  bytesPerRow: 5376,
+  buffer: buffer19,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 668, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let bindGroupLayout27 = device1.createBindGroupLayout({
+  label: '\u0ec7\u0226\u044a\ub866\uaca4\ub157\u6f5c',
+  entries: [
+    {
+      binding: 1016,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 2932,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder92 = device1.createCommandEncoder({label: '\u{1fdc1}\uf568\u7682\ue188\u279a\ub87e\u824b\ub3af\u4b0c\u0be6\u{1f8cc}'});
+let querySet48 = device1.createQuerySet({label: '\uc38f\u0d17\u723c\uc454\ufd8e\u967d\u{1fa46}\u2433', type: 'occlusion', count: 235});
+let textureView125 = texture67.createView({
+  label: '\u{1f978}\uc8cf\u5448\u95a8\u{1f85e}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+});
+let sampler55 = device1.createSampler({
+  label: '\u2aac\uc04c\u7b62\u8b91\u{1f7e4}\u0a1d\u6065',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.14,
+  maxAnisotropy: 10,
+});
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 295, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 1, y: 3, z: 75},
+  aspect: 'all',
+},
+{width: 74, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter0.label = '\u5e16\u06ec\udcad\u{1f99d}\u35b2';
+} catch {}
+gc();
+let imageData25 = new ImageData(68, 180);
+let externalTexture53 = device1.importExternalTexture({
+  label: '\ue9b1\u{1f881}\u{1fb6d}\u04dd\u{1fd90}\u{1f988}\uf0f5\u06f8\ue426\u{1fd71}\u129d',
+  source: video13,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext23.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let video27 = await videoWithData();
+let videoFrame23 = new VideoFrame(video4, {timestamp: 0});
+let pipelineLayout17 = device1.createPipelineLayout({bindGroupLayouts: []});
+let textureView126 = texture63.createView({
+  label: '\u0271\u1f7f\u0807\u{1ffcf}\u{1fb76}\uc7c5\ub41a',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 85,
+});
+let renderBundle52 = renderBundleEncoder44.finish({label: '\u00a1\u2a98\ue8e1'});
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 35, y: 7, z: 128},
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 172, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 58607 */
+{offset: 897, bytesPerRow: 229, rowsPerImage: 42}, {width: 1, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let textureView127 = texture66.createView({label: '\u0b61\u014f\u{1fdba}\ubb3a\u{1fc4f}\ub365\u{1f7f5}\u195e\u0ad4\u5e98\u0f40'});
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 1790, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(80)), /* required buffer size: 168 */
+{offset: 168}, {width: 3486, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(965, 151);
+let imageBitmap20 = await createImageBitmap(imageData11);
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\u{1f8ec}\u{1fb25}\u02bd\u0891\u8dc6',
+  entries: [
+    {
+      binding: 1168,
+      visibility: 0,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer21 = device1.createBuffer({
+  label: '\u0750\u0345\u5300\u0b1d\u0f45\u3a4f\u{1fd12}\u52d1\u11a1',
+  size: 283351,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder93 = device1.createCommandEncoder({label: '\u2646\u{1fbf9}'});
+let textureView128 = texture61.createView({label: '\u391b\u08c4\uf786\u85ff\u0c59\u0a7d\u4001', baseMipLevel: 1});
+let sampler56 = device1.createSampler({
+  label: '\ube76\u07c6\u{1fa5b}\uc700\u096b\ue637',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.23,
+  maxAnisotropy: 19,
+});
+let img31 = await imageWithData(192, 248, '#6aa6bcad', '#5acc5ec3');
+let videoFrame24 = new VideoFrame(videoFrame22, {timestamp: 0});
+let commandEncoder94 = device1.createCommandEncoder();
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({label: '\u71e4\ub2a3\u0667\u96d9\u9855', colorFormats: ['r16sint', 'rgba16sint'], depthReadOnly: true});
+try {
+commandEncoder90.copyBufferToBuffer(buffer19, 105468, buffer21, 183504, 35068);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 4516 widthInBlocks: 2258 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21072 */
+  offset: 21072,
+  rowsPerImage: 168,
+  buffer: buffer19,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 2258, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 289, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 26},
+  aspect: 'all',
+},
+{width: 56, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas34.getContext('webgpu');
+let imageBitmap21 = await createImageBitmap(videoFrame22);
+let bindGroupLayout29 = device1.createBindGroupLayout({label: '\uab64\u{1fc82}\u{1f936}\u{1fb94}', entries: []});
+let commandEncoder95 = device1.createCommandEncoder({label: '\u2300\u3f8e\u0e7b\ucd1e\u0890\u{1f89e}\u6b78\u1a1a'});
+let computePassEncoder43 = commandEncoder87.beginComputePass({label: '\u3968\ua60c\u0206\u{1fc0f}\u{1fa31}\u0217\u{1fb31}\u5040\u1841'});
+try {
+commandEncoder90.copyBufferToBuffer(buffer19, 193840, buffer21, 42780, 19384);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 1784 widthInBlocks: 223 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24072 */
+  offset: 22288,
+  bytesPerRow: 2048,
+  buffer: buffer20,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 119, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 223, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet48, 144, 25, buffer21, 225024);
+} catch {}
+let buffer22 = device1.createBuffer({label: '\u{1f83a}\u0c52', size: 154176, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder96 = device1.createCommandEncoder({});
+let sampler57 = device1.createSampler({
+  label: '\u4fc1\u0407',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.42,
+  compare: 'greater',
+});
+try {
+commandEncoder93.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 155},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 864 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 24048 */
+  offset: 3984,
+  bytesPerRow: 1280,
+  buffer: buffer22,
+}, {width: 216, height: 64, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 15},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer6), /* required buffer size: 1232829 */
+{offset: 555, bytesPerRow: 94, rowsPerImage: 58}, {width: 14, height: 2, depthOrArrayLayers: 227});
+} catch {}
+gc();
+let buffer23 = device1.createBuffer({
+  label: '\u9008\u{1fe79}',
+  size: 579489,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let texture70 = device1.createTexture({
+  label: '\u85e3\u066a\ue7b3\u09d8\u1f08\u0965',
+  size: {width: 1408},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler58 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 33.90,
+  lodMaxClamp: 51.11,
+});
+let externalTexture54 = device1.importExternalTexture({label: '\ud10b\ue172\ue3ba\ub5fc\u{1fb5c}', source: video10, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder45.setIndexBuffer(buffer20, 'uint16');
+} catch {}
+let promise25 = buffer23.mapAsync(GPUMapMode.READ, 0, 220588);
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 331502 */
+  offset: 43758,
+  bytesPerRow: 256,
+  rowsPerImage: 281,
+  buffer: buffer20,
+}, {
+  texture: texture62,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 5});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 160, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+offscreenCanvas34.width = 1274;
+let video28 = await videoWithData();
+let promise26 = adapter0.requestAdapterInfo();
+let sampler59 = device1.createSampler({
+  label: '\u689e\u{1fd5f}\ueb0b\u0d87\u40c3',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.22,
+  lodMaxClamp: 80.50,
+  maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder45.setIndexBuffer(buffer20, 'uint16');
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer20, 335752, buffer23, 30700, 6056);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer23);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video8);
+gc();
+let commandEncoder97 = device1.createCommandEncoder({label: '\ua647\u9e96\u1927\u8d40\u8ee3\u9f6b'});
+let sampler60 = device1.createSampler({
+  label: '\u3660\u02d0\ued2d\u{1faba}\u5f3a\u44da\u0bd9\u1d3e',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.40,
+  lodMaxClamp: 31.17,
+  maxAnisotropy: 15,
+});
+let commandEncoder98 = device1.createCommandEncoder({label: '\u{1f60a}\ua5a1\uc887'});
+let textureView129 = texture69.createView({label: '\u8d7d\u7e11\u0c08\u82bf\u0b9f', baseMipLevel: 2, mipLevelCount: 1});
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 3952 widthInBlocks: 1976 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 19698 */
+  offset: 19698,
+  buffer: buffer20,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 510, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1976, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet48, 85, 123, buffer21, 268288);
+} catch {}
+try {
+commandEncoder88.insertDebugMarker('\u{1f7ee}');
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let videoFrame25 = new VideoFrame(canvas12, {timestamp: 0});
+let textureView130 = texture63.createView({
+  label: '\ue2ab\u026f\u06b4\ucbd0\uc3ef\u8d46',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 12,
+  arrayLayerCount: 114,
+});
+let buffer24 = device1.createBuffer({
+  label: '\u{1f80d}\u15cb\u09c9\u2f73\u340b\u{1fc5b}\u05dc\ufbab\u{1ff82}',
+  size: 128533,
+  usage: GPUBufferUsage.COPY_SRC,
+});
+let commandEncoder99 = device1.createCommandEncoder({label: '\ud5f0\uf6eb\u5691\u0900\u0ce9\u{1fd77}\u8462\u039e\u18ef\u{1fb91}'});
+let commandBuffer15 = commandEncoder97.finish({});
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 3840 widthInBlocks: 480 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 17888 */
+  offset: 14048,
+  bytesPerRow: 3840,
+  buffer: buffer24,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 480, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer21, 155852, 26004);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+gpuCanvasContext27.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 151},
+  aspect: 'all',
+}, new ArrayBuffer(16332127), /* required buffer size: 16332127 */
+{offset: 181, bytesPerRow: 443, rowsPerImage: 288}, {width: 154, height: 3, depthOrArrayLayers: 129});
+} catch {}
+let img32 = await imageWithData(60, 153, '#de7432bc', '#d5a60fc3');
+let offscreenCanvas35 = new OffscreenCanvas(55, 137);
+let videoFrame26 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let offscreenCanvas36 = new OffscreenCanvas(720, 901);
+let promise27 = adapter0.requestAdapterInfo();
+let computePassEncoder44 = commandEncoder98.beginComputePass({});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({
+  label: '\u0e96\u{1ff57}',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 45456 */
+  offset: 45456,
+  bytesPerRow: 0,
+  rowsPerImage: 177,
+  buffer: buffer24,
+}, {
+  texture: texture69,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 8});
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2978 widthInBlocks: 1489 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6042 */
+  offset: 6042,
+  bytesPerRow: 3072,
+  buffer: buffer22,
+}, {width: 1489, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+  await promise25;
+} catch {}
+document.body.prepend(canvas26);
+let bindGroupLayout30 = device1.createBindGroupLayout({
+  label: '\u40a8\uf109\u3699\ufaa9',
+  entries: [
+    {binding: 1879, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {binding: 102, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false }},
+    {
+      binding: 1003,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let bindGroup20 = device1.createBindGroup({
+  label: '\u{1fe11}\u02a5\u0666\ub14e\u0f04\u02a9\udaa8\u2aee\uc1c7\u{1fc66}\u76e3',
+  layout: bindGroupLayout29,
+  entries: [],
+});
+let commandEncoder100 = device1.createCommandEncoder({label: '\u{1febe}\u0265\uc369\u046b\u0ea3\u85b0\u543b\u049b\u9f79\u{1fa13}\u0aef'});
+let querySet49 = device1.createQuerySet({label: '\u0383\ua647', type: 'occlusion', count: 2357});
+let textureView131 = texture62.createView({label: '\u053b\uf94d\u{1f613}\u{1ffdc}\uebc2\uab4e', baseMipLevel: 5});
+try {
+commandEncoder86.clearBuffer(buffer23, 147356, 89304);
+dissociateBuffer(device1, buffer23);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet48, 176, 8, buffer21, 202240);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer22, 24500, new Int16Array(57590));
+} catch {}
+try {
+adapter4.label = '\u0e5b\u0ed7\ub551\ue99b\u{1f739}\ua6c3\u0125\u0451';
+} catch {}
+try {
+  await promise26;
+} catch {}
+let bindGroupLayout31 = device1.createBindGroupLayout({
+  label: '\u59b9\u{1fc27}\u40a3',
+  entries: [
+    {binding: 519, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true }},
+    {
+      binding: 1322,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 1366,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder101 = device1.createCommandEncoder({label: '\u{1faa1}\u1b22\u13b2\uc62d\u88c1\ufce6\u3610\u{1f974}\u{1fbe2}'});
+let textureView132 = texture62.createView({
+  label: '\u{1fb7f}\uaaa3\u0761\u{1f887}\u407c\ufcc3\u1c1d\ud1c5\u0b03',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer21, 148220, 63684);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet48, 61, 100, buffer21, 196096);
+} catch {}
+try {
+  await promise27;
+} catch {}
+offscreenCanvas2.height = 5936;
+document.body.prepend(video4);
+let renderBundle53 = renderBundleEncoder44.finish();
+let externalTexture55 = device1.importExternalTexture({label: '\u860a\ufc81\ub5b1\ud4f9\u6121\u062d', source: video27, colorSpace: 'srgb'});
+try {
+computePassEncoder41.setBindGroup(5, bindGroup20);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer21, 194332, 66660);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(querySet45, 1176, 799, buffer21, 215808);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let canvas32 = document.createElement('canvas');
+let offscreenCanvas37 = new OffscreenCanvas(555, 168);
+let imageData26 = new ImageData(64, 180);
+let videoFrame27 = new VideoFrame(canvas19, {timestamp: 0});
+let img33 = await imageWithData(149, 193, '#a3094218', '#6697cb15');
+let imageData27 = new ImageData(132, 136);
+let commandEncoder102 = device1.createCommandEncoder({label: '\u76cf\u0888\u0493\u3c8c'});
+let querySet50 = device1.createQuerySet({label: '\ua6ba\ub95b\u1302\u03c6', type: 'occlusion', count: 616});
+try {
+commandEncoder92.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 40, y: 8, z: 23},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1056 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1984 */
+  offset: 1984,
+  bytesPerRow: 1536,
+  buffer: buffer22,
+}, {width: 264, height: 44, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer22);
+} catch {}
+let videoFrame28 = new VideoFrame(imageBitmap21, {timestamp: 0});
+let bindGroup21 = device1.createBindGroup({label: '\u8469\u{1ff4d}', layout: bindGroupLayout29, entries: []});
+let querySet51 = device1.createQuerySet({label: '\udd7c\u73c4\uc7a9\u6e85\u{1faf7}', type: 'occlusion', count: 2686});
+let texture71 = device1.createTexture({
+  label: '\uc4c1\u6135',
+  size: {width: 352},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView133 = texture66.createView({label: '\u1e8c\u{1f7a5}', baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderBundleEncoder45.setBindGroup(6, bindGroup20);
+} catch {}
+try {
+buffer24.destroy();
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 256, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer21, 36336, 85488);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder89.resolveQuerySet(querySet49, 1434, 726, buffer21, 195840);
+} catch {}
+let canvas33 = document.createElement('canvas');
+try {
+canvas32.getContext('webgl2');
+} catch {}
+let commandEncoder103 = device1.createCommandEncoder({});
+let textureView134 = texture68.createView({label: '\u8aa3\uc50d\u{1fd51}\u15d4\u9a54'});
+let renderBundleEncoder47 = device1.createRenderBundleEncoder({label: '\ubc64\u09a5', colorFormats: ['r16sint', 'rgba16sint']});
+let renderBundle54 = renderBundleEncoder43.finish();
+try {
+renderBundleEncoder45.setBindGroup(5, bindGroup21, []);
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer21, 77940, 138804);
+dissociateBuffer(device1, buffer21);
+} catch {}
+let bindGroup22 = device1.createBindGroup({
+  label: '\u2560\u0efa\u0b9a\u{1f89c}\ubccf\u{1f6d6}\u05df\u66b8\u{1f8a1}\u0e30',
+  layout: bindGroupLayout29,
+  entries: [],
+});
+let commandEncoder104 = device1.createCommandEncoder();
+let computePassEncoder45 = commandEncoder102.beginComputePass({});
+try {
+renderBundleEncoder45.setVertexBuffer(3778, undefined, 2351189586, 137669206);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder103.resolveQuerySet(querySet49, 1026, 997, buffer21, 78336);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 289, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 678 */
+{offset: 678}, {width: 116, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({});
+let imageBitmap22 = await createImageBitmap(offscreenCanvas2);
+let bindGroupLayout32 = device1.createBindGroupLayout({
+  label: '\u{1fd09}\uc90b\u0e50\u047f\u8d52\u{1f668}\u0290\uaf73',
+  entries: [
+    {
+      binding: 2992,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer19, 76104, buffer23, 245584, 72432);
+dissociateBuffer(device1, buffer19);
+dissociateBuffer(device1, buffer23);
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 52, y: 1, z: 44},
+  aspect: 'all',
+},
+{width: 78, height: 4, depthOrArrayLayers: 35});
+} catch {}
+let gpuCanvasContext30 = offscreenCanvas35.getContext('webgpu');
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageBitmap23 = await createImageBitmap(video1);
+let commandEncoder105 = device1.createCommandEncoder({label: '\u30e6\u489a\ub753\u7542\u031a\u8aa2\u{1fa87}\u{1f8a8}\u{1f966}\u0b0b\u081a'});
+let texture72 = device1.createTexture({
+  label: '\u4827\u0590\ub491\u0d0f\u22af\u544b\u1ff4\u0e12\u819c\u4728\u07c8',
+  size: [1408, 128, 1290],
+  mipLevelCount: 5,
+  format: 'rgba16sint',
+  usage: 0,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let textureView135 = texture61.createView({label: '\u{1f99b}\u323e\u6df6\uf79a\u02be\u0e29\u{1fd33}'});
+let computePassEncoder46 = commandEncoder93.beginComputePass({label: '\u0c01\u0aa5'});
+try {
+renderBundleEncoder45.setBindGroup(4, bindGroup20);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 208 widthInBlocks: 104 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 67082 */
+  offset: 17722,
+  bytesPerRow: 256,
+  rowsPerImage: 36,
+  buffer: buffer20,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 471},
+  aspect: 'all',
+}, {width: 104, height: 13, depthOrArrayLayers: 6});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 5,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(158), /* required buffer size: 158 */
+{offset: 158}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+window.someLabel = textureView0.label;
+} catch {}
+document.body.prepend(img28);
+let textureView136 = texture65.createView({label: '\u793e\u073b\u026f\u{1fdcf}\u04a7\u{1f9e6}\u6638\uf657', baseMipLevel: 4, baseArrayLayer: 0});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(5, bindGroup22, new Uint32Array(1063), 1001, 0);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer24, 48008, buffer22, 98148, 31100);
+dissociateBuffer(device1, buffer24);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 377, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 3117 */
+{offset: 455}, {width: 1331, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext31 = canvas33.getContext('webgpu');
+gc();
+let adapter8 = await navigator.gpu.requestAdapter({});
+let bindGroupLayout33 = device1.createBindGroupLayout({
+  label: '\u0480\u{1ff35}\u9235',
+  entries: [
+    {
+      binding: 1731,
+      visibility: 0,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 556, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true }},
+    {binding: 1723, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let buffer25 = device1.createBuffer({
+  label: '\u53ed\uba87\ud763\u4bc9\u0dd4\u{1f730}\u0667\ub02a\u05b3',
+  size: 64335,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder106 = device1.createCommandEncoder({label: '\u7822\u0666'});
+let texture73 = device1.createTexture({
+  label: '\u0555\u{1f955}\u0efe\ufa6b\u{1ffe3}\u5cf5\u{1fde3}\u{1fc2d}\uc0b8',
+  size: {width: 1389},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder96.copyBufferToBuffer(buffer24, 97484, buffer22, 142044, 8248);
+dissociateBuffer(device1, buffer24);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet44, 332, 390, buffer21, 87808);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData28 = new ImageData(156, 64);
+try {
+offscreenCanvas37.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  label: '\u{1fc38}\u0a2d\u5def\u10ab\u5da8\u2ad9\u0341',
+  entries: [
+    {
+      binding: 216,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 2334, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let buffer26 = device1.createBuffer({
+  label: '\ub714\ue8e4\u0d67\u18ca\u0128\u{1ff03}\u3ec2\uc7fb',
+  size: 111163,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+});
+let renderBundleEncoder48 = device1.createRenderBundleEncoder({
+  label: '\u8259\u0abb\u7fae\u45f8\u6bd0\u{1f792}\u5784',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 321, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 63 */
+{offset: 63, bytesPerRow: 290}, {width: 129, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder107 = device1.createCommandEncoder({});
+let texture74 = device1.createTexture({
+  label: '\u2963\u0f5b',
+  size: {width: 704, height: 64, depthOrArrayLayers: 1290},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder47 = commandEncoder91.beginComputePass({});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(buffer24, 112436, buffer23, 234028, 4796);
+dissociateBuffer(device1, buffer24);
+dissociateBuffer(device1, buffer23);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 3736 widthInBlocks: 467 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 48576 */
+  offset: 48576,
+  rowsPerImage: 284,
+  buffer: buffer20,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 467, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 177, y: 0, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 80, height: 1, depthOrArrayLayers: 69});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer21, 94460, new BigUint64Array(43173), 40977, 632);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 9402029 */
+{offset: 45, bytesPerRow: 452, rowsPerImage: 270}, {width: 48, height: 11, depthOrArrayLayers: 78});
+} catch {}
+let imageBitmap24 = await createImageBitmap(imageBitmap9);
+let imageData29 = new ImageData(16, 196);
+let img34 = await imageWithData(27, 108, '#afaf68c1', '#581a23a3');
+let video29 = await videoWithData();
+gc();
+let img35 = await imageWithData(165, 133, '#e97d0122', '#35271dde');
+try {
+offscreenCanvas36.getContext('webgpu');
+} catch {}
+let externalTexture56 = device1.importExternalTexture({label: '\u96db\u{1fb71}\ue209\u8792', source: videoFrame26, colorSpace: 'display-p3'});
+try {
+computePassEncoder44.setBindGroup(5, bindGroup22, new Uint32Array(1366), 360, 0);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer24, 6196, buffer22, 79164, 36860);
+dissociateBuffer(device1, buffer24);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer22, 10156, new BigUint64Array(29622), 29391);
+} catch {}
+let imageData30 = new ImageData(76, 72);
+let textureView137 = texture65.createView({
+  label: '\u02ad\u8825\u{1fe3a}\u{1f689}\u866d\u{1f7cc}\u{1ff47}\u0a9f',
+  aspect: 'all',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+});
+let renderBundle55 = renderBundleEncoder43.finish({label: '\u007d\uf3f8\ue8dc\u0622\u012b\u5c83'});
+let sampler61 = device1.createSampler({
+  label: '\ueda3\ue9e5\u9af6\u{1f96e}\u3aca\u0e0d\u0d4f\u33f8\u{1f7c6}\uc077',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.00,
+  lodMaxClamp: 55.92,
+  compare: 'always',
+});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer24, 26076, buffer21, 179392, 892);
+dissociateBuffer(device1, buffer24);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 3894 widthInBlocks: 1947 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 100000 */
+  offset: 100000,
+  buffer: buffer20,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 435, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1947, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer20);
+} catch {}
+let promise28 = device1.queue.onSubmittedWorkDone();
+let commandEncoder108 = device1.createCommandEncoder({});
+let texture75 = device1.createTexture({
+  label: '\uc975\u0c7b\u00dc\u0fe4',
+  size: {width: 176},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let renderBundleEncoder49 = device1.createRenderBundleEncoder({
+  label: '\u{1f8c9}\u{1f664}\u{1f9bf}\u{1ff0c}\u7af8\u0d50',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder45.setBindGroup(0, bindGroup22, new Uint32Array(3197), 143, 0);
+} catch {}
+let promise29 = buffer25.mapAsync(GPUMapMode.WRITE, 0, 8084);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let canvas34 = document.createElement('canvas');
+let gpuCanvasContext32 = canvas34.getContext('webgpu');
+let videoFrame29 = new VideoFrame(img0, {timestamp: 0});
+let textureView138 = texture67.createView({
+  label: '\u{1f882}\u{1ff55}\u368b\u0d66\u63bb\u409b\ud4fc\ud5b3',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(2, bindGroup21, new Uint32Array(9525), 6195, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder109 = device1.createCommandEncoder({label: '\uc273\u04bf\u055b\u0c2b\u{1f9a2}'});
+let texture76 = device1.createTexture({
+  label: '\u003b\ucb2f\u86c5',
+  size: {width: 694, height: 1, depthOrArrayLayers: 189},
+  mipLevelCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['depth16unorm', 'depth16unorm'],
+});
+let textureView139 = texture60.createView({label: '\u8677\u3758\u407b', baseMipLevel: 1, mipLevelCount: 1});
+let externalTexture57 = device1.importExternalTexture({
+  label: '\u6491\u{1fec4}\u0c46\u8023\u9c58\u0c1d\u{1ff3d}\ua272\u12ea',
+  source: video24,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder46.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+commandEncoder109.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 400 widthInBlocks: 200 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 13624 */
+  offset: 13624,
+  buffer: buffer26,
+}, {width: 200, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer21, 21948, new BigUint64Array(37026), 31993, 952);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2122 */
+{offset: 780}, {width: 671, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let canvas35 = document.createElement('canvas');
+try {
+canvas35.getContext('2d');
+} catch {}
+gc();
+let device2 = await promise0;
+let offscreenCanvas38 = new OffscreenCanvas(615, 900);
+let commandEncoder110 = device1.createCommandEncoder({label: '\u{1f847}\u{1f77f}\u03d8\u11f6\u{1f973}\u03c5\uf2b9\u04e9\u0fde'});
+let sampler62 = device1.createSampler({
+  label: '\u0897\u{1ff2e}\u75c4\u{1f9d5}\u0b8a\u31cb\u{1f9b6}\u03e2\u8218',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 62.68,
+  maxAnisotropy: 5,
+});
+let bindGroup23 = device1.createBindGroup({label: '\u{1fdfd}\u0cbb\u80c1\u3833', layout: bindGroupLayout29, entries: []});
+let texture77 = device1.createTexture({
+  label: '\ua46d\uf0ba\u{1f8dc}\uca89\uff59',
+  size: [5556],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint', 'r16sint'],
+});
+let textureView140 = texture64.createView({label: '\u9460\u04ef\u0212\u0203\u7b0e\u0978\ud4d5\u{1f93d}\u3c62'});
+let renderBundleEncoder50 = device1.createRenderBundleEncoder({
+  label: '\u6081\uf181\u9165\u576c\u{1fb06}\u{1fbce}',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let sampler63 = device1.createSampler({
+  label: '\u{1fc8c}\u076f',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.57,
+});
+let externalTexture58 = device1.importExternalTexture({label: '\u0a2d\u{1f9d3}\u053e\u{1f641}', source: videoFrame15, colorSpace: 'srgb'});
+try {
+commandEncoder90.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 24, y: 12, z: 113},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2128 widthInBlocks: 133 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 31120 */
+  offset: 5952,
+  bytesPerRow: 2560,
+  rowsPerImage: 134,
+  buffer: buffer22,
+}, {width: 532, height: 40, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer22);
+} catch {}
+let commandEncoder111 = device2.createCommandEncoder({label: '\u11bb\u0f58'});
+let querySet52 = device2.createQuerySet({label: '\u5a2d\u0eb5', type: 'occlusion', count: 694});
+let renderBundleEncoder51 = device2.createRenderBundleEncoder({
+  label: '\u5fba\u331f\u0d22\u513e\u{1f9b4}\u0a44\u0007\ud245\uf5de\u{1fea7}',
+  colorFormats: ['r16sint', 'rg32float'],
+});
+try {
+videoFrame21.close();
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas39 = new OffscreenCanvas(554, 646);
+gc();
+let video30 = await videoWithData();
+try {
+adapter6.label = '\u08e1\ue99b\u5695';
+} catch {}
+let commandEncoder112 = device1.createCommandEncoder({label: '\u1490\ue34e\u0567\u0224\u2153\uedb8\u1853\u6248\u{1fcad}\u1ee9'});
+let texture78 = device1.createTexture({
+  size: {width: 2778, height: 3, depthOrArrayLayers: 189},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle56 = renderBundleEncoder50.finish({label: '\uf511\u0b06'});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup20, new Uint32Array(5209), 1391, 0);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer20, 329952, buffer22, 117040, 9280);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 460 widthInBlocks: 230 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2496 */
+  offset: 2036,
+  bytesPerRow: 512,
+  buffer: buffer26,
+}, {width: 230, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 1,
+  origin: {x: 1380, y: 0, z: 20},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder108.pushDebugGroup('\u0842');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img36 = await imageWithData(78, 215, '#b60f1ed0', '#6eff0b83');
+let querySet53 = device1.createQuerySet({label: '\u035f\u{1fd0e}\u0dd0\u6c84\u12e7\u{1ffdf}\ud893', type: 'occlusion', count: 1200});
+let textureView141 = texture78.createView({dimension: '2d', format: 'rgba16sint', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 164});
+try {
+commandEncoder90.copyBufferToBuffer(buffer24, 5312, buffer22, 52668, 91452);
+dissociateBuffer(device1, buffer24);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer21, 7312, 162992);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder108.popDebugGroup();
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u39cb');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 308, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer5), /* required buffer size: 830 */
+{offset: 830}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2508 */
+{offset: 964, bytesPerRow: 1722, rowsPerImage: 113}, {width: 772, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video10);
+let offscreenCanvas40 = new OffscreenCanvas(1012, 329);
+let texture79 = device2.createTexture({
+  label: '\u7733\u401e\u4db3\u0e60',
+  size: {width: 175},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let textureView142 = texture79.createView({});
+let renderBundleEncoder52 = device2.createRenderBundleEncoder({label: '\u{1f7ca}\u0e15', colorFormats: ['r16sint', 'rg32float']});
+try {
+renderBundleEncoder52.setVertexBuffer(2248, undefined, 2234963918, 1751768015);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+try {
+offscreenCanvas38.getContext('webgl2');
+} catch {}
+let sampler64 = device2.createSampler({
+  label: '\u0eaa\u694d',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.00,
+  lodMaxClamp: 90.42,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder52.setVertexBuffer(2750, undefined, 2246187389, 208930843);
+} catch {}
+try {
+querySet52.destroy();
+} catch {}
+try {
+  await promise29;
+} catch {}
+let img37 = await imageWithData(160, 137, '#d3a21e47', '#81525e9b');
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+try {
+textureView124.label = '\u{1f746}\u{1f881}\uda3c\u0db4\u0d3a\u0d38\u0e64\u6542\udd46\u0b01';
+} catch {}
+let texture80 = device1.createTexture({
+  label: '\u{1ff30}\u741c\u0489\u0f82\u5676\ucf19\u{1f867}',
+  size: [5556, 6, 189],
+  mipLevelCount: 9,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint'],
+});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({
+  label: '\u0860\u5a44\u{1faaa}\u0017\u3d17',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let imageData31 = new ImageData(208, 256);
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2876,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 3013,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder113 = device1.createCommandEncoder({label: '\ua88a\u8518\u5031\u5047\u6f9d'});
+let querySet54 = device1.createQuerySet({
+  label: '\u0d80\u0774\ud115\u05ef\u08ff\u{1fca3}\u{1fb8b}\u{1fba9}\u{1f977}\u{1f97d}',
+  type: 'occlusion',
+  count: 1359,
+});
+let commandBuffer16 = commandEncoder105.finish({label: '\u{1f832}\ua6cc\uc531\uc093\u6bd5\u{1fd29}\u{1ffd1}\ud302\u{1f707}\u5ed7\ua44a'});
+let textureView143 = texture58.createView({label: '\u0500\u0695\u94fd', baseArrayLayer: 865, arrayLayerCount: 227});
+let renderBundleEncoder54 = device1.createRenderBundleEncoder({
+  label: '\u8a89\u5fa4\u3b93\u{1ffc6}\u2406',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  stencilReadOnly: true,
+});
+let renderBundle57 = renderBundleEncoder44.finish();
+try {
+computePassEncoder41.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer2), /* required buffer size: 189 */
+{offset: 189, rowsPerImage: 123}, {width: 554, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas39.getContext('webgl');
+} catch {}
+let renderBundle58 = renderBundleEncoder45.finish({label: '\uf4f6\u{1fc09}\u4c23\u28d5\ubbef\u0011\u{1f621}\uec82\ub418\u9ff0'});
+try {
+renderBundleEncoder47.setVertexBuffer(4605, undefined, 2865973858, 485591722);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer25, 22256, buffer26, 51368, 18672);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1167, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2730 widthInBlocks: 1365 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 11956 */
+  offset: 9226,
+  buffer: buffer26,
+}, {width: 1365, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer26, 9384, new Float32Array(25600), 1956, 1360);
+} catch {}
+let textureView144 = texture74.createView({
+  label: '\u02f8\u7a76\u001e\u0514\uaa5d\u6d3d\u0ea1\u{1f621}\u{1fbe9}',
+  baseArrayLayer: 1032,
+  arrayLayerCount: 61,
+});
+let computePassEncoder48 = commandEncoder86.beginComputePass({label: '\u0e24\uc6c8\u047e\u{1f800}\u3454\u0d74\ud486\u0b03\u0d2a\ue29e\u{1f6e8}'});
+let renderBundle59 = renderBundleEncoder43.finish();
+try {
+computePassEncoder45.setBindGroup(5, bindGroup20, new Uint32Array(2603), 2044, 0);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(5, bindGroup22, new Uint32Array(6406), 5795, 0);
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 1292 widthInBlocks: 646 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 18410 */
+  offset: 17118,
+  buffer: buffer20,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 105, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 646, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer20);
+} catch {}
+let commandEncoder114 = device2.createCommandEncoder({label: '\u6cc1\u{1fd5a}\u0421\u8d14\u{1fe9f}\u33cb\u8f35\u{1fe3c}\ua6fa'});
+let sampler65 = device2.createSampler({
+  label: '\ua746\u0556\u5bc2\u0b98\u03ce\u1bd5\u2f2f\u09c9\u02d7\uaaee\u{1fafb}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.21,
+  lodMaxClamp: 46.79,
+  maxAnisotropy: 13,
+});
+try {
+offscreenCanvas40.getContext('2d');
+} catch {}
+let renderBundle60 = renderBundleEncoder51.finish();
+try {
+renderBundleEncoder52.insertDebugMarker('\uf441');
+} catch {}
+let videoFrame30 = new VideoFrame(videoFrame4, {timestamp: 0});
+let textureView145 = texture79.createView({aspect: 'all', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+gpuCanvasContext18.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise30 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise30;
+} catch {}
+let buffer27 = device0.createBuffer({size: 661344, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let querySet55 = device0.createQuerySet({label: '\u0fc7\uae8e', type: 'occlusion', count: 3974});
+let texture81 = device0.createTexture({
+  label: '\u7737\u{1f919}\u6687\u0e6e\u89a3\u3ad5\u{1f63a}\u6c78\u{1fbb9}',
+  size: {width: 864},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+try {
+computePassEncoder8.setPipeline(pipeline44);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(140262374, 121956749);
+} catch {}
+try {
+commandEncoder78.clearBuffer(buffer10, 68992, 372);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet8, 27, 12, buffer27, 641792);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 7,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 989 */
+{offset: 989}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 240}
+*/
+{
+  source: offscreenCanvas18,
+  origin: { x: 87, y: 146 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline57 = await promise7;
+let bindGroupLayout36 = device1.createBindGroupLayout({
+  label: '\u03f5\u7c71\u{1f934}\u5b84',
+  entries: [{binding: 328, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let computePassEncoder49 = commandEncoder109.beginComputePass({});
+try {
+renderBundleEncoder47.setIndexBuffer(buffer20, 'uint32');
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(689, undefined, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer26, 30900, new BigUint64Array(2373), 984, 168);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(72)), /* required buffer size: 210 */
+{offset: 210, rowsPerImage: 165}, {width: 883, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture42.label = '\u{1ffa9}\u0737\u09da\uc391\u2313\u{1f818}';
+} catch {}
+let commandEncoder115 = device1.createCommandEncoder();
+try {
+computePassEncoder41.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(3, bindGroup22, new Uint32Array(924), 211, 0);
+} catch {}
+try {
+commandEncoder104.copyBufferToBuffer(buffer25, 14520, buffer22, 150596, 3268);
+dissociateBuffer(device1, buffer25);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer22);
+dissociateBuffer(device1, buffer22);
+} catch {}
+let commandEncoder116 = device1.createCommandEncoder();
+let texture82 = device1.createTexture({
+  label: '\u5615\u3296\ua475\u{1fbbd}\u4fd9\ue9f6',
+  size: [694, 1, 122],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let computePassEncoder50 = commandEncoder89.beginComputePass({label: '\u022f\u7c0c\u{1ff32}\u0bf4\u0884\u{1fe46}\u8d80\u4721\ue319'});
+try {
+renderBundleEncoder53.setBindGroup(0, bindGroup22, new Uint32Array(3815), 2135, 0);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageBitmap25 = await createImageBitmap(offscreenCanvas31);
+let querySet56 = device1.createQuerySet({label: '\ue60f\u06ff\u7cc7\u783f\u1ebb\udd73\u005e\u7820\u{1fa3a}', type: 'occlusion', count: 959});
+let textureView146 = texture71.createView({label: '\u0b0a\u{1f74c}\u0023\u8b04'});
+let renderBundleEncoder55 = device1.createRenderBundleEncoder({
+  label: '\u5c68\u{1fecd}\u5e38\u{1f78a}',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  stencilReadOnly: true,
+});
+let sampler66 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.30,
+  lodMaxClamp: 86.34,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder45.setBindGroup(6, bindGroup20, new Uint32Array(7477), 6649, 0);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer20, 'uint16', 18144, 251555);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(4059, undefined, 0, 3452940998);
+} catch {}
+try {
+commandEncoder108.resolveQuerySet(querySet54, 135, 549, buffer21, 123904);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer22, 424, new Float32Array(40174), 20248);
+} catch {}
+let commandEncoder117 = device2.createCommandEncoder({label: '\u07db\ube4f\u15cc\u0237\u7069\u213a\u48c6\u{1f9cf}\u8e4d\u1810'});
+let textureView147 = texture79.createView({label: '\u04c6\u0a35\u0c93\u5e58\u9277\u6a2d\u00d4\u5d6d\u1dc0\u{1f7bf}'});
+let renderBundle61 = renderBundleEncoder51.finish({label: '\u0042\ue133\u{1fea0}\u53f9\u05d2\u{1fcd3}\u438c\u0432\uadca\u6551'});
+try {
+renderBundleEncoder52.setVertexBuffer(1999, undefined, 2708708073);
+} catch {}
+let canvas36 = document.createElement('canvas');
+let gpuCanvasContext33 = canvas36.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let canvas37 = document.createElement('canvas');
+try {
+canvas37.getContext('webgl');
+} catch {}
+let texture83 = device2.createTexture({
+  label: '\u{1fd21}\uab4c\u9fcb\u{1fbfd}\u7e96\u4893\u87b3\u{1fef4}\u7f7c',
+  size: {width: 10, height: 1, depthOrArrayLayers: 536},
+  mipLevelCount: 10,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint', 'r16sint', 'r16sint'],
+});
+let textureView148 = texture79.createView({label: '\u{1fa02}\udb5f\u0d0d\u{1fde0}\u2aea'});
+let computePassEncoder51 = commandEncoder117.beginComputePass({label: '\ua8a5\u0a2e\u{1fece}\u3734\u4c3c\u{1fb8f}\u4473\u{1f94c}\ufbb8'});
+try {
+commandEncoder111.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext31.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let promise31 = adapter7.requestAdapterInfo();
+let querySet57 = device2.createQuerySet({type: 'occlusion', count: 2034});
+let textureView149 = texture79.createView({label: '\u98dd\u25f9\u036f', baseArrayLayer: 0});
+let sampler67 = device2.createSampler({
+  label: '\u3c02\u85a2\ua2cf',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 9.809,
+  maxAnisotropy: 1,
+});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout37 = device2.createBindGroupLayout({
+  label: '\u{1f824}\u{1ff2e}\u3223\u{1fbc0}',
+  entries: [
+    {
+      binding: 696,
+      visibility: 0,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 333, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let querySet58 = device2.createQuerySet({label: '\u{1fc0c}\u0e83\u{1fe72}\ueeaa\u1a8a\u{1fcd0}\u{1fd83}', type: 'occlusion', count: 2024});
+let textureView150 = texture83.createView({label: '\u{1f7d5}\u{1f81e}\u{1fb88}\ud30b\ub97f\u5847\u224f', baseMipLevel: 6, mipLevelCount: 2});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+  await promise31;
+} catch {}
+let img38 = await imageWithData(64, 142, '#38483dd6', '#60ed1465');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let adapter10 = await navigator.gpu.requestAdapter({});
+let textureView151 = texture65.createView({label: '\u{1f91c}\u{1fbfb}\u0b4e\u3887', baseMipLevel: 4, mipLevelCount: 2});
+let computePassEncoder52 = commandEncoder107.beginComputePass();
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({
+  label: '\u6911\u38d9\u06b2\ue12e\u9bad\u0a13\u0a32',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  depthReadOnly: true,
+});
+let sampler68 = device1.createSampler({
+  label: '\u0711\ua43e\u{1f76a}\u6965\u08cd\u05a5\u0f4d\u6c09',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 1.337,
+});
+try {
+renderBundleEncoder46.setBindGroup(3, bindGroup23, new Uint32Array(556), 363, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer21, 195044, new BigUint64Array(18489), 9371, 4384);
+} catch {}
+try {
+textureView122.label = '\u0a79\u0fe7\u680a\u3206\u015c';
+} catch {}
+let bindGroup24 = device1.createBindGroup({
+  label: '\u90cb\u0ed1\u6a4f\ue789\u0973\ubc71\u7917\u9e29\u0977\ued04',
+  layout: bindGroupLayout36,
+  entries: [{binding: 328, resource: externalTexture52}],
+});
+let buffer28 = device1.createBuffer({
+  label: '\u0d09\u{1fdda}\u78a4\u606a\u{1f736}\u929b\u2616\u4fe3\u18b1\u00c1\u2249',
+  size: 371520,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let textureView152 = texture62.createView({
+  label: '\u47b5\u0693\u{1fe71}\uaabc\u3d3c\u{1f65b}\u4244\u086d\u067c',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+});
+let computePassEncoder53 = commandEncoder112.beginComputePass({});
+try {
+commandEncoder110.resolveQuerySet(querySet46, 3122, 3, buffer21, 44032);
+} catch {}
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+let texture84 = device2.createTexture({
+  label: '\uecee\u0cc1\u043f\uc93c\u{1ff8a}\u{1f926}\u05b4\uf5c4\u48fd\u737e\u0a81',
+  size: {width: 80},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder57 = device2.createRenderBundleEncoder({
+  label: '\u037e\u7d82\u{1fbb2}\u09ff\u{1f7ca}\u{1fc98}\u55c7\u0ec7\u7e90\u{1fc2e}\ua027',
+  colorFormats: ['r16sint', 'rg32float'],
+  stencilReadOnly: true,
+});
+let renderBundle62 = renderBundleEncoder52.finish({});
+let imageData32 = new ImageData(212, 164);
+let promise32 = adapter0.requestAdapterInfo();
+let buffer29 = device1.createBuffer({
+  label: '\u0ce1\ub0de\u{1fafc}\ud319\u{1f7d3}\u08c5\u2404\ud38f',
+  size: 26897,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 96216 */
+  offset: 96216,
+  bytesPerRow: 0,
+  rowsPerImage: 155,
+  buffer: buffer19,
+}, {
+  texture: texture62,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 6});
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer26, 38324, new DataView(new ArrayBuffer(5168)), 4146, 820);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap26 = await createImageBitmap(canvas3);
+let textureView153 = texture79.createView({label: '\uc0b5\u6b62\u9c7e'});
+let computePassEncoder54 = commandEncoder114.beginComputePass({label: '\u{1faa8}\u0bc4\u0214\u{1f6a2}'});
+let renderBundleEncoder58 = device2.createRenderBundleEncoder({
+  label: '\ud77d\u0fe9\u{1fff8}\ue897\u9c2c\u0a28\ua859\u01fc\u4cc0\u7f4b\u55f9',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+});
+let externalTexture59 = device2.importExternalTexture({label: '\u{1fbb1}\u0f75\u0330\u03b8\u5dcb\u0124\u85b6\u87ee\uc475\u8793\u80e5', source: videoFrame4});
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise32;
+} catch {}
+let commandEncoder118 = device2.createCommandEncoder({label: '\u7a6c\u{1ff87}\u45e0\ufe13\u2622\u7331\u4581\u{1f952}'});
+let computePassEncoder55 = commandEncoder111.beginComputePass({label: '\u091e\u{1faa9}\u7d84\u{1f766}\u6666\u09ee'});
+let renderBundle63 = renderBundleEncoder57.finish({label: '\u58fb\ucfca\u{1f8b4}\u9b3a\u09f6\u5d56\u0cb8\u063e\ue0de\u87f7\uf0c3'});
+let externalTexture60 = device2.importExternalTexture({label: '\u01b1\u718a', source: video28, colorSpace: 'srgb'});
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+let commandEncoder119 = device2.createCommandEncoder({label: '\u09f9\u{1f814}\u0e66\ubfce\u9cae\u2543\u16ae\u3826'});
+let querySet59 = device2.createQuerySet({
+  label: '\u659c\u7ce4\ud04f\u08f5\u{1fefd}\u10b0\u08bb\u{1f815}\u{1fb2f}\ua8e0',
+  type: 'occlusion',
+  count: 1626,
+});
+let commandBuffer17 = commandEncoder118.finish({label: '\u079d\u2222\u4843\u03f0\u05da\u{1fe0c}\u5af5\u5d8c'});
+let texture85 = device2.createTexture({
+  label: '\u06e0\u191d\uba82\ue538\u7efe\u2901\u{1f825}',
+  size: [175],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let computePassEncoder56 = commandEncoder119.beginComputePass({label: '\uc92b\u0e5f\u1a77\u69d6\u0969\u068f\u2d1b\u0fd5'});
+let sampler69 = device2.createSampler({
+  label: '\uf1ba\u7496\u05b7\u0fb8\u{1fc23}\uff40\u{1f86c}\u0e8a\u07b3\u0ad5',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 48.64,
+});
+try {
+renderBundleEncoder58.setVertexBuffer(3012, undefined);
+} catch {}
+try {
+adapter3.label = '\u3660\u6e61\ua074\ud62c\u6bd7\u{1ffc5}\u698f\u{1faaa}\u{1f60c}\u1797\u{1feb3}';
+} catch {}
+let texture86 = device1.createTexture({
+  label: '\u0221\u042d\uc176\uc54f\uaa36\ucf4c',
+  size: {width: 1408, height: 128, depthOrArrayLayers: 802},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+let computePassEncoder57 = commandEncoder108.beginComputePass({label: '\u04ba\u{1fcfd}\u79b9\ub863\u8c37\uab93\u{1f8c5}\u{1fe20}'});
+let externalTexture61 = device1.importExternalTexture({
+  label: '\u{1fd77}\u{1f70b}\u294a\uec60\uff93\u{1fa4e}\u369c\u2c37',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder113.clearBuffer(buffer26, 55224, 33152);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder106.resolveQuerySet(querySet53, 1144, 25, buffer21, 14336);
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+canvas30.width = 421;
+gc();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let querySet60 = device2.createQuerySet({type: 'occlusion', count: 254});
+let textureView154 = texture85.createView({
+  label: '\u4e2d\ucfeb\u{1fa9a}\u06ce\ub76f\u0437\u8623\u0340\u7308\u{1f61f}',
+  aspect: 'all',
+  baseArrayLayer: 0,
+});
+try {
+device2.queue.submit([commandBuffer17]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer1), /* required buffer size: 912 */
+{offset: 912, rowsPerImage: 228}, {width: 54, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let offscreenCanvas41 = new OffscreenCanvas(72, 481);
+let video31 = await videoWithData();
+let canvas38 = document.createElement('canvas');
+let querySet61 = device1.createQuerySet({label: '\u{1faf2}\u218e\ud702\u{1fd1f}\uf916', type: 'occlusion', count: 2188});
+let renderBundle64 = renderBundleEncoder49.finish({label: '\u51f4\u0147\u9d22'});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup21, new Uint32Array(5577), 3684, 0);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+buffer28.destroy();
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer22, 70000);
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder92.resolveQuerySet(querySet44, 717, 276, buffer21, 9472);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer21, 44312, new Int16Array(420), 64, 48);
+} catch {}
+let gpuCanvasContext34 = offscreenCanvas41.getContext('webgpu');
+let videoFrame31 = new VideoFrame(offscreenCanvas11, {timestamp: 0});
+let commandBuffer18 = commandEncoder94.finish({});
+let texture87 = device1.createTexture({
+  label: '\u{1fd33}\u{1f795}\u{1fe63}\u02fa\ua8e2\u{1f8f2}',
+  size: [1408, 128, 453],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let renderBundle65 = renderBundleEncoder54.finish({label: '\u0b2c\ufc98'});
+try {
+commandEncoder88.clearBuffer(buffer21, 108804, 131420);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder106.resolveQuerySet(querySet42, 1629, 365, buffer21, 95488);
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(405, 25);
+let video32 = await videoWithData();
+let pipelineLayout18 = device1.createPipelineLayout({label: '\uf280\u{1f6ef}', bindGroupLayouts: [bindGroupLayout27]});
+let buffer30 = device1.createBuffer({
+  label: '\u856c\u{1fade}\udd93\u0cd8\u050c',
+  size: 289558,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle66 = renderBundleEncoder48.finish();
+try {
+renderBundleEncoder47.setIndexBuffer(buffer20, 'uint16', 70364, 171043);
+} catch {}
+let promise34 = buffer30.mapAsync(GPUMapMode.READ, 150952, 125544);
+let imageBitmap27 = await createImageBitmap(video21);
+let textureView155 = texture63.createView({dimension: '2d', baseMipLevel: 2, baseArrayLayer: 27});
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({
+  label: '\u0c03\ubb18\u03cf\u{1f670}\u{1ff34}\u0820\uca8d\ud078\uaf94\u{1fef2}',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture62 = device1.importExternalTexture({label: '\ub2d0\u9485\u26ec', source: video2, colorSpace: 'display-p3'});
+let pipelineLayout19 = device2.createPipelineLayout({label: '\ue1d9\u7152\u{1f62f}', bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37]});
+let commandEncoder120 = device2.createCommandEncoder();
+let querySet62 = device2.createQuerySet({label: '\u0173\u2a02\u03b5\uae40', type: 'occlusion', count: 992});
+let texture88 = device2.createTexture({
+  label: '\ua4bc\u0010\u0ab3\uf286\u90d0\u{1fb0d}\u14fa\uf2b0',
+  size: {width: 1400, height: 12, depthOrArrayLayers: 103},
+  mipLevelCount: 4,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg11b10ufloat'],
+});
+let computePassEncoder58 = commandEncoder120.beginComputePass();
+try {
+device2.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer7), /* required buffer size: 626 */
+{offset: 626, bytesPerRow: 2}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder121 = device2.createCommandEncoder({label: '\u{1fbe1}\uf4b0\uad69\u0d74\u0dcf\ub21d\u9f4e\u09d7'});
+let textureView156 = texture85.createView({label: '\ud230\ud6a8\ufe1f\u41ee', baseMipLevel: 0});
+let renderBundleEncoder60 = device2.createRenderBundleEncoder({
+  label: '\ufe20\ub8fd\u0521\u0a8b\u06ef\u2b49\u05f6\uf751\u0afa',
+  colorFormats: ['r16sint', 'rg32float'],
+  stencilReadOnly: true,
+});
+let canvas39 = document.createElement('canvas');
+let videoFrame32 = new VideoFrame(offscreenCanvas42, {timestamp: 0});
+let bindGroupLayout38 = device2.createBindGroupLayout({
+  label: '\uc737\uc778\u{1f638}',
+  entries: [
+    {
+      binding: 193,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 266,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let renderBundleEncoder61 = device2.createRenderBundleEncoder({
+  label: '\uf292\u0cfe\u{1fe72}\uc101\u229b\u7b3f\u8367\u0bf0\uc4db',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler70 = device2.createSampler({
+  label: '\udd8e\u32c9\u4f80\ubb3d\u{1fa72}\u{1f9ad}\u{1f84e}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.22,
+  maxAnisotropy: 17,
+});
+let buffer31 = device2.createBuffer({
+  label: '\u{1fe49}\u17da\u{1fd55}\u66a2',
+  size: 965035,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet63 = device2.createQuerySet({label: '\u68d4\u5daa', type: 'occlusion', count: 2490});
+let commandBuffer19 = commandEncoder121.finish();
+let texture89 = device2.createTexture({
+  label: '\ue7c0\u{1fb3e}\u5f5c\u23e9\uc32f\u0128\u{1f82a}\u04a7\u{1f96b}\u{1f654}',
+  size: {width: 1472, height: 1, depthOrArrayLayers: 1481},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView157 = texture83.createView({baseMipLevel: 3});
+let renderBundle67 = renderBundleEncoder60.finish();
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(8015, undefined, 2191040575, 4814469);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9304 */
+  offset: 9304,
+  buffer: buffer31,
+}, {
+  texture: texture83,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder122 = device2.createCommandEncoder({});
+let texture90 = device2.createTexture({
+  size: [192, 1, 346],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder59 = commandEncoder119.beginComputePass();
+let renderBundle68 = renderBundleEncoder61.finish({label: '\udb9e\u1f4a\u04ce\ua8a8\u094f\u3682\u0e58\u0795\uef75\u54d8\ud20f'});
+try {
+device2.queue.submit([commandBuffer19]);
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas42.getContext('webgpu');
+gc();
+try {
+renderBundleEncoder55.setIndexBuffer(buffer20, 'uint16');
+} catch {}
+let computePassEncoder60 = commandEncoder95.beginComputePass();
+let renderBundle69 = renderBundleEncoder55.finish();
+try {
+renderBundleEncoder59.setVertexBuffer(1, buffer29, 0, 5388);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 2499, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(157), /* required buffer size: 157 */
+{offset: 157}, {width: 279, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise34;
+} catch {}
+gc();
+let shaderModule14 = device2.createShaderModule({
+  label: '\u{1faac}\ue17c\u4686',
+  code: `@group(0) @binding(333)
+var<storage, read_write> type8: array<u32>;
+@group(1) @binding(696)
+var<storage, read_write> function9: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+  @location(9) f0: vec3<u32>,
+  @location(6) f1: vec2<f32>,
+  @location(8) f2: vec2<i32>,
+  @location(1) f3: vec3<u32>,
+  @location(15) f4: vec4<u32>,
+  @location(10) f5: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<f32>,
+  @location(3) f2: i32
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec3<f16>, @location(14) a1: vec3<i32>, @location(11) a2: vec2<f16>, @builtin(sample_mask) a3: u32, @location(12) a4: vec3<f16>, @location(0) a5: vec3<i32>, a6: S18, @location(13) a7: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f308: vec4<f32>,
+  @location(8) f309: vec2<i32>,
+  @location(11) f310: vec2<f16>,
+  @location(13) f311: vec3<f16>,
+  @location(10) f312: vec4<f16>,
+  @location(14) f313: vec3<i32>,
+  @location(15) f314: vec4<u32>,
+  @location(12) f315: vec3<f16>,
+  @location(6) f316: vec2<f32>,
+  @location(7) f317: vec3<f16>,
+  @location(9) f318: vec3<u32>,
+  @location(1) f319: vec3<u32>,
+  @location(0) f320: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<i32>, @location(10) a1: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let buffer32 = device2.createBuffer({
+  label: '\u0853\uee90',
+  size: 647748,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder123 = device2.createCommandEncoder({label: '\u28b7\u091a\u0ef9\ua4bf\u0848\u{1fe43}\u6a6a\ub9fb'});
+let textureView158 = texture88.createView({
+  label: '\ua53d\u9f1c\u1804\u4f6b\u{1f625}\ub470\u6870\ue226\u045c',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 76,
+});
+let pipeline58 = await device2.createComputePipelineAsync({
+  label: '\u0b8d\u{1f95b}',
+  layout: 'auto',
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let pipeline59 = await device0.createRenderPipelineAsync({
+  label: '\u06e3\u{1fb8e}\u{1f82f}\u{1f72c}\u{1f826}\u07f2\u5db6\u793b\u62bd\u{1fe3d}',
+  layout: pipelineLayout19,
+  multisample: {mask: 0xac287177},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 836,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x3', offset: 136, shaderLocation: 10}],
+      },
+      {arrayStride: 2048, attributes: [{format: 'sint32', offset: 1072, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let computePassEncoder61 = commandEncoder123.beginComputePass({label: '\ua802\u02d2'});
+try {
+canvas39.getContext('webgl2');
+} catch {}
+let bindGroupLayout39 = pipeline59.getBindGroupLayout(1);
+let commandEncoder124 = device2.createCommandEncoder({label: '\u57a9\u7c85\u1b9f\u4070\u7c78\u08ef\uafa1\u1b8d'});
+let querySet64 = device2.createQuerySet({
+  label: '\ubb8b\u0055\ue986\u2250\u{1ff3b}\uc970\uc0d4\u0fb2\u10d4\u92da\u{1f866}',
+  type: 'occlusion',
+  count: 2271,
+});
+let computePassEncoder62 = commandEncoder124.beginComputePass({label: '\u{1fee9}\u{1ff54}\u082e\u1302\u{1f827}\u355d\u0ad7\u0094'});
+let renderBundleEncoder62 = device2.createRenderBundleEncoder({
+  label: '\ufd67\ud394\u22f3\u{1ff07}\u82a5\u{1f93f}\u0f45\ubce8\uc79b\ud762\u183a',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  sampleCount: 1,
+});
+let promise35 = device2.popErrorScope();
+let arrayBuffer8 = buffer32.getMappedRange(0, 569008);
+try {
+buffer32.destroy();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer5), /* required buffer size: 294 */
+{offset: 294}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise33;
+} catch {}
+video7.width = 289;
+let renderBundleEncoder63 = device1.createRenderBundleEncoder({
+  label: '\udea9\u{1fdc1}\u98ab\u7208\u{1f95f}\u5c59\u1db3\u0f7a\u0ea7\u{1fe01}\u{1fb90}',
+  colorFormats: ['r16sint', 'rgba16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let arrayBuffer9 = buffer25.getMappedRange(4096, 2652);
+try {
+device1.queue.submit([commandBuffer16, commandBuffer15]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer22, 19376, new Float32Array(44645), 14102);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 38, y: 2, z: 42},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 21718547 */
+{offset: 980, bytesPerRow: 237, rowsPerImage: 276}, {width: 36, height: 4, depthOrArrayLayers: 333});
+} catch {}
+try {
+device1.destroy();
+} catch {}
+try {
+  await promise35;
+} catch {}
+let querySet65 = device0.createQuerySet({type: 'occlusion', count: 881});
+let commandBuffer20 = commandEncoder2.finish({label: '\u5d42\u077c\u{1f939}'});
+let texture91 = device0.createTexture({
+  label: '\u0ccc\u15fc\u3926\u0c22\u0af5\u8d91\u22d1\ud6b7\ub343',
+  size: {width: 720, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView159 = texture50.createView({label: '\u09b2\u088a\u24c0\u0b9c', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 41});
+try {
+renderBundleEncoder9.draw(407757356, 322039297, 458033975, 505354352);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(102484578);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 1332 widthInBlocks: 333 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30568 */
+  offset: 29236,
+  buffer: buffer0,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 333, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 566, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+},
+{width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 19700, new BigUint64Array(18821), 11179, 552);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 372 */
+{offset: 372, rowsPerImage: 71}, {width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = device0.createComputePipeline({
+  label: '\u0c1c\u567a\u6164\u0cd9\u8fc8\u{1fb03}\u5aec\u088e\uaf92',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let pipeline61 = await device0.createRenderPipelineAsync({
+  label: '\ubeba\u15e6\uadb0\u{1fcab}',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xffffffff},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: 0}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp'},
+    stencilReadMask: 4157082693,
+    stencilWriteMask: 849727228,
+    depthBiasSlopeScale: 131.952551179659,
+    depthBiasClamp: 853.5848335468586,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10908,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 1976, shaderLocation: 5},
+          {format: 'sint32x4', offset: 500, shaderLocation: 4},
+          {format: 'sint32x3', offset: 2208, shaderLocation: 25},
+          {format: 'sint8x2', offset: 3658, shaderLocation: 15},
+          {format: 'uint16x2', offset: 44, shaderLocation: 16},
+          {format: 'float16x4', offset: 892, shaderLocation: 0},
+          {format: 'sint32x4', offset: 2816, shaderLocation: 21},
+          {format: 'sint32x2', offset: 2796, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 244, shaderLocation: 23},
+          {format: 'sint16x4', offset: 4800, shaderLocation: 3},
+          {format: 'uint32x4', offset: 2680, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 1508, shaderLocation: 20},
+          {format: 'float32', offset: 5768, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x4', offset: 59872, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 8428, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 2240, shaderLocation: 24},
+          {format: 'unorm10-10-10-2', offset: 25720, shaderLocation: 11},
+          {format: 'float32x3', offset: 840, shaderLocation: 26},
+          {format: 'sint32x2', offset: 40980, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 15288,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 10678, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 45584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 5028, shaderLocation: 17},
+          {format: 'uint32x4', offset: 17908, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 2744,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 2240, shaderLocation: 14}],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 23332,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x4', offset: 4440, shaderLocation: 18}],
+      },
+    ],
+  },
+});
+document.body.prepend(img5);
+gc();
+let sampler71 = device2.createSampler({
+  label: '\u4260\u1656\u{1fc68}\u2f64\u87b3\u0fee\ub37e\u3894',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.94,
+  compare: 'never',
+});
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 100000 */
+  offset: 100000,
+  rowsPerImage: 280,
+  buffer: buffer32,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer32);
+} catch {}
+let querySet66 = device2.createQuerySet({label: '\u{1fc96}\u{1fb89}', type: 'occlusion', count: 2692});
+let textureView160 = texture79.createView({label: '\u6b38\u0802\u37e4\u{1fc1f}\u0d09\u9f4a\u74be\u09a6\u{1f846}\u{1fac1}', aspect: 'all'});
+let externalTexture63 = device2.importExternalTexture({label: '\ucbd2\u73dc\ua30d', source: videoFrame30, colorSpace: 'display-p3'});
+try {
+buffer31.unmap();
+} catch {}
+document.body.prepend(img32);
+try {
+canvas38.getContext('2d');
+} catch {}
+let shaderModule15 = device2.createShaderModule({
+  label: '\u0460\u0117',
+  code: `@group(1) @binding(696)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(696)
+var<storage, read_write> function10: array<u32>;
+@group(0) @binding(333)
+var<storage, read_write> n8: array<u32>;
+@group(1) @binding(333)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(7, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: i32,
+  @location(1) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: vec2<u32>, @location(9) a1: vec2<f32>, @location(6) a2: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let buffer33 = device2.createBuffer({size: 107582, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let renderBundle70 = renderBundleEncoder57.finish({label: '\u0d6c\u{1fb12}\u797f\uec63\u{1f6c8}\u5807\u2f21\u7ff3\uc4b6\u6a87\u06a1'});
+let sampler72 = device2.createSampler({
+  label: '\ua7e6\u5328\u{1f83a}\u{1ff27}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.45,
+  lodMaxClamp: 94.90,
+  compare: 'less-equal',
+});
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap'},
+    stencilReadMask: 1578971037,
+    depthBias: 0,
+    depthBiasSlopeScale: 54.08486350074304,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 868,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x4', offset: 32, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 1032,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 436, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let canvas40 = document.createElement('canvas');
+let videoFrame33 = new VideoFrame(canvas38, {timestamp: 0});
+let texture92 = device2.createTexture({
+  size: [350],
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg11b10ufloat'],
+});
+let textureView161 = texture85.createView({label: '\u{1fd87}\u114a\u60de\u0288\u0565\u{1fae0}\u805e\u{1f921}'});
+let renderBundle71 = renderBundleEncoder62.finish({label: '\u01d4\u1282\u31e7\uf990\u00c0\u28e2\u8194\u{1ffea}'});
+try {
+renderBundleEncoder58.setVertexBuffer(4, buffer33, 0, 104279);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 24},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas40.getContext('webgl');
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let device3 = await adapter7.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxColorAttachmentBytesPerSample: 57,
+    maxVertexBufferArrayStride: 39019,
+    maxStorageTexturesPerShaderStage: 25,
+    maxStorageBuffersPerShaderStage: 28,
+    maxDynamicStorageBuffersPerPipelineLayout: 50423,
+    maxDynamicUniformBuffersPerPipelineLayout: 47402,
+    maxBindingsPerBindGroup: 4716,
+    maxTextureArrayLayers: 789,
+    maxTextureDimension1D: 14555,
+    maxTextureDimension2D: 11576,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 144284691,
+    maxUniformBuffersPerShaderStage: 40,
+    maxSampledTexturesPerShaderStage: 34,
+    maxInterStageShaderVariables: 81,
+    maxInterStageShaderComponents: 82,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+gc();
+let videoFrame34 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+let commandEncoder125 = device3.createCommandEncoder({label: '\u004f\u7693\u{1fb22}\u7540\u09e2\u0aad\u64c1'});
+let computePassEncoder63 = commandEncoder125.beginComputePass({label: '\u493f\u{1f764}\u{1f96e}'});
+let renderBundleEncoder64 = device3.createRenderBundleEncoder({
+  label: '\u2cd8\u80e7\u{1f6bd}\u0741\uabe0\u{1f85c}\u01af\ued1a\u{1fbdb}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle72 = renderBundleEncoder64.finish({label: '\u82c2\u4f90\u6650\u54b6\u7076\ueef2\u92be'});
+let sampler73 = device3.createSampler({
+  label: '\u0e8b\u35ce\u095d\u068d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.35,
+  lodMaxClamp: 70.83,
+  compare: 'greater-equal',
+  maxAnisotropy: 4,
+});
+let externalTexture64 = device3.importExternalTexture({label: '\u{1ff26}\u0acf\ufd84', source: video20, colorSpace: 'srgb'});
+let imageData33 = new ImageData(160, 36);
+video6.height = 95;
+canvas20.width = 1272;
+canvas11.width = 362;
+let offscreenCanvas43 = new OffscreenCanvas(451, 958);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let querySet67 = device3.createQuerySet({label: '\u6549\u{1fa7a}\u{1fb4c}\u0d4c', type: 'occlusion', count: 840});
+let renderBundleEncoder65 = device3.createRenderBundleEncoder({
+  label: '\u{1f7ff}\u0d12\u074f\u{1faea}\u{1f8c9}\u63ae\ub806\u{1fbf9}\uee24\uffa2\uc86b',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle73 = renderBundleEncoder64.finish();
+try {
+offscreenCanvas43.getContext('webgl');
+} catch {}
+let sampler74 = device3.createSampler({
+  label: '\u0cb6\u1abc\u5b1a\ud609\u{1f9c5}\u8469\u461d\uf71f\u1445\u{1fb3f}\ueb7c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.49,
+});
+let externalTexture65 = device3.importExternalTexture({label: '\u9185\u0c7f\u05fe\u044a\u7ac4\u{1ff95}\u047a\u0d46\u0388\ub345\u{1f8a5}', source: video28});
+try {
+computePassEncoder63.end();
+} catch {}
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+let videoFrame35 = new VideoFrame(img25, {timestamp: 0});
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 134 widthInBlocks: 67 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 70390 */
+  offset: 70390,
+  bytesPerRow: 512,
+  buffer: buffer31,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 67, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 866 */
+{offset: 866}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise36 = buffer31.mapAsync(GPUMapMode.WRITE, 546720, 20800);
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 56112 */
+  offset: 56112,
+  buffer: buffer32,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer32);
+} catch {}
+let buffer34 = device3.createBuffer({
+  label: '\ufaab\u0024\u{1fdcc}\u{1fb90}\u080a\u0f1e\uf726\u{1f64d}\u9bf7',
+  size: 107959,
+  usage: GPUBufferUsage.UNIFORM,
+});
+let texture93 = device3.createTexture({
+  label: '\u7c4e\u03f6\u{1fabf}\u062a\u09d7\u{1fa14}\u{1f8e4}\u548d',
+  size: [24, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView162 = texture93.createView({
+  label: '\u{1fb8e}\u{1f928}\u40e3\u{1f980}\u07be\u0885\u{1f7f7}\u4dfb\u0ea9\ub7a3\u422a',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder64 = commandEncoder125.beginComputePass({label: '\u0376\u99e1\u0437'});
+let externalTexture66 = device3.importExternalTexture({label: '\u60f6\u6da8\u39f8\u0b34\u011e\u5d69\u01c2', source: videoFrame15, colorSpace: 'display-p3'});
+let promise37 = device3.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let imageData34 = new ImageData(188, 44);
+document.body.prepend(video32);
+try {
+adapter7.label = '\u0fa5\u0f45\u0d03\u00ba\u0301\u{1f84a}\u1830\u{1f6e2}\udcd6\u0439';
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(74, 472);
+let commandEncoder126 = device3.createCommandEncoder({label: '\u0c52\u17cb\u30df\u5391\uf883\u4e8f'});
+let texture94 = device3.createTexture({
+  label: '\u4a14\ua7db\u5f3c\ua4c9\u{1f9c3}\u28e9',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let renderBundle74 = renderBundleEncoder64.finish({label: '\u85ec\u{1fca3}\u3a85\u800a\ud9dd'});
+try {
+buffer34.unmap();
+} catch {}
+let promise38 = device3.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas35.width = 381;
+let commandEncoder127 = device3.createCommandEncoder({label: '\u4b5c\ub1d2\u0f14\u0f11\u06df\ub0a4\u0bab\u{1f7d1}'});
+let querySet68 = device3.createQuerySet({label: '\u4aab\uc2ba\u{1f856}\u0cea\u0dbd', type: 'occlusion', count: 564});
+let texture95 = device3.createTexture({
+  label: '\uce9d\uc7d9\u{1f8da}\uf997\uc654\u{1ffbd}\u0179\uc7c1\u2bcf\u0e8d',
+  size: [192],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder66 = device3.createRenderBundleEncoder({
+  label: '\u0742\ua430\u55c0\u{1fc04}\uc382\u7d95\u8743\uf7c8',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle75 = renderBundleEncoder65.finish({label: '\udff7\u1210\u12d2\u{1fae6}\u9e04'});
+let sampler75 = device3.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.32,
+  maxAnisotropy: 17,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 720 */
+{offset: 720, rowsPerImage: 165}, {width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame36 = new VideoFrame(canvas33, {timestamp: 0});
+let texture96 = device2.createTexture({
+  label: '\u{1fd8a}\u03f7\u53e5\u1618\u0856\u{1fbef}\u9232',
+  size: {width: 700},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle76 = renderBundleEncoder57.finish({label: '\u0d74\ua590\u{1ff2f}\u953a\u{1fcfe}\u0e61'});
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 94 widthInBlocks: 47 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 53930 */
+  offset: 53930,
+  buffer: buffer32,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 47, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer32);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext36 = offscreenCanvas44.getContext('webgpu');
+canvas8.width = 120;
+let canvas41 = document.createElement('canvas');
+let commandEncoder128 = device3.createCommandEncoder({label: '\u{1f630}\u{1f9a3}\u6a4d\u6294\u9d84\uf673\u5938\u05e7\u1e53'});
+let commandBuffer21 = commandEncoder127.finish();
+let texture97 = device3.createTexture({
+  size: [192, 0, 1],
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView163 = texture94.createView({});
+let computePassEncoder65 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+  await promise36;
+} catch {}
+let video33 = await videoWithData();
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+canvas21.height = 447;
+let offscreenCanvas45 = new OffscreenCanvas(1015, 26);
+try {
+  await promise38;
+} catch {}
+let commandEncoder129 = device2.createCommandEncoder({label: '\u0d7f\uf4a8\u0cb4\u9c8d\u{1f960}\u01a5\u8c15\u{1f64c}\u04d1'});
+let querySet69 = device2.createQuerySet({type: 'occlusion', count: 2369});
+let arrayBuffer10 = buffer31.getMappedRange(560104, 2224);
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 86490 */
+  offset: 10456,
+  bytesPerRow: 256,
+  rowsPerImage: 297,
+  buffer: buffer32,
+}, {
+  texture: texture83,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device2, buffer32);
+} catch {}
+try {
+commandEncoder122.insertDebugMarker('\u9479');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(56)), /* required buffer size: 385 */
+{offset: 385}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise39 = device2.queue.onSubmittedWorkDone();
+let promise40 = device2.createRenderPipelineAsync({
+  label: '\u{1fe2d}\u0479\u5bed\u57e1',
+  layout: pipelineLayout19,
+  multisample: {},
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 264,
+        attributes: [
+          {format: 'uint32x3', offset: 36, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 136, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+try {
+offscreenCanvas45.getContext('webgl');
+} catch {}
+let texture98 = device2.createTexture({
+  label: '\u{1fa08}\u4366\uefd9\u11f8\uab0f\u3def\u{1fc33}\udb72\u0e92\u299e\u0798',
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16sint'],
+});
+let buffer35 = device3.createBuffer({
+  label: '\u0c80\u0990\u{1f9aa}\u06e3\u{1ff72}\u1576\ua851',
+  size: 373212,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder130 = device3.createCommandEncoder({label: '\udbd9\uece8\u971f'});
+let textureView164 = texture94.createView({label: '\u0d28\u802c\u{1f8ea}\u8e64\u04c4\u981d\ud91e'});
+let externalTexture67 = device3.importExternalTexture({label: '\u4c45\u0c05', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+gpuCanvasContext8.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture99 = device3.createTexture({
+  label: '\ue891\u{1f7b8}\u0067',
+  size: {width: 192, height: 0, depthOrArrayLayers: 186},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let computePassEncoder66 = commandEncoder130.beginComputePass({label: '\u0be3\u0d4f\u1e69\u{1fae6}\u28ad\u89c4\u0f9d\u{1fec3}\u4f3d'});
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder128.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 1,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 35580 */
+  offset: 35580,
+  buffer: buffer35,
+}, {width: 58, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+let imageBitmap28 = await createImageBitmap(img38);
+try {
+  await promise39;
+} catch {}
+gc();
+let img39 = await imageWithData(46, 109, '#69d8d8c5', '#0b4886f1');
+let imageBitmap29 = await createImageBitmap(canvas41);
+let promise41 = adapter7.requestAdapterInfo();
+let offscreenCanvas46 = new OffscreenCanvas(328, 976);
+let bindGroupLayout40 = device2.createBindGroupLayout({label: '\uf199\u{1fce5}\u{1fde4}\u5afa\u922d\u8b79', entries: []});
+let texture100 = device2.createTexture({
+  label: '\u{1fb6e}\u2e65\u011d\u0a44\u0525\ud7ac\uc411\u0779\u59a7\u050b',
+  size: {width: 700, height: 6, depthOrArrayLayers: 103},
+  mipLevelCount: 7,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let textureView165 = texture96.createView({mipLevelCount: 1});
+let renderBundle77 = renderBundleEncoder62.finish();
+let externalTexture68 = device2.importExternalTexture({label: '\uf6e0\u{1fce5}', source: videoFrame30, colorSpace: 'display-p3'});
+canvas20.height = 1216;
+let promise42 = navigator.gpu.requestAdapter({});
+try {
+offscreenCanvas46.getContext('webgpu');
+} catch {}
+let renderBundle78 = renderBundleEncoder22.finish();
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(1173444148, 1035949364, 1189017288, 255911460, 1138305799);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer1, 382496, 51557);
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer14, 2108, 20);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let renderBundle79 = renderBundleEncoder62.finish({label: '\u056d\u0bf7\u086c'});
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 376868 */
+  offset: 9484,
+  bytesPerRow: 256,
+  rowsPerImage: 41,
+  buffer: buffer32,
+}, {
+  texture: texture100,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 30},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 36});
+dissociateBuffer(device2, buffer32);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout41 = pipeline59.getBindGroupLayout(0);
+let commandEncoder131 = device2.createCommandEncoder({label: '\u{1f941}\u8fb9\u2a9b\u3bd3'});
+let renderBundle80 = renderBundleEncoder57.finish({});
+let externalTexture69 = device2.importExternalTexture({label: '\u{1fd2b}\ub2ae\u4e75\u5e98\u{1fec3}\ud9b2\u0569', source: videoFrame23});
+try {
+canvas41.getContext('webgpu');
+} catch {}
+gc();
+let buffer36 = device2.createBuffer({label: '\ue1de\u5798\u091f', size: 168086, usage: GPUBufferUsage.COPY_SRC});
+let textureView166 = texture92.createView({
+  label: '\u{1f81e}\u6397\u{1fd7f}\u{1fed3}\u0cba\u8b2c\u217f\u2695\u0e6b\u7cf4',
+  format: 'rg11b10ufloat',
+});
+let computePassEncoder67 = commandEncoder122.beginComputePass();
+try {
+renderBundleEncoder58.setIndexBuffer(buffer33, 'uint32', 6332, 55577);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(4, buffer33, 95008, 11140);
+} catch {}
+let commandBuffer22 = commandEncoder128.finish({label: '\uc9b6\uab69\u1b49\ufaf8\u0d6a\u8716\u0412\ue10a\u0ea4'});
+let texture101 = device3.createTexture({
+  size: [24, 1, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let renderBundleEncoder67 = device3.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+commandEncoder126.copyTextureToBuffer({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8828 */
+  offset: 8828,
+  rowsPerImage: 171,
+  buffer: buffer35,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageData9);
+let commandBuffer23 = commandEncoder126.finish({label: '\u079c\ub964\u{1f7de}\u4909\u1aaf\u{1f84d}\uba73\ud7c6\ufc2b'});
+let textureView167 = texture93.createView({label: '\u{1fc5e}\u0fc0\ud0f9\u5dd2\u6d03\u53d2\u9345\u062b', dimension: '2d-array', baseMipLevel: 1});
+let sampler76 = device3.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 66.02,
+  lodMaxClamp: 87.50,
+});
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+texture93.destroy();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 631 */
+{offset: 631}, {width: 175, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame37 = new VideoFrame(canvas9, {timestamp: 0});
+try {
+adapter5.label = '\ub595\u2f60\u{1ff63}\u6f7e\u9a94\u6f02';
+} catch {}
+let video34 = await videoWithData();
+let textureView168 = texture62.createView({label: '\u0611\u0b78', baseMipLevel: 6, mipLevelCount: 1});
+let renderBundleEncoder68 = device1.createRenderBundleEncoder({
+  label: '\u{1f9ba}\u308f\u0017\uc34e\u0008\uf6b8\uf49f\u05d8\ue723\ud6c5',
+  colorFormats: ['r16sint', 'rgba16sint'],
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+commandEncoder104.clearBuffer(buffer28, 30724);
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+renderBundleEncoder56.insertDebugMarker('\u6abc');
+} catch {}
+try {
+device1.queue.submit([commandBuffer18]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 176, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer9), /* required buffer size: 60 */
+{offset: 60}, {width: 1587, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer24 = commandEncoder131.finish({label: '\uf7a6\u2543\u8871\u049a\u0d4c\u{1fede}\u17a3\u{1f916}\u9c38'});
+let textureView169 = texture89.createView({
+  label: '\u{1fe42}\u0798\u0f56\u{1fb6c}\u0c59\u6eb4\u{1fced}\u0bdd\u4569\u08f1\u0bbe',
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder69 = device2.createRenderBundleEncoder({label: '\uaa4e\u{1ffbe}\u{1f66d}\u54e5', colorFormats: ['r16sint', 'rg32float'], sampleCount: 1});
+try {
+device2.queue.submit([]);
+} catch {}
+try {
+window.someLabel = commandEncoder121.label;
+} catch {}
+let commandBuffer25 = commandEncoder129.finish({label: '\u{1f911}\u3fca\u{1fc78}\u{1f768}\u9a1e\u48ab\uada6\u0cf0'});
+let texture102 = device2.createTexture({
+  size: {width: 24, height: 1, depthOrArrayLayers: 19},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let externalTexture70 = device2.importExternalTexture({
+  label: '\u{1fac1}\u037a\u0d5b\u47f7\u88a3\u3cb5\u{1f7ad}\u0664',
+  source: videoFrame18,
+  colorSpace: 'display-p3',
+});
+let pipeline63 = device2.createRenderPipeline({
+  label: '\u0dee\u0afa',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg32float'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'greater', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 456442147,
+    stencilWriteMask: 2302902264,
+    depthBiasSlopeScale: 580.106302102314,
+    depthBiasClamp: 731.3486447815534,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 608,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 204, shaderLocation: 9}],
+      },
+      {arrayStride: 220, attributes: [{format: 'sint32x2', offset: 120, shaderLocation: 10}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder132 = device2.createCommandEncoder({});
+let texture103 = device2.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 579},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let computePassEncoder68 = commandEncoder132.beginComputePass({label: '\u0e07\u07fb\u331d'});
+let sampler77 = device2.createSampler({
+  label: '\u{1fde6}\u{1fb0a}\uc1a5\u{1f88d}\u5096\u017c\u{1f9e9}\u6fe7\u53c9\uba5c\u7f74',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 64.66,
+  lodMaxClamp: 89.35,
+  compare: 'less',
+});
+let externalTexture71 = device2.importExternalTexture({source: videoFrame36, colorSpace: 'display-p3'});
+let videoFrame38 = new VideoFrame(canvas25, {timestamp: 0});
+let renderBundle81 = renderBundleEncoder64.finish({});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+renderBundleEncoder67.insertDebugMarker('\u019f');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 62964, new DataView(new ArrayBuffer(21041)), 3222, 2492);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(0)), /* required buffer size: 1102 */
+{offset: 854, bytesPerRow: 454}, {width: 62, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder133 = device3.createCommandEncoder({label: '\u86f9\u6371\ub642\u{1ff1b}'});
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap31 = await createImageBitmap(img20);
+try {
+window.someLabel = externalTexture51.label;
+} catch {}
+let video35 = await videoWithData();
+let imageBitmap32 = await createImageBitmap(canvas11);
+let commandEncoder134 = device2.createCommandEncoder({label: '\ue0cc\u20b4\u049e'});
+let renderBundleEncoder70 = device2.createRenderBundleEncoder({
+  label: '\u0fd2\u3609\u7e41',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  depthReadOnly: true,
+});
+let sampler78 = device2.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 95.14,
+  lodMaxClamp: 99.70,
+});
+try {
+computePassEncoder62.setPipeline(pipeline58);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+querySet66.destroy();
+} catch {}
+let offscreenCanvas47 = new OffscreenCanvas(89, 988);
+let imageData35 = new ImageData(220, 76);
+let promise43 = adapter5.requestAdapterInfo();
+let textureView170 = texture99.createView({label: '\ud59a\u0007\u{1fd60}\u{1fc86}\u065e'});
+let renderBundle82 = renderBundleEncoder64.finish();
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 55704 */
+  offset: 55528,
+  buffer: buffer35,
+}, {width: 44, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+let canvas42 = document.createElement('canvas');
+let texture104 = device2.createTexture({
+  label: '\uf6f2\u5924\u6a5e',
+  size: [10],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let renderBundle83 = renderBundleEncoder61.finish({label: '\u{1fb08}\u{1f7f8}\u5dad\ue819\ud55e\u494a\u7043\ubfaf\u01d4\u082f\u5bd3'});
+try {
+device2.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer8), /* required buffer size: 27083 */
+{offset: 947, bytesPerRow: 22, rowsPerImage: 297}, {width: 1, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let img40 = await imageWithData(223, 193, '#e6e9ab9b', '#58acc3a5');
+try {
+gpuCanvasContext31.unconfigure();
+} catch {}
+offscreenCanvas42.width = 967;
+let imageBitmap33 = await createImageBitmap(img20);
+let textureView171 = texture94.createView({baseArrayLayer: 0});
+let computePassEncoder69 = commandEncoder125.beginComputePass({label: '\u7860\u2b6a\uba23\ucf87\u07a6\u8691\u7f85\ue1d1\u0cea\u1cef\u0e3a'});
+let renderBundleEncoder71 = device3.createRenderBundleEncoder({
+  label: '\u943d\u{1faed}\u00cf\u8d03\u0fdd',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle84 = renderBundleEncoder66.finish({label: '\uce92\u063e\ud556\u092f\u117b\u2a6c\u6adb\u0790\u{1fabf}\u07d4'});
+try {
+commandEncoder133.copyTextureToBuffer({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 25712 */
+  offset: 25712,
+  buffer: buffer35,
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 60 */
+{offset: 60}, {width: 161, height: 0, depthOrArrayLayers: 1});
+} catch {}
+video15.width = 21;
+let offscreenCanvas48 = new OffscreenCanvas(37, 1005);
+let imageData36 = new ImageData(220, 36);
+let commandEncoder135 = device3.createCommandEncoder({label: '\u{1ff6f}\u7a09\u7322\u9b49\u{1fe5f}\u0f71\uc365'});
+let texture105 = device3.createTexture({
+  label: '\u0681\u5e89\u2798',
+  size: {width: 24, height: 1, depthOrArrayLayers: 168},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView172 = texture95.createView({label: '\u{1ffe4}\u05e8\u0243\u5c39\u{1f8a2}\u{1fbbd}\ub8cd\u0ceb\u0262\u{1fab7}'});
+try {
+renderBundleEncoder67.setVertexBuffer(7076, undefined, 760402094, 3376717435);
+} catch {}
+try {
+commandEncoder135.copyTextureToBuffer({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 10128 */
+  offset: 9968,
+  buffer: buffer35,
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder135.clearBuffer(buffer35, 177212);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+gpuCanvasContext23.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let textureView173 = texture93.createView({label: '\ubba1\uc442\u29a4\u{1f881}\u0717\u8a09\u3dcb', dimension: '2d-array', mipLevelCount: 1});
+let promise44 = adapter8.requestDevice({
+  label: '\u0bae\u5f90\u{1fb82}\u7fe2\u0e1e\u0025\u{1f8ef}\u0992\udfc0',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 55,
+    maxVertexAttributes: 17,
+    maxVertexBufferArrayStride: 21749,
+    maxStorageTexturesPerShaderStage: 15,
+    maxStorageBuffersPerShaderStage: 16,
+    maxDynamicStorageBuffersPerPipelineLayout: 26626,
+    maxDynamicUniformBuffersPerPipelineLayout: 37681,
+    maxBindingsPerBindGroup: 5563,
+    maxTextureArrayLayers: 1985,
+    maxTextureDimension1D: 9238,
+    maxTextureDimension2D: 9279,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 170402735,
+    maxUniformBuffersPerShaderStage: 20,
+    maxSampledTexturesPerShaderStage: 26,
+    maxInterStageShaderVariables: 61,
+    maxInterStageShaderComponents: 85,
+  },
+});
+let video36 = await videoWithData();
+try {
+offscreenCanvas47.getContext('webgl2');
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let buffer37 = device3.createBuffer({size: 16656, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let textureView174 = texture97.createView({label: '\u2b06\u9038\u008e\u2175\u51d6\u0628\u0783\u0358', baseMipLevel: 1, mipLevelCount: 2});
+let renderBundle85 = renderBundleEncoder67.finish({label: '\u252b\u356f\u4ba2\ufa71\u09c3\u464d\ubfc6\u054c\u753c\uf079'});
+try {
+renderBundleEncoder71.setVertexBuffer(6194, undefined, 1283242141, 2619539399);
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 119604, new Int16Array(63042));
+} catch {}
+let commandEncoder136 = device2.createCommandEncoder({label: '\u8fe0\u9788\u3354\ub2b9\u6657\u069a\u9af4\u1991'});
+let textureView175 = texture79.createView({label: '\uac7a\u0fdd\u{1f8b7}\u23d4\u9c98\u0e74\ucc3b\uad0b\ucc3c\uf8ef'});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\u00b2\u0d63\u5cc9\u040d\ue515\u0aeb\u5e8f\u832c\u0434\u{1fd7a}',
+  colorFormats: ['r16sint', 'rg32float'],
+  depthReadOnly: true,
+});
+let renderBundle86 = renderBundleEncoder58.finish({});
+let externalTexture72 = device2.importExternalTexture({source: videoFrame31, colorSpace: 'srgb'});
+try {
+renderBundleEncoder70.setIndexBuffer(buffer33, 'uint32', 68160, 16181);
+} catch {}
+let pipeline64 = device2.createRenderPipeline({
+  label: '\u88f5\u{1f7ac}\u{1fb14}\u0209\u{1f839}',
+  layout: 'auto',
+  multisample: {mask: 0xa91edbe6},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'keep', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 2896961186,
+    stencilWriteMask: 3678796484,
+    depthBias: 255111998,
+    depthBiasClamp: 792.6839106114938,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 140,
+        attributes: [
+          {format: 'sint16x4', offset: 44, shaderLocation: 9},
+          {format: 'sint16x2', offset: 20, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let offscreenCanvas49 = new OffscreenCanvas(581, 257);
+let textureView176 = texture92.createView({label: '\uf8b2\u09b8'});
+try {
+gpuCanvasContext14.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+let pipeline65 = device2.createComputePipeline({
+  label: '\u0217\ue0de\uc311\u0b76\u4b08\u3545\u{1fe43}\u0e9a\u4d22\u0abc\u899f',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas48.getContext('webgl2');
+} catch {}
+let commandEncoder137 = device2.createCommandEncoder();
+let textureView177 = texture88.createView({aspect: 'all', baseMipLevel: 3, baseArrayLayer: 96, arrayLayerCount: 2});
+let renderBundleEncoder73 = device2.createRenderBundleEncoder({colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'], depthReadOnly: true});
+let externalTexture73 = device2.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder58.setPipeline(pipeline65);
+} catch {}
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture100,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 65},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet70 = device3.createQuerySet({label: '\u062e\u{1fff0}', type: 'occlusion', count: 2037});
+try {
+renderBundleEncoder71.setVertexBuffer(7959, undefined, 0);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let promise45 = buffer35.mapAsync(GPUMapMode.READ, 264920);
+try {
+commandEncoder133.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 384 */
+{offset: 384}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas49.getContext('webgl2');
+} catch {}
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  label: '\ue2d6\u{1fa7d}\u1ad6\u0ccf\u4c2d\u{1fb45}\u7177\u0bf7\uf68a',
+  entries: [
+    {
+      binding: 1311,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 940733, hasDynamicOffset: true },
+    },
+    {
+      binding: 1015,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder138 = device3.createCommandEncoder({label: '\u0801\u{1f89b}\uc22c\u6ae2\u69f6\uf925\u53af\u09cf\u9a91\u606f'});
+let texture106 = device3.createTexture({
+  label: '\u057e\uafd4\u{1fd26}\u9499\uac2a',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+try {
+commandEncoder135.insertDebugMarker('\u9c62');
+} catch {}
+let video37 = await videoWithData();
+try {
+renderBundleEncoder71.setVertexBuffer(4110, undefined, 3831157503, 406872853);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture97,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 1666 */
+{offset: 906, bytesPerRow: 946}, {width: 190, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData37 = new ImageData(176, 172);
+try {
+canvas42.getContext('2d');
+} catch {}
+let pipelineLayout20 = device3.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout42, bindGroupLayout42, bindGroupLayout42, bindGroupLayout42],
+});
+let textureView178 = texture97.createView({label: '\u{1f756}\ubb21\u7f11\u1c03\ud11b\u72b8\u39e2', baseMipLevel: 2, mipLevelCount: 1});
+try {
+commandEncoder133.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+canvas24.width = 1448;
+let offscreenCanvas50 = new OffscreenCanvas(121, 669);
+let shaderModule16 = device2.createShaderModule({
+  code: `@group(0) @binding(696)
+var<storage, read_write> function11: array<u32>;
+@group(0) @binding(333)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(696)
+var<storage, read_write> type10: array<u32>;
+@group(1) @binding(333)
+var<storage, read_write> field11: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(1) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(3) f0: vec3<i32>,
+  @location(2) f1: vec4<f16>,
+  @location(10) f2: vec2<i32>,
+  @location(4) f3: i32,
+  @location(12) f4: vec3<i32>,
+  @location(7) f5: vec3<f32>,
+  @location(6) f6: vec2<f32>,
+  @location(11) f7: vec3<f32>,
+  @location(1) f8: f16,
+  @builtin(instance_index) f9: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: u32, @location(8) a1: vec2<f32>, @location(13) a2: f16, @location(9) a3: vec4<f16>, @location(15) a4: f32, @location(0) a5: vec4<u32>, @location(14) a6: vec4<f16>, a7: S19, @builtin(vertex_index) a8: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView179 = texture96.createView({});
+let renderBundle87 = renderBundleEncoder51.finish({label: '\u0c6e\u0da7\u2b4b\u08fd\u01c6\uab65\u{1fd1d}\u94ee'});
+try {
+renderBundleEncoder70.setVertexBuffer(7, buffer33);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 31736 */
+  offset: 31736,
+  rowsPerImage: 120,
+  buffer: buffer32,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer32);
+} catch {}
+let commandBuffer26 = commandEncoder135.finish();
+let textureView180 = texture106.createView({label: '\u08bf\uf1b8\u{1fda0}\u4609\ucf40\u0e4b\u9fa3\u{1fc1f}\u11e3\u0ce5', dimension: '1d'});
+let renderBundle88 = renderBundleEncoder71.finish({label: '\u26f3\u0215\u{1f6dd}\u{1f91e}\u02f4'});
+try {
+  await buffer37.mapAsync(GPUMapMode.WRITE, 0, 13492);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 54 */
+{offset: 54}, {width: 89, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let canvas43 = document.createElement('canvas');
+let imageBitmap34 = await createImageBitmap(canvas42);
+let commandEncoder139 = device3.createCommandEncoder({label: '\u0d14\u{1fba3}\u{1fc52}\udf34\u56eb\u171e\u{1f909}\udde4'});
+let textureView181 = texture106.createView({label: '\ub30e\u0000\u41c7', aspect: 'all', format: 'rgba8unorm-srgb', baseMipLevel: 0});
+try {
+device3.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 283 */
+{offset: 283, bytesPerRow: 407}, {width: 85, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder140 = device3.createCommandEncoder({label: '\u{1fbfa}\u{1ffbc}\u2cab\uf8f2\u59b1\u5228\udcdf'});
+let externalTexture74 = device3.importExternalTexture({
+  label: '\u640a\u0d8d\u{1f633}\u6701\u0bd3\u{1fa36}\u5d9c\u{1ff44}',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+let arrayBuffer11 = buffer37.getMappedRange(0, 644);
+try {
+commandEncoder138.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+canvas43.getContext('webgl');
+} catch {}
+try {
+offscreenCanvas50.getContext('bitmaprenderer');
+} catch {}
+try {
+  await promise41;
+} catch {}
+let canvas44 = document.createElement('canvas');
+let imageBitmap35 = await createImageBitmap(img9);
+let shaderModule17 = device3.createShaderModule({
+  label: '\u{1f655}\u46c2\uf664\u{1faec}',
+  code: `@group(0) @binding(1311)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(1015)
+var<storage, read_write> n9: array<u32>;
+@group(2) @binding(1311)
+var<storage, read_write> type11: array<u32>;
+@group(1) @binding(1311)
+var<storage, read_write> local10: array<u32>;
+@group(3) @binding(1311)
+var<storage, read_write> local11: array<u32>;
+@group(4) @binding(1311)
+var<storage, read_write> parameter7: array<u32>;
+@group(3) @binding(1015)
+var<storage, read_write> global8: array<u32>;
+@group(4) @binding(1015)
+var<storage, read_write> local12: array<u32>;
+@group(2) @binding(1015)
+var<storage, read_write> type12: array<u32>;
+@group(1) @binding(1015)
+var<storage, read_write> local13: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+  @location(53) f0: vec3<i32>,
+  @location(56) f1: vec4<f16>,
+  @location(36) f2: vec3<f16>,
+  @location(16) f3: vec2<f16>,
+  @location(55) f4: vec3<f16>,
+  @location(59) f5: f16,
+  @location(2) f6: vec4<i32>,
+  @location(52) f7: vec3<f16>,
+  @location(78) f8: f16,
+  @location(37) f9: vec3<u32>,
+  @location(0) f10: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(6) f1: vec4<f32>,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(70) a0: f16, @location(49) a1: vec2<f32>, @location(15) a2: vec3<f32>, @builtin(sample_index) a3: u32, @location(79) a4: f32, @builtin(position) a5: vec4<f32>, @location(17) a6: f16, @builtin(front_facing) a7: bool, @location(46) a8: vec2<i32>, @location(44) a9: vec3<u32>, @location(5) a10: u32, @location(34) a11: vec2<f32>, @location(13) a12: vec3<f32>, @location(21) a13: f16, @location(30) a14: f32, @location(3) a15: f16, @location(1) a16: vec3<i32>, @location(71) a17: vec2<u32>, @location(76) a18: f16, @location(51) a19: vec4<i32>, @location(74) a20: vec3<u32>, @builtin(sample_mask) a21: u32, @location(58) a22: vec4<f32>, @location(41) a23: vec2<i32>, @location(38) a24: vec2<f32>, @location(4) a25: u32, a26: S21, @location(48) a27: i32, @location(62) a28: f16, @location(47) a29: vec2<u32>, @location(40) a30: vec3<u32>, @location(10) a31: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @builtin(vertex_index) f0: u32,
+  @builtin(instance_index) f1: u32,
+  @location(9) f2: vec3<u32>,
+  @location(14) f3: u32,
+  @location(8) f4: u32,
+  @location(7) f5: vec4<f16>,
+  @location(5) f6: vec4<f16>,
+  @location(6) f7: vec3<u32>,
+  @location(4) f8: vec3<f16>,
+  @location(13) f9: vec3<i32>,
+  @location(2) f10: vec3<f16>,
+  @location(3) f11: vec2<u32>,
+  @location(1) f12: vec4<i32>,
+  @location(0) f13: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(71) f321: vec2<u32>,
+  @location(52) f322: vec3<f16>,
+  @location(79) f323: f32,
+  @location(44) f324: vec3<u32>,
+  @location(55) f325: vec3<f16>,
+  @location(48) f326: i32,
+  @location(47) f327: vec2<u32>,
+  @location(15) f328: vec3<f32>,
+  @location(2) f329: vec4<i32>,
+  @location(4) f330: u32,
+  @location(76) f331: f16,
+  @location(21) f332: f16,
+  @location(78) f333: f16,
+  @location(40) f334: vec3<u32>,
+  @location(59) f335: f16,
+  @location(1) f336: vec3<i32>,
+  @location(13) f337: vec3<f32>,
+  @location(51) f338: vec4<i32>,
+  @location(17) f339: f16,
+  @location(0) f340: vec3<i32>,
+  @location(34) f341: vec2<f32>,
+  @location(3) f342: f16,
+  @location(30) f343: f32,
+  @location(36) f344: vec3<f16>,
+  @location(37) f345: vec3<u32>,
+  @location(46) f346: vec2<i32>,
+  @location(49) f347: vec2<f32>,
+  @location(53) f348: vec3<i32>,
+  @location(38) f349: vec2<f32>,
+  @location(70) f350: f16,
+  @location(58) f351: vec4<f32>,
+  @location(10) f352: f16,
+  @location(5) f353: u32,
+  @location(74) f354: vec3<u32>,
+  @location(56) f355: vec4<f16>,
+  @location(62) f356: f16,
+  @location(16) f357: vec2<f16>,
+  @location(41) f358: vec2<i32>,
+  @builtin(position) f359: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S20, @location(11) a1: vec4<i32>, @location(12) a2: vec2<f16>, @location(15) a3: vec3<u32>, @location(10) a4: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout43 = device3.createBindGroupLayout({
+  label: '\u63a9\u8742\u0b05',
+  entries: [
+    {
+      binding: 2165,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 4294,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture107 = device3.createTexture({
+  label: '\uede6\u{1fb48}\ued2c\u0bab\u0ad7\u61d7\u{1ff42}\u0c54\u06af\u9fef',
+  size: [48],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderBundleEncoder74 = device3.createRenderBundleEncoder({label: '\ua2ce\uc726\u8959\u0d5d\u88d6\u0964\u074a', colorFormats: ['rgb10a2uint', 'rgba8unorm']});
+let renderBundle89 = renderBundleEncoder64.finish({});
+let arrayBuffer12 = buffer37.getMappedRange(11848, 776);
+try {
+commandEncoder133.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+let bindGroup25 = device3.createBindGroup({
+  label: '\u0368\u0805\u44ec',
+  layout: bindGroupLayout43,
+  entries: [{binding: 4294, resource: sampler75}, {binding: 2165, resource: sampler76}],
+});
+let textureView182 = texture93.createView({label: '\uaba9\u3349\u{1fdcf}\u0d55\ub7b4\u00bd\u0328\ua38c\u4f78', dimension: '2d-array'});
+let renderBundle90 = renderBundleEncoder71.finish();
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline66 = device3.createComputePipeline({layout: pipelineLayout20, compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}}});
+let commandEncoder141 = device2.createCommandEncoder({});
+let textureView183 = texture98.createView({label: '\u{1f84d}\u{1f6ea}\u{1fc6a}\u04b3\u087f\u5425\u10cd\u638e\uaf39'});
+let computePassEncoder70 = commandEncoder137.beginComputePass();
+let sampler79 = device2.createSampler({
+  label: '\u0f73\u02c5\u6021\u03f2\u0b7a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.21,
+  lodMaxClamp: 89.46,
+  maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder69.setVertexBuffer(7, buffer33);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 22056 */
+  offset: 21896,
+  bytesPerRow: 256,
+  buffer: buffer36,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer36);
+} catch {}
+let pipeline67 = await device2.createRenderPipelineAsync({
+  label: '\u0978\ud535\uc780\u00c4\u43f9\udc52\u{1f6a2}',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 412,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 60, shaderLocation: 6},
+          {format: 'float32x4', offset: 128, shaderLocation: 1},
+          {format: 'float32x3', offset: 24, shaderLocation: 15},
+          {format: 'uint32x2', offset: 172, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 108, shaderLocation: 11},
+          {format: 'uint8x4', offset: 36, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 952,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 272, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 32, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 672, attributes: [{format: 'snorm16x2', offset: 88, shaderLocation: 7}]},
+      {
+        arrayStride: 708,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 416, shaderLocation: 9},
+          {format: 'sint32x4', offset: 116, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 56, shaderLocation: 14},
+          {format: 'sint32x2', offset: 8, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 352,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x4', offset: 8, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x4', offset: 424, shaderLocation: 12},
+          {format: 'sint32x4', offset: 836, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let querySet71 = device3.createQuerySet({type: 'occlusion', count: 1223});
+let textureView184 = texture93.createView({label: '\u0712\u0bcc', dimension: '2d-array', baseArrayLayer: 0});
+let externalTexture75 = device3.importExternalTexture({label: '\u{1fcfe}\ud0a9\u91c6\uf787\u0783\ua3d7\u98b9', source: video25, colorSpace: 'srgb'});
+let pipeline68 = device3.createComputePipeline({
+  label: '\u222c\u{1f98b}\u10f5',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext37 = canvas44.getContext('webgpu');
+try {
+  await promise37;
+} catch {}
+try {
+window.someLabel = texture74.label;
+} catch {}
+let video38 = await videoWithData();
+let commandEncoder142 = device3.createCommandEncoder({label: '\u011d\u0e2c\u5a87\u{1f88b}\uc079\u7136\uadc5\ub3d3\u{1fc43}\u6afd'});
+let externalTexture76 = device3.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+commandEncoder139.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(24)), /* required buffer size: 453 */
+{offset: 453}, {width: 23, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise45;
+} catch {}
+let offscreenCanvas51 = new OffscreenCanvas(130, 22);
+try {
+  await promise43;
+} catch {}
+let computePassEncoder71 = commandEncoder139.beginComputePass({label: '\u{1fd06}\u07ec\u5d45\u01b6\u9831\u{1fb8e}\u{1fde0}\u8b9b\u{1f8ed}\u01bc\u04d7'});
+let renderBundleEncoder75 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler80 = device3.createSampler({
+  label: '\ue17e\ufbd7\u0909',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.87,
+  lodMaxClamp: 78.42,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder74.setBindGroup(6, bindGroup25);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let gpuCanvasContext38 = offscreenCanvas51.getContext('webgpu');
+offscreenCanvas0.width = 4921;
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let canvas45 = document.createElement('canvas');
+let imageBitmap36 = await createImageBitmap(img24);
+let texture108 = device3.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder75.setVertexBuffer(8548, undefined, 140116683, 1755213415);
+} catch {}
+try {
+commandEncoder142.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture97,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 674 */
+{offset: 674}, {width: 21, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext39 = canvas45.getContext('webgpu');
+let buffer38 = device2.createBuffer({
+  label: '\u{1fc62}\ue4d1\u390d\ue864\uaf25',
+  size: 148014,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+});
+let texture109 = device2.createTexture({
+  label: '\u{1faf1}\u9ce9\u76cd\u0a43\u021b',
+  size: [10],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView185 = texture92.createView({label: '\u2826\u{1fd7e}', baseMipLevel: 0});
+let sampler81 = device2.createSampler({
+  label: '\u3aab\u0e7b\u0d9d\u0ffe\uc48e\u{1fa94}\u2b7b\u9713\u3177',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.16,
+  lodMaxClamp: 57.17,
+  maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder69.setVertexBuffer(2, buffer33, 0, 24020);
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 89540 */
+  offset: 1220,
+  bytesPerRow: 256,
+  rowsPerImage: 69,
+  buffer: buffer31,
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 6});
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+commandEncoder136.clearBuffer(buffer38, 130572, 4860);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+adapter10.label = '\u0444\u6fce\u9a64\ud4ce\u027b\u33b4\u{1f70e}';
+} catch {}
+let shaderModule18 = device2.createShaderModule({
+  label: '\u473e\uf9ec\u1508\u66c8\u22c5\u9a15\u9108\u004f\u0f86\u0aaa',
+  code: `@group(1) @binding(333)
+var<storage, read_write> function12: array<u32>;
+@group(0) @binding(696)
+var<storage, read_write> local14: array<u32>;
+@group(1) @binding(696)
+var<storage, read_write> n10: array<u32>;
+@group(0) @binding(333)
+var<storage, read_write> parameter8: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+  @location(9) f0: vec2<f32>,
+  @location(12) f1: vec3<f32>,
+  @builtin(sample_index) f2: u32,
+  @location(14) f3: vec4<u32>,
+  @location(7) f4: f16,
+  @location(5) f5: u32,
+  @location(4) f6: vec4<i32>,
+  @location(2) f7: u32,
+  @location(15) f8: vec4<f16>,
+  @location(10) f9: vec4<f32>,
+  @location(3) f10: u32,
+  @location(0) f11: vec4<f16>,
+  @location(6) f12: vec3<i32>,
+  @builtin(front_facing) f13: bool,
+  @builtin(position) f14: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: i32,
+  @location(5) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(11) a1: f16, a2: S23) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S22 {
+  @location(9) f0: vec3<f16>,
+  @location(5) f1: i32,
+  @location(1) f2: vec3<f16>,
+  @location(6) f3: f32,
+  @location(10) f4: vec4<i32>,
+  @location(14) f5: vec2<f16>,
+  @location(3) f6: vec4<f32>,
+  @location(13) f7: f16,
+  @location(0) f8: vec2<f32>,
+  @location(4) f9: vec2<u32>,
+  @location(12) f10: f16
+}
+struct VertexOutput0 {
+  @location(7) f360: f16,
+  @location(14) f361: vec4<u32>,
+  @location(0) f362: vec4<f16>,
+  @location(9) f363: vec2<f32>,
+  @location(3) f364: u32,
+  @location(4) f365: vec4<i32>,
+  @location(6) f366: vec3<i32>,
+  @location(12) f367: vec3<f32>,
+  @location(5) f368: u32,
+  @builtin(position) f369: vec4<f32>,
+  @location(10) f370: vec4<f32>,
+  @location(15) f371: vec4<f16>,
+  @location(2) f372: u32,
+  @location(11) f373: f16
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<i32>, @location(11) a1: i32, a2: S22, @location(2) a3: f16, @location(15) a4: u32, @location(7) a5: vec2<u32>, @builtin(vertex_index) a6: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet72 = device2.createQuerySet({label: '\u02f1\u{1f7a3}\u{1f79c}', type: 'occlusion', count: 1092});
+let texture110 = device2.createTexture({
+  label: '\u{1f752}\u{1febf}\u0d10\u0dcd\u0e63\u{1f89c}\u577a\u89d3\u01a9\u0fd9\u6476',
+  size: {width: 192},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float', 'rg32float', 'rg32float'],
+});
+let textureView186 = texture79.createView({label: '\u0c10\uc9f4\u{1f9ff}'});
+let sampler82 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 21.07,
+});
+try {
+renderBundleEncoder69.setPipeline(pipeline67);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(2, buffer33, 21984, 19738);
+} catch {}
+try {
+commandEncoder136.copyTextureToBuffer({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 92844 */
+  offset: 9900,
+  bytesPerRow: 256,
+  rowsPerImage: 162,
+  buffer: buffer38,
+}, {width: 8, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer11), /* required buffer size: 953 */
+{offset: 863}, {width: 45, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let buffer39 = device3.createBuffer({size: 490029, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandBuffer27 = commandEncoder138.finish({label: '\u8093\ube3b'});
+let texture111 = gpuCanvasContext17.getCurrentTexture();
+let textureView187 = texture93.createView({label: '\uf3bd\ue4c6\u0cb9\u{1fe28}', dimension: '2d-array', format: 'rgb10a2uint', arrayLayerCount: 1});
+let renderBundle91 = renderBundleEncoder67.finish();
+let sampler83 = device3.createSampler({
+  label: '\ub894\u09be\uf187\uc69b\u0c7e\ucdcd\u08f7\ub3d8\uadc1\u{1f78f}\uc3dc',
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.89,
+  compare: 'greater',
+});
+try {
+renderBundleEncoder74.setBindGroup(1, bindGroup25, []);
+} catch {}
+let arrayBuffer13 = buffer37.getMappedRange(648, 848);
+try {
+commandEncoder133.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+let promise46 = device3.createComputePipelineAsync({
+  label: '\u87d4\u0cde\u18d2\u4804\u0c5a\ue3f5\u02f9\u0c2d\u7d7e\u0ddf\u093d',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let promise47 = device3.createRenderPipelineAsync({
+  layout: pipelineLayout20,
+  multisample: {count: 4, mask: 0xe19f69aa},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8unorm', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'keep', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp'},
+    stencilWriteMask: 2653011058,
+    depthBiasSlopeScale: -38.33219165938901,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 924,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 160, shaderLocation: 13},
+          {format: 'uint32x4', offset: 112, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 64, shaderLocation: 5},
+          {format: 'uint8x4', offset: 68, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 292, shaderLocation: 4},
+          {format: 'sint32x4', offset: 484, shaderLocation: 11},
+          {format: 'uint32', offset: 296, shaderLocation: 0},
+          {format: 'uint16x4', offset: 156, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 892, shaderLocation: 2},
+          {format: 'uint8x4', offset: 540, shaderLocation: 8},
+          {format: 'uint8x2', offset: 190, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 484, shaderLocation: 7},
+          {format: 'sint8x4', offset: 196, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 4580,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 2580, shaderLocation: 12},
+          {format: 'sint32x2', offset: 1312, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 22972, stepMode: 'vertex', attributes: []},
+      {arrayStride: 35496, attributes: []},
+      {arrayStride: 6748, attributes: []},
+      {arrayStride: 5680, attributes: []},
+      {
+        arrayStride: 5328,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 3000, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw', unclippedDepth: false},
+});
+let adapter11 = await promise21;
+let querySet73 = device3.createQuerySet({label: '\u2da0\u{1fed9}\u{1ff92}', type: 'occlusion', count: 4018});
+let textureView188 = texture107.createView({label: '\u77d9\u050c\uc712\u0842\uf0c9\uc726\ubb42\ubdef\u0f8f', arrayLayerCount: 1});
+let computePassEncoder72 = commandEncoder133.beginComputePass();
+let sampler84 = device3.createSampler({
+  label: '\u{1fce2}\u010d\u0a82',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.4034,
+  maxAnisotropy: 19,
+});
+try {
+buffer35.destroy();
+} catch {}
+gc();
+document.body.prepend(video5);
+let video39 = await videoWithData();
+let offscreenCanvas52 = new OffscreenCanvas(911, 103);
+let shaderModule19 = device0.createShaderModule({
+  label: '\uf849\u64b8\ub881',
+  code: `@group(7) @binding(402)
+var<storage, read_write> parameter9: array<u32>;
+@group(0) @binding(4138)
+var<storage, read_write> field12: array<u32>;
+@group(1) @binding(402)
+var<storage, read_write> local15: array<u32>;
+@group(0) @binding(4109)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(5, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout44 = device0.createBindGroupLayout({label: '\uc704\u020c\u{1f846}\ua209\u6475\u{1f858}\u0145\u0ff8\u0dc6\u005e', entries: []});
+let textureView189 = texture6.createView({});
+let computePassEncoder73 = commandEncoder79.beginComputePass({label: '\u034f\u57d9'});
+let renderBundleEncoder76 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgb10a2unorm', 'rg16float', 'r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle92 = renderBundleEncoder3.finish({label: '\u4e1d\uefc5\u6039'});
+try {
+renderBundleEncoder9.draw(256896287, 112115767, 425308090, 897751457);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 202, y: 0, z: 44},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 112112, new BigUint64Array(14383), 14082, 8);
+} catch {}
+let gpuCanvasContext40 = offscreenCanvas52.getContext('webgpu');
+let bindGroup26 = device3.createBindGroup({
+  label: '\u00f7\u5751\u{1fa04}\u43ee\u024c\ud51e\ua448\ucd54',
+  layout: bindGroupLayout43,
+  entries: [{binding: 2165, resource: sampler84}, {binding: 4294, resource: sampler80}],
+});
+let textureView190 = texture97.createView({
+  label: '\u0e5c\u0d87\u0284\u{1f677}\u2f43\u036d\u074c\ua7de',
+  aspect: 'all',
+  baseMipLevel: 3,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder77 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+  stencilReadOnly: true,
+});
+let sampler85 = device3.createSampler({
+  label: '\u{1fee2}\u1661\u{1fdf8}\uc976\u4132\u8b71\ud23f\ufaa9\u058a',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 44.09,
+  lodMaxClamp: 79.63,
+});
+try {
+renderBundleEncoder77.setBindGroup(6, bindGroup25);
+} catch {}
+let pipeline69 = await device3.createComputePipelineAsync({
+  label: '\u{1f7b2}\u2d2c\u8d55',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let video40 = await videoWithData();
+let shaderModule20 = device2.createShaderModule({
+  code: `@group(1) @binding(696)
+var<storage, read_write> n11: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(3) f2: vec4<i32>,
+  @location(2) f3: vec3<f32>,
+  @location(7) f4: vec3<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec3<i32>, @location(10) a1: vec4<u32>, @location(6) a2: vec3<f32>, @location(2) a3: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder143 = device2.createCommandEncoder({});
+let textureView191 = texture90.createView({
+  label: '\u6fe0\u{1fbda}\u7c27\ua040\u{1fda8}\u{1fe0f}\ua963\u0b77\u0e7c\u0963\ub2d4',
+  dimension: '3d',
+  aspect: 'all',
+});
+try {
+commandEncoder141.copyBufferToBuffer(buffer32, 646084, buffer38, 60992, 416);
+dissociateBuffer(device2, buffer32);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder141.clearBuffer(buffer38, 132960, 14256);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+device2.queue.submit([commandBuffer25]);
+} catch {}
+let pipeline70 = await device2.createComputePipelineAsync({
+  label: '\u1f70\u47a6\u6ffd\u18dc\uc9ef\u{1fcf0}\u48aa\u{1fe4a}\ueb5a',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let renderBundleEncoder78 = device3.createRenderBundleEncoder({
+  label: '\uc315\uf523\ud053\u6410\u0890\u021c\u{1fede}\udc74\u7fe9',
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+  sampleCount: 1,
+});
+let externalTexture77 = device3.importExternalTexture({source: videoFrame33, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder77.setBindGroup(5, bindGroup26, new Uint32Array(4502), 2395, 0);
+} catch {}
+try {
+commandEncoder142.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder142.resolveQuerySet(querySet68, 325, 123, buffer39, 395008);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 448837 */
+{offset: 547, bytesPerRow: 293, rowsPerImage: 255}, {width: 1, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let videoFrame39 = new VideoFrame(img23, {timestamp: 0});
+try {
+adapter5.label = '\u4115\u505f\u0711\u{1f670}\ub499\uacbf\u2e8c\u0348';
+} catch {}
+let commandEncoder144 = device2.createCommandEncoder({});
+let textureView192 = texture79.createView({label: '\u{1fa81}\u0be2\u{1fee7}'});
+let sampler86 = device2.createSampler({
+  label: '\uf99e\u6e0d\u047c\u7117\uf336\u{1fd38}\u{1f60a}\u{1fe58}\u07ef',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.37,
+  lodMaxClamp: 97.54,
+});
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder134.copyBufferToBuffer(buffer36, 68764, buffer38, 103128, 22948);
+dissociateBuffer(device2, buffer36);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer2), /* required buffer size: 699805 */
+{offset: 205, bytesPerRow: 48, rowsPerImage: 275}, {width: 0, height: 1, depthOrArrayLayers: 54});
+} catch {}
+let pipeline71 = await device2.createRenderPipelineAsync({
+  label: '\ub7a9\ucc1b\u89b9\u0a61\u7046\u02a7',
+  layout: pipelineLayout19,
+  multisample: {count: 4, mask: 0x861a0d18},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32float', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm8x2', offset: 74, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 924, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 64, shaderLocation: 9},
+          {format: 'sint16x2', offset: 292, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 124, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 612,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 28, shaderLocation: 4},
+          {format: 'uint8x2', offset: 58, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 78, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 196, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 176, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 92, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 520,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 220, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 2048,
+        attributes: [
+          {format: 'uint16x2', offset: 172, shaderLocation: 0},
+          {format: 'float32x3', offset: 684, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 436, attributes: [{format: 'unorm16x4', offset: 64, shaderLocation: 13}]},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 244, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let img41 = await imageWithData(249, 276, '#fef7e59c', '#2af0d0e8');
+let bindGroup27 = device3.createBindGroup({
+  label: '\u{1f7f8}\ub1b4\u{1fa67}',
+  layout: bindGroupLayout43,
+  entries: [{binding: 4294, resource: sampler74}, {binding: 2165, resource: sampler84}],
+});
+let commandEncoder145 = device3.createCommandEncoder({label: '\ubb40\u0a6c\u02bf\u{1f6cb}\u66ab'});
+try {
+computePassEncoder71.setPipeline(pipeline69);
+} catch {}
+try {
+buffer39.destroy();
+} catch {}
+try {
+commandEncoder142.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 600 */
+{offset: 472, bytesPerRow: 352}, {width: 32, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap37 = await createImageBitmap(offscreenCanvas10);
+let renderBundle93 = renderBundleEncoder65.finish();
+try {
+computePassEncoder69.setBindGroup(3, bindGroup26, new Uint32Array(3918), 1235, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline68);
+} catch {}
+let bindGroupLayout45 = device2.createBindGroupLayout({
+  label: '\ud453\uefe3\u005c\u5ae6\ud0c2\u0226',
+  entries: [
+    {
+      binding: 589,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 869106, hasDynamicOffset: true },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let renderBundleEncoder79 = device2.createRenderBundleEncoder({colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'], depthReadOnly: true});
+let sampler87 = device2.createSampler({
+  label: '\ub883\u3217\u{1fe4d}',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.09,
+  lodMaxClamp: 96.38,
+});
+try {
+renderBundleEncoder79.setVertexBuffer(4, buffer33, 0);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext24.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas1);
+let buffer40 = device3.createBuffer({size: 129898, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture112 = device3.createTexture({
+  label: '\u3182\u6bef\ufa9e\u0625\u57fb\u01e7\u{1fd94}\u05cf',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let sampler88 = device3.createSampler({
+  label: '\u1210\u1797\u0912',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.03,
+  lodMaxClamp: 42.29,
+  maxAnisotropy: 1,
+});
+let textureView193 = texture96.createView({dimension: '1d'});
+let computePassEncoder74 = commandEncoder141.beginComputePass({label: '\uf8cd\u7f42'});
+let sampler89 = device2.createSampler({
+  label: '\udec7\u082f\u6d47\ud3eb\u{1fef9}\uda13\ub6bd\u0963\ub256',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 16.36,
+  lodMaxClamp: 27.37,
+  compare: 'less-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderBundleEncoder72.setPipeline(pipeline67);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(0, buffer33, 0, 38890);
+} catch {}
+try {
+commandEncoder144.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 27},
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+commandEncoder124.clearBuffer(buffer38, 57332, 74956);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let commandEncoder146 = device0.createCommandEncoder({label: '\u0187\u0be5\u04cd'});
+let textureView194 = texture9.createView({
+  label: '\u6555\u0cb8\u0428\ud984',
+  dimension: '2d-array',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder80 = device0.createRenderBundleEncoder({
+  label: '\u{1ff99}\u{1f689}\u010f\u32ac\u6a9b\ua744\u0d33\u{1f997}\u{1f99b}\u{1f6bd}',
+  colorFormats: ['rg8uint', 'rgba32sint', 'r8sint', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: false,
+});
+let sampler90 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 14.73,
+  lodMaxClamp: 81.49,
+});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer14, 120);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer8, 7580);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 4,
+  origin: {x: 41, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline72 = await promise11;
+let pipeline73 = device0.createRenderPipeline({
+  label: '\ucdd9\u4501',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, undefined, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 2942722209,
+    stencilWriteMask: 3255001353,
+    depthBiasSlopeScale: 935.5300683673802,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4528,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 168, shaderLocation: 5},
+          {format: 'uint16x4', offset: 476, shaderLocation: 16},
+          {format: 'float16x4', offset: 428, shaderLocation: 22},
+          {format: 'sint8x4', offset: 1064, shaderLocation: 21},
+          {format: 'uint32x3', offset: 156, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 7308,
+        attributes: [
+          {format: 'unorm16x2', offset: 24, shaderLocation: 12},
+          {format: 'sint32x2', offset: 240, shaderLocation: 25},
+          {format: 'uint32x4', offset: 2184, shaderLocation: 1},
+          {format: 'sint8x4', offset: 2568, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 260, shaderLocation: 18},
+          {format: 'sint16x2', offset: 3368, shaderLocation: 20},
+          {format: 'sint32', offset: 2316, shaderLocation: 0},
+          {format: 'float16x4', offset: 1692, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 1232, shaderLocation: 3},
+          {format: 'float32x3', offset: 4296, shaderLocation: 8},
+          {format: 'uint32x2', offset: 2844, shaderLocation: 7},
+          {format: 'uint32x2', offset: 2128, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 1020, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 988, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let bindGroup28 = device3.createBindGroup({
+  label: '\ua965\u0825\u1eba\u58c2\u82fb\ua45b\u3950',
+  layout: bindGroupLayout43,
+  entries: [{binding: 4294, resource: sampler75}, {binding: 2165, resource: sampler88}],
+});
+let commandEncoder147 = device3.createCommandEncoder({label: '\u{1fce4}\ua8ce\u0778'});
+let sampler91 = device3.createSampler({
+  label: '\u010b\u0da1\u0b16\u0b55\u{1fc28}\u{1f94d}\u8633',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.33,
+  lodMaxClamp: 75.58,
+  compare: 'equal',
+  maxAnisotropy: 18,
+});
+try {
+commandEncoder147.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder147.resolveQuerySet(querySet71, 573, 435, buffer39, 389120);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline74 = await device3.createRenderPipelineAsync({
+  label: '\u0a11\u0e92\u99b1',
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5944,
+        attributes: [
+          {format: 'uint32x3', offset: 2020, shaderLocation: 3},
+          {format: 'float16x2', offset: 1904, shaderLocation: 2},
+          {format: 'uint8x4', offset: 284, shaderLocation: 15},
+          {format: 'uint32x3', offset: 588, shaderLocation: 0},
+          {format: 'uint8x4', offset: 2564, shaderLocation: 6},
+          {format: 'sint32x4', offset: 676, shaderLocation: 1},
+          {format: 'sint16x4', offset: 1304, shaderLocation: 13},
+          {format: 'uint32x3', offset: 116, shaderLocation: 8},
+          {format: 'sint16x2', offset: 320, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 11456, attributes: [{format: 'uint16x2', offset: 1336, shaderLocation: 9}]},
+      {
+        arrayStride: 2184,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 2180, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 792, shaderLocation: 7},
+          {format: 'sint32x4', offset: 532, shaderLocation: 10},
+          {format: 'uint8x4', offset: 716, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 3016,
+        attributes: [
+          {format: 'float16x2', offset: 436, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 84, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw'},
+});
+let img42 = await imageWithData(291, 50, '#dd10bfd3', '#60c797bb');
+let computePassEncoder75 = commandEncoder134.beginComputePass({});
+try {
+renderBundleEncoder69.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(2, buffer33, 95876);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 18},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 6717633 */
+{offset: 29, bytesPerRow: 99, rowsPerImage: 129}, {width: 29, height: 1, depthOrArrayLayers: 527});
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+document.body.prepend(img37);
+let commandEncoder148 = device3.createCommandEncoder({label: '\u{1fe19}\u8f31'});
+let renderBundleEncoder81 = device3.createRenderBundleEncoder({label: '\u320b\u{1fe16}\u{1faae}', colorFormats: ['rgb10a2uint', 'rgba8unorm'], stencilReadOnly: true});
+try {
+commandEncoder142.resolveQuerySet(querySet70, 932, 733, buffer39, 186880);
+} catch {}
+try {
+computePassEncoder69.pushDebugGroup('\uad38');
+} catch {}
+try {
+renderBundleEncoder75.insertDebugMarker('\u633f');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 242 */
+{offset: 242}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline75 = await promise47;
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let commandEncoder149 = device2.createCommandEncoder();
+let commandBuffer28 = commandEncoder144.finish({label: '\uec71\u8770\u{1f809}\u0c6d\u483b\u59dc\ucfab'});
+try {
+renderBundleEncoder79.setIndexBuffer(buffer33, 'uint32', 35780, 41080);
+} catch {}
+try {
+commandEncoder136.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 324 widthInBlocks: 162 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 20630 */
+  offset: 20306,
+  buffer: buffer38,
+}, {width: 162, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder124.clearBuffer(buffer38, 54680, 54204);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let pipeline76 = await device2.createRenderPipelineAsync({
+  label: '\u07f8\u0448\u0ac9\u4919\u0949\u0fbc\ud7a1\u0e99\u{1f71c}\u6df7',
+  layout: pipelineLayout19,
+  multisample: {count: 4, mask: 0xe5669a73},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg32float'}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 176, attributes: []},
+      {
+        arrayStride: 360,
+        attributes: [
+          {format: 'sint32x3', offset: 8, shaderLocation: 10},
+          {format: 'sint8x4', offset: 356, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let imageData38 = new ImageData(148, 120);
+let bindGroupLayout46 = device3.createBindGroupLayout({entries: [{binding: 437, visibility: GPUShaderStage.VERTEX, externalTexture: {}}]});
+let querySet74 = device3.createQuerySet({label: '\u09e2\u9a31\u0c63\u527f\u023c\u{1f861}', type: 'occlusion', count: 3918});
+let sampler92 = device3.createSampler({
+  label: '\ua974\u{1fd7d}\ue567\u00aa\u3c31\u140c\u{1fa01}\u2347\ube14\ub7bb\uaf1a',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.75,
+  lodMaxClamp: 93.21,
+  compare: 'not-equal',
+});
+try {
+buffer39.destroy();
+} catch {}
+try {
+commandEncoder145.copyTextureToBuffer({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22056 */
+  offset: 22004,
+  buffer: buffer35,
+}, {width: 13, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+let pipeline77 = device3.createRenderPipeline({
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8unorm', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3880, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 39016,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 12364, shaderLocation: 1},
+          {format: 'sint8x4', offset: 6532, shaderLocation: 10},
+          {format: 'sint32x2', offset: 18848, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 1056, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 13276, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 13180, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 924, shaderLocation: 2},
+          {format: 'uint32', offset: 2460, shaderLocation: 14},
+          {format: 'uint8x2', offset: 5880, shaderLocation: 0},
+          {format: 'uint8x4', offset: 3860, shaderLocation: 6},
+          {format: 'uint16x4', offset: 1324, shaderLocation: 3},
+          {format: 'uint32x3', offset: 21004, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 6620, shaderLocation: 4},
+          {format: 'uint32x2', offset: 1188, shaderLocation: 8},
+          {format: 'uint8x4', offset: 1944, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 1440, attributes: []},
+      {
+        arrayStride: 2380,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 1020, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+document.body.prepend(video14);
+let texture113 = device2.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 209},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32float', 'rg32float'],
+});
+try {
+gpuCanvasContext20.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData39 = new ImageData(12, 12);
+try {
+gpuCanvasContext33.unconfigure();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let offscreenCanvas53 = new OffscreenCanvas(665, 302);
+let bindGroupLayout47 = pipeline70.getBindGroupLayout(0);
+let commandEncoder150 = device2.createCommandEncoder({label: '\u50fb\u9127\u{1f95a}'});
+let textureView195 = texture102.createView({
+  label: '\u{1fca2}\u0ade\u9625\u{1fc69}\ud09a\u{1f7d9}\u{1ff10}\uf01e\u{1faa3}\u230a\u0e95',
+  dimension: '2d',
+  baseArrayLayer: 13,
+});
+let renderBundle94 = renderBundleEncoder51.finish({label: '\u{1fe25}\ua2a4\u4859\ua930\ubee6'});
+let sampler93 = device2.createSampler({
+  label: '\u2f04\ue99f\u0ca2\u074d\u583c\uc288\u{1fe40}\u{1fa8c}\u0c4d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.29,
+  lodMaxClamp: 96.86,
+});
+try {
+renderBundleEncoder73.setIndexBuffer(buffer33, 'uint32', 18140, 24666);
+} catch {}
+try {
+commandEncoder143.copyTextureToBuffer({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 72 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 19922 */
+  offset: 19922,
+  rowsPerImage: 21,
+  buffer: buffer38,
+}, {width: 72, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 57040, new Int16Array(54282), 5140, 9272);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder82 = device2.createRenderBundleEncoder({
+  label: '\u9454\u30a1\uca44\u77b2',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  stencilReadOnly: false,
+});
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21262 */
+  offset: 21158,
+  rowsPerImage: 151,
+  buffer: buffer32,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 52, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer32);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 18772, new Int16Array(6206), 5082, 244);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let img43 = await imageWithData(19, 42, '#215f509d', '#468a1186');
+let textureView196 = texture109.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundle95 = renderBundleEncoder70.finish();
+let externalTexture78 = device2.importExternalTexture({label: '\u25fa\u065b\u{1fb2d}\uec14', source: video13, colorSpace: 'display-p3'});
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 56},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 22124, new DataView(new ArrayBuffer(17752)), 11998, 472);
+} catch {}
+let commandEncoder151 = device2.createCommandEncoder({});
+let computePassEncoder76 = commandEncoder136.beginComputePass({});
+try {
+renderBundleEncoder72.setIndexBuffer(buffer33, 'uint32', 33232, 21034);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(2, buffer33, 0, 70652);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img44 = await imageWithData(272, 23, '#9793197e', '#ca3c0709');
+offscreenCanvas34.width = 176;
+let gpuCanvasContext41 = offscreenCanvas53.getContext('webgpu');
+document.body.prepend(canvas13);
+let img45 = await imageWithData(211, 222, '#3300e0af', '#82e844d6');
+let video41 = await videoWithData();
+let imageBitmap38 = await createImageBitmap(imageBitmap22);
+offscreenCanvas51.height = 2760;
+let img46 = await imageWithData(214, 59, '#eeae24ef', '#040ff060');
+let commandEncoder152 = device2.createCommandEncoder({label: '\u{1fcb6}\u105c\u1dc5\u716e\u{1fd19}\u{1f9d3}\u7f6a'});
+let texture114 = device2.createTexture({
+  label: '\uc9e1\u4736\uf289\u5ddd\u2c46\ua46a\u{1f70a}\u{1f88d}\u0b13\u0bf8\u0567',
+  size: {width: 175},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8unorm'],
+});
+let renderBundleEncoder83 = device2.createRenderBundleEncoder({
+  label: '\u{1f782}\u3cad\u{1ff76}\u93fa\u6a45\u00d2\u072f\u8c9c\u{1fcaf}',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture79 = device2.importExternalTexture({source: videoFrame19});
+try {
+commandEncoder149.clearBuffer(buffer38, 141336, 604);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 2660, new Float32Array(15487), 11929, 3556);
+} catch {}
+let imageData40 = new ImageData(108, 256);
+let textureView197 = texture88.createView({
+  label: '\ud4e7\u51f0\ub5c2\u4494\u0145\u03be\u7203\u0d01\u938e\u2813',
+  mipLevelCount: 3,
+  baseArrayLayer: 84,
+  arrayLayerCount: 9,
+});
+let renderBundleEncoder84 = device2.createRenderBundleEncoder({colorFormats: ['r16sint', 'rg32float'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle96 = renderBundleEncoder83.finish({label: '\ub286\ucb83\u2ad5\u0c37\ua3d6\u069b'});
+try {
+renderBundleEncoder79.setVertexBuffer(1, buffer33, 0, 51706);
+} catch {}
+let promise48 = buffer31.mapAsync(GPUMapMode.WRITE, 315744, 564812);
+try {
+commandEncoder124.copyTextureToBuffer({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 118 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 30378 */
+  offset: 30378,
+  rowsPerImage: 25,
+  buffer: buffer38,
+}, {width: 118, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder150.clearBuffer(buffer38, 28420, 29732);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let pipeline78 = await device2.createRenderPipelineAsync({
+  label: '\uccc2\u130a\uc6f5\u41ab\u{1f81f}\u0c0f\u0ff4\u{1f990}\u0474',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 252, shaderLocation: 0},
+          {format: 'uint8x2', offset: 646, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1932,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 48, shaderLocation: 8},
+          {format: 'uint16x2', offset: 228, shaderLocation: 15},
+          {format: 'float16x2', offset: 532, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 14},
+          {format: 'uint32x3', offset: 936, shaderLocation: 4},
+          {format: 'float32x2', offset: 536, shaderLocation: 3},
+          {format: 'float32x3', offset: 288, shaderLocation: 9},
+          {format: 'float32x2', offset: 712, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 932,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 336, shaderLocation: 5},
+          {format: 'sint8x4', offset: 476, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 126, shaderLocation: 12},
+          {format: 'sint32x3', offset: 8, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 28, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1300, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 576,
+        attributes: [
+          {format: 'snorm16x4', offset: 20, shaderLocation: 2},
+          {format: 'float32', offset: 320, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+let offscreenCanvas54 = new OffscreenCanvas(387, 59);
+let shaderModule21 = device3.createShaderModule({
+  label: '\u025c\u301f\u22d0\u{1fb42}\u{1f697}\u619f\u7594\ucf85\u7622\u05e8',
+  code: `@group(0) @binding(1311)
+var<storage, read_write> local16: array<u32>;
+@group(0) @binding(1015)
+var<storage, read_write> field13: array<u32>;
+@group(4) @binding(1015)
+var<storage, read_write> parameter10: array<u32>;
+@group(4) @binding(1311)
+var<storage, read_write> field14: array<u32>;
+@group(3) @binding(1015)
+var<storage, read_write> field15: array<u32>;
+@group(2) @binding(1311)
+var<storage, read_write> function13: array<u32>;
+@group(1) @binding(1015)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(1015)
+var<storage, read_write> n12: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<u32>,
+  @location(6) f1: vec4<i32>,
+  @location(2) f2: vec3<i32>,
+  @location(1) f3: vec2<i32>,
+  @location(4) f4: vec3<f32>,
+  @location(5) f5: vec4<i32>,
+  @location(7) f6: vec4<u32>,
+  @location(0) f7: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f32>, @location(2) a1: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder153 = device3.createCommandEncoder();
+let computePassEncoder77 = commandEncoder148.beginComputePass({label: '\u9fba\u03bf\u5df8\u0fee\u{1fdb5}\ueadc\u05fb\u04bb\u3fb4\u4587\u03f3'});
+try {
+computePassEncoder66.setPipeline(pipeline66);
+} catch {}
+let pipeline79 = await device3.createComputePipelineAsync({
+  label: '\u0646\u{1fbf1}\ua0c7\u0386\u0e03',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule21, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout48 = device2.createBindGroupLayout({label: '\u{1f6e0}\u9dac\ua41b\u097e\u0b4f\u{1f6fe}\uafd6\u043c\u01fe\u085b\u2ec9', entries: []});
+let commandEncoder154 = device2.createCommandEncoder({label: '\u0ba3\u{1f70f}\ube84\u3bf7\u{1fbba}'});
+let renderBundleEncoder85 = device2.createRenderBundleEncoder({
+  label: '\ua4c3\u{1ffbf}\u06b6\ud2b1\u0933\u2862',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  depthReadOnly: true,
+});
+let promise49 = device2.queue.onSubmittedWorkDone();
+let pipeline80 = await device2.createComputePipelineAsync({layout: pipelineLayout19, compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}}});
+let commandEncoder155 = device2.createCommandEncoder({label: '\u{1fa5b}\u032b\uccd7\u{1f7c7}\ubf47\u2c94\u032d\u784f\u09ea\uc0f0\u0349'});
+let textureView198 = texture85.createView({label: '\u0dde\u8cb0\u0fef\u0837\u826f\u{1f7c8}'});
+let sampler94 = device2.createSampler({
+  label: '\u9358\u{1fe89}\u3735\u18cd\u0f79',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 46.90,
+  lodMaxClamp: 49.16,
+});
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder152.clearBuffer(buffer38, 60412, 61256);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+device2.queue.submit([commandBuffer24]);
+} catch {}
+let promise50 = device2.queue.onSubmittedWorkDone();
+let shaderModule22 = device2.createShaderModule({
+  code: `@group(0) @binding(333)
+var<storage, read_write> local17: array<u32>;
+@group(0) @binding(696)
+var<storage, read_write> type13: array<u32>;
+@group(1) @binding(333)
+var<storage, read_write> global11: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: i32,
+  @location(1) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @location(4) f0: f16,
+  @builtin(instance_index) f1: u32,
+  @location(1) f2: vec2<u32>,
+  @location(6) f3: i32,
+  @location(13) f4: vec2<f16>,
+  @location(15) f5: vec3<f32>,
+  @location(11) f6: vec4<u32>,
+  @location(10) f7: u32,
+  @location(8) f8: vec3<f16>,
+  @location(5) f9: vec2<u32>
+}
+struct VertexOutput0 {
+  @builtin(position) f374: vec4<f32>,
+  @location(4) f375: u32
+}
+
+@vertex
+fn vertex0(@location(9) a0: u32, a1: S24) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder156 = device2.createCommandEncoder({label: '\u479d\u{1fb9b}\u09db\u0970\u0726\u{1fa6d}\u942f\u039a\u{1ff7a}\u0dae'});
+let querySet75 = device2.createQuerySet({label: '\u0bff\u{1f84e}', type: 'occlusion', count: 3378});
+let texture115 = device2.createTexture({
+  size: [1400, 12, 1247],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let textureView199 = texture92.createView({mipLevelCount: 1});
+let renderBundle97 = renderBundleEncoder83.finish({label: '\u0055\u03b9\ue41a\u{1fbd7}\u370d\u945a'});
+let sampler95 = device2.createSampler({
+  label: '\ub729\u18c7\ucc4c\ucd67\u8390\u{1f857}\u{1f6a9}\u8134\u0456\u47a6\u148c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.81,
+  lodMaxClamp: 91.89,
+  maxAnisotropy: 17,
+});
+try {
+commandEncoder155.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 116 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 20008 */
+  offset: 20008,
+  buffer: buffer36,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 116, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture115,
+  mipLevel: 4,
+  origin: {x: 65, y: 0, z: 77},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline81 = await promise40;
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let video42 = await videoWithData();
+try {
+computePassEncoder54.setPipeline(pipeline70);
+} catch {}
+try {
+renderBundleEncoder72.setIndexBuffer(buffer33, 'uint16');
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder149.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 382},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer9), /* required buffer size: 615 */
+{offset: 547}, {width: 34, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline82 = await device2.createComputePipelineAsync({
+  label: '\ucfdc\udd6b\uf1ab\u6c5d\u173f\u0410\uba8d\u09ec\u{1f816}',
+  layout: 'auto',
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame40 = new VideoFrame(img22, {timestamp: 0});
+let texture116 = device2.createTexture({
+  label: '\u0c98\uaaa1\u2d24\u{1f614}\u7a5f\u7bbf\u0f66\u9d41\ufb5f\u60b5',
+  size: {width: 96, height: 1, depthOrArrayLayers: 32},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView200 = texture104.createView({dimension: '1d', aspect: 'all'});
+let renderBundleEncoder86 = device2.createRenderBundleEncoder({
+  label: '\ufda1\u0a65',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  depthReadOnly: true,
+});
+try {
+commandEncoder156.clearBuffer(buffer38, 27768, 44316);
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder156.insertDebugMarker('\ucc97');
+} catch {}
+let pipeline83 = device2.createComputePipeline({
+  label: '\u0c8e\u{1fe84}\uc641\u0a43',
+  layout: 'auto',
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+let pipeline84 = await device2.createRenderPipelineAsync({
+  label: '\u1a95\u0867\u{1f957}\u74c9\u008f\uaf1d\u4af0\u06fc\u{1fcb8}',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: 0}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r16sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 2630702342,
+    stencilWriteMask: 1397535637,
+    depthBias: -1969534516,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 504,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 60, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 6},
+          {format: 'uint32', offset: 312, shaderLocation: 10},
+          {format: 'sint16x4', offset: 12, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+});
+let texture117 = device3.createTexture({
+  size: [192, 0, 19],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView201 = texture108.createView({label: '\u{1fe26}\u0c38\u0953', arrayLayerCount: 1});
+let sampler96 = device3.createSampler({
+  label: '\ue8ae\u0150',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.18,
+  lodMaxClamp: 60.02,
+  compare: 'greater-equal',
+});
+try {
+device3.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer3), /* required buffer size: 176 */
+{offset: 176, rowsPerImage: 232}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise49;
+} catch {}
+let querySet76 = device3.createQuerySet({label: '\u{1fa66}\u0cd3\u1b24\u{1fe96}\u0599\u0f09\u{1f720}\ue036', type: 'occlusion', count: 2112});
+let textureView202 = texture99.createView({label: '\uf2f5\u06f4\u18b4', arrayLayerCount: 1});
+try {
+gpuCanvasContext29.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 1,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 44050 */
+{offset: 886, bytesPerRow: 327, rowsPerImage: 22}, {width: 15, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let gpuCanvasContext42 = offscreenCanvas54.getContext('webgpu');
+let video43 = await videoWithData();
+let shaderModule23 = device0.createShaderModule({
+  label: '\u05a5\ud0e7\u587c\uda62\u02ce\u03c8',
+  code: `@group(2) @binding(1012)
+var<storage, read_write> type14: array<u32>;
+@group(1) @binding(185)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(3245)
+var<storage, read_write> n13: array<u32>;
+@group(1) @binding(3290)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(24) f0: vec2<f16>,
+  @location(2) f1: vec4<i32>,
+  @location(16) f2: vec3<f32>,
+  @location(4) f3: vec3<f16>,
+  @location(18) f4: vec3<f16>,
+  @location(20) f5: vec3<u32>,
+  @location(11) f6: vec4<u32>,
+  @location(12) f7: i32,
+  @location(1) f8: vec2<f32>,
+  @location(17) f9: f16,
+  @location(3) f10: vec3<f16>,
+  @location(13) f11: vec3<f16>,
+  @location(8) f12: vec4<u32>,
+  @location(14) f13: vec2<u32>,
+  @location(15) f14: vec2<f32>,
+  @location(23) f15: vec2<i32>,
+  @location(19) f16: vec4<i32>,
+  @location(6) f17: vec4<f32>,
+  @location(7) f18: vec3<i32>,
+  @location(26) f19: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<f16>, @location(9) a1: vec4<f16>, @location(21) a2: vec2<i32>, a3: S25, @location(0) a4: f16, @location(25) a5: vec3<f32>, @location(5) a6: f16, @location(22) a7: vec4<i32>, @builtin(instance_index) a8: u32, @builtin(vertex_index) a9: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\u{1f832}\u0472\u{1f854}\u0357\u0a6f\u25c9',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout5, bindGroupLayout15],
+});
+let textureView203 = texture23.createView({dimension: '2d', mipLevelCount: 2, baseArrayLayer: 21});
+let computePassEncoder78 = commandEncoder30.beginComputePass({label: '\u{1fb6b}\u1adf\u069b\u1fd4\u{1f896}\u0568\u5f26'});
+try {
+renderBundleEncoder9.drawIndexed(667348778, 454042695, 186038640, 463106605, 1212836248);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer14, 40);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(5, buffer1, 563500, 391);
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer11, 60604);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(querySet16, 1786, 671, buffer27, 508160);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 120, y: 2, z: 14},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer8), /* required buffer size: 618674 */
+{offset: 710, bytesPerRow: 338, rowsPerImage: 261}, {width: 25, height: 2, depthOrArrayLayers: 8});
+} catch {}
+let pipeline85 = device0.createRenderPipeline({
+  label: '\u02da\u85b9\u7f2c\u1882\u0487\u436c\u0046\uc438\u0001',
+  layout: pipelineLayout21,
+  multisample: {count: 4},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 466543462,
+    stencilWriteMask: 2001982085,
+    depthBias: 557929724,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3544,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 172, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 62, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 36792,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 1408, shaderLocation: 21},
+          {format: 'float16x2', offset: 20740, shaderLocation: 8},
+          {format: 'uint32x2', offset: 4692, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 17820, shaderLocation: 11},
+          {format: 'uint32x4', offset: 4992, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 29608,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 3692, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 9624, shaderLocation: 7},
+          {format: 'sint16x2', offset: 4480, shaderLocation: 4},
+          {format: 'sint8x4', offset: 20716, shaderLocation: 18},
+          {format: 'uint8x4', offset: 10688, shaderLocation: 10},
+          {format: 'float16x2', offset: 900, shaderLocation: 23},
+          {format: 'sint16x2', offset: 10144, shaderLocation: 17},
+          {format: 'float32x2', offset: 3800, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 1106, shaderLocation: 24},
+          {format: 'sint32x4', offset: 532, shaderLocation: 19},
+          {format: 'sint32x2', offset: 4212, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm8x2', offset: 1316, shaderLocation: 20},
+          {format: 'sint32', offset: 25160, shaderLocation: 14},
+          {format: 'uint32', offset: 44236, shaderLocation: 1},
+          {format: 'sint32x2', offset: 5980, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+let textureView204 = texture109.createView({});
+let externalTexture80 = device2.importExternalTexture({label: '\u{1fc94}\u25ce\uffca\u6f2e\u52c5\u06ca', source: videoFrame19, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder79.setIndexBuffer(buffer33, 'uint16', 33726, 37035);
+} catch {}
+try {
+buffer31.destroy();
+} catch {}
+try {
+commandEncoder151.clearBuffer(buffer38, 16172, 58688);
+dissociateBuffer(device2, buffer38);
+} catch {}
+video37.height = 34;
+let texture118 = device3.createTexture({
+  label: '\u0e10\uac15\u{1f8e3}\u{1fec4}\u{1fbf2}\u1bbf\u{1fe58}\ub089\ub365\u0929',
+  size: [192, 0, 1],
+  mipLevelCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let textureView205 = texture101.createView({
+  label: '\u241a\u22ae\u039e\u{1fa12}\u{1ffd3}\u4f5a\u77d2\u4bd8\u9f66\u5724\u8374',
+  aspect: 'all',
+  baseMipLevel: 0,
+});
+try {
+renderBundleEncoder77.setBindGroup(1, bindGroup27, new Uint32Array(5526), 2237, 0);
+} catch {}
+try {
+commandEncoder145.copyTextureToBuffer({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20144 */
+  offset: 20144,
+  buffer: buffer35,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+let pipeline86 = device3.createRenderPipeline({
+  label: '\u0921\ua6ab\ua97a\ud323\u{1ff40}\ue483\u054b\u8977\u08a9\u{1fb8e}',
+  layout: pipelineLayout20,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: 0}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg16sint', writeMask: 0}, {format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'always', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'keep', passOp: 'decrement-wrap'},
+    stencilWriteMask: 3304090205,
+    depthBias: 1606919138,
+    depthBiasSlopeScale: 39.953613569856486,
+  },
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3848, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1104, stepMode: 'instance', attributes: []},
+      {arrayStride: 2992, attributes: []},
+      {
+        arrayStride: 20284,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 13644, shaderLocation: 3}],
+      },
+      {arrayStride: 21244, attributes: [{format: 'sint8x4', offset: 1532, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+let offscreenCanvas55 = new OffscreenCanvas(714, 513);
+let pipelineLayout22 = device3.createPipelineLayout({
+  label: '\uf5ae\u0ab9\u0005\ufea0\ub041\uec6d\u05a8\u0f93\u06a1\u84dd\u030f',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout46],
+});
+let buffer41 = device3.createBuffer({
+  label: '\u{1fbfe}\u{1f98d}\u05ec\uc82d\u{1f837}\u0184\u0e15',
+  size: 185544,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture119 = gpuCanvasContext25.getCurrentTexture();
+let textureView206 = texture105.createView({baseMipLevel: 2, baseArrayLayer: 0});
+let computePassEncoder79 = commandEncoder142.beginComputePass();
+try {
+commandEncoder140.resolveQuerySet(querySet74, 3128, 529, buffer41, 69376);
+} catch {}
+try {
+commandEncoder147.pushDebugGroup('\u3c19');
+} catch {}
+try {
+adapter1.label = '\u{1ff88}\u2088\ud263\u69e0\u36b7';
+} catch {}
+let bindGroupLayout49 = device2.createBindGroupLayout({
+  label: '\u813e\u{1f71a}\u0ab3\uc624\u32fd\u1ba0\u04d8',
+  entries: [
+    {binding: 860, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 316, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 461,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder157 = device2.createCommandEncoder();
+let querySet77 = device2.createQuerySet({type: 'occlusion', count: 1455});
+let renderBundle98 = renderBundleEncoder69.finish({label: '\ub12a\u0bcc\u{1fde3}\u08cb\u{1f83a}\u{1fe7f}\ua4d6\u{1f732}\u{1fee9}\u{1f729}\u{1f6bc}'});
+try {
+computePassEncoder51.setPipeline(pipeline58);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+let gpuCanvasContext43 = offscreenCanvas55.getContext('webgpu');
+let textureView207 = texture112.createView({label: '\u286e\u05dc\u{1fb8a}', baseMipLevel: 0});
+let renderBundle99 = renderBundleEncoder78.finish({label: '\u{1f6a0}\u{1fcf6}\u0309\uc647\u292e\u{1fd73}'});
+try {
+commandEncoder153.copyTextureToBuffer({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12420 */
+  offset: 12420,
+  buffer: buffer35,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder145.resolveQuerySet(querySet68, 297, 26, buffer39, 76800);
+} catch {}
+let pipeline87 = await device3.createComputePipelineAsync({layout: pipelineLayout22, compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}}});
+let pipeline88 = device3.createRenderPipeline({
+  label: '\ufad6\ucb85',
+  layout: pipelineLayout22,
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg8uint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'always', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 3564059350,
+    stencilWriteMask: 3477310788,
+    depthBias: 0,
+    depthBiasSlopeScale: 596.4621022755018,
+  },
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4416,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 808, shaderLocation: 2}],
+      },
+      {arrayStride: 4892, stepMode: 'instance', attributes: []},
+      {arrayStride: 17044, attributes: []},
+      {arrayStride: 560, attributes: [{format: 'snorm16x4', offset: 552, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw'},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let bindGroup29 = device2.createBindGroup({label: '\u{1fbf7}\uf3d7', layout: bindGroupLayout40, entries: []});
+let texture120 = device2.createTexture({
+  label: '\ub772\u198a\ud03f\u04c6\u3fd2\u4fff\u{1f857}',
+  size: [350, 3, 82],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+try {
+commandEncoder143.copyTextureToBuffer({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 908 widthInBlocks: 454 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 11770 */
+  offset: 11770,
+  buffer: buffer38,
+}, {width: 454, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+commandEncoder149.clearBuffer(buffer38, 66128, 7732);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let videoFrame41 = new VideoFrame(imageBitmap9, {timestamp: 0});
+let computePassEncoder80 = commandEncoder152.beginComputePass({label: '\u46e0\u9976\u{1fa9e}\u04a1\u{1fdaa}\udd07\u21fb\u{1ff1a}'});
+let externalTexture81 = device2.importExternalTexture({label: '\u7f61\u029c\ub3d9\u06aa', source: video4, colorSpace: 'display-p3'});
+try {
+commandEncoder156.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 108, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.submit([commandBuffer28]);
+} catch {}
+offscreenCanvas6.height = 1726;
+let shaderModule24 = device3.createShaderModule({
+  label: '\u0d9d\u7b98\u8892',
+  code: `@group(3) @binding(1311)
+var<storage, read_write> n14: array<u32>;
+@group(3) @binding(1015)
+var<storage, read_write> n15: array<u32>;
+@group(2) @binding(1311)
+var<storage, read_write> parameter11: array<u32>;
+@group(4) @binding(1311)
+var<storage, read_write> field16: array<u32>;
+@group(1) @binding(1015)
+var<storage, read_write> local19: array<u32>;
+@group(0) @binding(1015)
+var<storage, read_write> type16: array<u32>;
+@group(0) @binding(1311)
+var<storage, read_write> local20: array<u32>;
+@group(2) @binding(1015)
+var<storage, read_write> type17: array<u32>;
+@group(4) @binding(1015)
+var<storage, read_write> n16: array<u32>;
+
+@compute @workgroup_size(5, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S27 {
+  @location(17) f0: f16,
+  @builtin(front_facing) f1: bool,
+  @location(65) f2: vec3<f32>,
+  @location(11) f3: vec4<u32>,
+  @location(67) f4: vec4<i32>,
+  @location(64) f5: vec4<f16>,
+  @location(0) f6: vec2<u32>,
+  @location(43) f7: vec3<u32>,
+  @location(62) f8: vec3<i32>,
+  @location(46) f9: vec2<f16>,
+  @location(21) f10: vec4<f32>,
+  @location(44) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(0) f1: vec4<u32>,
+  @location(4) f2: vec2<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(2) f4: vec3<i32>,
+  @location(3) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(41) a0: vec3<u32>, a1: S27, @location(60) a2: vec2<f32>, @builtin(position) a3: vec4<f32>, @location(23) a4: u32, @location(20) a5: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S26 {
+  @location(2) f0: vec3<f32>,
+  @location(12) f1: f32,
+  @location(15) f2: vec4<i32>,
+  @location(1) f3: vec3<f32>,
+  @location(13) f4: vec2<f16>,
+  @location(10) f5: f16
+}
+struct VertexOutput0 {
+  @location(20) f376: u32,
+  @location(41) f377: vec3<u32>,
+  @location(67) f378: vec4<i32>,
+  @location(46) f379: vec2<f16>,
+  @location(43) f380: vec3<u32>,
+  @location(77) f381: vec3<u32>,
+  @location(44) f382: vec4<f32>,
+  @location(6) f383: vec2<f32>,
+  @builtin(position) f384: vec4<f32>,
+  @location(17) f385: f16,
+  @location(60) f386: vec2<f32>,
+  @location(45) f387: vec2<f16>,
+  @location(65) f388: vec3<f32>,
+  @location(49) f389: vec4<f32>,
+  @location(0) f390: vec2<u32>,
+  @location(37) f391: vec2<f32>,
+  @location(23) f392: u32,
+  @location(64) f393: vec4<f16>,
+  @location(62) f394: vec3<i32>,
+  @location(11) f395: vec4<u32>,
+  @location(21) f396: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<i32>, @location(6) a1: vec2<u32>, @location(8) a2: vec3<i32>, @location(5) a3: vec3<u32>, a4: S26, @location(9) a5: f32, @location(0) a6: vec3<u32>, @location(7) a7: vec3<f32>, @location(11) a8: vec2<f32>, @location(4) a9: vec4<i32>, @location(14) a10: vec4<f16>, @builtin(vertex_index) a11: u32, @builtin(instance_index) a12: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder87 = device3.createRenderBundleEncoder({
+  label: '\u474a\ucd41\ue190\u0bc9\u53df\ue15c\ufacd\ua288',
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+});
+try {
+computePassEncoder69.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder75.setBindGroup(7, bindGroup28);
+} catch {}
+let pipeline89 = device3.createComputePipeline({
+  label: '\u{1fa3e}\u05b6\u0a43\u{1f648}\u08a6\u6b26',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let img47 = await imageWithData(9, 251, '#75dbc301', '#965eb5f8');
+let videoFrame42 = new VideoFrame(videoFrame0, {timestamp: 0});
+let canvas46 = document.createElement('canvas');
+let commandEncoder158 = device3.createCommandEncoder();
+let querySet78 = device3.createQuerySet({label: '\u0470\u0dc0\u069c\u0b48\udec8', type: 'occlusion', count: 1634});
+let texture121 = device3.createTexture({
+  label: '\u{1fb24}\u0ef7\u8dc2\u0fa3\u{1f62f}\u0008\u4b86\u94e1\u1259\ue6bc',
+  size: [48],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView208 = texture108.createView({label: '\u6491\u{1f9c0}\u91c4'});
+let renderBundle100 = renderBundleEncoder71.finish({label: '\u7b38\uc908\ue44c\u5b77\u3b1c\u04c1\ud365\ue232\u0625\ua688'});
+let externalTexture82 = device3.importExternalTexture({source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline77);
+} catch {}
+try {
+  await buffer40.mapAsync(GPUMapMode.READ, 0, 21012);
+} catch {}
+let commandEncoder159 = device2.createCommandEncoder({label: '\u0a68\ue9ec\u5c62\u4cc8\u0f99\ue8b8\u1f05\u2f5e\u1c0a\u{1fec2}\ub454'});
+let texture122 = device2.createTexture({
+  size: {width: 350, height: 3, depthOrArrayLayers: 1466},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler97 = device2.createSampler({
+  label: '\u{1fc16}\u{1ffee}\u0b33\u{1ffa4}\u{1fdf9}\ub334',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 76.30,
+});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder85.setBindGroup(3, bindGroup29, new Uint32Array(6607), 266, 0);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 62304, new Int16Array(6291), 1652, 936);
+} catch {}
+let pipeline90 = device2.createComputePipeline({layout: 'auto', compute: {module: shaderModule20, entryPoint: 'compute0', constants: {}}});
+try {
+canvas46.getContext('bitmaprenderer');
+} catch {}
+try {
+  await promise50;
+} catch {}
+let commandEncoder160 = device3.createCommandEncoder({label: '\u{1fa8c}\u43d1\ud829\u9698\u064d\uf50b\u4d6b'});
+let querySet79 = device3.createQuerySet({
+  label: '\u{1fa0e}\u2a64\ueb53\u4d79\u{1fb85}\ub880\u3198\u0d0f\u0b81\u0741',
+  type: 'occlusion',
+  count: 1996,
+});
+let textureView209 = texture105.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+renderBundleEncoder87.setBindGroup(6, bindGroup27);
+} catch {}
+try {
+commandEncoder140.copyTextureToBuffer({
+  texture: texture117,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6036 */
+  offset: 6036,
+  buffer: buffer35,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder140.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture117,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder140.resolveQuerySet(querySet67, 638, 115, buffer41, 42752);
+} catch {}
+document.body.prepend(video30);
+try {
+  await promise48;
+} catch {}
+let device4 = await adapter10.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 60,
+    maxVertexBufferArrayStride: 33694,
+    maxStorageTexturesPerShaderStage: 39,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 33653,
+    maxDynamicUniformBuffersPerPipelineLayout: 22555,
+    maxBindingsPerBindGroup: 7021,
+    maxTextureArrayLayers: 761,
+    maxTextureDimension1D: 9382,
+    maxTextureDimension2D: 16039,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 108844836,
+    maxUniformBuffersPerShaderStage: 23,
+    maxSampledTexturesPerShaderStage: 32,
+    maxInterStageShaderVariables: 84,
+    maxInterStageShaderComponents: 77,
+    maxSamplersPerShaderStage: 17,
+  },
+});
+try {
+adapter11.label = '\u8bae\u0631\uacb4\ubc54\u3d06\u2c1b\u006a\u074b\u{1f878}';
+} catch {}
+let querySet80 = device3.createQuerySet({label: '\u27be\u31a8\uf5e1\u{1fa61}', type: 'occlusion', count: 1104});
+let renderBundleEncoder88 = device3.createRenderBundleEncoder({
+  label: '\u028c\u500f\u8f34',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup25);
+} catch {}
+let pipeline91 = await device3.createComputePipelineAsync({
+  label: '\ubb67\u8f22\u5d03\u0dcd',
+  layout: 'auto',
+  compute: {module: shaderModule24, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let querySet81 = device4.createQuerySet({label: '\u0e94\uf2e2\udd66', type: 'occlusion', count: 3215});
+document.body.prepend(video38);
+let renderBundleEncoder89 = device2.createRenderBundleEncoder({
+  label: '\u{1fdf3}\u8739\u{1fe9a}\ud2f6\u64b8\ub931\u845e\u{1fd80}',
+  colorFormats: ['r16sint', 'rg32float'],
+  stencilReadOnly: false,
+});
+let renderBundle101 = renderBundleEncoder62.finish({label: '\u{1f75d}\u{1fa28}'});
+let externalTexture83 = device2.importExternalTexture({label: '\u6741\ue648', source: videoFrame10});
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 16428 */
+  offset: 16428,
+  rowsPerImage: 15,
+  buffer: buffer32,
+}, {
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer32);
+} catch {}
+let pipeline92 = await device2.createComputePipelineAsync({
+  label: '\u34a6\u09a3\u0fa9\u{1ff6f}\u7cc3\u0674',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+let img48 = await imageWithData(290, 286, '#ecbe2568', '#ffc18976');
+let buffer42 = device2.createBuffer({
+  label: '\uec04\u0812\u{1f8ab}\u{1fa71}\u63f0\ua0d1\u{1fc2e}\u0362',
+  size: 433848,
+  usage: GPUBufferUsage.STORAGE,
+});
+let textureView210 = texture104.createView({dimension: '1d', mipLevelCount: 1});
+let externalTexture84 = device2.importExternalTexture({label: '\u2cff\u050a\u0896\ua42a\u{1fcd3}\u459c\ud18d\ucc90\u8c45\u05eb\u05c1', source: video11});
+try {
+computePassEncoder76.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer38, 92608, 10548);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let offscreenCanvas56 = new OffscreenCanvas(540, 567);
+let commandEncoder161 = device3.createCommandEncoder({label: '\ue3f4\ua88b\u{1fdbc}\u{1fcbe}'});
+try {
+computePassEncoder66.setPipeline(pipeline66);
+} catch {}
+try {
+commandEncoder145.copyTextureToTexture({
+  texture: texture97,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder147.resolveQuerySet(querySet70, 1528, 94, buffer41, 160256);
+} catch {}
+let gpuCanvasContext44 = offscreenCanvas56.getContext('webgpu');
+let bindGroupLayout50 = device3.createBindGroupLayout({entries: []});
+let renderBundle102 = renderBundleEncoder65.finish({label: '\uc60d\u2c6a'});
+try {
+renderBundleEncoder81.setPipeline(pipeline74);
+} catch {}
+try {
+commandEncoder160.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder140.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder140.resolveQuerySet(querySet74, 878, 2193, buffer41, 151808);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 512 */
+{offset: 512}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img49 = await imageWithData(205, 214, '#631f6794', '#cfa72ddf');
+let imageBitmap39 = await createImageBitmap(img9);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let videoFrame43 = new VideoFrame(img47, {timestamp: 0});
+let buffer43 = device3.createBuffer({label: '\u000c\u{1f6fe}\u03bc\u9c95\u{1f6cc}\u2f2a', size: 7850, usage: GPUBufferUsage.COPY_DST});
+let texture123 = device3.createTexture({
+  label: '\u{1f62c}\ud157',
+  size: [24, 1, 1],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let renderBundleEncoder90 = device3.createRenderBundleEncoder({
+  label: '\udf72\u0e11\u703b\u0c6b\u7430\ued71\uaf89\uddb7\u{1ff27}\u3c54',
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle103 = renderBundleEncoder74.finish({label: '\u1c35\u1814'});
+let externalTexture85 = device3.importExternalTexture({label: '\u585b\u01ba\u0270\u0e24\uc80c\u052f\u639f', source: video8, colorSpace: 'display-p3'});
+try {
+computePassEncoder72.setBindGroup(2, bindGroup26, new Uint32Array(7016), 1504, 0);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 18},
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 1606 */
+{offset: 586, bytesPerRow: 17, rowsPerImage: 3}, {width: 0, height: 1, depthOrArrayLayers: 21});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(canvas29);
+offscreenCanvas35.width = 638;
+try {
+window.someLabel = externalTexture47.label;
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+canvas28.height = 454;
+let bindGroupLayout51 = device3.createBindGroupLayout({
+  label: '\uea0b\u0e92\u0efc\u{1fad2}\u006e',
+  entries: [
+    {
+      binding: 2518,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 892, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false }},
+    {binding: 4316, visibility: 0, externalTexture: {}},
+  ],
+});
+let bindGroup30 = device3.createBindGroup({
+  label: '\u0e5a\u03a5\uf517\uc182\u89c6\u{1fd8e}',
+  layout: bindGroupLayout43,
+  entries: [{binding: 2165, resource: sampler74}, {binding: 4294, resource: sampler85}],
+});
+let textureView211 = texture108.createView({label: '\ued0a\ue3ef\u0c1e\u{1fd32}\u0ca3'});
+let renderBundleEncoder91 = device3.createRenderBundleEncoder({
+  label: '\u1599\u{1fde8}\u0a2f',
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle104 = renderBundleEncoder74.finish({label: '\ua3af\uc257\uefb8\uc4c6\u{1f6f4}\u{1fca0}\u575a\u{1fb78}\ue73c\u{1f95a}'});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup30, new Uint32Array(4744), 307, 0);
+} catch {}
+try {
+commandEncoder140.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 316 widthInBlocks: 79 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1004 */
+  offset: 1004,
+  buffer: buffer35,
+}, {width: 79, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder140.resolveQuerySet(querySet73, 3960, 16, buffer39, 449536);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer21, commandBuffer26]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer10), /* required buffer size: 877 */
+{offset: 877}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline93 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32uint', writeMask: 0}, undefined, {format: 'rg8sint'}, {format: 'r16sint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.BLUE}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 1250321038,
+    stencilWriteMask: 1791538162,
+    depthBiasSlopeScale: -37.62071033531416,
+  },
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4132,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x2', offset: 216, shaderLocation: 15},
+          {format: 'uint16x2', offset: 552, shaderLocation: 0},
+          {format: 'float32x4', offset: 236, shaderLocation: 7},
+          {format: 'uint32x3', offset: 1292, shaderLocation: 6},
+          {format: 'sint32x4', offset: 3936, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 664, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 216, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 812, shaderLocation: 9},
+          {format: 'sint8x2', offset: 2556, shaderLocation: 3},
+          {format: 'sint32', offset: 1140, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 28, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 664, shaderLocation: 12},
+          {format: 'uint16x2', offset: 732, shaderLocation: 5},
+          {format: 'float16x4', offset: 1492, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 996, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 10880,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x4', offset: 7276, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+let bindGroupLayout52 = device4.createBindGroupLayout({
+  label: '\uc19e\u0ceb\u0c45',
+  entries: [
+    {
+      binding: 3942,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let sampler98 = device4.createSampler({
+  label: '\u5585\u{1f935}\u7f30\u73b8\u06bc\uef7e\u0c12\u09f4\u4a0e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 24.95,
+  lodMaxClamp: 25.59,
+});
+let texture124 = device4.createTexture({
+  label: '\u3661\u{1fb95}\uef22\uff91\u16d3\u{1fb0c}\ub2da\u0b1f\u2091\u2bf5',
+  size: [2119],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler99 = device4.createSampler({
+  label: '\u0b66\ub3a1\u{1f9fa}\u3d18\u8029\u{1f785}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.80,
+  maxAnisotropy: 8,
+});
+document.body.prepend(img8);
+let canvas47 = document.createElement('canvas');
+let offscreenCanvas57 = new OffscreenCanvas(171, 205);
+let gpuCanvasContext45 = canvas47.getContext('webgpu');
+try {
+offscreenCanvas57.getContext('webgl');
+} catch {}
+let canvas48 = document.createElement('canvas');
+let canvas49 = document.createElement('canvas');
+try {
+device2.label = '\u5ccc\ue553\u0aac';
+} catch {}
+let querySet82 = device2.createQuerySet({type: 'occlusion', count: 3750});
+let textureView212 = texture122.createView({label: '\u09d1\u04a7\u6b79\u{1f901}\ua4a1\u0769\u8576\u092f\u8cba\uf6bb\u{1fa0e}', baseMipLevel: 1});
+let renderBundle105 = renderBundleEncoder61.finish({label: '\ufb3f\ua1cc\ua723\u1cbd\u{1fd52}\u9a3c'});
+try {
+computePassEncoder70.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder85.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder143.clearBuffer(buffer38, 135640, 9480);
+dissociateBuffer(device2, buffer38);
+} catch {}
+let imageBitmap40 = await createImageBitmap(offscreenCanvas33);
+let buffer44 = device2.createBuffer({
+  label: '\u0b2b\u09d1\u{1faef}\u8d76\u0bea\u00b5\u5ad8\ufbab\u{1fac1}',
+  size: 1038721,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder162 = device2.createCommandEncoder({label: '\u8ecb\u8e4d'});
+let computePassEncoder81 = commandEncoder143.beginComputePass({label: '\ucf8a\u0cf0\u042f'});
+let renderBundle106 = renderBundleEncoder72.finish({label: '\u0492\u05bb\u0824'});
+let externalTexture86 = device2.importExternalTexture({
+  label: '\u7989\u8bd2\u{1f6e8}\ub1e7\u0020\u{1f9d3}\u{1f88b}\ube1d',
+  source: video7,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(0, bindGroup29, new Uint32Array(4670), 2635, 0);
+} catch {}
+try {
+commandEncoder159.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 88, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2104 */
+  offset: 2104,
+  rowsPerImage: 123,
+  buffer: buffer44,
+}, {width: 22, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(56)), /* required buffer size: 86614 */
+{offset: 913, bytesPerRow: 53, rowsPerImage: 231}, {width: 4, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let textureView213 = texture124.createView({label: '\u2793\ua331\u{1fd94}\u0af0\u0688\u259a\u0d72\u046e\u9b90', aspect: 'all'});
+let renderBundleEncoder92 = device4.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'r32uint', 'r8unorm', 'rgba32sint', 'rgba16uint', 'rgba16sint', 'r8sint'],
+  depthReadOnly: false,
+});
+let renderBundle107 = renderBundleEncoder92.finish({label: '\u4b94\u4509\uf15a'});
+let externalTexture87 = device4.importExternalTexture({
+  label: '\u7370\ube0e\ue540\u3000\u425f\u2e07\u1072\u0ea9\u004d\uea4a\u15e0',
+  source: video34,
+  colorSpace: 'srgb',
+});
+try {
+device4.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 111, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer7), /* required buffer size: 2318 */
+{offset: 510}, {width: 452, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+canvas49.getContext('2d');
+} catch {}
+let gpuCanvasContext46 = canvas48.getContext('webgpu');
+let commandEncoder163 = device3.createCommandEncoder({label: '\uca45\u0e40'});
+let textureView214 = texture101.createView({label: '\u7abe\u9811\u0d88\u502e\u{1f916}', dimension: '2d'});
+let renderBundle108 = renderBundleEncoder64.finish({label: '\u{1f82d}\ub180'});
+let sampler100 = device3.createSampler({
+  label: '\ubd81\u597b\u0ae1\u6797\u024f\u7246\u06f9\u035a\u{1f906}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 89.33,
+  lodMaxClamp: 91.38,
+});
+let externalTexture88 = device3.importExternalTexture({
+  label: '\u97ff\u46b8\u15e6\u1f6c\u0f1d\u{1f7c1}\ua5e5\u{1fb0e}',
+  source: videoFrame9,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder88.setVertexBuffer(8268, undefined, 727394068);
+} catch {}
+try {
+commandEncoder145.copyTextureToBuffer({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 45470 */
+  offset: 45468,
+  rowsPerImage: 266,
+  buffer: buffer35,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder163.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer43, 168, new Float32Array(15435), 9335, 12);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1541 */
+{offset: 917, bytesPerRow: 645}, {width: 156, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline94 = await device3.createComputePipelineAsync({layout: pipelineLayout20, compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}}});
+try {
+window.someLabel = externalTexture87.label;
+} catch {}
+let commandEncoder164 = device4.createCommandEncoder({label: '\udb77\u0e65'});
+let textureView215 = texture124.createView({label: '\u03e3\u8112\u0ddf\ue459\u0ca3\u0e4f\ue771\u3ba7', baseMipLevel: 0});
+let commandEncoder165 = device2.createCommandEncoder({label: '\u{1f8f2}\u0e7b\u0a0d\u0c0d\u0e27\ud3d7\u08e6\u0fe6\u9c79\u{1f70b}\udae8'});
+let renderBundleEncoder93 = device2.createRenderBundleEncoder({
+  label: '\ue704\u{1fb7a}\u7d0f\ub4d2\u05e5\uc7c0\u0c10',
+  colorFormats: ['rgba8sint', 'rg11b10ufloat', 'rg8unorm', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler101 = device2.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.27,
+  compare: 'always',
+  maxAnisotropy: 16,
+});
+try {
+commandEncoder156.copyTextureToBuffer({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 332 widthInBlocks: 166 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4976 */
+  offset: 4644,
+  buffer: buffer44,
+}, {width: 166, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder155.clearBuffer(buffer44, 335220, 431248);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+gpuCanvasContext37.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline95 = device2.createRenderPipeline({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: 0}, {format: 'rg32float'}],
+},
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 328,
+        attributes: [
+          {format: 'uint32x2', offset: 312, shaderLocation: 13},
+          {format: 'uint16x2', offset: 52, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 1380, attributes: []},
+      {arrayStride: 964, stepMode: 'instance', attributes: []},
+      {arrayStride: 196, attributes: [{format: 'unorm16x2', offset: 36, shaderLocation: 9}]},
+    ],
+  },
+});
+let bindGroupLayout53 = device4.createBindGroupLayout({
+  entries: [
+    {binding: 2843, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 5548,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 6744,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView216 = texture124.createView({label: '\u6ae9\ubd69\u08e5\u078c\ue581\u2c02\ua1c7\u36e2\u5095'});
+let sampler102 = device4.createSampler({
+  label: '\uab65\uccdc\u397f\u0b87',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  lodMinClamp: 85.89,
+  lodMaxClamp: 94.06,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 1263, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer8), /* required buffer size: 3085 */
+{offset: 573}, {width: 628, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas58 = new OffscreenCanvas(333, 152);
+let imageData41 = new ImageData(64, 72);
+let canvas50 = document.createElement('canvas');
+let imageData42 = new ImageData(152, 132);
+let video44 = await videoWithData();
+let commandBuffer29 = commandEncoder154.finish();
+let computePassEncoder82 = commandEncoder151.beginComputePass({label: '\ub77f\u{1f75e}\u855a\u0ea6\u{1fc4c}'});
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+renderBundleEncoder86.setVertexBuffer(6, buffer33, 0);
+} catch {}
+try {
+commandEncoder162.copyBufferToTexture({
+  /* bytesInLastRow: 54 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 68502 */
+  offset: 68502,
+  bytesPerRow: 256,
+  buffer: buffer36,
+}, {
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 27, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 126512, new BigUint64Array(6678), 2632, 2364);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 43},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 5180553 */
+{offset: 981, bytesPerRow: 1246, rowsPerImage: 134}, {width: 299, height: 3, depthOrArrayLayers: 32});
+} catch {}
+let pipeline96 = await device2.createComputePipelineAsync({
+  label: '\ue2e8\uae05\u0963\u{1f7b3}',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let textureView217 = texture124.createView({label: '\ub88d\u08c2\u0d55\u{1f9dd}', baseArrayLayer: 0});
+try {
+device4.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(80)), /* required buffer size: 7123 */
+{offset: 567, bytesPerRow: 6789, rowsPerImage: 81}, {width: 1639, height: 1, depthOrArrayLayers: 1});
+} catch {}
+video6.width = 209;
+let commandEncoder166 = device2.createCommandEncoder({label: '\u7b95\u{1f88c}\u6801\u50c7\u4a29\u30b8'});
+let texture125 = device2.createTexture({
+  size: {width: 1472, height: 1, depthOrArrayLayers: 146},
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView218 = texture96.createView({});
+let renderBundle109 = renderBundleEncoder79.finish({label: '\u{1f92f}\u27a8\u06a1\u{1f7ff}\u089c\u047b\u357f\u06e2\u0b0e\u{1fe94}'});
+let promise51 = buffer44.mapAsync(GPUMapMode.READ, 0, 22412);
+try {
+commandEncoder124.copyBufferToBuffer(buffer38, 94588, buffer44, 673572, 35592);
+dissociateBuffer(device2, buffer38);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 3,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 67380 */
+{offset: 500, bytesPerRow: 38, rowsPerImage: 220}, {width: 0, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let pipeline97 = await device2.createRenderPipelineAsync({
+  label: '\u001f\u0947',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 383026813,
+    stencilWriteMask: 1262258413,
+    depthBiasSlopeScale: 97.53099295377174,
+  },
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 236, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2048,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 68, shaderLocation: 13},
+          {format: 'uint16x2', offset: 40, shaderLocation: 6},
+          {format: 'float32', offset: 372, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+});
+try {
+offscreenCanvas58.getContext('webgl2');
+} catch {}
+let texture126 = device2.createTexture({
+  label: '\u8073\u{1fc6a}\u8231\u6bef',
+  size: [175, 1, 103],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float'],
+});
+let computePassEncoder83 = commandEncoder165.beginComputePass({label: '\ue5b7\u{1f8f8}\uf797\u{1fcff}'});
+try {
+computePassEncoder68.setPipeline(pipeline96);
+} catch {}
+try {
+renderBundleEncoder82.setBindGroup(0, bindGroup29, new Uint32Array(2623), 2184, 0);
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(1, buffer33);
+} catch {}
+try {
+commandEncoder166.copyBufferToBuffer(buffer38, 18004, buffer44, 435684, 4712);
+dissociateBuffer(device2, buffer38);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder149.clearBuffer(buffer44, 990204, 23088);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let pipeline98 = await device2.createComputePipelineAsync({
+  label: '\u{1fd06}\u0fa6',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule20, entryPoint: 'compute0', constants: {}},
+});
+let pipeline99 = device2.createRenderPipeline({
+  label: '\ube6c\u434d\u0a71\u{1fa0b}',
+  layout: pipelineLayout19,
+  multisample: {mask: 0xf555b5d},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {format: 'rg32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 2687336243,
+    stencilWriteMask: 4110368701,
+    depthBias: 2074522859,
+    depthBiasSlopeScale: 492.8882231298104,
+    depthBiasClamp: 681.5708078765609,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 516,
+        attributes: [
+          {format: 'sint32', offset: 4, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 138, shaderLocation: 14},
+          {format: 'sint32x2', offset: 152, shaderLocation: 10},
+          {format: 'float32x3', offset: 48, shaderLocation: 8},
+          {format: 'uint32x4', offset: 84, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 76, shaderLocation: 6},
+          {format: 'float16x2', offset: 456, shaderLocation: 11},
+          {format: 'float32x2', offset: 136, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 0, shaderLocation: 1},
+          {format: 'sint8x4', offset: 4, shaderLocation: 3},
+          {format: 'sint32x4', offset: 0, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 15},
+          {format: 'float32x4', offset: 0, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 548, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2048,
+        attributes: [
+          {format: 'uint16x4', offset: 148, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 64, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let video45 = await videoWithData();
+let bindGroup31 = device0.createBindGroup({
+  label: '\u{1f64a}\u{1ff8f}\uf9f4\u{1fc9c}\u{1f638}\ubc4c\u5867\uddf9\u{1f9a4}\u05e3',
+  layout: bindGroupLayout22,
+  entries: [],
+});
+let textureView219 = texture18.createView({
+  label: '\u3790\ud9fd\u3628\u8335\u03b7\u{1f631}',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 5,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup17, new Uint32Array(9877), 9860, 0);
+} catch {}
+try {
+computePassEncoder12.dispatchWorkgroups(2, 3, 1);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup18, []);
+} catch {}
+try {
+renderBundleEncoder9.draw(922353557, 1179584272);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline43);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet5, 3392, 33, buffer14, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+let gpuCanvasContext47 = canvas50.getContext('webgpu');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+  await promise51;
+} catch {}
+let textureView220 = texture116.createView({label: '\u01b0\u5c20', format: 'r16sint', mipLevelCount: 2});
+let renderBundle110 = renderBundleEncoder70.finish({label: '\u7e30\u4ddb\u50cb\u{1f908}\uaed9\ua5eb\u17ca'});
+let externalTexture89 = device2.importExternalTexture({label: '\u8b12\u1a28\uc3e1\u3c1f\u017e\u9364', source: videoFrame37, colorSpace: 'srgb'});
+try {
+computePassEncoder70.setPipeline(pipeline80);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(0, buffer33, 63476, 33469);
+} catch {}
+try {
+computePassEncoder75.insertDebugMarker('\u2ded');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+adapter9.label = '\u0603\u{1f9f0}\u0ba1\u554d\uf365';
+} catch {}
+let textureView221 = texture124.createView({label: '\u{1fc2f}\u{1fe8d}\ua1a4\ua401\u6bd7\ue9a5\u31b2\u80b2\u0ba7\u0597'});
+try {
+device4.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 646, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer6), /* required buffer size: 1345 */
+{offset: 797}, {width: 137, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let img50 = await imageWithData(180, 264, '#04f81938', '#ba676355');
+let buffer45 = device2.createBuffer({
+  label: '\u78fe\uf5c2\u{1fab3}',
+  size: 641012,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let renderBundle111 = renderBundleEncoder85.finish({label: '\u011c\u0285\u7774\ua1c8\ucbee\ua719\u0815\u{1febe}\u8244\u{1f723}'});
+let externalTexture90 = device2.importExternalTexture({
+  label: '\u{1ff48}\u{1f7bc}\u6067\u9217\u{1f8f2}\u9792',
+  source: videoFrame12,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder61.setPipeline(pipeline92);
+} catch {}
+try {
+renderBundleEncoder84.setVertexBuffer(6, buffer33);
+} catch {}
+try {
+commandEncoder124.copyTextureToBuffer({
+  texture: texture100,
+  mipLevel: 3,
+  origin: {x: 11, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 42772 */
+  offset: 20244,
+  bytesPerRow: 256,
+  rowsPerImage: 44,
+  buffer: buffer38,
+}, {width: 35, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device2, buffer38);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let commandEncoder167 = device3.createCommandEncoder({});
+let textureView222 = texture119.createView({label: '\u04e7\u4859\u0abc\u6575\u038a\u1564\ue9ce\uf80c', dimension: '2d-array', mipLevelCount: 1});
+let sampler103 = device3.createSampler({
+  label: '\uae26\u04ee\ua5f5\u{1fbf7}\u0a33\u3db1\u6110\uf049\u04b9\u93be\u{1feb4}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.07,
+  compare: 'greater-equal',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder69.setBindGroup(7, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(buffer41, 'uint16');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer7), /* required buffer size: 116 */
+{offset: 116, bytesPerRow: 283}, {width: 94, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout23 = device4.createPipelineLayout({label: '\u80f7\u0fa1\u5301', bindGroupLayouts: []});
+let renderBundleEncoder94 = device4.createRenderBundleEncoder({
+  label: '\u065b\u84ef\u06d0\u{1f6bb}\u0b9f',
+  colorFormats: ['rg8uint', 'r32uint', 'r8unorm', 'rgba32sint', 'rgba16uint', 'rgba16sint', 'r8sint'],
+  stencilReadOnly: true,
+});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder168 = device3.createCommandEncoder();
+try {
+computePassEncoder77.end();
+} catch {}
+try {
+commandEncoder153.clearBuffer(buffer35, 278676);
+dissociateBuffer(device3, buffer35);
+} catch {}
+let imageData43 = new ImageData(172, 12);
+let commandEncoder169 = device3.createCommandEncoder();
+try {
+computePassEncoder66.setBindGroup(3, bindGroup26, new Uint32Array(1510), 1434, 0);
+} catch {}
+try {
+commandEncoder158.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 18496 */
+  offset: 18496,
+  buffer: buffer35,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline100 = device3.createComputePipeline({
+  label: '\u{1fbdc}\u0c3a\u0bc1\ua312\u{1f613}\u07c5\u0bd8\u6fba\u{1fba6}\u4cb6\u7f04',
+  layout: 'auto',
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+canvas45.height = 36;
+let bindGroup32 = device3.createBindGroup({
+  label: '\u55b6\uf33f\u5130',
+  layout: bindGroupLayout46,
+  entries: [{binding: 437, resource: externalTexture67}],
+});
+let textureView223 = texture123.createView({label: '\u3366\u0c7d\u0a05\u76ad\u0e13\u088c', dimension: '2d-array'});
+let renderBundleEncoder95 = device3.createRenderBundleEncoder({
+  label: '\u4d28\u01a7\u06ca\uf10e\u8033\u{1fef7}\u{1f944}\u099f\ua283',
+  colorFormats: ['rg16sint', 'r8sint', 'rg16sint', 'rg8uint', 'rg8unorm', 'rg32sint', 'rgba8sint', 'rgba8uint'],
+  depthReadOnly: false,
+});
+let renderBundle112 = renderBundleEncoder77.finish();
+try {
+commandEncoder153.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2808 */
+  offset: 2808,
+  buffer: buffer43,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer43);
+} catch {}
+try {
+window.someLabel = externalTexture87.label;
+} catch {}
+let commandEncoder170 = device4.createCommandEncoder();
+let renderBundleEncoder96 = device4.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'r32uint', 'r8unorm', 'rgba32sint', 'rgba16uint', 'rgba16sint', 'r8sint'],
+  stencilReadOnly: true,
+});
+let renderBundle113 = renderBundleEncoder94.finish({label: '\ue357\u03ac'});
+let renderBundleEncoder97 = device4.createRenderBundleEncoder({
+  label: '\u04d0\u0a7a\u79f0\ua56a\u96a1',
+  colorFormats: ['rg8uint', 'r32uint', 'r8unorm', 'rgba32sint', 'rgba16uint', 'rgba16sint', 'r8sint'],
+  depthReadOnly: true,
+});
+let renderBundle114 = renderBundleEncoder96.finish({label: '\u8edf\u063c\u0672\u{1f9d1}\ub4ab\ucf24'});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let video46 = await videoWithData();
+let buffer46 = device2.createBuffer({
+  label: '\ufa26\u66bf\u0da2',
+  size: 543530,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder171 = device2.createCommandEncoder({label: '\u7bda\u29f4\uf596'});
+let commandBuffer30 = commandEncoder149.finish({label: '\ud4fc\u35dc\u9f06\ua8b3\u070b\u1a08\u4424\u{1f794}\u0438\u3891'});
+let renderBundleEncoder98 = device2.createRenderBundleEncoder({
+  label: '\u0e16\ue99a\u59f6\udac4\u{1fa2f}\u8540\u8ad1\u0d7b',
+  colorFormats: ['r16sint', 'rg32float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder82.setPipeline(pipeline90);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer44, 864364, 5296);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder150.resolveQuerySet(querySet58, 306, 931, buffer46, 331776);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer38, 8124, new DataView(new ArrayBuffer(32328)), 1186, 328);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 2,
+  origin: {x: 25, y: 0, z: 6},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 509281 */
+{offset: 751, bytesPerRow: 253, rowsPerImage: 201}, {width: 30, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let textureView224 = texture123.createView({
+  label: '\u88de\u0bae\ue015\u0210\ub897\u0994\u0fc5\u{1fc5a}\u0d01\u0919',
+  dimension: '2d',
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder72.setBindGroup(4, bindGroup28, new Uint32Array(3179), 2848, 0);
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(7, bindGroup26, new Uint32Array(951), 597, 0);
+} catch {}
+try {
+commandEncoder161.copyTextureToBuffer({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8012 */
+  offset: 8012,
+  bytesPerRow: 256,
+  buffer: buffer35,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder140.clearBuffer(buffer35);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+computePassEncoder66.insertDebugMarker('\u09c3');
+} catch {}
+let pipeline101 = device3.createRenderPipeline({
+  label: '\u2453\udd28\u0de5\uf68d\u20c2\u{1fe5e}\u0b9c\u0711\u0403\u4d67',
+  layout: pipelineLayout22,
+  multisample: {mask: 0x48ec5ca5},
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32uint', writeMask: 0}, undefined, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 700,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 12, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 360, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 1492, shaderLocation: 10},
+          {format: 'uint16x2', offset: 1700, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 5192, shaderLocation: 7},
+          {format: 'sint32x4', offset: 9136, shaderLocation: 4},
+          {format: 'float16x2', offset: 15584, shaderLocation: 2},
+          {format: 'sint32x2', offset: 12340, shaderLocation: 3},
+          {format: 'uint8x2', offset: 35044, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 1760, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 1132, shaderLocation: 14},
+          {format: 'sint16x2', offset: 2924, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 620,
+        attributes: [
+          {format: 'float32x2', offset: 12, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 164, shaderLocation: 13},
+          {format: 'sint8x2', offset: 6, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 12108,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 3644, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+let textureView225 = texture112.createView({label: '\u2c50\u06be\u{1f834}', arrayLayerCount: 1});
+try {
+computePassEncoder69.setPipeline(pipeline69);
+} catch {}
+try {
+commandEncoder163.copyTextureToBuffer({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 552 */
+  offset: 552,
+  rowsPerImage: 152,
+  buffer: buffer35,
+}, {width: 19, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder145.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder161.clearBuffer(buffer43, 6308, 1192);
+dissociateBuffer(device3, buffer43);
+} catch {}
+try {
+commandEncoder161.resolveQuerySet(querySet71, 25, 1106, buffer41, 136704);
+} catch {}
+try {
+computePassEncoder69.popDebugGroup();
+} catch {}
+let pipeline102 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16sint'}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 808,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 140, shaderLocation: 3},
+          {format: 'sint32x2', offset: 232, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16'},
+});
+let pipelineLayout24 = device2.createPipelineLayout({
+  label: '\u90e9\ucf20\u0535\u{1fe8c}\u{1fd10}\u0dc4\u8167',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37, bindGroupLayout40],
+});
+let buffer47 = device2.createBuffer({
+  label: '\u48ec\u0979\u1a58\u{1fe1d}\u5e96\u8d00\u3984',
+  size: 4477,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView226 = texture79.createView({label: '\u45ca\uebd4\u{1fdd9}\u0791\u05a4\u33c5'});
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+renderBundleEncoder84.setPipeline(pipeline78);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(874350), /* required buffer size: 874350 */
+{offset: 198, bytesPerRow: 426, rowsPerImage: 76}, {width: 32, height: 0, depthOrArrayLayers: 28});
+} catch {}
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+let querySet83 = device2.createQuerySet({label: '\uddcf\u2205\u25e1\u0397\u06f9\u1ea6', type: 'occlusion', count: 1161});
+let textureView227 = texture100.createView({
+  label: '\u{1f801}\u4b46\u7cb3\u7f14\u280c\u6b5c\uc807\u{1f733}\u0e8d\u{1fd3a}\u0f8c',
+  baseMipLevel: 6,
+  baseArrayLayer: 27,
+  arrayLayerCount: 16,
+});
+try {
+computePassEncoder70.setPipeline(pipeline80);
+} catch {}
+try {
+device2.queue.submit([commandBuffer30]);
+} catch {}
+let textureView228 = texture118.createView({
+  label: '\u{1fbbf}\uffb7\u9ec2\u1561\u0f9d\u052a\u597f\u0956\u01fa\u1f2b',
+  dimension: '2d-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+let renderBundleEncoder99 = device3.createRenderBundleEncoder({
+  label: '\uc07e\u012c\ubf47\u{1fef6}\u0906\u2479\u0ec1\u0992\u074d\u05ed',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup27, new Uint32Array(5207), 881, 0);
+} catch {}
+try {
+commandEncoder153.resolveQuerySet(querySet67, 188, 488, buffer39, 63488);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer43, 176, new BigUint64Array(22737), 5809, 112);
+} catch {}
+let promise52 = device3.queue.onSubmittedWorkDone();
+let texture127 = device3.createTexture({
+  label: '\u{1fe8e}\u026c\uc648\u43fd\u0b86\u04dc\u{1fbc7}\u01d3\ub3ae\ud861\u051a',
+  size: [96, 1, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm'],
+});
+let textureView229 = texture118.createView({label: '\uea11\u8bca\ud2d0\u067d\u179a\ue986\ue8c1\u0b83\u{1fa6a}\u{1f7b0}\u0242', baseMipLevel: 1});
+let externalTexture91 = device3.importExternalTexture({label: '\u0440\u{1f6bf}\u07f8\u722b\u141d\u421d\u5bf8', source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder69.setPipeline(pipeline87);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+  await promise52;
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -108,6 +108,9 @@ void Queue::setEncoderForBuffer(id<MTLCommandBuffer> commandBuffer, id<MTLComman
 
 std::pair<id<MTLCommandBuffer>, id<MTLSharedEvent>> Queue::commandBufferWithDescriptor(MTLCommandBufferDescriptor* descriptor)
 {
+    if (!isValid())
+        return std::make_pair(nil, nil);
+
     constexpr auto maxCommandBufferCount = 64;
     if (m_createdNotCommittedBuffers.count >= maxCommandBufferCount) {
         id<MTLCommandBuffer> buffer = [m_createdNotCommittedBuffers objectAtIndex:0];


### PR DESCRIPTION
#### 684d2627908f820f0b7b47fcd00be6eb20baf191
<pre>
[WebGPU] waitUntilCompleted call will fail when Queue is invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=274161">https://bugs.webkit.org/show_bug.cgi?id=274161</a>
&lt;radar://128065164&gt;

Reviewed by Dan Glastonbury.

An invalid queue will return a nil command buffer, so
check if the queue is valid prior to entering this logic.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274161.html: Added.
* LayoutTests/fast/webgpu/fuzz-274161.txt: Added.
Add test.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::commandBufferWithDescriptor):
Return nil if Queue is invalid.

Canonical link: <a href="https://commits.webkit.org/278984@main">https://commits.webkit.org/278984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b9ba5be62d1945c04d21f2ac969cac84b28ba14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55436 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42450 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23521 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26397 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2293 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2494 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11407 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->