### PR TITLE
REGRESSION(278000@main): [Filters] CanvasFilters should be properly enabled and disabled by the setting

### DIFF
--- a/Source/WebCore/html/canvas/CanvasFilters.idl
+++ b/Source/WebCore/html/canvas/CanvasFilters.idl
@@ -24,7 +24,9 @@
  */
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters
-interface mixin CanvasFilters {
+[
+    EnabledBySetting=CanvasFiltersEnabled
+] interface mixin CanvasFilters {
     // filters
     [ImplementedAs=filterString] attribute DOMString filter; // (default "none")
 };


### PR DESCRIPTION
#### d8672929f45bd6a13e8c0626710d16e71a136bf9
<pre>
REGRESSION(278000@main): [Filters] CanvasFilters should be properly enabled and disabled by the setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=274185">https://bugs.webkit.org/show_bug.cgi?id=274185</a>
<a href="https://rdar.apple.com/127861271">rdar://127861271</a>

Reviewed by Sam Weinig and Simon Fraser.

Since the CanvasFilters feature is not marked `stable` yet, it should be an
internal setting and it is marked as `disabled` be default. The attribute `filters`
in CanvasFilters.idl is missing `EnabledBySetting=CanvasFiltersEnabled`.

* Source/WebCore/html/canvas/CanvasFilters.idl:

Canonical link: <a href="https://commits.webkit.org/278799@main">https://commits.webkit.org/278799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ad0d2377c0abd10f21f94ab23612c92363e7e85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1971 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1764 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56456 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1725 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44575 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11292 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->