### PR TITLE
[JSC] AI should observe attribute change transitions for PutByIdDirect in DFG compilation

### DIFF
--- a/JSTests/stress/dfg-ai-direct-get-by-id-attribute-change-transition.js
+++ b/JSTests/stress/dfg-ai-direct-get-by-id-attribute-change-transition.js
@@ -1,0 +1,51 @@
+function returnObject(object) {
+    return object;
+}
+
+class Opt extends returnObject {
+    p2 = 1;
+
+    constructor(object) {
+        object.p1;
+
+        super(object);
+    }
+}
+
+function createObject() {
+    const object = {p1: 1};
+    Object.defineProperty(object, 'p2', {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: 1
+    });
+
+    return object;
+}
+
+function getStructureID(object) {
+    const desc = describe(object);
+
+    return desc.match(/StructureID: (\d+)/)[1];
+}
+
+function main() {
+    const a = createObject();
+    new Opt(a);
+
+    for (let i = 0; i < 100000; i++) {
+        new Opt(createObject());
+    }
+
+    const b = createObject();
+    new Opt(b);
+
+    const aStructureID = getStructureID(a);
+    const bStructureID = getStructureID(b);
+
+    if (aStructureID !== bStructureID)
+        throw new Error('Structure ID mismatch.');
+}
+
+main();

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -404,7 +404,17 @@ PutByStatus PutByStatus::computeFor(JSGlobalObject* globalObject, const Structur
 
             if (attributes & (PropertyAttribute::Accessor | PropertyAttribute::ReadOnly))
                 return PutByStatus(LikelyTakesSlowPath);
-            
+
+            if (isDirect && attributes) {
+                Structure* existingTransition = Structure::attributeChangeTransitionToExistingStructureConcurrently(structure, identifier.uid(), 0, offset);
+                if (!existingTransition)
+                    return PutByStatus(LikelyTakesSlowPath);
+                bool didAppend = result.appendVariant(PutByVariant::transition(identifier, structure, existingTransition, { }, offset));
+                if (!didAppend)
+                    return PutByStatus(LikelyTakesSlowPath);
+                continue;
+            }
+
             WatchpointSet* replaceSet = structure->propertyReplacementWatchpointSet(offset);
             if (!replaceSet || replaceSet->isStillValid()) {
                 // When this executes, it'll create, and fire, this replacement watchpoint set.

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -684,7 +684,7 @@ Structure* Structure::changePrototypeTransition(VM& vm, Structure* structure, JS
     return transition;
 }
 
-Structure* Structure::attributeChangeTransitionToExistingStructure(Structure* structure, PropertyName propertyName, unsigned attributes, PropertyOffset& offset)
+Structure* Structure::attributeChangeTransitionToExistingStructureImpl(Structure* structure, PropertyName propertyName, unsigned attributes, PropertyOffset& offset)
 {
     ASSERT(structure->isObject());
 
@@ -700,6 +700,18 @@ Structure* Structure::attributeChangeTransitionToExistingStructure(Structure* st
     }
 
     return nullptr;
+}
+
+Structure* Structure::attributeChangeTransitionToExistingStructure(Structure* structure, PropertyName propertyName, unsigned attributes, PropertyOffset& offset)
+{
+    ASSERT(!isCompilationThread());
+    return attributeChangeTransitionToExistingStructureImpl(structure, propertyName, attributes, offset);
+}
+
+Structure* Structure::attributeChangeTransitionToExistingStructureConcurrently(Structure* structure, PropertyName propertyName, unsigned attributes, PropertyOffset& offset)
+{
+    ConcurrentJSLocker locker(structure->m_lock);
+    return attributeChangeTransitionToExistingStructureImpl(structure, propertyName, attributes, offset);
 }
 
 Structure* Structure::attributeChangeTransition(VM& vm, Structure* structure, PropertyName propertyName, unsigned attributes, DeferredStructureTransitionWatchpointFire* deferred)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -294,6 +294,7 @@ public:
     static Structure* removePropertyTransitionFromExistingStructureConcurrently(Structure*, PropertyName, PropertyOffset&);
     static Structure* changePrototypeTransition(VM&, Structure*, JSValue prototype, DeferredStructureTransitionWatchpointFire&);
     JS_EXPORT_PRIVATE static Structure* attributeChangeTransition(VM&, Structure*, PropertyName, unsigned attributes, DeferredStructureTransitionWatchpointFire* = nullptr);
+    static Structure* attributeChangeTransitionToExistingStructureConcurrently(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     JS_EXPORT_PRIVATE static Structure* attributeChangeTransitionToExistingStructure(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     JS_EXPORT_PRIVATE static Structure* toCacheableDictionaryTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* toUncacheableDictionaryTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
@@ -938,8 +939,9 @@ private:
     Structure(VM&, CreatingEarlyCellTag);
 
     static Structure* create(VM&, Structure*, DeferredStructureTransitionWatchpointFire*);
-    
+
     static Structure* addPropertyTransitionToExistingStructureImpl(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);
+    ALWAYS_INLINE static Structure* attributeChangeTransitionToExistingStructureImpl(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     static Structure* removePropertyTransitionFromExistingStructureImpl(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     static Structure* setBrandTransitionFromExistingStructureImpl(Structure*, UniquedStringImpl*);
 


### PR DESCRIPTION
#### 332ec81baece8f72fadd3cb37ca079825c2e18fc
<pre>
[JSC] AI should observe attribute change transitions for PutByIdDirect in DFG compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=270265">https://bugs.webkit.org/show_bug.cgi?id=270265</a>
<a href="https://rdar.apple.com/122515736">rdar://122515736</a>

Reviewed by Yusuke Suzuki.

Since DirectPutById can trigger and cache attribute change transitions,
the AI should observe these kinds of transitions when computing for
GetByStatus in the DFG compilation.

* JSTests/stress/dfg-ai-attribute-change-transition-1.js: Added.
(returnObject):
(Opt):
(createObjectA):
(createObjectB):
(initialize):
* JSTests/stress/dfg-ai-attribute-change-transition-2.js: Added.
(returnObject):
(Opt):
(createObject):
(getStructureID):
(main):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeFor):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::attributeChangeTransitionToExistingStructureImpl):
(JSC::Structure::attributeChangeTransitionToExistingStructure):
(JSC::Structure::attributeChangeTransitionToExistingStructureConcurrently):
* Source/JavaScriptCore/runtime/Structure.h:

Originally-landed-as: 272448.651@safari-7618-branch (4e48bdad7045). <a href="https://rdar.apple.com/128090341">rdar://128090341</a>
Canonical link: <a href="https://commits.webkit.org/278870@main">https://commits.webkit.org/278870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80efee7d7e4f1334e59775912ff61fea8ae645d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2383 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1854 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45033 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56549 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51196 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49475 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48704 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28946 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63516 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7564 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27786 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11988 "Found 10 new JSC stress test failures: stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.bytecode-cache, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.default, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.dfg-eager, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.dfg-eager-no-cjit-validate, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.eager-jettison-no-cjit, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.lockdown, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.mini-mode, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-cjit-collect-continuously, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-cjit-validate-phases, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->