### PR TITLE
Rename DisbursementPaymentRequest to DisbursementRequest

### DIFF
--- a/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Should have a feature for `disbursementPaymentRequest`.
+PASS Should have a feature for `disbursementRequest`.
 PASS Should propagate all data as part of the request.
 PASS Should propagate recipient contact information as part of the request.
 PASS Should error when incorrect `requiredRecipientContactFields` are provided as part of the request.

--- a/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https.html
+++ b/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
 <title>
-    Tests for providing `disbursementPaymentRequest` as part of
+    Tests for providing `disbursementRequest` as part of
     `ApplePayModifier`.
 </title>
 <script src="/js-test-resources/ui-helper.js"></script>
@@ -23,7 +23,7 @@
                 method.data.features = ["paymentRequestDisbursements"];
                 new PaymentRequest([method], validPaymentDetails());
             }
-        }, "Should have a feature for `disbursementPaymentRequest`.");
+        }, "Should have a feature for `disbursementRequest`.");
 
         const RESOLVED_PROMISE = Promise.resolve({});
 
@@ -60,10 +60,10 @@
             ];
         }
 
-        function testValidDisbursementPaymentRequest(description, options) {
+        function testValidDisbursementRequest(description, options) {
             const {
-                initialDisbursementPaymentRequest,
-                expectedDisbursementPaymentRequest,
+                initialDisbursementRequest,
+                expectedDisbursementRequest,
             } = options;
             user_activation_test(async (test) => {
                 const detailsInit = {
@@ -75,11 +75,11 @@
                         },
                     },
                 };
-                if (initialDisbursementPaymentRequest !== undefined) {
+                if (initialDisbursementRequest !== undefined) {
                     detailsInit.modifiers = modifiersWithData(
                         {
-                            disbursementPaymentRequest:
-                                initialDisbursementPaymentRequest,
+                            disbursementRequest:
+                                initialDisbursementRequest,
                         },
                         validLineItems
                     );
@@ -107,23 +107,23 @@
 
                 const response = await request.show();
 
-                const { disbursementPaymentRequest } =
+                const { disbursementRequest } =
                     internals.mockPaymentCoordinator;
-                const assert = disbursementPaymentRequest
+                const assert = disbursementRequest
                     ? assert_object_equals
                     : assert_equals;
                 assert(
-                    disbursementPaymentRequest,
-                    expectedDisbursementPaymentRequest,
-                    "check that the `DisbursementPaymentRequest` matches"
+                    disbursementRequest,
+                    expectedDisbursementRequest,
+                    "check that the `DisbursementRequest` matches"
                 );
                 await response.complete("success");
             }, description + " as part of the request.");
         }
 
-        function testInvalidDisbursementPaymentRequest(
+        function testInvalidDisbursementRequest(
             description,
-            { disbursementPaymentRequest, expectedErrorType }
+            { disbursementRequest, expectedErrorType }
         ) {
             user_activation_test(async (test) => {
                 const detailsInit = {
@@ -136,9 +136,9 @@
                     },
                 };
 
-                if (disbursementPaymentRequest) {
+                if (disbursementRequest) {
                     detailsInit.modifiers = modifiersWithData(
-                        { disbursementPaymentRequest },
+                        { disbursementRequest },
                         validLineItems
                     );
                 }
@@ -159,27 +159,27 @@
             }, description + " as part of the request.");
         }
 
-        testValidDisbursementPaymentRequest("Should propagate all data", {
-            initialDisbursementPaymentRequest: {},
-            expectedDisbursementPaymentRequest: {},
+        testValidDisbursementRequest("Should propagate all data", {
+            initialDisbursementRequest: {},
+            expectedDisbursementRequest: {},
         });
 
-        testValidDisbursementPaymentRequest(
+        testValidDisbursementRequest(
             "Should propagate recipient contact information",
             {
-                initialDisbursementPaymentRequest: {
+                initialDisbursementRequest: {
                     requiredRecipientContactFields: ["email", "name"],
                 },
-                expectedDisbursementPaymentRequest: {
+                expectedDisbursementRequest: {
                     requiredRecipientContactFields: ["email", "name"],
                 },
             }
         );
 
-        testInvalidDisbursementPaymentRequest(
+        testInvalidDisbursementRequest(
             "Should error when incorrect `requiredRecipientContactFields` are provided",
             {
-                disbursementPaymentRequest: {
+                disbursementRequest: {
                     requiredRecipientContactFields: ["invalid1", "invalid2"],
                 },
                 expectedErrorType: TypeError,

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -149,7 +149,7 @@ accessibility/ios-simulator/image-overlay-elements.html [ Pass ]
 http/tests/ssl/applepay [ Pass ]
 webkit.org/b/212975 http/tests/ssl/applepay/PaymentRequest.https.html [ Pass Timeout ]
 
-http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https.html [ Skip ]
+http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https.html [ Skip ]
 http/tests/paymentrequest/paymentrequest-merchantCategoryCode.https.html [ Skip ]
 http/tests/paymentrequest [ Pass ]
 imported/w3c/web-platform-tests/payment-request [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -69,7 +69,7 @@ fast/visual-viewport/rubberbanding-viewport-rects.html [ Pass ]
 fast/visual-viewport/rubberbanding-viewport-rects-header-footer.html  [ Pass ]
 
 
-http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https.html [ Skip ]
+http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https.html [ Skip ]
 http/tests/paymentrequest/paymentrequest-merchantCategoryCode.https.html [ Skip ]
 http/tests/paymentrequest [ Pass ]
 http/tests/inspector/paymentrequest [ Pass ]

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -348,7 +348,7 @@ $(PROJECT_DIR)/Modules/applepay/ApplePayCouponCodeUpdate.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDateComponents.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDateComponentsRange.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDeferredPaymentRequest.idl
-$(PROJECT_DIR)/Modules/applepay/ApplePayDisbursementPaymentRequest.idl
+$(PROJECT_DIR)/Modules/applepay/ApplePayDisbursementRequest.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDetailsUpdateBase.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayError.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayErrorCode.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -123,8 +123,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDeferredPaymentRequest.cp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDeferredPaymentRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDetailsUpdateBase.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDetailsUpdateBase.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDisbursementPaymentRequest.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDisbursementPaymentRequest.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDisbursementRequest.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayDisbursementRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayError.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayError.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSApplePayErrorCode.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -222,7 +222,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/applepay/ApplePayDateComponents.idl \
     $(WebCore)/Modules/applepay/ApplePayDateComponentsRange.idl \
     $(WebCore)/Modules/applepay/ApplePayDeferredPaymentRequest.idl \
-    $(WebCore)/Modules/applepay/ApplePayDisbursementPaymentRequest.idl \
+    $(WebCore)/Modules/applepay/ApplePayDisbursementRequest.idl \
     $(WebCore)/Modules/applepay/ApplePayDetailsUpdateBase.idl \
     $(WebCore)/Modules/applepay/ApplePayError.idl \
     $(WebCore)/Modules/applepay/ApplePayErrorCode.idl \

--- a/Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.h
+++ b/Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.h
@@ -29,7 +29,7 @@
 
 #include "ApplePayAutomaticReloadPaymentRequest.h"
 #include "ApplePayDeferredPaymentRequest.h"
-#include "ApplePayDisbursementPaymentRequest.h"
+#include "ApplePayDisbursementRequest.h"
 #include "ApplePayLineItem.h"
 #include "ApplePayPaymentTokenContext.h"
 #include "ApplePayRecurringPaymentRequest.h"
@@ -58,7 +58,7 @@ struct ApplePayDetailsUpdateBase {
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> newDisbursementPaymentRequest;
+    std::optional<ApplePayDisbursementRequest> newDisbursementRequest;
 #endif
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.idl
@@ -37,5 +37,5 @@
 
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] ApplePayDeferredPaymentRequest newDeferredPaymentRequest;
 
-    [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementPaymentRequest newDisbursementPaymentRequest;
+    [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementRequest newDisbursementRequest;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.h
@@ -23,10 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=APPLE_PAY_DISBURSEMENTS,
-    ExportMacro=WEBCORE_EXPORT,
-    JSGenerateToJSObject,
-] dictionary ApplePayDisbursementPaymentRequest {
-    sequence<ApplePayContactField> requiredRecipientContactFields;
+#pragma once
+
+#if ENABLE(APPLE_PAY_DISBURSEMENTS)
+
+#include <WebCore/ApplePayLineItem.h>
+#include <wtf/WallTime.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+enum class ApplePayContactField : uint8_t;
+
+template<typename> class ExceptionOr;
+
+struct ApplePayDisbursementRequest final {
+    std::optional<Vector<ApplePayContactField>> requiredRecipientContactFields;
+
+    ExceptionOr<void> validate() const;
+    ExceptionOr<ApplePayDisbursementRequest> convertAndValidate() &&;
 };
+
+} // namespace WebCore
+
+#endif // ENABLE(APPLE_PAY_DISBURSEMENTS)

--- a/Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.idl
@@ -23,27 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#if ENABLE(APPLE_PAY_DISBURSEMENTS)
-
-#include <WebCore/ApplePayLineItem.h>
-#include <wtf/WallTime.h>
-#include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-enum class ApplePayContactField : uint8_t;
-
-template<typename> class ExceptionOr;
-
-struct ApplePayDisbursementPaymentRequest final {
-    std::optional<Vector<ApplePayContactField>> requiredRecipientContactFields;
-
-    ExceptionOr<void> validate() const;
-    ExceptionOr<ApplePayDisbursementPaymentRequest> convertAndValidate() &&;
+[
+    Conditional=APPLE_PAY_DISBURSEMENTS,
+    ExportMacro=WEBCORE_EXPORT,
+    JSGenerateToJSObject,
+] dictionary ApplePayDisbursementRequest {
+    sequence<ApplePayContactField> requiredRecipientContactFields;
 };
-
-} // namespace WebCore
-
-#endif // ENABLE(APPLE_PAY_DISBURSEMENTS)

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.h
@@ -29,7 +29,7 @@
 
 #include "ApplePayAutomaticReloadPaymentRequest.h"
 #include "ApplePayDeferredPaymentRequest.h"
-#include "ApplePayDisbursementPaymentRequest.h"
+#include "ApplePayDisbursementRequest.h"
 #include "ApplePayLineItem.h"
 #include "ApplePayPaymentContact.h"
 #include "ApplePayPaymentTokenContext.h"
@@ -68,7 +68,7 @@ struct ApplePayPaymentRequest : ApplePayRequestBase {
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> disbursementPaymentRequest;
+    std::optional<ApplePayDisbursementRequest> disbursementRequest;
 #endif
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.idl
@@ -51,6 +51,6 @@
 
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] ApplePayDeferredPaymentRequest deferredPaymentRequest;
 
-    [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementPaymentRequest disbursementPaymentRequest;
+    [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementRequest disbursementRequest;
 
 };

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -333,8 +333,8 @@ static ExceptionOr<ApplePaySessionPaymentRequest> convertAndValidate(Document& d
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    if (paymentRequest.disbursementPaymentRequest)
-        result.setDisbursementPaymentRequest(WTFMove(*paymentRequest.disbursementPaymentRequest));
+    if (paymentRequest.disbursementRequest)
+        result.setDisbursementRequest(WTFMove(*paymentRequest.disbursementRequest));
 #endif
 
     // FIXME: Merge this validation into the validation we are doing above.

--- a/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
@@ -29,7 +29,7 @@
 
 #include "ApplePayAutomaticReloadPaymentRequest.h"
 #include "ApplePayDeferredPaymentRequest.h"
-#include "ApplePayDisbursementPaymentRequest.h"
+#include "ApplePayDisbursementRequest.h"
 #include "ApplePayError.h"
 #include "ApplePayLaterAvailability.h"
 #include "ApplePayLineItem.h"
@@ -170,8 +170,8 @@ public:
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    const std::optional<ApplePayDisbursementPaymentRequest>& disbursementPaymentRequest() const { return m_disbursementPaymentRequest; }
-    void setDisbursementPaymentRequest(std::optional<ApplePayDisbursementPaymentRequest>&& disbursementPaymentRequest) { m_disbursementPaymentRequest = WTFMove(disbursementPaymentRequest); }
+    const std::optional<ApplePayDisbursementRequest>& disbursementRequest() const { return m_disbursementRequest; }
+    void setDisbursementRequest(std::optional<ApplePayDisbursementRequest>&& disbursementRequest) { m_disbursementRequest = WTFMove(disbursementRequest); }
 #endif
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
@@ -222,7 +222,7 @@ public:
         , std::optional<ApplePayDeferredPaymentRequest>&& deferredPaymentRequest
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-        , std::optional<ApplePayDisbursementPaymentRequest>&& disbursementPaymentRequest
+        , std::optional<ApplePayDisbursementRequest>&& disbursementRequest
 #endif
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
         , std::optional<ApplePayLaterAvailability>&& applePayLaterAvailability
@@ -269,7 +269,7 @@ public:
             , m_deferredPaymentRequest(WTFMove(deferredPaymentRequest))
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-            , m_disbursementPaymentRequest(WTFMove(disbursementPaymentRequest))
+            , m_disbursementRequest(WTFMove(disbursementRequest))
 #endif
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
             , m_applePayLaterAvailability(WTFMove(applePayLaterAvailability))
@@ -335,7 +335,7 @@ private:
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> m_disbursementPaymentRequest;
+    std::optional<ApplePayDisbursementRequest> m_disbursementRequest;
 #endif
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.h
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.h
@@ -29,7 +29,7 @@
 
 #include "ApplePayAutomaticReloadPaymentRequest.h"
 #include "ApplePayDeferredPaymentRequest.h"
-#include "ApplePayDisbursementPaymentRequest.h"
+#include "ApplePayDisbursementRequest.h"
 #include "ApplePayLineItem.h"
 #include "ApplePayPaymentMethodType.h"
 #include "ApplePayPaymentTokenContext.h"
@@ -63,7 +63,7 @@ struct ApplePayModifier {
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> disbursementPaymentRequest;
+    std::optional<ApplePayDisbursementRequest> disbursementRequest;
 #endif
 };
 

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.idl
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.idl
@@ -39,6 +39,6 @@
 
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] ApplePayDeferredPaymentRequest deferredPaymentRequest;
 
-    [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementPaymentRequest disbursementPaymentRequest;
+    [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementRequest disbursementRequest;
 
 };

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -303,7 +303,7 @@ ExceptionOr<void> ApplePayPaymentHandler::show(Document& document)
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-        request.setDisbursementPaymentRequest(WTFMove(applePayModifier->disbursementPaymentRequest));
+        request.setDisbursementRequest(WTFMove(applePayModifier->disbursementRequest));
 #endif
     }
 
@@ -711,7 +711,7 @@ ExceptionOr<void> ApplePayPaymentHandler::shippingAddressUpdated(Vector<Ref<Appl
         update.newDeferredPaymentRequest = WTFMove(applePayModifier.deferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-        update.newDisbursementPaymentRequest = WTFMove(applePayModifier.disbursementPaymentRequest);
+        update.newDisbursementRequest = WTFMove(applePayModifier.disbursementRequest);
 #endif
     }
 
@@ -761,7 +761,7 @@ ExceptionOr<void> ApplePayPaymentHandler::shippingOptionUpdated()
         update.newDeferredPaymentRequest = WTFMove(applePayModifier.deferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-        update.newDisbursementPaymentRequest = WTFMove(applePayModifier.disbursementPaymentRequest);
+        update.newDisbursementRequest = WTFMove(applePayModifier.disbursementRequest);
 #endif
     }
 
@@ -811,7 +811,7 @@ ExceptionOr<void> ApplePayPaymentHandler::paymentMethodUpdated(Vector<Ref<AppleP
             update.newDeferredPaymentRequest = WTFMove(applePayModifier.deferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-            update.newDisbursementPaymentRequest = WTFMove(applePayModifier.disbursementPaymentRequest);
+            update.newDisbursementRequest = WTFMove(applePayModifier.disbursementRequest);
 #endif
         }
 
@@ -864,7 +864,7 @@ ExceptionOr<void> ApplePayPaymentHandler::paymentMethodUpdated(Vector<Ref<AppleP
         update.newDeferredPaymentRequest = WTFMove(applePayModifier.deferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-        update.newDisbursementPaymentRequest = WTFMove(applePayModifier.disbursementPaymentRequest);
+        update.newDisbursementRequest = WTFMove(applePayModifier.disbursementRequest);
 #endif
     }
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -31,7 +31,7 @@ JSApplePayCouponCodeUpdate.cpp
 JSApplePayDateComponents.cpp
 JSApplePayDateComponentsRange.cpp
 JSApplePayDeferredPaymentRequest.cpp
-JSApplePayDisbursementPaymentRequest.cpp
+JSApplePayDisbursementRequest.cpp
 JSApplePayDetailsUpdateBase.cpp
 JSApplePayError.cpp
 JSApplePayErrorCode.cpp

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -142,7 +142,7 @@ bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const
     m_deferredPaymentRequest = request.deferredPaymentRequest();
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    m_disbursementPaymentRequest = request.disbursementPaymentRequest();
+    m_disbursementRequest = request.disbursementRequest();
 #endif
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
     m_applePayLaterAvailability = request.applePayLaterAvailability();
@@ -189,7 +189,7 @@ void MockPaymentCoordinator::completeShippingMethodSelection(std::optional<Apple
     m_deferredPaymentRequest = WTFMove(shippingMethodUpdate->newDeferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    m_disbursementPaymentRequest = WTFMove(shippingMethodUpdate->newDisbursementPaymentRequest);
+    m_disbursementRequest = WTFMove(shippingMethodUpdate->newDisbursementRequest);
 #endif
 }
 
@@ -222,7 +222,7 @@ void MockPaymentCoordinator::completeShippingContactSelection(std::optional<Appl
     m_deferredPaymentRequest = WTFMove(shippingContactUpdate->newDeferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    m_disbursementPaymentRequest = WTFMove(shippingContactUpdate->newDisbursementPaymentRequest);
+    m_disbursementRequest = WTFMove(shippingContactUpdate->newDisbursementRequest);
 #endif
 
 }
@@ -251,7 +251,7 @@ void MockPaymentCoordinator::completePaymentMethodSelection(std::optional<AppleP
     m_deferredPaymentRequest = WTFMove(paymentMethodUpdate->newDeferredPaymentRequest);
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    m_disbursementPaymentRequest = WTFMove(paymentMethodUpdate->newDisbursementPaymentRequest);
+    m_disbursementRequest = WTFMove(paymentMethodUpdate->newDisbursementRequest);
 #endif
 }
 

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -105,7 +105,7 @@ public:
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    const std::optional<ApplePayDisbursementPaymentRequest>& disbursementPaymentRequest() const { return m_disbursementPaymentRequest; }
+    const std::optional<ApplePayDisbursementRequest>& disbursementRequest() const { return m_disbursementRequest; }
 #endif
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
@@ -187,7 +187,7 @@ private:
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> m_disbursementPaymentRequest;
+    std::optional<ApplePayDisbursementRequest> m_disbursementRequest;
 #endif
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)

--- a/Source/WebCore/testing/MockPaymentCoordinator.idl
+++ b/Source/WebCore/testing/MockPaymentCoordinator.idl
@@ -63,7 +63,7 @@
 
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] readonly attribute ApplePayDeferredPaymentRequest? deferredPaymentRequest;
 
-    [Conditional=APPLE_PAY_DISBURSEMENTS] readonly attribute ApplePayDisbursementPaymentRequest? disbursementPaymentRequest;
+    [Conditional=APPLE_PAY_DISBURSEMENTS] readonly attribute ApplePayDisbursementRequest? disbursementRequest;
 
     [Conditional=APPLE_PAY_LATER_AVAILABILITY] readonly attribute ApplePayLaterAvailability? applePayLaterAvailability;
 

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -350,7 +350,7 @@ void PaymentAuthorizationPresenter::completeShippingContactSelection(std::option
 
     RetainPtr<PKPaymentRequestShippingContactUpdate> shippingContactUpdate;
 #if HAVE(PASSKIT_DISBURSEMENTS)
-    if (update->newDisbursementPaymentRequest)
+    if (update->newDisbursementRequest)
         shippingContactUpdate = adoptNS([PAL::allocPKPaymentRequestShippingContactUpdateInstance() initWithPaymentSummaryItems:WebCore::platformDisbursementSummaryItems(WTFMove(update->newLineItems))]);
     else
 #endif // HAVE(PASSKIT_DISBURSEMENTS)

--- a/Source/WebKit/Shared/ApplePay/DisbursementRequest.h
+++ b/Source/WebKit/Shared/ApplePay/DisbursementRequest.h
@@ -38,7 +38,7 @@ enum class ApplePayContactField : uint8_t;
 
 namespace WebKit {
 
-RetainPtr<PKDisbursementPaymentRequest> platformDisbursementPaymentRequest(const WebCore::ApplePaySessionPaymentRequest&, const URL& originatingURL, const std::optional<Vector<WebCore::ApplePayContactField>>& requiredrecipientContactFields);
+RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const WebCore::ApplePaySessionPaymentRequest&, const URL& originatingURL, const std::optional<Vector<WebCore::ApplePayContactField>>& requiredrecipientContactFields);
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -24,14 +24,14 @@
  */
 
 #import "config.h"
-#import "DisbursementPaymentRequest.h"
+#import "DisbursementRequest.h"
 
 #if HAVE(PASSKIT_DISBURSEMENTS)
 
 #import "WebPaymentCoordinatorProxyCocoa.h"
 
 #import <WebCore/ApplePayContactField.h>
-#import <WebCore/ApplePayDisbursementPaymentRequest.h>
+#import <WebCore/ApplePayDisbursementRequest.h>
 #import <WebCore/ApplePaySessionPaymentRequest.h>
 #import <WebCore/PaymentSummaryItems.h>
 
@@ -44,7 +44,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-RetainPtr<PKDisbursementPaymentRequest> platformDisbursementPaymentRequest(const ApplePaySessionPaymentRequest& request, const URL& originatingURL, const std::optional<Vector<ApplePayContactField>>& requiredRecipientContactFields)
+RetainPtr<PKDisbursementPaymentRequest> platformDisbursementRequest(const ApplePaySessionPaymentRequest& request, const URL& originatingURL, const std::optional<Vector<ApplePayContactField>>& requiredRecipientContactFields)
 {
     // This merchantID is not actually used for web payments, passing an empty string here is fine
     auto disbursementRequest = adoptNS([PAL::allocPKDisbursementRequestInstance() initWithMerchantIdentifier:@"" currencyCode:request.currencyCode() regionCode:request.countryCode() supportedNetworks:createNSArray(request.supportedNetworks()).get() merchantCapabilities:toPKMerchantCapabilities(request.merchantCapabilities()) summaryItems:WebCore::platformDisbursementSummaryItems(request.lineItems())]);

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -32,7 +32,7 @@
 #import "ApplePayPaymentSetupFeaturesWebKit.h"
 #import "AutomaticReloadPaymentRequest.h"
 #import "DeferredPaymentRequest.h"
-#import "DisbursementPaymentRequest.h"
+#import "DisbursementRequest.h"
 #import "PaymentSetupConfigurationWebKit.h"
 #import "PaymentTokenContext.h"
 #import "RecurringPaymentRequest.h"

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -50,9 +50,9 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 
     RetainPtr<PKPaymentRequest> paymentRequest;
 #if HAVE(PASSKIT_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> webDisbursementPaymentRequest = request.disbursementPaymentRequest();
-    if (webDisbursementPaymentRequest) {
-        auto disbursementRequest = platformDisbursementPaymentRequest(request, originatingURL, webDisbursementPaymentRequest->requiredRecipientContactFields);
+    std::optional<ApplePayDisbursementRequest> webDisbursementRequest = request.disbursementRequest();
+    if (webDisbursementRequest) {
+        auto disbursementRequest = platformDisbursementRequest(request, originatingURL, webDisbursementRequest->requiredRecipientContactFields);
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest);
     } else
 #endif

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -66,9 +66,9 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 
     RetainPtr<PKPaymentRequest> paymentRequest;
 #if HAVE(PASSKIT_DISBURSEMENTS)
-    std::optional<ApplePayDisbursementPaymentRequest> webDisbursementPaymentRequest = request.disbursementPaymentRequest();
-    if (webDisbursementPaymentRequest) {
-        auto disbursementRequest = platformDisbursementPaymentRequest(request, originatingURL, webDisbursementPaymentRequest->requiredRecipientContactFields);
+    std::optional<ApplePayDisbursementRequest> webDisbursementRequest = request.disbursementRequest();
+    if (webDisbursementRequest) {
+        auto disbursementRequest = platformDisbursementRequest(request, originatingURL, webDisbursementRequest->requiredRecipientContactFields);
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest);
     } else
 #endif

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -211,7 +211,7 @@ class WebCore::PaymentSessionError {
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<WebCore::ApplePayDisbursementPaymentRequest> disbursementPaymentRequest();
+    std::optional<WebCore::ApplePayDisbursementRequest> disbursementRequest();
 #endif
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1185,7 +1185,7 @@ struct WebCore::ApplePayDetailsUpdateBase {
     std::optional<WebCore::ApplePayDeferredPaymentRequest> newDeferredPaymentRequest;
 #endif
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    std::optional<WebCore::ApplePayDisbursementPaymentRequest> newDisbursementPaymentRequest;
+    std::optional<WebCore::ApplePayDisbursementRequest> newDisbursementRequest;
 #endif
 }
 
@@ -1259,7 +1259,7 @@ enum class WebCore::ApplePayErrorCode : uint8_t {
 #endif // ENABLE(APPLE_PAY)
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-struct WebCore::ApplePayDisbursementPaymentRequest {
+struct WebCore::ApplePayDisbursementRequest {
     std::optional<Vector<WebCore::ApplePayContactField>> requiredRecipientContactFields
 };
 #endif

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -135,7 +135,7 @@ Shared/ApplePay/ApplePayPaymentSetupFeatures.mm
 Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
 Shared/ApplePay/cocoa/AutomaticReloadPaymentRequestCocoa.mm
 Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
-Shared/ApplePay/cocoa/DisbursementPaymentRequestCocoa.mm
+Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
 Shared/ApplePay/cocoa/PaymentSetupConfigurationCocoa.mm
 Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
 Shared/ApplePay/cocoa/RecurringPaymentRequestCocoa.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1073,7 +1073,7 @@
 		41F898F028ED69470070549C /* LibWebRTCCodecs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4172198A23B6128200AE5686 /* LibWebRTCCodecs.cpp */; };
 		41FAF5F51E3C0649001AE678 /* WebRTCResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FAF5F41E3C0641001AE678 /* WebRTCResolver.h */; };
 		41FAF5F81E3C1021001AE678 /* LibWebRTCResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FAF5F61E3C0B47001AE678 /* LibWebRTCResolver.h */; };
-		42057BEC2AD435E0001B963B /* DisbursementPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 42057BE92AD433C6001B963B /* DisbursementPaymentRequest.h */; };
+		42057BEC2AD435E0001B963B /* DisbursementRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 42057BE92AD433C6001B963B /* DisbursementRequest.h */; };
 		440C0BE52BBCAA3C0086046E /* WKTextIndicatorStyleManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 440C0BE42BBCAA180086046E /* WKTextIndicatorStyleManager.h */; };
 		441379612964F10A003C34C6 /* CacheStoragePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */; };
 		442E7BEB27B4586900C69AC1 /* RevealItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 442E7BEA27B4581300C69AC1 /* RevealItem.h */; };
@@ -5284,8 +5284,8 @@
 		41FFD2DA275A560B00501BBF /* ServiceWorkerDownloadTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDownloadTask.cpp; sourceTree = "<group>"; };
 		41FFD2DB275A560C00501BBF /* ServiceWorkerDownloadTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDownloadTask.h; sourceTree = "<group>"; };
 		41FFD2DC275A6A9400501BBF /* ServiceWorkerDownloadTask.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ServiceWorkerDownloadTask.messages.in; sourceTree = "<group>"; };
-		42057BE92AD433C6001B963B /* DisbursementPaymentRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisbursementPaymentRequest.h; sourceTree = "<group>"; };
-		4253D3732AD4394700EE168C /* DisbursementPaymentRequestCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisbursementPaymentRequestCocoa.mm; sourceTree = "<group>"; };
+		42057BE92AD433C6001B963B /* DisbursementRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisbursementRequest.h; sourceTree = "<group>"; };
+		4253D3732AD4394700EE168C /* DisbursementRequestCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisbursementRequestCocoa.mm; sourceTree = "<group>"; };
 		440C0BE22BBCA9E00086046E /* WKTextIndicatorStyleManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTextIndicatorStyleManager.mm; sourceTree = "<group>"; };
 		440C0BE42BBCAA180086046E /* WKTextIndicatorStyleManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextIndicatorStyleManager.h; sourceTree = "<group>"; };
 		44122266296A89820057E1A5 /* SameDocumentNavigationType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SameDocumentNavigationType.serialization.in; sourceTree = "<group>"; };
@@ -9399,7 +9399,7 @@
 				5C53DCDF24465BF900A93124 /* ApplePayPaymentSetupFeaturesWebKit.h */,
 				950FECF0285026EA0002DE4E /* AutomaticReloadPaymentRequest.h */,
 				74C2F54029AC9C44006C5F97 /* DeferredPaymentRequest.h */,
-				42057BE92AD433C6001B963B /* DisbursementPaymentRequest.h */,
+				42057BE92AD433C6001B963B /* DisbursementRequest.h */,
 				86AA525129366FFC0065399E /* PaymentSetupConfiguration.serialization.in */,
 				5C53DCDE24465BF900A93124 /* PaymentSetupConfigurationWebKit.h */,
 				950FECF32850271F0002DE4E /* PaymentTokenContext.h */,
@@ -9416,7 +9416,7 @@
 			children = (
 				950FECF8285027440002DE4E /* AutomaticReloadPaymentRequestCocoa.mm */,
 				74C2F54229AC9CBF006C5F97 /* DeferredPaymentRequestCocoa.mm */,
-				4253D3732AD4394700EE168C /* DisbursementPaymentRequestCocoa.mm */,
+				4253D3732AD4394700EE168C /* DisbursementRequestCocoa.mm */,
 				5C53DCE024465BF900A93124 /* PaymentSetupConfigurationCocoa.mm */,
 				950FECF6285027430002DE4E /* PaymentTokenContextCocoa.mm */,
 				950FECF7285027430002DE4E /* RecurringPaymentRequestCocoa.mm */,
@@ -16221,7 +16221,7 @@
 				2D0C56FD229F1DEA00BD33E7 /* DeviceManagementSoftLink.h in Headers */,
 				2DAADA8F2298C21000E36B0C /* DeviceManagementSPI.h in Headers */,
 				83891B6C1A68C30B0030F386 /* DiagnosticLoggingClient.h in Headers */,
-				42057BEC2AD435E0001B963B /* DisbursementPaymentRequest.h in Headers */,
+				42057BEC2AD435E0001B963B /* DisbursementRequest.h in Headers */,
 				7AFA6F6D2A9F58440055322A /* DisplayLink.h in Headers */,
 				0F189CAC24749F2F00E58D81 /* DisplayLinkObserverID.h in Headers */,
 				7AFA6F6E2A9F584A0055322A /* DisplayLinkProcessProxyClient.h in Headers */,


### PR DESCRIPTION
#### 675a7bed2417d29530db12b9ce4acfd6a5cbfa06
<pre>
Rename DisbursementPaymentRequest to DisbursementRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=274172">https://bugs.webkit.org/show_bug.cgi?id=274172</a>
<a href="https://rdar.apple.com/128075614">rdar://128075614</a>

Reviewed by Abrar Rahman Protyasha.

Simple find and replace. Should rename those bits.

* LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https-expected.txt: Renamed from LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https-expected.txt.
* LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementRequest.https.html: Renamed from LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https.html.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.h:
* Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.idl:
* Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.h: Renamed from Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.h.
* Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.idl: Renamed from Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.idl.
* Source/WebCore/Modules/applepay/ApplePayPaymentRequest.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentRequest.idl:
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::convertAndValidate):
* Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h:
(WebCore::ApplePaySessionPaymentRequest::disbursementRequest const):
(WebCore::ApplePaySessionPaymentRequest::setDisbursementRequest):
(WebCore::ApplePaySessionPaymentRequest::ApplePaySessionPaymentRequest):
(WebCore::ApplePaySessionPaymentRequest::disbursementPaymentRequest const): Deleted.
(WebCore::ApplePaySessionPaymentRequest::setDisbursementPaymentRequest): Deleted.
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.h:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.idl:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::ApplePayPaymentHandler::show):
(WebCore::ApplePayPaymentHandler::shippingAddressUpdated):
(WebCore::ApplePayPaymentHandler::shippingOptionUpdated):
(WebCore::ApplePayPaymentHandler::paymentMethodUpdated):
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::showPaymentUI):
(WebCore::MockPaymentCoordinator::completeShippingMethodSelection):
(WebCore::MockPaymentCoordinator::completeShippingContactSelection):
(WebCore::MockPaymentCoordinator::completePaymentMethodSelection):
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/testing/MockPaymentCoordinator.idl:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::PaymentAuthorizationPresenter::completeShippingContactSelection):
* Source/WebKit/Shared/ApplePay/DisbursementRequest.h: Renamed from Source/WebKit/Shared/ApplePay/DisbursementPaymentRequest.h.
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm: Renamed from Source/WebKit/Shared/ApplePay/cocoa/DisbursementPaymentRequestCocoa.mm.
(WebKit::platformDisbursementRequest):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/278835@main">https://commits.webkit.org/278835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23244ff7217dbb903d9b27861bac4ce183abbb3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2074 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28651 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23205 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1858 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26819 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44668 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11308 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28953 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->