### PR TITLE
[JSC] AccessCase should not hold CallLinkInfo*

### DIFF
--- a/JSTests/stress/decouple-calllinkinfo-from-access-case.js
+++ b/JSTests/stress/decouple-calllinkinfo-from-access-case.js
@@ -1,0 +1,96 @@
+// runDefault("--validateOptions=true", "--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true")
+
+const ProxyConstructor = Proxy;
+const getPrototypeOf = Object.getPrototypeOf;
+const ReflectGet = Reflect.get;
+const ReflectSet = Reflect.set;
+const ReflectHas = Reflect.has;
+const setPrototypeOf = Object.setPrototypeOf;
+
+function probe(id, value) {
+    let originalPrototype, newPrototype;
+    let handler = {
+        get(target, key, receiver) {
+            if (key === '__proto__' && receiver === value) return originalPrototype;
+            if (receiver === newPrototype) return ReflectGet(target, key);
+            return ReflectGet(target, key, receiver);
+        },
+        set(target, key, value, receiver) {
+            if (receiver === newPrototype) return ReflectSet(target, key, value);
+            return ReflectSet(target, key, value, receiver);
+        },
+        has(target, key) {
+            return ReflectHas(target, key);
+        },
+    };
+
+    try {
+        originalPrototype = getPrototypeOf(value);
+        newPrototype = new ProxyConstructor(originalPrototype, handler);
+        setPrototypeOf(value, newPrototype);
+    } catch (e) {}
+}
+
+probe("v1", "2003629588");
+let v4 = 9150;
+v4--;
+probe("v6", 51828);
+function F7(a9, a10, a11) {
+    if (!new.target) { throw 'must be called with new'; }
+    const v12 = this?.constructor;
+    try { new v12(this, "object", 447824390); } catch (e) {}
+    a11 % a11;
+    this.b = a9;
+    this.g = a10;
+}
+const v15 = new F7("2003629588", "object", 447824390);
+const v16 = new F7(v15, v4, v4);
+const v17 = new F7("2003629588", 51828, 51828);
+probe("v17", v17);
+const v18 = v17?.constructor;
+probe("v18", v18);
+let v19;
+try { v19 = new v18("r", v17, "r"); } catch (e) {}
+probe("v19", v19);
+const v20 = [v17,v17];
+probe("v20", v20);
+const v21 = [F7,v15,v20,v15,v4];
+const v22 = [v4,"object",51828];
+probe("v22", v22);
+let v23;
+try { v23 = v22.reduce(v15); } catch (e) {}
+const v24 = [2,-354747782,-16,10251,-1485280459,5,6,536870888,-47153,-193790246];
+probe("v24", v24);
+function f25(a26, a27) {
+    const o28 = {
+        [a27]: a26,
+        "d": v21,
+    };
+    return o28;
+}
+f25(v16, v22);
+f25(v23, v16);
+f25(v15, v22);
+v24[4];
+function f33(a34, a35, a36, a37) {
+    probe("v36", a36);
+    ~a35;
+    v22.length = 1;
+    a36?.[v21];
+}
+v24.flatMap(f33);
+gc();
+class C20 {
+    valueOf(a22, a23) {
+        return ("n")[1204] - this;
+    }
+}
+const v26 = new C20();
+function f27(a28, a29) {
+    new BigInt64Array(3603);
+    return v26 * v26;
+}
+try {
+v26[Symbol.toPrimitive] = f27;
+v26.valueOf();
+} catch { }

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -701,9 +701,6 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     switch (type()) {
     case Getter:
     case Setter: {
-        auto& accessor = this->as<GetterSetterAccessCase>();
-        if (accessor.callLinkInfo())
-            accessor.callLinkInfo()->forEachDependentCell(functor);
         break;
     }
     case CustomValueGetter:
@@ -731,9 +728,6 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     case ProxyObjectLoad:
     case ProxyObjectStore:
     case IndexedProxyObjectLoad: {
-        auto& accessor = this->as<ProxyObjectAccessCase>();
-        if (accessor.callLinkInfo())
-            accessor.callLinkInfo()->forEachDependentCell(functor);
         break;
     }
     case InstanceOfHit:
@@ -844,7 +838,7 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     }
 }
 
-bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) const
+bool AccessCase::doesCalls(VM&) const
 {
     bool doesCalls = false;
     switch (type()) {
@@ -970,12 +964,6 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case Replace:
         doesCalls = viaGlobalProxy();
         break;
-    }
-
-    if (doesCalls && cellsToMarkIfDoesCalls) {
-        forEachDependentCell(vm, [&](JSCell* cell) {
-            cellsToMarkIfDoesCalls->append(cell);
-        });
     }
     return doesCalls;
 }
@@ -1213,136 +1201,18 @@ void AccessCase::dump(PrintStream& out) const
 
 bool AccessCase::visitWeak(VM& vm) const
 {
-    switch (type()) {
-    case Getter:
-    case Setter: {
-        auto& accessor = this->as<GetterSetterAccessCase>();
-        if (accessor.callLinkInfo())
-            accessor.callLinkInfo()->visitWeak(vm);
-        break;
-    }
-    case ProxyObjectHas:
-    case ProxyObjectLoad:
-    case ProxyObjectStore:
-    case IndexedProxyObjectLoad: {
-        auto& accessor = this->as<ProxyObjectAccessCase>();
-        if (accessor.callLinkInfo())
-            accessor.callLinkInfo()->visitWeak(vm);
-        break;
-    }
-    case CustomValueGetter:
-    case CustomValueSetter:
-    case IntrinsicGetter:
-    case ModuleNamespaceLoad:
-    case InstanceOfHit:
-    case InstanceOfMiss:
-    case CustomAccessorGetter:
-    case CustomAccessorSetter:
-    case Load:
-    case LoadMegamorphic:
-    case StoreMegamorphic:
-    case InMegamorphic:
-    case Transition:
-    case Delete:
-    case DeleteNonConfigurable:
-    case DeleteMiss:
-    case Replace:
-    case Miss:
-    case GetGetter:
-    case InHit:
-    case InMiss:
-    case CheckPrivateBrand:
-    case SetPrivateBrand:
-    case ArrayLength:
-    case StringLength:
-    case DirectArgumentsLength:
-    case ScopedArgumentsLength:
-    case InstanceOfGeneric:
-    case IndexedMegamorphicLoad:
-    case IndexedMegamorphicStore:
-    case IndexedMegamorphicIn:
-    case IndexedInt32Load:
-    case IndexedDoubleLoad:
-    case IndexedContiguousLoad:
-    case IndexedArrayStorageLoad:
-    case IndexedScopedArgumentsLoad:
-    case IndexedDirectArgumentsLoad:
-    case IndexedTypedArrayInt8Load:
-    case IndexedTypedArrayUint8Load:
-    case IndexedTypedArrayUint8ClampedLoad:
-    case IndexedTypedArrayInt16Load:
-    case IndexedTypedArrayUint16Load:
-    case IndexedTypedArrayInt32Load:
-    case IndexedTypedArrayUint32Load:
-    case IndexedTypedArrayFloat32Load:
-    case IndexedTypedArrayFloat64Load:
-    case IndexedResizableTypedArrayInt8Load:
-    case IndexedResizableTypedArrayUint8Load:
-    case IndexedResizableTypedArrayUint8ClampedLoad:
-    case IndexedResizableTypedArrayInt16Load:
-    case IndexedResizableTypedArrayUint16Load:
-    case IndexedResizableTypedArrayInt32Load:
-    case IndexedResizableTypedArrayUint32Load:
-    case IndexedResizableTypedArrayFloat32Load:
-    case IndexedResizableTypedArrayFloat64Load:
-    case IndexedStringLoad:
-    case IndexedNoIndexingMiss:
-    case IndexedInt32Store:
-    case IndexedDoubleStore:
-    case IndexedContiguousStore:
-    case IndexedArrayStorageStore:
-    case IndexedTypedArrayInt8Store:
-    case IndexedTypedArrayUint8Store:
-    case IndexedTypedArrayUint8ClampedStore:
-    case IndexedTypedArrayInt16Store:
-    case IndexedTypedArrayUint16Store:
-    case IndexedTypedArrayInt32Store:
-    case IndexedTypedArrayUint32Store:
-    case IndexedTypedArrayFloat32Store:
-    case IndexedTypedArrayFloat64Store:
-    case IndexedResizableTypedArrayInt8Store:
-    case IndexedResizableTypedArrayUint8Store:
-    case IndexedResizableTypedArrayUint8ClampedStore:
-    case IndexedResizableTypedArrayInt16Store:
-    case IndexedResizableTypedArrayUint16Store:
-    case IndexedResizableTypedArrayInt32Store:
-    case IndexedResizableTypedArrayUint32Store:
-    case IndexedResizableTypedArrayFloat32Store:
-    case IndexedResizableTypedArrayFloat64Store:
-    case IndexedInt32InHit:
-    case IndexedDoubleInHit:
-    case IndexedContiguousInHit:
-    case IndexedArrayStorageInHit:
-    case IndexedScopedArgumentsInHit:
-    case IndexedDirectArgumentsInHit:
-    case IndexedTypedArrayInt8InHit:
-    case IndexedTypedArrayUint8InHit:
-    case IndexedTypedArrayUint8ClampedInHit:
-    case IndexedTypedArrayInt16InHit:
-    case IndexedTypedArrayUint16InHit:
-    case IndexedTypedArrayInt32InHit:
-    case IndexedTypedArrayUint32InHit:
-    case IndexedTypedArrayFloat32InHit:
-    case IndexedTypedArrayFloat64InHit:
-    case IndexedResizableTypedArrayInt8InHit:
-    case IndexedResizableTypedArrayUint8InHit:
-    case IndexedResizableTypedArrayUint8ClampedInHit:
-    case IndexedResizableTypedArrayInt16InHit:
-    case IndexedResizableTypedArrayUint16InHit:
-    case IndexedResizableTypedArrayInt32InHit:
-    case IndexedResizableTypedArrayUint32InHit:
-    case IndexedResizableTypedArrayFloat32InHit:
-    case IndexedResizableTypedArrayFloat64InHit:
-    case IndexedStringInHit:
-    case IndexedNoIndexingInMiss:
-        break;
-    }
-
     bool isValid = true;
     forEachDependentCell(vm, [&](JSCell* cell) {
         isValid &= vm.heap.isMarked(cell);
     });
     return isValid;
+}
+
+void AccessCase::collectDependentCells(VM& vm, Vector<JSCell*>& cells) const
+{
+    forEachDependentCell(vm, [&](JSCell* cell) {
+        cells.append(cell);
+    });
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -224,9 +224,7 @@ public:
     WatchpointSet* additionalSet() const;
     bool viaGlobalProxy() const { return m_viaGlobalProxy; }
 
-    // If you supply the optional vector, this will append the set of cells that this will need to keep alive
-    // past the call.
-    bool doesCalls(VM&, Vector<JSCell*>* cellsToMark = nullptr) const;
+    bool doesCalls(VM&) const;
 
     bool isCustom() const
     {
@@ -293,6 +291,8 @@ public:
     }
 
     static bool canBeShared(const AccessCase&, const AccessCase&);
+
+    void collectDependentCells(VM&, Vector<JSCell*>&) const;
 
     template<typename Func>
     void runWithDowncast(const Func&);

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -276,7 +276,7 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                 auto& accessCase = access.as<ProxyObjectAccessCase>();
                 auto status = GetByStatus(accessCase);
                 auto callLinkStatus = makeUnique<CallLinkStatus>();
-                if (CallLinkInfo* callLinkInfo = accessCase.callLinkInfo())
+                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, 0))
                     *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
                 status.appendVariant(GetByVariant(accessCase.identifier(), { }, invalidOffset, { }, WTFMove(callLinkStatus)));
                 return status;
@@ -390,10 +390,8 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                     }
                     case AccessCase::Getter: {
                         callLinkStatus = makeUnique<CallLinkStatus>();
-                        if (CallLinkInfo* callLinkInfo = access.as<GetterSetterAccessCase>().callLinkInfo()) {
-                            *callLinkStatus = CallLinkStatus::computeFor(
-                                locker, profiledBlock, *callLinkInfo, callExitSiteData);
-                        }
+                        if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, listIndex))
+                            *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
                         break;
                     }
                     default: {

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
@@ -86,8 +86,6 @@ void GetterSetterAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Ind
 {
     Base::dumpImpl(out, comma, indent);
     out.print(comma, "customSlotBase = ", RawPointer(customSlotBase()));
-    if (callLinkInfo())
-        out.print(comma, "callLinkInfo = ", RawPointer(callLinkInfo()));
     out.print(comma, "customAccessor = ", RawPointer(m_customAccessor.taggedPtr()));
 }
 

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
@@ -38,14 +38,6 @@ public:
     friend class AccessCase;
     friend class InlineCacheCompiler;
 
-    // This can return null if it hasn't been generated yet. That's
-    // actually somewhat likely because of how we do buffering of new cases.
-    // CallLinkInfo's ownership is held both by generated code via GCAwareJITStubRoutine and PolymorphicAccess.
-    // The ownership relation is PolymorphicAccess -> GCAwareJITStubRoutine -> CallLinkInfo.
-    // PolymorphicAccess can be destroyed while GCAwareJITStubRoutine is alive if we are destroying PolymorphicAccess
-    // while we are executing GCAwareJITStubRoutine. It is not possible that GetterSetterAccessCase is alive while
-    // GCAwareJITStubRoutine is destroyed.
-    OptimizingCallLinkInfo* callLinkInfo() const { return m_callLinkInfo; }
     JSObject* customSlotBase() const { return m_customSlotBase.get(); }
     std::optional<DOMAttributeAnnotation> domAttribute() const { return m_domAttribute; }
 
@@ -69,9 +61,7 @@ private:
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
     Ref<AccessCase> cloneImpl() const;
 
-
     WriteBarrier<JSObject> m_customSlotBase;
-    OptimizingCallLinkInfo* m_callLinkInfo { nullptr };
     CodePtr<CustomAccessorPtrTag> m_customAccessor;
     std::optional<DOMAttributeAnnotation> m_domAttribute;
 };

--- a/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp
@@ -62,8 +62,6 @@ Ref<AccessCase> ProxyObjectAccessCase::cloneImpl() const
 void ProxyObjectAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const
 {
     Base::dumpImpl(out, comma, indent);
-    if (callLinkInfo())
-        out.print(comma, "callLinkInfo = ", RawPointer(callLinkInfo()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.h
@@ -41,16 +41,12 @@ public:
 
     void emit(InlineCacheCompiler&, MacroAssembler::JumpList& fallThrough);
 
-    OptimizingCallLinkInfo* callLinkInfo() const { return m_callLinkInfo; }
-
 private:
     ProxyObjectAccessCase(VM&, JSCell* owner, AccessType, CacheableIdentifier);
     ProxyObjectAccessCase(const ProxyObjectAccessCase&);
 
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
     Ref<AccessCase> cloneImpl() const;
-
-    OptimizingCallLinkInfo* m_callLinkInfo { nullptr };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -292,10 +292,8 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
 
                 case ComplexGetStatus::Inlineable: {
                     auto callLinkStatus = makeUnique<CallLinkStatus>();
-                    if (CallLinkInfo* callLinkInfo = access.as<GetterSetterAccessCase>().callLinkInfo()) {
-                        *callLinkStatus = CallLinkStatus::computeFor(
-                            locker, profiledBlock, *callLinkInfo, callExitSiteData);
-                    }
+                    if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, i))
+                        *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
 
                     auto variant = PutByVariant::setter(access.identifier(), structure, complexGetStatus.offset(), complexGetStatus.conditionSet(), WTFMove(callLinkStatus));
                     if (!result.appendVariant(variant))
@@ -312,7 +310,7 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
             case AccessCase::ProxyObjectStore: {
                 auto& accessCase = access.as<ProxyObjectAccessCase>();
                 auto callLinkStatus = makeUnique<CallLinkStatus>();
-                if (CallLinkInfo* callLinkInfo = accessCase.callLinkInfo())
+                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, i))
                     *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
                 auto variant = PutByVariant::proxy(accessCase.identifier(), access.structure(), WTFMove(callLinkStatus));
                 if (!result.appendVariant(variant))

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
@@ -415,6 +415,13 @@ void StructureStubInfo::propagateTransitions(Visitor& visitor)
 template void StructureStubInfo::propagateTransitions(AbstractSlotVisitor&);
 template void StructureStubInfo::propagateTransitions(SlotVisitor&);
 
+CallLinkInfo* StructureStubInfo::callLinkInfoAt(const ConcurrentJSLocker& locker, unsigned index)
+{
+    if (!m_handler)
+        return nullptr;
+    return m_handler->callLinkInfoAt(locker, index);
+}
+
 StubInfoSummary StructureStubInfo::summary(VM& vm) const
 {
     StubInfoSummary takesSlowPath = StubInfoSummary::TakesSlowPath;

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -237,6 +237,9 @@ public:
     {
         return m_inlineAccessBaseStructureID.get();
     }
+
+    CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned index);
+
 private:
     ALWAYS_INLINE bool considerRepatchingCacheImpl(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
     {

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -159,7 +159,7 @@ void PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet()
 
 MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(
     Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner,
-    const Vector<JSCell*>& cells, Bag<OptimizingCallLinkInfo>&& callLinkInfos)
+    const Vector<JSCell*>& cells, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos)
     : PolymorphicAccessJITStubRoutine(type, code, vm, WTFMove(cases), WTFMove(weakStructures), owner)
     , m_cells(cells.size())
     , m_callLinkInfos(WTFMove(callLinkInfos))
@@ -184,7 +184,23 @@ void MarkingGCAwareJITStubRoutine::markRequiredObjectsImpl(SlotVisitor& visitor)
     markRequiredObjectsInternalImpl(visitor);
 }
 
-GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner, const Vector<JSCell*>& cells, Bag<OptimizingCallLinkInfo>&& callLinkInfos,
+bool MarkingGCAwareJITStubRoutine::visitWeakImpl(VM& vm)
+{
+    for (auto& callLinkInfo : m_callLinkInfos) {
+        if (callLinkInfo)
+            callLinkInfo->visitWeak(vm);
+    }
+    return PolymorphicAccessJITStubRoutine::visitWeakImpl(vm);
+}
+
+CallLinkInfo* MarkingGCAwareJITStubRoutine::callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned index)
+{
+    if (index < m_callLinkInfos.size())
+        return m_callLinkInfos[index].get();
+    return nullptr;
+}
+
+GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner, const Vector<JSCell*>& cells, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos,
     CodeBlock* codeBlockForExceptionHandlers, DisposableCallSiteIndex exceptionHandlerCallSiteIndex)
     : MarkingGCAwareJITStubRoutine(JITStubRoutine::Type::GCAwareJITStubRoutineWithExceptionHandlerType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos))
     , m_codeBlockWithExceptionHandler(codeBlockForExceptionHandlers)
@@ -230,13 +246,16 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     JSCell* owner,
     bool makesCalls,
     const Vector<JSCell*>& cells,
-    Bag<OptimizingCallLinkInfo>&& callLinkInfos,
+    Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos,
     CodeBlock* codeBlockForExceptionHandlers,
     DisposableCallSiteIndex exceptionHandlerCallSiteIndex)
 {
     if (!makesCalls) {
         // Allocating CallLinkInfos means we should have calls.
-        ASSERT(callLinkInfos.isEmpty());
+#if ASSERT_ENABLED
+        for (auto& callLinkInfo : callLinkInfos)
+            ASSERT(!callLinkInfo);
+#endif
         auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
         constexpr bool isCodeImmutable = false;
         stub->makeGCAware(vm, isCodeImmutable);
@@ -251,7 +270,15 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
         return stub;
     }
 
-    if (cells.isEmpty() && callLinkInfos.isEmpty()) {
+    bool hasCallLinkInfo = false;
+    for (auto& callLinkInfo : callLinkInfos) {
+        if (callLinkInfo) {
+            hasCallLinkInfo = true;
+            break;
+        }
+    }
+
+    if (cells.isEmpty() && !hasCallLinkInfo) {
         auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
         constexpr bool isCodeImmutable = false;
         stub->makeGCAware(vm, isCodeImmutable);

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -159,7 +159,10 @@ public:
     using Base = PolymorphicAccessJITStubRoutine;
     friend class JITStubRoutine;
 
-    MarkingGCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Bag<OptimizingCallLinkInfo>&&);
+    MarkingGCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&);
+
+    bool visitWeakImpl(VM&);
+    CallLinkInfo* callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned);
 
 protected:
     template<typename Visitor> void markRequiredObjectsInternalImpl(Visitor&);
@@ -168,7 +171,7 @@ protected:
 
 private:
     FixedVector<WriteBarrier<JSCell>> m_cells;
-    Bag<OptimizingCallLinkInfo> m_callLinkInfos;
+    FixedVector<std::unique_ptr<OptimizingCallLinkInfo>> m_callLinkInfos;
 };
 
 
@@ -180,7 +183,7 @@ public:
     using Base = MarkingGCAwareJITStubRoutine;
     friend class JITStubRoutine;
 
-    GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Bag<OptimizingCallLinkInfo>&&, CodeBlock*, DisposableCallSiteIndex);
+    GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&, CodeBlock*, DisposableCallSiteIndex);
     ~GCAwareJITStubRoutineWithExceptionHandler();
 
 
@@ -224,7 +227,7 @@ private:
 
 Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, VM&, JSCell* owner, bool makesCalls,
-    const Vector<JSCell*>&, Bag<OptimizingCallLinkInfo>&& callLinkInfos,
+    const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos,
     CodeBlock* codeBlockForExceptionHandlers, DisposableCallSiteIndex exceptionHandlingCallSiteIndex);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.cpp
@@ -89,6 +89,15 @@ bool JITStubRoutine::visitWeak(VM& vm)
     return result;
 }
 
+CallLinkInfo* JITStubRoutine::callLinkInfoAt(const ConcurrentJSLocker& locker, unsigned index)
+{
+    CallLinkInfo* result = nullptr;
+    runWithDowncast([&](auto* derived) {
+        result = derived->callLinkInfoAtImpl(locker, index);
+    });
+    return result;
+}
+
 void JITStubRoutine::markRequiredObjects(AbstractSlotVisitor& visitor)
 {
     runWithDowncast([&](auto* derived) {

--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -126,6 +126,7 @@ public:
     }
     
     bool visitWeak(VM&);
+    CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned);
     void markRequiredObjects(AbstractSlotVisitor&);
     void markRequiredObjects(SlotVisitor&);
 
@@ -148,6 +149,7 @@ protected:
     // false, you will usually not do any clearing because the idea is that you will simply be
     // destroyed.
     ALWAYS_INLINE bool visitWeakImpl(VM&) { return true; }
+    ALWAYS_INLINE CallLinkInfo* callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned) { return nullptr; }
 
     template<typename Func>
     ALWAYS_INLINE void runWithDowncast(const Func& function);


### PR DESCRIPTION
#### b25150796310098d1c10f98c45825c4be34912ee
<pre>
[JSC] AccessCase should not hold CallLinkInfo*
<a href="https://bugs.webkit.org/show_bug.cgi?id=268221">https://bugs.webkit.org/show_bug.cgi?id=268221</a>
<a href="https://rdar.apple.com/121733122">rdar://121733122</a>

Reviewed by Justin Michaud.

AccessCase holds CallLinkInfo*. But when the underlying JITStubRoutine gets destroyed, this becomes invalid.
Previously, it does not matter since we always destroy CodeBlock first (synchronously), and then we clean up JITStubRoutine.
So there were strict ordering.  But now CodeBlock destruction can get delayed.

But fundamentally speaking, having CallLinkInfo* in AccessCase is not right. This is compiled code&apos;s data structure and
AccessCase should be just a data for IC feedback.

In this patch we decouple CallLinkInfo* from AccessCase. CallLinkInfo&apos;s lifetime should be correctly managed by visitWeak, so,
we add visitWeak iteration in MarkingGCAwareJITStubRoutine. Then we can remove CallLinkInfo from AccessCase.

* JSTests/stress/decouple-calllinkinfo-from-access-case.js: Added.
(F7):
(f25):
(f33):
(C20.prototype.valueOf):
(C20):
(f27):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::visitWeak const):
(JSC::AccessCase::collectDependentCells const):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp:
(JSC::GetterSetterAccessCase::dumpImpl const):
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generate):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::regenerate):
(JSC::InlineCacheHandler::callLinkInfoAt):
(JSC::InlineCacheHandler::visitWeak const):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp:
(JSC::ProxyObjectAccessCase::dumpImpl const):
* Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.h:
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::callLinkInfoAt):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine):
(JSC::MarkingGCAwareJITStubRoutine::visitWeakImpl):
(JSC::MarkingGCAwareJITStubRoutine::callLinkInfoAtImpl):
(JSC::GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler):
(JSC::createICJITStubRoutine):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
* Source/JavaScriptCore/jit/JITStubRoutine.cpp:
(JSC::JITStubRoutine::callLinkInfoAt):
* Source/JavaScriptCore/jit/JITStubRoutine.h:
(JSC::JITStubRoutine::callLinkInfoAtImpl):

Originally-landed-as: 272448.633@safari-7618-branch (f25738c69a33). <a href="https://rdar.apple.com/128077399">rdar://128077399</a>
Canonical link: <a href="https://commits.webkit.org/278779@main">https://commits.webkit.org/278779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01c854decd6be6bb500727375259d6485287d02d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1892 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23073 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1695 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44862 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56378 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51023 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49345 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48536 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28771 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63345 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7515 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27613 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11963 "Passed tests") | 
<!--EWS-Status-Bubble-End-->