### PR TITLE
Implement source textIndicators.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1078,6 +1078,7 @@ def headers_for_type(type):
         'WebKit::SelectionTouch': ['"GestureTypes.h"'],
         'WebKit::TapIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::TextCheckerRequestID': ['"IdentifierTypes.h"'],
+        'WebKit::TextIndicatorStyle': ['"TextIndicatorStyle.h"'],
         'WebKit::WebEventType': ['"WebEvent.h"'],
         'WebKit::WebExtensionContextInstallReason': ['"WebExtensionContext.h"'],
         'WebKit::WebExtensionCookieFilterParameters': ['"WebExtensionCookieParameters.h"'],

--- a/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
+++ b/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
@@ -56,4 +56,11 @@ struct WebKit::WebUnifiedTextReplacementContextData {
     WebCore::AttributedString attributedText;
     WebCore::CharacterRange range;
 };
+
+header: "TextIndicatorStyle.h"
+[CustomHeader] enum class WebKit::TextIndicatorStyle : uint8_t {
+    Initial,
+    Source,
+    Final,
+};
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1786,12 +1786,23 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-- (void)_removeTextIndicatorStyleForID:(NSUUID *)nsuuid
+- (void)_addTextIndicatorStyleForID:(NSUUID *)nsUUID withStyleType:(WKTextIndicatorStyleType)styleType
 {
 #if PLATFORM(IOS_FAMILY)
-    [_contentView removeTextIndicatorStyleForID:nsuuid];
+    [_contentView addTextIndicatorStyleForID:nsUUID withStyleType:styleType];
 #elif PLATFORM(MAC)
-    auto uuid = WTF::UUID::fromNSUUID(nsuuid);
+    auto uuid = WTF::UUID::fromNSUUID(nsUUID);
+    if (!uuid)
+        return;
+    _impl->addTextIndicatorStyleForID(*uuid, styleType);
+#endif
+}
+- (void)_removeTextIndicatorStyleForID:(NSUUID *)nsUUID
+{
+#if PLATFORM(IOS_FAMILY)
+    [_contentView removeTextIndicatorStyleForID:nsUUID];
+#elif PLATFORM(MAC)
+    auto uuid = WTF::UUID::fromNSUUID(nsUUID);
     if (!uuid)
         return;
     _impl->removeTextIndicatorStyleForID(*uuid);
@@ -2828,13 +2839,13 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 #endif
 }
 
-- (void)_disableTextIndicatorStylingWithUUID:(NSUUID *)nsuuid
+- (void)_disableTextIndicatorStylingWithUUID:(NSUUID *)nsUUID
 {
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
 #if PLATFORM(IOS_FAMILY)
-    [_contentView removeTextIndicatorStyleForID:nsuuid];
+    [_contentView removeTextIndicatorStyleForID:nsUUID];
 #elif PLATFORM(MAC) && ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
-    auto uuid = WTF::UUID::fromNSUUID(nsuuid);
+    auto uuid = WTF::UUID::fromNSUUID(nsUUID);
     if (!uuid)
         return;
     _impl->removeTextIndicatorStyleForID(*uuid);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -60,6 +60,10 @@
 #define WK_WEB_VIEW_PROTOCOLS <WKShareSheetDelegate>
 #endif
 
+#if PLATFORM(COCOA)
+#import "WKTextIndicatorStyleType.h"
+#endif
+
 #if !defined(WK_WEB_VIEW_PROTOCOLS)
 #define WK_WEB_VIEW_PROTOCOLS
 #endif
@@ -390,6 +394,7 @@ struct PerWebProcessState {
 - (void)_textReplacementSession:(NSUUID *)sessionUUID showInformationForReplacementWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect;
 
 - (void)_textReplacementSession:(NSUUID *)sessionUUID updateState:(WebKit::WebTextReplacementDataState)state forReplacementWithUUID:(NSUUID *)replacementUUID;
+- (void)_addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType;
 - (void)_removeTextIndicatorStyleForID:(NSUUID *)uuid;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -46,6 +46,8 @@ struct AppHighlight;
 
 namespace WebKit {
 
+enum class TextIndicatorStyle : uint8_t;
+
 class PageClientImplCocoa : public PageClient {
 public:
     PageClientImplCocoa(WKWebView *);
@@ -97,6 +99,7 @@ public:
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyle) final;
     void removeTextIndicatorStyleForID(const WTF::UUID&) final;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "PageClientImplCocoa.h"
 
+#import "TextIndicatorStyle.h"
+#import "WKTextIndicatorStyleType.h"
 #import "WKWebViewInternal.h"
 #import <WebCore/AlternativeTextUIController.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -155,6 +157,11 @@ void PageClientImplCocoa::storeAppHighlight(const WebCore::AppHighlight &highlig
 #endif // ENABLE(APP_HIGHLIGHTS)
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+void PageClientImplCocoa::addTextIndicatorStyleForID(const WTF::UUID& uuid, WebKit::TextIndicatorStyle styleType)
+{
+    [m_webView _addTextIndicatorStyleForID:uuid withStyleType:(WKTextIndicatorStyleType)styleType];
+}
+
 void PageClientImplCocoa::removeTextIndicatorStyleForID(const WTF::UUID& uuid)
 {
     [m_webView _removeTextIndicatorStyleForID:uuid];

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -30,6 +30,7 @@
 #include "PDFPluginIdentifier.h"
 #include "PasteboardAccessIntent.h"
 #include "SameDocumentNavigationType.h"
+#include "TextIndicatorStyle.h"
 #include "WebColorPicker.h"
 #include "WebDateTimePicker.h"
 #include "WebPopupMenuProxy.h"
@@ -698,6 +699,7 @@ public:
     virtual void storeAppHighlight(const WebCore::AppHighlight&) = 0;
 #endif
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    virtual void addTextIndicatorStyleForID(const WTF::UUID&, WebKit::TextIndicatorStyle) = 0;
     virtual void removeTextIndicatorStyleForID(const WTF::UUID&) = 0;
 #endif
     virtual void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) { }

--- a/Source/WebKit/UIProcess/TextIndicatorStyle.h
+++ b/Source/WebKit/UIProcess/TextIndicatorStyle.h
@@ -25,8 +25,12 @@
 
 #pragma once
 
-typedef NS_ENUM(NSInteger, WKTextIndicatorStyleType) {
-    WKTextIndicatorStyleTypeInitial,
-    WKTextIndicatorStyleTypeSource,
-    WKTextIndicatorStyleTypeFinal
+namespace WebKit {
+
+enum class TextIndicatorStyle : uint8_t {
+    Initial,
+    Source,
+    Final
 };
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -528,6 +528,7 @@ enum class SelectionTouch : uint8_t;
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool;
 enum class SyntheticEditingCommandType : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
+enum class TextIndicatorStyle : uint8_t;
 enum class UndoOrRedo : bool;
 enum class WasNavigationIntercepted : bool;
 enum class WebContentMode : uint8_t;
@@ -2413,6 +2414,7 @@ public:
     void textReplacementSessionShowInformationForReplacementWithUUIDRelativeToRect(const WTF::UUID& sessionUUID, const WTF::UUID& replacementUUID, WebCore::IntRect selectionBoundsInRootView);
     void textReplacementSessionUpdateStateForReplacementWithUUID(const WTF::UUID& sessionUUID, WebTextReplacementDataState, const WTF::UUID& replacementUUID);
 
+    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyle, const WebCore::TextIndicatorData&);
     void removeTextIndicatorStyleForID(const WTF::UUID&);
     void enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID&);
     void enableTextIndicatorStyleForElementWithID(const String& elementID, const WTF::UUID&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -525,6 +525,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    AddTextIndicatorStyleForID(WTF::UUID uuid, enum:uint8_t WebKit::TextIndicatorStyle style, struct WebCore::TextIndicatorData data)
     RemoveTextIndicatorStyleForID(WTF::UUID uuid)
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -47,6 +47,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
 #include <pal/HysteresisActivity.h>
+#include <wtf/UUID.h>
 
 #if ENABLE(APPLE_PAY)
 #include "WebPaymentCoordinatorProxy.h"
@@ -290,6 +291,10 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 
 #if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
     Deque<QueuedTouchEvents> touchEventQueue;
+#endif
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    HashMap<WTF::UUID, WebCore::TextIndicatorData> textIndicatorDataForChunk;
 #endif
 
     MonotonicTime didFinishDocumentLoadForMainFrameTimestamp;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -71,6 +71,7 @@
 #import "WKSelectMenuListViewController.h"
 #import "WKSyntheticFlagsChangedWebEvent.h"
 #import "WKTapHighlightView.h"
+#import "WKTextIndicatorStyleType.h"
 #import "WKTextInputListViewController.h"
 #import "WKTextInteractionWrapper.h"
 #import "WKTextPlaceholder.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1080,6 +1080,7 @@
 		4447F0202BC833F0006988E9 /* WKTextIndicatorStyleType.h in Headers */ = {isa = PBXBuildFile; fileRef = 4447F01F2BC833F0006988E9 /* WKTextIndicatorStyleType.h */; };
 		445979392BBB8E9A00087EBC /* WKSTextStyleManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 445979382BBB8E9A00087EBC /* WKSTextStyleManager.h */; };
 		4459984222833E8700E61373 /* SyntheticEditingCommandType.h in Headers */ = {isa = PBXBuildFile; fileRef = 4459984122833E6000E61373 /* SyntheticEditingCommandType.h */; };
+		446C003D2BD8B625003D1276 /* TextIndicatorStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 446C003C2BD8B625003D1276 /* TextIndicatorStyle.h */; };
 		4476EF0925BFC8B7004A0587 /* _WKAppHighlightDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4476EF0825BFC8B7004A0587 /* _WKAppHighlightDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4482734724528F6000A95493 /* CocoaImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4482734624528F6000A95493 /* CocoaImage.h */; };
 		4486A15C2B730D0000E48068 /* CoreIPCNSShadow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4486A15B2B730CF200E48068 /* CoreIPCNSShadow.h */; };
@@ -5294,6 +5295,7 @@
 		4447F01F2BC833F0006988E9 /* WKTextIndicatorStyleType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextIndicatorStyleType.h; sourceTree = "<group>"; };
 		445979382BBB8E9A00087EBC /* WKSTextStyleManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKSTextStyleManager.h; sourceTree = "<group>"; };
 		4459984122833E6000E61373 /* SyntheticEditingCommandType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyntheticEditingCommandType.h; sourceTree = "<group>"; };
+		446C003C2BD8B625003D1276 /* TextIndicatorStyle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextIndicatorStyle.h; sourceTree = "<group>"; };
 		4476EF0825BFC8B7004A0587 /* _WKAppHighlightDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKAppHighlightDelegate.h; sourceTree = "<group>"; };
 		4482734624528F6000A95493 /* CocoaImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaImage.h; sourceTree = "<group>"; };
 		4486A1592B730CF100E48068 /* CoreIPCNSShadow.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSShadow.mm; sourceTree = "<group>"; };
@@ -13975,6 +13977,7 @@
 				1AA417C912C00CCA002BE67B /* TextChecker.h */,
 				53CFBBC62224D1B000266546 /* TextCheckerCompletion.cpp */,
 				53CFBBC72224D1B000266546 /* TextCheckerCompletion.h */,
+				446C003C2BD8B625003D1276 /* TextIndicatorStyle.h */,
 				CD9A64A027C8972C003827C0 /* UIProcessLogInitialization.cpp */,
 				CD9A649F27C8972C003827C0 /* UIProcessLogInitialization.h */,
 				07297F9C1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.cpp */,
@@ -16702,6 +16705,7 @@
 				1AA417CB12C00CCA002BE67B /* TextChecker.h in Headers */,
 				53CFBBC82224D1B500266546 /* TextCheckerCompletion.h in Headers */,
 				1A5E4DA412D3BD3D0099A2BB /* TextCheckerState.h in Headers */,
+				446C003D2BD8B625003D1276 /* TextIndicatorStyle.h in Headers */,
 				CE1A0BD71A48E6C60054EF74 /* TextInputSPI.h in Headers */,
 				E3C6727329D4A3AD00AD4452 /* TextTrackRepresentationCocoa.h in Headers */,
 				1AAF263914687C39004A1E8A /* TiledCoreAnimationDrawingArea.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -48,6 +48,8 @@ namespace WebKit {
 
 enum class WebUnifiedTextReplacementType : uint8_t;
 
+enum class RemoveAllMarkersForSession : uint8_t { No, Yes };
+
 class WebPage;
 
 struct WebUnifiedTextReplacementContextData;
@@ -76,8 +78,9 @@ public:
     void updateStateForSelectedReplacementIfNeeded();
 
     std::optional<WebCore::SimpleRange> contextRangeForSessionWithUUID(const WTF::UUID&) const;
+    std::optional<WebCore::SimpleRange> contextRangeForSessionOrRangeWithUUID(const WTF::UUID&) const;
 
-    void removeTransparentMarkersForSession(const WTF::UUID&, WebCore::SimpleRange&);
+    void removeTransparentMarkersForSession(const WTF::UUID&, RemoveAllMarkersForSession);
 
 private:
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(const WebCore::SimpleRange&) const;
@@ -96,6 +99,9 @@ private:
     RefPtr<WebCore::Document> document() const;
 
     WeakPtr<WebPage> m_webPage;
+
+    using TextIndicatorCharacterRange = std::pair<WTF::UUID, WebCore::CharacterRange>;
+    Vector<std::pair<WTF::UUID, Vector<TextIndicatorCharacterRange>>> m_textIndicatorCharacterRangesForSessions;
 
     // FIXME: Unify these states into a single `State` struct.
     HashMap<WTF::UUID, Ref<WebCore::Range>> m_contextRanges;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9148,6 +9148,11 @@ void WebPage::lastNavigationWasAppInitiated(CompletionHandler<void(bool)>&& comp
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
 
+void WebPage::addTextIndicatorStyleForID(const WTF::UUID& uuid, const WebKit::TextIndicatorStyle styleType, const WebCore::TextIndicatorData& data)
+{
+    send(Messages::WebPageProxy::AddTextIndicatorStyleForID(uuid, styleType, data));
+}
+
 void WebPage::removeTextIndicatorStyleForID(const WTF::UUID& uuid)
 {
     send(Messages::WebPageProxy::RemoveTextIndicatorStyleForID(uuid));

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -153,6 +153,7 @@
 #if PLATFORM(COCOA)
 #include <WebCore/VisibleSelection.h>
 #include <wtf/RetainPtr.h>
+
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSObject;
@@ -383,6 +384,7 @@ enum class FindDecorationStyle : uint8_t;
 enum class NavigatingToAppBoundDomain : bool;
 enum class SyntheticEditingCommandType : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
+enum class TextIndicatorStyle : uint8_t;
 enum class WebTextReplacementDataEditAction : uint8_t;
 enum class WebTextReplacementDataState : uint8_t;
 
@@ -1745,7 +1747,10 @@ public:
 
     void enableTextIndicatorStyleAfterElementWithID(const String&, const WTF::UUID&);
     void enableTextIndicatorStyleForElementWithID(const String&, const WTF::UUID&);
+    void addTextIndicatorStyleForID(const WTF::UUID&, WebKit::TextIndicatorStyle, const WebCore::TextIndicatorData&);
     void removeTextIndicatorStyleForID(const WTF::UUID&);
+    void createTextIndicatorForRange(const WebCore::SimpleRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void createTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
 #endif
 
     void startObservingNowPlayingMetadata();
@@ -2253,8 +2258,6 @@ private:
     void textReplacementSessionDidReceiveEditAction(const WTF::UUID&, WebKit::WebTextReplacementDataEditAction);
 
     std::optional<WebCore::SimpleRange> getRangeForUUID(const WTF::UUID&);
-
-    void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
 
     void updateTextIndicatorStyleVisibilityForID(const WTF::UUID, bool, CompletionHandler<void()>&&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -381,7 +381,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
     
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-    GetTextIndicatorForID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
+    CreateTextIndicatorForID(WTF::UUID uuid) -> (std::optional<WebCore::TextIndicatorData> textIndicator)
     UpdateTextIndicatorStyleVisibilityForID(WTF::UUID uuid, bool visible) -> ()
 #endif
 


### PR DESCRIPTION
#### 5092e5de93782ddb9e2be8a9504f55a66a7e4616
<pre>
Implement source textIndicators.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274176">https://bugs.webkit.org/show_bug.cgi?id=274176</a>
<a href="https://rdar.apple.com/128080035">rdar://128080035</a>

Reviewed by Aditya Keerthi.

Implement source text indicators based on
character ranges of the original range to
avoid issues when ranges are collapsed after
text is replaced.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/UnifiedTextReplacement.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _addTextIndicatorStyleForID:withStyleType:]):
(-[WKWebView _removeTextIndicatorStyleForID:]):
(-[WKWebView _enableTextIndicatorStylingAfterElementWithID:]):
(-[WKWebView _disableTextIndicatorStylingWithUUID:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::addTextIndicatorStyleForID):
* Source/WebKit/UIProcess/Cocoa/WKTextIndicatorStyleType.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addTextIndicatorStyleForID):
(WebKit::WebPageProxy::getTextIndicatorForID):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/TextIndicatorStyle.h: Copied from Source/WebKit/UIProcess/Cocoa/WKTextIndicatorStyleType.h.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView targetedPreviewForID:withStyle:completionHandler:]):
(-[WKContentView targetedPreviewForID:completionHandler:]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::contextRangeForSessionOrRangeWithUUID const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getRangeForUUID):
(WebKit::WebPage::createTextIndicatorForRange):
(WebKit::WebPage::createTextIndicatorForID):
(WebKit::WebPage::updateTextIndicatorStyleVisibilityForID):
(WebKit::WebPage::getTextIndicatorForID): Deleted.
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addTextIndicatorStyleForID):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/278793@main">https://commits.webkit.org/278793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c734ad7c7b1dda4e68dd13adca963295bdee57a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2269 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1950 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23114 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51425 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_message_argument_description") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25817 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56435 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1703 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44554 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->