### PR TITLE
[Navigation] Implement the "abort the ongoing navigation" algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-preventDefault-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT currententrychange does not fire when onnavigate preventDefault() is called Test timed out
+PASS currententrychange does not fire when onnavigate preventDefault() is called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate-expected.txt
@@ -1,2 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Navigation aborted
+
+FAIL if navigate() is called inside onnavigate, the previous navigation and navigate event are cancelled assert_array_equals: expected property 1 to be "#2" but got "" (expected array ["", "#2"] got ["", ""])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-preventDefault-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() when the onnavigate handler calls preventDefault() Test timed out
+PASS navigate() when the onnavigate handler calls preventDefault()
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL NavigationHistoryEntry properties after detach assert_equals: expected (object) null but got (string) "http://web-platform.test:8800/common/blank.html"
+PASS NavigationHistoryEntry properties after detach
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -164,6 +164,8 @@ private:
     RefPtr<NavigationAPIMethodTracker> addUpcomingTrarveseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
     void cleanupAPIMethodTracker(NavigationAPIMethodTracker*);
     void resolveFinishedPromise(NavigationAPIMethodTracker*);
+    void rejectFinishedPromise(NavigationAPIMethodTracker*, Exception&&, JSC::JSValue exceptionObject);
+    void abortOngoingNavigation(NavigateEvent&);
     void promoteUpcomingAPIMethodTracker(const String& destinationKey);
     void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*);
     Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);


### PR DESCRIPTION
#### 4cce2f294a54545203b4960ec4a580c21a271e97
<pre>
[Navigation] Implement the &quot;abort the ongoing navigation&quot; algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=274170">https://bugs.webkit.org/show_bug.cgi?id=274170</a>

Reviewed by Alex Christensen.

Implement the &quot;abort the ongoing navigation&quot; algorithm [1].

Use it to abort ongoing navigations when a new one starts and to
abort events with defaultPrevented.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#abort-the-ongoing-navigation">https://html.spec.whatwg.org/multipage/nav-history-apis.html#abort-the-ongoing-navigation</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-preventDefault-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/278874@main">https://commits.webkit.org/278874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c32b9137be9b33acbd0e5a45483c2a9c60dee88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42127 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23257 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26005 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1922 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56634 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49530 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11323 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->