### PR TITLE
[Site Isolation] Handle more cases of provisional navigations cancelling other provisional navigations

### DIFF
--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -78,7 +78,7 @@ public:
     WEBCORE_EXPORT void detachFromAllOpenedFrames();
     virtual bool isRootFrame() const = 0;
 #if ASSERT_ENABLED
-    static bool isRootFrameIdentifier(FrameIdentifier);
+    WEBCORE_EXPORT static bool isRootFrameIdentifier(FrameIdentifier);
 #endif
 
     WEBCORE_EXPORT void detachFromPage();

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -232,13 +232,7 @@ LocalFrame::~LocalFrame()
     if (!isMainFrame() && localMainFrame)
         localMainFrame->selfOnlyDeref();
 
-    if (isRootFrame()) {
-        if (RefPtr page = this->page()) {
-            page->removeRootFrame(*this);
-            if (auto* scrollingCoordinator = page->scrollingCoordinator())
-                scrollingCoordinator->rootFrameWasRemoved(frameID());
-        }
-    }
+    detachFromPage();
 }
 
 void LocalFrame::addDestructionObserver(FrameDestructionObserver& observer)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -452,7 +452,6 @@ Page::~Page()
     m_validationMessageClient = nullptr;
     m_diagnosticLoggingClient = nullptr;
     m_performanceLoggingClient = nullptr;
-    m_rootFrames.clear();
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame))
         localMainFrame->setView(nullptr);
     setGroupName(String());
@@ -468,6 +467,7 @@ Page::~Page()
         frame.willDetachPage();
         frame.detachFromPage();
     });
+    ASSERT(m_rootFrames.isEmpty());
 
     if (RefPtr scrollingCoordinator = m_scrollingCoordinator)
         scrollingCoordinator->pageDestroyed();

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -439,7 +439,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
     RegistrableDomain navigationDomain(navigation.currentRequest().url());
     // addAllowedFirstPartyForCookies can be sync, but we need completionHander to be invoked after this function.
     auto aggregator = CallbackAggregator::create(WTFMove(completionHandler));
-    if (!m_provisionalFrame || navigation.currentRequestIsCrossSiteRedirect()) {
+    if (!m_provisionalFrame || m_provisionalFrame->process().coreProcessIdentifier() != process.coreProcessIdentifier() || navigation.currentRequestIsCrossSiteRedirect()) {
         RefPtr page = m_page.get();
         // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
         RegistrableDomain mainFrameDomain(page->mainFrame()->url());

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -134,6 +134,7 @@ void RemoteLayerTreeDrawingArea::attachViewOverlayGraphicsLayer(WebCore::FrameId
 
 void RemoteLayerTreeDrawingArea::addRootFrame(WebCore::FrameIdentifier frameID)
 {
+    ASSERT(Frame::isRootFrameIdentifier(frameID));
     auto layer = GraphicsLayer::create(graphicsLayerFactory(), *this);
     layer->setName(makeString("drawing area root "_s, frameID));
     m_rootLayers.append(RootLayerInfo {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -395,6 +395,8 @@ void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHosting
     if (corePage->focusController().focusedFrame() == localFrame.get())
         corePage->focusController().setFocusedFrame(newFrame.ptr(), FocusController::BroadcastFocusedFrame::No);
 
+    localFrame->loader().detachFromParent();
+
     if (ownerElement)
         ownerElement->scheduleInvalidateStyleAndLayerComposition();
 }


### PR DESCRIPTION
#### 84d2d4884a37bd9f3639f0b3bc34d27d1629433c
<pre>
[Site Isolation] Handle more cases of provisional navigations cancelling other provisional navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=274179">https://bugs.webkit.org/show_bug.cgi?id=274179</a>
<a href="https://rdar.apple.com/128083411">rdar://128083411</a>

Reviewed by Sihui Liu.

In order to get more tests to work correctly, a few changes were needed:

1. The accounting for whether a frame identifier is a root frame identifier needed to be more robust
for the assertion to be correct near the time when a root frame was transitioning to or from being local.
I introduced the debug-only class FrameLifetimeVerifier for this.  Instead of keeping track of just the
most recently created Frame with a given identifier, keep track of both the most recently created LocalFrame
and the most recently created RemoteFrame.  Then we can strengthen our assertions to make sure that
Frame existence is exactly as we expect: there should only be one except during the time of transitioning
from one type to the other.

2. If Frame::detachFromPage is ever called before destruction of a Frame, then we would be unable to
inform the Page of the destruction of a root frame.  To make this work, move that informing to
Frame::detachFromPage and have the root frame collections contain all the root frames that are attached
to a Page instead of all the root frames that haven&apos;t been destroyed.

3. WebFrameProxy::prepareForProvisionalLoadInProcess was missing a case when there is a ProvisionalFrameProxy
but it&apos;s from a provisional navigation to a different process that we are now cancelling.  In that case,
we do need to make a new ProvisionalFrameProxy representing the navigation to the new process.

4. WebFrame::loadDidCommitInAnotherProcess was missing a call to FrameLoader::detachFromParent which is needed
to drop all strong references to the LocalFrame so it can be destroyed so we don&apos;t have multiple LocalFrames
in the same process with the same identifier.

I also updated checkFrameTreesInProcesses to copy the expected results so they print out correctly if
they don&apos;t match the actual results in a place in the frame tree that is not the beginning.

* Source/WebCore/page/Frame.cpp:
(WebCore::FrameLifetimeVerifier::singleton):
(WebCore::FrameLifetimeVerifier::frameCreated):
(WebCore::FrameLifetimeVerifier::frameDestroyed):
(WebCore::FrameLifetimeVerifier::isRootFrameIdentifier):
(WebCore::Frame::Frame):
(WebCore::Frame::~Frame):
(WebCore::Frame::detachFromPage):
(WebCore::Frame::isRootFrameIdentifier):
(WebCore::allFrames): Deleted.
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::addRootFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::checkFrameTreesInProcesses):
(TestWebKitAPI::TEST(SiteIsolation, CancelProvisionalLoad)):

Canonical link: <a href="https://commits.webkit.org/278823@main">https://commits.webkit.org/278823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38664c33ca8643123473c803cd5d7abd1267da33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2323 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42035 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23161 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25892 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1800 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56489 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49431 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48641 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28886 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7536 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->