### PR TITLE
Allow a TiledBackingClient to be a client for multiple TiledBackings

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2068,6 +2068,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/TabSize.h
     platform/graphics/TextRun.h
     platform/graphics/TextTrackRepresentation.h
+    platform/graphics/TileGridIdentifier.h
     platform/graphics/TiledBacking.h
     platform/graphics/TrackBuffer.h
     platform/graphics/TrackPrivateBase.h

--- a/Source/WebCore/platform/graphics/TileGridIdentifier.h
+++ b/Source/WebCore/platform/graphics/TileGridIdentifier.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+enum class TileGridIdentifierType { };
+using TileGridIdentifier = ObjectIdentifier<TileGridIdentifierType>;
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntPoint.h"
+#include "TileGridIdentifier.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/MonotonicTime.h>
@@ -70,18 +71,19 @@ enum class TiledBackingScrollability : uint8_t {
 };
 
 using TileIndex = IntPoint;
-using TileGridIndex = unsigned;
+class TiledBacking;
 
 class TiledBackingClient : public CanMakeWeakPtr<TiledBackingClient> {
 public:
     virtual ~TiledBackingClient() = default;
 
     // paintDirtyRect is in the same coordinate system as tileClip.
-    virtual void willRepaintTile(TileGridIndex, TileIndex, const FloatRect& tileClip, const FloatRect& paintDirtyRect) = 0;
-    virtual void willRemoveTile(TileGridIndex, TileIndex) = 0;
-    virtual void willRepaintAllTiles(TileGridIndex) = 0;
-    virtual void coverageRectDidChange(const FloatRect&) = 0;
-    virtual void tilingScaleFactorDidChange(float) = 0;
+    virtual void willRepaintTile(TiledBacking&, TileGridIdentifier, TileIndex, const FloatRect& tileClip, const FloatRect& paintDirtyRect) = 0;
+    virtual void willRemoveTile(TiledBacking&, TileGridIdentifier, TileIndex) = 0;
+    virtual void willRepaintAllTiles(TiledBacking&, TileGridIdentifier) = 0;
+    virtual void willRemoveGrid(TiledBacking&, TileGridIdentifier) = 0;
+    virtual void coverageRectDidChange(TiledBacking&, const FloatRect&) = 0;
+    virtual void tilingScaleFactorDidChange(TiledBacking&, float) = 0;
 };
 
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -58,7 +58,8 @@ static String validationPolicyAsString(OptionSet<TileGrid::ValidationPolicyFlag>
 #endif
 
 TileGrid::TileGrid(TileController& controller)
-    : m_controller(controller)
+    : m_identifier(TileGridIdentifier::generate())
+    , m_controller(controller)
     , m_containerLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_cohortRemovalTimer(*this, &TileGrid::cohortRemovalTimerFired)
     , m_tileSize(kDefaultTileSize, kDefaultTileSize)

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -28,6 +28,7 @@
 #include "IntPointHash.h"
 #include "IntRect.h"
 #include "PlatformCALayerClient.h"
+#include "TileGridIdentifier.h"
 #include "Timer.h"
 #include <wtf/Deque.h>
 #include <wtf/HashCountedSet.h>
@@ -52,6 +53,8 @@ class TileGrid : public PlatformCALayerClient {
 public:
     explicit TileGrid(TileController&);
     ~TileGrid();
+
+    TileGridIdentifier identifier() const { return m_identifier; }
 
 #if USE(CA)
     PlatformCALayer& containerLayer() { return m_containerLayer; }
@@ -150,6 +153,7 @@ private:
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override;
     bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
 
+    TileGridIdentifier m_identifier;
     TileController& m_controller;
 #if USE(CA)
     Ref<PlatformCALayer> m_containerLayer;


### PR DESCRIPTION
#### a9ca2712f944864544be392b09fdc34ab5d354d5
<pre>
Allow a TiledBackingClient to be a client for multiple TiledBackings
<a href="https://rdar.apple.com/128073464">rdar://128073464</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274164">https://bugs.webkit.org/show_bug.cgi?id=274164</a>

Reviewed by Sammy Gill.

AsyncPDFRenderer will need to handle multiple TiledBackings in future, and currently
there&apos;s no way to tell which TiledBacking a client callback is associated with. So
pass a `TiledBacking&amp;` to all the client callbacks.

Also make TileGrid identifiers unique; previously they were 0 or 1, but that allows
for confusion between TileGrids belonging to different TiledBackings. So give TileGrid
a TileGridIdentifier and pass it to the client callbacks.

We also have to add TiledBackingClient::willRemoveGrid() so that clients don&apos;t
accumulate data for TileGrids that have gone away (now that the identifiers are
monotonically increasing). AsyncPDFRenderer implements this, but it will actually
never get hit because AsyncPDFRenderer doesn&apos;t enable two-level tile caches.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/TileGridIdentifier.h: Added.
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setContentsScale):
(WebCore::TileController::setCoverageRect):
(WebCore::TileController::willRepaintTile):
(WebCore::TileController::willRemoveTile):
(WebCore::TileController::willRepaintAllTiles):
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::TileGrid):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
(WebCore::TileGrid::identifier const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
(WebKit::TileForGrid::computeHash const):
(WTF::TileForGridHash::hash):
(WTF::TileForGridHash::equal):
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::emptyValue):
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::deletedValue):
(WebKit::AsyncPDFRenderer::TileRenderInfo::equivalentForPainting const): Deleted.
(WebKit::AsyncPDFRenderer::TileRenderInfo::equivalentForPaintingIgnoringContentVersion const): Deleted.
(WebKit::AsyncPDFRenderer::renderInfoForTile): Deleted.
(WebKit::AsyncPDFRenderer::enqueueTilePaintIfNecessary): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::willRepaintAllTiles):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::tilingScaleFactorDidChange):
(WebKit::AsyncPDFRenderer::willRemoveGrid):
(WebKit::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/278791@main">https://commits.webkit.org/278791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d814d52cdb18ea84b0ee4e320f124fafbaadeb89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41942 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1682 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49337 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48526 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11284 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28762 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->