### PR TITLE
[JSC] CallLinkInfo that AccessCase sometimes creates should live on the JITStubRoutine

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -315,11 +315,6 @@ JSObject* AccessCase::tryGetAlternateBaseImpl() const
     }
 }
 
-Ref<AccessCase> AccessCase::cloneImpl() const
-{
-    return adoptRef(*new AccessCase(*this));
-}
-
 bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
 {
     if (viaGlobalProxy())
@@ -1575,15 +1570,6 @@ void AccessCase::operator delete(AccessCase* accessCase, std::destroying_delete_
         std::destroy_at(accessCase);
         std::decay_t<decltype(*accessCase)>::freeAfterDestruction(accessCase);
     });
-}
-
-Ref<AccessCase> AccessCase::clone() const
-{
-    RefPtr<AccessCase> result;
-    const_cast<AccessCase*>(this)->runWithDowncast([&](auto* accessCase) {
-        result = accessCase->cloneImpl();
-    });
-    return result.releaseNonNull();
 }
 
 WatchpointSet* AccessCase::additionalSet() const

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -323,7 +323,6 @@ protected:
 
     AccessCase& operator=(const AccessCase&) = delete;
 
-    Ref<AccessCase> cloneImpl() const;
     WatchpointSet* additionalSetImpl() const { return nullptr; }
     JSObject* tryGetAlternateBaseImpl() const;
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const { }
@@ -346,10 +345,6 @@ private:
     DECLARE_VISIT_AGGREGATE_WITH_MODIFIER(const);
     bool visitWeak(VM&) const;
     template<typename Visitor> void propagateTransitions(Visitor&) const;
-
-    // FIXME: This only exists because of how AccessCase puts post-generation things into itself.
-    // https://bugs.webkit.org/show_bug.cgi?id=156456
-    Ref<AccessCase> clone() const;
 
     AccessType m_type;
 protected:

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
@@ -70,11 +70,6 @@ GetterSetterAccessCase::GetterSetterAccessCase(const GetterSetterAccessCase& oth
     m_domAttribute = other.m_domAttribute;
 }
 
-Ref<AccessCase> GetterSetterAccessCase::cloneImpl() const
-{
-    return adoptRef(*new GetterSetterAccessCase(*this));
-}
-
 JSObject* GetterSetterAccessCase::tryGetAlternateBaseImpl() const
 {
     if (auto* object = customSlotBase())

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
@@ -59,7 +59,6 @@ private:
 
     JSObject* tryGetAlternateBaseImpl() const;
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
-    Ref<AccessCase> cloneImpl() const;
 
     WriteBarrier<JSObject> m_customSlotBase;
     CodePtr<CustomAccessorPtrTag> m_customAccessor;

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -3990,10 +3990,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             // If the case had been generated, then we have to keep the original in m_list in case we
             // fail to regenerate. That case may have data structures that are used by the code that it
             // had generated. If the case had not been generated, then we want to remove it from m_list.
-            if (doesJSCalls(someCase->type()))
-                cases.append(someCase->clone());
-            else
-                cases.append(someCase);
+            cases.append(someCase);
 
             additionalWatchpointSets.appendVector(sets);
         }();

--- a/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp
@@ -46,11 +46,6 @@ void InstanceOfAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Inden
     out.print(comma, "prototype = ", JSValue(prototype()));
 }
 
-Ref<AccessCase> InstanceOfAccessCase::cloneImpl() const
-{
-    return adoptRef(*new InstanceOfAccessCase(*this));
-}
-
 InstanceOfAccessCase::InstanceOfAccessCase(
     VM& vm, JSCell* owner, AccessType accessType, Structure* structure,
     const ObjectPropertyConditionSet& conditionSet, JSObject* prototype)

--- a/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h
@@ -49,7 +49,6 @@ private:
         JSObject* prototype);
 
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
-    Ref<AccessCase> cloneImpl() const;
 
     WriteBarrier<JSObject> m_prototype;
 };

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
@@ -45,11 +45,6 @@ Ref<AccessCase> IntrinsicGetterAccessCase::create(VM& vm, JSCell* owner, Cacheab
     return adoptRef(*new IntrinsicGetterAccessCase(vm, owner, identifier, offset, structure, conditionSet, intrinsicFunction, WTFMove(prototypeAccessChain)));
 }
 
-Ref<AccessCase> IntrinsicGetterAccessCase::cloneImpl() const
-{
-    return adoptRef(*new IntrinsicGetterAccessCase(*this));
-}
-
 bool IntrinsicGetterAccessCase::doesCalls() const
 {
     switch (intrinsic()) {

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h
@@ -47,8 +47,6 @@ public:
 private:
     IntrinsicGetterAccessCase(VM&, JSCell*, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet&, JSFunction* intrinsicFunction, RefPtr<PolyProtoAccessChain>&&);
 
-    Ref<AccessCase> cloneImpl() const;
-
     WriteBarrier<JSFunction> m_intrinsicFunction;
 };
 

--- a/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp
@@ -50,11 +50,6 @@ Ref<AccessCase> ModuleNamespaceAccessCase::create(VM& vm, JSCell* owner, Cacheab
     return adoptRef(*new ModuleNamespaceAccessCase(vm, owner, identifier, moduleNamespaceObject, moduleEnvironment, scopeOffset));
 }
 
-Ref<AccessCase> ModuleNamespaceAccessCase::cloneImpl() const
-{
-    return adoptRef(*new ModuleNamespaceAccessCase(*this));
-}
-
 } // namespace JSC
 
 #endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h
@@ -50,8 +50,6 @@ public:
 private:
     ModuleNamespaceAccessCase(VM&, JSCell* owner, CacheableIdentifier, JSModuleNamespaceObject*, JSModuleEnvironment*, ScopeOffset);
 
-    Ref<AccessCase> cloneImpl() const;
-
     WriteBarrier<JSModuleNamespaceObject> m_moduleNamespaceObject;
     WriteBarrier<JSModuleEnvironment> m_moduleEnvironment;
     ScopeOffset m_scopeOffset;

--- a/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp
@@ -54,11 +54,6 @@ Ref<AccessCase> ProxyObjectAccessCase::create(VM& vm, JSCell* owner, AccessType 
     return adoptRef(*new ProxyObjectAccessCase(vm, owner, type, identifier));
 }
 
-Ref<AccessCase> ProxyObjectAccessCase::cloneImpl() const
-{
-    return adoptRef(*new ProxyObjectAccessCase(*this));
-}
-
 void ProxyObjectAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const
 {
     Base::dumpImpl(out, comma, indent);

--- a/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.h
@@ -46,7 +46,6 @@ private:
     ProxyObjectAccessCase(const ProxyObjectAccessCase&);
 
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
-    Ref<AccessCase> cloneImpl() const;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp
@@ -44,11 +44,6 @@ Ref<AccessCase> ProxyableAccessCase::create(VM& vm, JSCell* owner, AccessType ty
     return adoptRef(*new ProxyableAccessCase(vm, owner, type, identifier, offset, structure, conditionSet, viaGlobalProxy, additionalSet, WTFMove(prototypeAccessChain)));
 }
 
-Ref<AccessCase> ProxyableAccessCase::cloneImpl() const
-{
-    return adoptRef(*new ProxyableAccessCase(*this));
-}
-
 void ProxyableAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const
 {
     Base::dumpImpl(out, comma, indent);

--- a/Source/JavaScriptCore/bytecode/ProxyableAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ProxyableAccessCase.h
@@ -45,7 +45,6 @@ protected:
 
     WatchpointSet* additionalSetImpl() const { return m_additionalSet.get(); }
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
-    Ref<AccessCase> cloneImpl() const;
 
 private:
     RefPtr<WatchpointSet> m_additionalSet;


### PR DESCRIPTION
#### 5c5f7187e068f2b55de98601a80e8a049b7169f7
<pre>
[JSC] CallLinkInfo that AccessCase sometimes creates should live on the JITStubRoutine
<a href="https://bugs.webkit.org/show_bug.cgi?id=156456">https://bugs.webkit.org/show_bug.cgi?id=156456</a>
<a href="https://rdar.apple.com/128088573">rdar://128088573</a>

Reviewed by Justin Michaud.

Now, CallLinkInfo gets detached from AccessCase.
We no longer need to clone AccessCase.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::cloneImpl const): Deleted.
(JSC::AccessCase::clone const): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp:
(JSC::GetterSetterAccessCase::cloneImpl const): Deleted.
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/InstanceOfAccessCase.cpp:
(JSC::InstanceOfAccessCase::cloneImpl const): Deleted.
* Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h:
* Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp:
(JSC::IntrinsicGetterAccessCase::cloneImpl const): Deleted.
* Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h:
* Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.cpp:
(JSC::ModuleNamespaceAccessCase::cloneImpl const): Deleted.
* Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h:
* Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp:
(JSC::ProxyObjectAccessCase::cloneImpl const): Deleted.
* Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.h:
* Source/JavaScriptCore/bytecode/ProxyableAccessCase.cpp:
(JSC::ProxyableAccessCase::cloneImpl const): Deleted.
* Source/JavaScriptCore/bytecode/ProxyableAccessCase.h:

Canonical link: <a href="https://commits.webkit.org/278809@main">https://commits.webkit.org/278809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2294625796f2f7c8fddfe3630987470ab1de8ad2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2237 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41963 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1715 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44887 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56403 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51048 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49362 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48553 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28797 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63370 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7529 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27638 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11966 "Passed tests") | 
<!--EWS-Status-Bubble-End-->