### PR TITLE
[iOS] File picker dialog remains after opening a new tab in 3rd-party browsers

### DIFF
--- a/LayoutTests/fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window-expected.txt
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window-expected.txt
@@ -1,0 +1,14 @@
+Test that the file upload panel is dismissed when its presenting view is removed from the window on iOS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Present file picker
+PASS areArraysEqual(typeIdentifiers, ['public.plain-text']) is true
+
+Remove view from window
+PASS areArraysEqual(typeIdentifiers, []) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false shouldPresentPopovers=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<input id="fileInput" type="file" accept=".txt">
+<script>
+description("Test that the file upload panel is dismissed when its presenting view is removed from the window on iOS.");
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    debug("Present file picker");
+    await UIHelper.activateElement(fileInput);
+    typeIdentifiers = await UIHelper.filePickerAcceptedTypeIdentifiers();
+    shouldBeTrue("areArraysEqual(typeIdentifiers, ['public.plain-text'])");
+
+    debug("\nRemove view from window");
+    await UIHelper.removeViewFromWindow();
+    typeIdentifiers = await UIHelper.filePickerAcceptedTypeIdentifiers();
+    shouldBeTrue("areArraysEqual(typeIdentifiers, [])");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h
@@ -60,6 +60,8 @@ protected:
     AudioProcessor* processor() { return m_processor.get(); }
     const AudioProcessor* processor() const { return m_processor.get(); }
 
+    float noiseInjectionMultiplier() const override { return 0.01; }
+
     std::unique_ptr<AudioProcessor> m_processor;
 };
 

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -86,7 +86,8 @@ public:
     
     bool topologyMatches(const AudioBuffer&) const;
 
-    void setNeedsAdditionalNoise() { m_needsAdditionalNoise = true; }
+    void increaseNoiseInjectionMultiplier(float amount = 0.001) { m_noiseInjectionMultiplier += amount; }
+    float noiseInjectionMultiplier() const { return m_noiseInjectionMultiplier; }
 
 private:
     AudioBuffer(unsigned numberOfChannels, size_t length, float sampleRate, LegacyPreventDetaching = LegacyPreventDetaching::No);
@@ -109,7 +110,7 @@ private:
     FixedVector<JSValueInWrappedObject> m_channelWrappers;
     bool m_isDetachable { true };
     mutable Lock m_channelsLock;
-    bool m_needsAdditionalNoise { false };
+    float m_noiseInjectionMultiplier { 0 };
 };
 
 WebCoreOpaqueRoot root(AudioBuffer*);

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -590,6 +590,22 @@ bool AudioBufferSourceNode::propagatesSilence() const
     return !m_buffer;
 }
 
+float AudioBufferSourceNode::noiseInjectionMultiplier() const
+{
+    Locker locker { m_processLock };
+
+    if (!m_buffer)
+        return 0;
+
+    auto multiplier = m_buffer->noiseInjectionMultiplier();
+    if (m_isLooping && m_loopStart < m_loopEnd) {
+        static constexpr auto noiseMultiplierPerLoop = 0.005;
+        auto loopCount = m_buffer->duration() / (m_loopEnd - m_loopStart);
+        multiplier *= std::max(1.0, noiseMultiplierPerLoop * loopCount);
+    }
+    return multiplier;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -86,6 +86,8 @@ private:
     double tailTime() const final { return 0; }
     double latencyTime() const final { return 0; }
 
+    float noiseInjectionMultiplier() const final;
+
     ExceptionOr<void> startPlaying(double when, double grainOffset, std::optional<double> grainDuration);
     void adjustGrainParameters() WTF_REQUIRES_LOCK(m_processLock);
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -198,6 +198,7 @@ public:
     void setIsTailProcessing(bool isTailProcessing) { m_isTailProcessing = isTailProcessing; }
 
     NoiseInjectionPolicy noiseInjectionPolicy() const;
+    virtual float noiseInjectionMultiplier() const { return 0; }
 
 protected:
     // Inputs and outputs must be created before the AudioNode is initialized.

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -175,6 +175,14 @@ void AudioNodeOutput::removeInput(AudioNodeInput* input)
     m_inputs.remove(input);
 }
 
+void AudioNodeOutput::forEachInputNode(Function<void(AudioNode&)>&& callback) const
+{
+    for (auto& node : m_inputs.values()) {
+        if (node)
+            callback(*node);
+    }
+}
+
 void AudioNodeOutput::disconnectAllInputs()
 {
     ASSERT(context().isGraphOwner());

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -68,6 +68,7 @@ public:
 
     // Must be called with the context's graph lock.
     void disconnectAll();
+    void forEachInputNode(Function<void(AudioNode&)>&&) const;
 
     void setNumberOfChannels(unsigned);
     unsigned numberOfChannels() const { return m_numberOfChannels; }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -221,7 +221,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
             if (auto& input = m_inputs[inputIndex]) {
                 for (unsigned channelIndex = 0; channelIndex < input->numberOfChannels(); ++channelIndex) {
                     auto* channel = input->channel(channelIndex);
-                    AudioUtilities::applyNoise(channel->mutableData(), channel->length(), 0.001);
+                    AudioUtilities::applyNoise(channel->mutableData(), channel->length(), 0.01);
                 }
             }
         }

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -251,6 +251,10 @@ protected:
 
     void clear();
 
+protected:
+    // Only accessed when the graph lock is held.
+    const Vector<AudioConnectionRefPtr<AudioNode>>& referencedSourceNodes() const { return m_referencedSourceNodes; }
+
 private:
     void scheduleNodeDeletion();
     void workletIsReady();

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h
@@ -69,6 +69,8 @@ private:
     double latencyTime() const final;
     bool requiresTailProcessing() const final;
 
+    float noiseInjectionMultiplier() const final { return 0.01; }
+
     std::unique_ptr<DynamicsCompressor> m_dynamicsCompressor;
     Ref<AudioParam> m_threshold;
     Ref<AudioParam> m_knee;

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
@@ -56,6 +56,9 @@ public:
 private:
     OfflineAudioContext(Document&, const OfflineAudioContextOptions&);
 
+    void lazyInitialize() final;
+    void increaseNoiseMultiplierIfNeeded();
+
     AudioBuffer* renderTarget() const { return destination().renderTarget(); }
 
     // ActiveDOMObject

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.h
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.h
@@ -65,6 +65,8 @@ private:
 
     bool propagatesSilence() const final;
 
+    float noiseInjectionMultiplier() const final { return 0.01; }
+
     // One of the waveform types defined in the enum.
     OscillatorType m_type; // Only used on the main thread.
     

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
@@ -90,10 +90,16 @@ ExceptionOr<void> WaveShaperNode::setCurveForBindings(RefPtr<Float32Array>&& cur
     return { };
 }
 
-Float32Array* WaveShaperNode::curveForBindings()
+RefPtr<Float32Array> WaveShaperNode::curveForBindings()
 {
     ASSERT(isMainThread());
-    return waveShaperProcessor()->curveForBindings();
+    RefPtr curve = waveShaperProcessor()->curveForBindings();
+    if (!curve)
+        return nullptr;
+
+    // Make a clone of our internal array so that JS cannot modify our internal array
+    // on the main thread while the audio thread is using it for rendering.
+    return Float32Array::create(curve->data(), curve->length());
 }
 
 static inline WaveShaperProcessor::OverSampleType processorType(OverSampleType type)

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.h
@@ -41,7 +41,7 @@ public:
 
     // setCurve() is called on the main thread.
     ExceptionOr<void> setCurveForBindings(RefPtr<Float32Array>&&);
-    Float32Array* curveForBindings();
+    RefPtr<Float32Array> curveForBindings();
 
     void setOversampleForBindings(OverSampleType);
     OverSampleType oversampleForBindings() const;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3763,6 +3763,9 @@ private:
             return true;
         };
 
+        if (!ArrayBufferView::verifySubRangeLength(arrayBuffer->byteLength(), byteOffset, length.value_or(0), 1))
+            return false;
+
         switch (arrayBufferViewSubtag) {
         case DataViewTag:
             return makeArrayBufferView(DataView::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());

--- a/Source/WebCore/platform/audio/AudioUtilities.cpp
+++ b/Source/WebCore/platform/audio/AudioUtilities.cpp
@@ -27,6 +27,7 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "AudioUtilities.h"
+#include <random>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MathExtras.h>
 #include <wtf/WeakRandom.h>
@@ -77,11 +78,30 @@ size_t timeToSampleFrame(double time, double sampleRate, SampleFrameRounding rou
     return static_cast<size_t>(frame);
 }
 
-void applyNoise(float* values, size_t numberOfElementsToProcess, float magnitude)
+void applyNoise(float* values, size_t numberOfElementsToProcess, float standardDeviation)
 {
-    WeakRandom generator;
+    std::random_device device;
+    std::mt19937 generator(device());
+    std::normal_distribution<float> distribution(1, standardDeviation);
+
+    HashMap<float, float> noiseMultipliers;
+    auto computeNoiseMultiplier = [&](float rawValue) {
+        if (!noiseMultipliers.isValidKey(rawValue))
+            return distribution(generator);
+
+        auto result = noiseMultipliers.ensure(rawValue, [&] {
+            return distribution(generator);
+        }).iterator->value;
+
+        static constexpr auto maxNoiseMultiplierMapSize = 250000;
+        if (noiseMultipliers.size() >= maxNoiseMultiplierMapSize)
+            noiseMultipliers.remove(noiseMultipliers.random());
+
+        return result;
+    };
+
     for (size_t i = 0; i < numberOfElementsToProcess; ++i)
-        values[i] *= 1 + magnitude * (2 * generator.get() - 1);
+        values[i] *= computeNoiseMultiplier(values[i]);
 }
 
 } // AudioUtilites

--- a/Source/WebCore/platform/audio/AudioUtilities.h
+++ b/Source/WebCore/platform/audio/AudioUtilities.h
@@ -64,7 +64,7 @@ inline float decibelsToLinear(float decibels)
     return powf(10, 0.05f * decibels);
 }
 
-void applyNoise(float* values, size_t numberOfElementsToProcess, float magnitude);
+void applyNoise(float* values, size_t numberOfElementsToProcess, float standardDeviation);
 
 } // AudioUtilites
 

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
@@ -44,6 +44,8 @@ struct ContactsRequestData;
 
 - (void)presentWithRequestData:(const WebCore::ContactsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&)completionHandler;
 
+- (void)dismiss;
+
 @property (nonatomic, weak) id<WKContactPickerDelegate> delegate;
 
 @end

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -179,6 +179,11 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 #endif
 }
 
+- (void)dismiss
+{
+    [self dismissWithContacts:nil];
+}
+
 #pragma mark - Completion
 
 #if HAVE(CNCONTACTPICKERVIEWCONTROLLER)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -522,6 +522,9 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 
         [self _updateForScreen:newWindow.screen];
     }
+
+    if (window && !newWindow)
+        [self dismissPickers];
 }
 
 - (void)didMoveToWindow

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -681,6 +681,8 @@ struct ImageAnalysisContextMenuActionData {
 - (void)cleanUpInteraction;
 - (void)cleanUpInteractionPreviewContainers;
 
+- (void)dismissPickers;
+
 - (void)scrollViewWillStartPanOrPinchGesture;
 
 - (void)buildMenuForWebViewWithBuilder:(id <UIMenuBuilder>)builder;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1561,19 +1561,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _unregisterPreview];
 #endif
 
-    if (_fileUploadPanel) {
-        [_fileUploadPanel setDelegate:nil];
-        [_fileUploadPanel dismiss];
-        _fileUploadPanel = nil;
-    }
-
-#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-    if (_shareSheet) {
-        [_shareSheet setDelegate:nil];
-        [_shareSheet dismiss];
-        _shareSheet = nil;
-    }
-#endif
+    [self dismissPickers];
 
     [self stopDeferringInputViewUpdatesForAllSources];
     _focusedElementInformation = { };
@@ -9098,6 +9086,31 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     [_webView _didDismissContactPicker];
 }
 #endif
+
+- (void)dismissPickers
+{
+    if (_fileUploadPanel) {
+        [_fileUploadPanel setDelegate:nil];
+        [_fileUploadPanel dismiss];
+        _fileUploadPanel = nil;
+    }
+
+#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
+    if (_shareSheet) {
+        [_shareSheet setDelegate:nil];
+        [_shareSheet dismiss];
+        _shareSheet = nil;
+    }
+#endif
+
+#if HAVE(CONTACTSUI)
+    if (_contactPicker) {
+        [_contactPicker setDelegate:nil];
+        [_contactPicker dismiss];
+        _contactPicker = nil;
+    }
+#endif
+}
 
 - (NSString *)inputLabelText
 {

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -877,6 +877,7 @@ TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)
     checkFingerprintForNoise(@"testOscillatorCompressor");
     checkFingerprintForNoise(@"testOscillatorCompressorWorklet");
     checkFingerprintForNoise(@"testOscillatorCompressorAnalyzer");
+    checkFingerprintForNoise(@"testLoopingOscillatorCompressorBiquadFilter");
 }
 
 // FIXME when rdar://115137641 is resolved.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/audio-fingerprinting.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/audio-fingerprinting.html
@@ -32,8 +32,10 @@ button {
 <script>
 function combineSamples(samples) {
     let result = 0;
-    for (const value of samples)
-        result += value;
+    for (const value of samples) {
+        if (isFinite(value))
+            result += value;
+    }
     return result;
 }
 
@@ -144,6 +146,109 @@ async function testOscillatorCompressorAnalyzer() {
     gain.disconnect();
 
     return combineSamples(bins);
+}
+
+async function testLoopingOscillatorCompressorBiquadFilter() {
+    const sampleRate = 44100;
+    const cloneCount = 40000;
+    const targetSampleIndex = 3395;
+    const stabilizationPrecision = 6.2;
+
+    async function getBaseAudioFingerprint() {
+        const baseSignal = await (async function() {
+            const context = new OfflineAudioContext(1, targetSampleIndex + 1, 44100);
+
+            const oscillator = context.createOscillator();
+            oscillator.type = "square";
+            oscillator.frequency.value = 1000;
+
+            const compressor = context.createDynamicsCompressor();
+            compressor.threshold.value = -70;
+            compressor.knee.value = 40;
+            compressor.ratio.value = 12;
+            compressor.attack.value = 0;
+            compressor.release.value = 0.25;
+
+            const filter = context.createBiquadFilter();
+            filter.type = "allpass";
+            filter.frequency.value = 5.239622852977861;
+            filter.Q.value = 0.1;
+
+            oscillator.connect(compressor);
+            compressor.connect(filter);
+            filter.connect(context.destination);
+            oscillator.start(0);
+
+            return await context.startRendering();
+        })();
+
+        const context = new OfflineAudioContext(1, baseSignal.length - 1 + cloneCount, sampleRate);
+        const sourceNode = context.createBufferSource();
+        sourceNode.buffer = baseSignal;
+        sourceNode.loop = true;
+        sourceNode.loopStart = (baseSignal.length - 1) / sampleRate;
+        sourceNode.loopEnd = baseSignal.length / sampleRate;
+        sourceNode.connect(context.destination);
+        sourceNode.start();
+
+        const clonedSignal = await context.startRendering();
+        const fingerprint = extractFingerprint(baseSignal, clonedSignal.getChannelData(0).subarray(baseSignal.length - 1));
+        return Math.abs(fingerprint);
+    }
+
+    function extractFingerprint(baseSignal, clonedSample) {
+        let fingerprint;
+        let needsDenoising = false;
+
+        for (let i = 0; i < clonedSample.length; i += Math.floor(clonedSample.length / 10)) {
+            if (clonedSample[i] === 0) {
+                // Intentionally ignored.
+                continue;
+            }
+
+            if (fingerprint === undefined) {
+                fingerprint = clonedSample[i];
+                continue;
+            }
+
+            if (fingerprint !== clonedSample[i]) {
+                needsDenoising = true;
+                break;
+            }
+        }
+
+        if (fingerprint === undefined)
+            fingerprint = baseSignal.getChannelData(0)[baseSignal.length - 1];
+        else if (needsDenoising)
+            fingerprint = getMean(clonedSample);
+
+        return fingerprint;
+    }
+
+    function getMean(signal) {
+        let total = 0;
+        let finiteValueCount = 0;
+        for (let i = 0; i < signal.length; i++) {
+            const value = signal[i];
+            if (!isFinite(value))
+                continue;
+            total += value;
+            finiteValueCount++;
+        }
+        return finiteValueCount ? (total / finiteValueCount) : 0;
+    }
+
+    function stabilize(value, precision) {
+        if (value === 0)
+            return value;
+        const power = Math.floor(Math.log10(Math.abs(value)));
+        const precisionPower = power - Math.floor(precision) + 1;
+        const precisionBase = 10 ** -precisionPower * ((precision * 10) % 10 || 1);
+        return Math.round(value * precisionBase) / precisionBase;
+    }
+
+    const rawFingerprint = await getBaseAudioFingerprint();
+    return stabilize(rawFingerprint, stabilizationPrecision);
 }
 </script>
 </body>


### PR DESCRIPTION
#### ef2e9b1c7fdb76cdc1ba094c5643c0cb0e4899e7
<pre>
[iOS] File picker dialog remains after opening a new tab in 3rd-party browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=265602">https://bugs.webkit.org/show_bug.cgi?id=265602</a>
<a href="https://rdar.apple.com/119001046">rdar://119001046</a>

Reviewed by Abrar Rahman Protyasha.

The file upload panel does not dismiss itself after a new tab is opened, and can
end up displayed over a site that&apos;s unrelated to the one requesting the upload.

The panel itself is a modal view controller that is presented from an appropriate
view controller containing the `WKWebView`. Safari has explicit logic to dismiss
presented modal view controllers on tab switch, but it is not reasonable to expect
other clients to guarantee this behavior.

Fix by dismissing all pickers if the `WKWebView` is removed from the hierarchy.

* LayoutTests/fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window-expected.txt: Added.
* LayoutTests/fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html: Added.
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.h:
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker dismiss]):

Add a new hook to dismiss the contact picker.

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView willMoveToWindow:]):

If the content view has moved to a `nil` window, it has been removed from the
view hierarchy, and presented pickers should be dismissed.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):

Factor out logic into `-[WKContentView dismissPickers]`.

(-[WKContentView dismissPickers]):

Dismiss all pickers that the content view is aware of.

Originally-landed-as: 272448.703@safari-7618-branch (a3524e350ec9). <a href="https://rdar.apple.com/128089287">rdar://128089287</a>
Canonical link: <a href="https://commits.webkit.org/278816@main">https://commits.webkit.org/278816@main</a>
</pre>
----------------------------------------------------------------------
#### 775bac300c8b006803ba1d5c2f7bf28a0f77bc69
<pre>
AudioBuffer noise injection in Private Browsing can be negated using a looping audio buffer source
<a href="https://bugs.webkit.org/show_bug.cgi?id=270767">https://bugs.webkit.org/show_bug.cgi?id=270767</a>
<a href="https://rdar.apple.com/124156971">rdar://124156971</a>

Reviewed by Chris Dumez, Charlie Wolfe and Matthew Finkel.

Implement several mitigations to make it impractical to reverse noise injection by looping a single
audio sample many times in a single audio buffer and averaging the results.

1.  Adjust noise injection to use normally-distributed noise, instead of a uniform random
    distribution. This raises the bar for &quot;averaging-style&quot; attacks, which can currently converge on
    a stable result by averaging the min/max values in the random distribution. A similar attack
    will now require more iterations to converge on the original value.

2.  Store previously-generated random values while applying noise, and reapply these random values
    to the values that are encountered repeatedly. This ensures that an attacker does not gain more
    information about the original value, by causing it to be computed repeatedly in the same audio
    buffer.

3.  Instead of uniformly applying a fixed noise level (0.001) for all readback using
    `OfflineAudioContext`, allow certain node types that are known to expose hardware or OS
    differences (i.e. `DynamicsCompressorNode` and `OscillatorNode`) to increase the amount of
    injected noise beyond the baseline of 0.1%. `AudioBufferSourceNode`, in particular, will amplify
    the noise level more, depending on the number of times the audio buffer is looped.

* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.h:
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::releaseMemory):

Replace the single boolean flag (`m_needsAdditionalNoise`) with a `m_noiseInjectionMultiplier`,
which indicates the magnitude of noise injection (the standard deviation of the normal distribution
used to inject noise).

(WebCore::AudioBuffer::copyToChannel):
(WebCore::AudioBuffer::zero):
(WebCore::AudioBuffer::copyTo const):
(WebCore::AudioBuffer::applyNoiseIfNeeded):
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
(WebCore::AudioBuffer::increaseNoiseInjectionMultiplier):
(WebCore::AudioBuffer::noiseInjectionMultiplier const):
(WebCore::AudioBuffer::setNeedsAdditionalNoise): Deleted.
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::noiseInjectionMultiplier const):

Increase the noise injection level for an audio buffer, if it&apos;s downstream from an
`AudioBufferSourceNode` that loops many times. For an audio buffer source that loops more than 200
times, this boosts the existing noise level for the audio buffer by a factor of 0.005 per loop,
leading to a massive amount of noise in the case where a tiny sample is looped back-to-back in a
large buffer.

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioNode.h:
(WebCore::AudioNode::noiseInjectionMultiplier const):

Add a subclassing hook that allows each `AudioNode` subclass to inject additional noise when reading
back the final `AudioBuffer`. This allows us to selectively increase the amount of injected noise
when using specific types of audio nodes, which are known to expose larger differences w.r.t. the
underlying OS or CPU architecture.

* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::forEachInputNode const):

Add a helper method to iterate over each input node (i.e. the next destination in the processing
graph) that&apos;s attached to this output. Note that this must be called from underneath the context&apos;s
graph lock.

* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):

Increase the noise level when passing raw data into worklets, to adjust for the new normally-
distributed noise injection.

* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::referencedSourceNodes const):

Add a helper method to iterate over all source nodes in the audio context; must be called only when
the context&apos;s graph lock is held.

* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.h:

Add additional buffer readback noise when using certain audio node types.

* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::OfflineAudioContext):
(WebCore::OfflineAudioContext::lazyInitialize):
(WebCore::OfflineAudioContext::increaseNoiseMultiplierIfNeeded):

Upon initialization, traverse the audio processing graph in search for audio nodes that warrant
additional noise injection, and accumulate this extra noise on the target buffer.

* Source/WebCore/Modules/webaudio/OfflineAudioContext.h:
* Source/WebCore/Modules/webaudio/OscillatorNode.h:
* Source/WebCore/platform/audio/AudioUtilities.cpp:
(WebCore::AudioUtilities::applyNoise):

Switch to normally-distributed noise injection, rather than uniformally random noise. Additionally,
ensure that if a value appears again in the same buffer, it&apos;ll use the same, previously computed
noise multiplier value instead of a newly generated random value.

* Source/WebCore/platform/audio/AudioUtilities.h:
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/audio-fingerprinting.html:

Add a new test case to exercise these mitigations.

Originally-landed-as: 272448.707@safari-7618-branch (3c7dd1781475). <a href="https://rdar.apple.com/128089250">rdar://128089250</a>
Canonical link: <a href="https://commits.webkit.org/278815@main">https://commits.webkit.org/278815@main</a>
</pre>
----------------------------------------------------------------------
#### 7fc383d48e2c73be33e18f9734d158eb24847210
<pre>
Verify range of ArrayBuffer when deserializing an ArrayBufferView
<a href="https://bugs.webkit.org/show_bug.cgi?id=270949">https://bugs.webkit.org/show_bug.cgi?id=270949</a>
<a href="https://rdar.apple.com/123906915">rdar://123906915</a>

Reviewed by Chris Dumez.

byteOffset and length come from an untrusted source, and if out of bounds they
can lead to arbitrary reads.  If they are out of bounds, fail to deserialize.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readArrayBufferViewImpl):

Originally-landed-as: 272448.733@safari-7618-branch (7d7e9c948a3b). <a href="https://rdar.apple.com/128088960">rdar://128088960</a>
Canonical link: <a href="https://commits.webkit.org/278814@main">https://commits.webkit.org/278814@main</a>
</pre>
----------------------------------------------------------------------
#### cf7cd9dbde003ce941e1963570ee8aa9a4e9c531
<pre>
Use-after-free in WebCore::WaveShaperDSPKernel::processCurve()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271654">https://bugs.webkit.org/show_bug.cgi?id=271654</a>
<a href="https://rdar.apple.com/123631199">rdar://123631199</a>

Reviewed by Jer Noble.

Make sure WaveShaperNode::curveForBindings() clones our internal array
before returning it to JS. This is important so that the JS cannot
modify our internal array on the main thread while the audio thread is
using it for rendering.

* Source/WebCore/Modules/webaudio/WaveShaperNode.cpp:
(WebCore::WaveShaperNode::curveForBindings):
* Source/WebCore/Modules/webaudio/WaveShaperNode.h:

Originally-landed-as: 272448.781@safari-7618-branch (bc1031419c11). <a href="https://rdar.apple.com/128088238">rdar://128088238</a>
Canonical link: <a href="https://commits.webkit.org/278813@main">https://commits.webkit.org/278813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a771a84234c8ec6ec78b3dafaeaf26aee6313f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41973 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1735 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49368 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44543 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48559 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28812 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->