### PR TITLE
Do not query HashMap at RenderObject destruction

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -156,11 +156,11 @@ public:
         // Protect against double insert where a descendant would end up with multiple containing blocks.
         auto previousContainingBlock = m_containerMap.get(positionedDescendant);
         if (previousContainingBlock && previousContainingBlock != &containingBlock) {
-            if (auto* descendants = m_descendantsMap.get(previousContainingBlock.get()))
+            if (auto* descendants = m_descendantsMap.get(*previousContainingBlock.get()))
                 descendants->remove(positionedDescendant);
         }
 
-        auto& descendants = m_descendantsMap.ensure(&containingBlock, [] {
+        auto& descendants = m_descendantsMap.ensure(containingBlock, [] {
             return makeUnique<TrackedRendererListHashSet>();
         }).iterator->value;
 
@@ -199,7 +199,7 @@ public:
         if (!containingBlock)
             return;
 
-        auto descendantsIterator = m_descendantsMap.find(containingBlock.get());
+        auto descendantsIterator = m_descendantsMap.find(*containingBlock.get());
         ASSERT(descendantsIterator != m_descendantsMap.end());
         if (descendantsIterator == m_descendantsMap.end())
             return;
@@ -214,7 +214,7 @@ public:
     
     void removeContainingBlock(const RenderBlock& containingBlock)
     {
-        auto descendants = m_descendantsMap.take(&containingBlock);
+        auto descendants = m_descendantsMap.take(containingBlock);
         if (!descendants)
             return;
 
@@ -224,11 +224,11 @@ public:
     
     TrackedRendererListHashSet* positionedRenderers(const RenderBlock& containingBlock) const
     {
-        return m_descendantsMap.get(&containingBlock);
+        return m_descendantsMap.get(containingBlock);
     }
 
 private:
-    using DescendantsMap = HashMap<CheckedPtr<const RenderBlock>, std::unique_ptr<TrackedRendererListHashSet>>;
+    using DescendantsMap = SingleThreadWeakHashMap<const RenderBlock, std::unique_ptr<TrackedRendererListHashSet>>;
     using ContainerMap = SingleThreadWeakHashMap<const RenderBox, SingleThreadWeakPtr<const RenderBlock>>;
     
     DescendantsMap m_descendantsMap;
@@ -316,31 +316,10 @@ RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, Opt
     ASSERT(isRenderBlock());
 }
 
-static void removeBlockFromPercentageDescendantAndContainerMaps(RenderBlock& block)
-{
-    if (!percentHeightDescendantsMap)
-        return;
-    auto descendantSet = percentHeightDescendantsMap->take(block);
-    if (!descendantSet)
-        return;
-    
-    for (auto& descendant : *descendantSet) {
-        auto it = percentHeightContainerMap->find(descendant);
-        ASSERT(it != percentHeightContainerMap->end());
-        if (it == percentHeightContainerMap->end())
-            continue;
-        auto& containerSet = it->value;
-        ASSERT(containerSet.contains(block));
-        containerSet.remove(block);
-        if (containerSet.isEmptyIgnoringNullReferences())
-            percentHeightContainerMap->remove(it);
-    }
-}
-
 RenderBlock::~RenderBlock()
 {
     // Blocks can be added to gRareDataMap during willBeDestroyed(), so this code can't move there.
-    if (gRareDataMap)
+    if (renderBlockHasRareData())
         gRareDataMap->remove(this);
 
     // Do not add any more code here. Add it to willBeDestroyed() instead.
@@ -354,22 +333,7 @@ void RenderBlock::willBeDestroyed()
             parent()->dirtyLinesFromChangedChild(*this);
     }
 
-    blockWillBeDestroyed();
-
     RenderBox::willBeDestroyed();
-}
-
-void RenderBlock::blockWillBeDestroyed()
-{
-    removeFromUpdateScrollInfoAfterLayoutTransaction();
-
-    removeBlockFromPercentageDescendantAndContainerMaps(*this);
-    positionedDescendantsMap().removeContainingBlock(*this);
-}
-
-bool RenderBlock::hasRareData() const
-{
-    return gRareDataMap ? gRareDataMap->contains(this) : false;
 }
 
 void RenderBlock::removePositionedObjectsIfNeeded(const RenderStyle& oldStyle, const RenderStyle& newStyle)
@@ -547,12 +511,6 @@ void RenderBlock::endAndCommitUpdateScrollInfoAfterLayoutTransaction()
     }
 }
 
-void RenderBlock::removeFromUpdateScrollInfoAfterLayoutTransaction()
-{
-    if (auto* transaction = view().frameView().layoutContext().updateScrollInfoAfterLayoutTransactionIfExists(); transaction && transaction->nestedCount)
-        transaction->blocks.remove(*this);
-}
-
 void RenderBlock::updateScrollInfoAfterLayout()
 {
     if (!hasNonVisibleOverflow())
@@ -591,20 +549,23 @@ void RenderBlock::layout()
     invalidateBackgroundObscurationStatus();
 }
 
-static RenderBlockRareData* getBlockRareData(const RenderBlock& block)
+RenderBlockRareData* RenderBlock::getBlockRareData() const
 {
-    return gRareDataMap ? gRareDataMap->get(block) : nullptr;
+    if (!renderBlockHasRareData())
+        return nullptr;
+    ASSERT(gRareDataMap);
+    return gRareDataMap->get(*this);
 }
 
-static RenderBlockRareData& ensureBlockRareData(const RenderBlock& block)
+RenderBlockRareData& RenderBlock::ensureBlockRareData()
 {
     if (!gRareDataMap)
         gRareDataMap = new RenderBlockRareDataMap;
-    
-    auto& rareData = gRareDataMap->add(block, nullptr).iterator->value;
-    if (!rareData)
-        rareData = makeUnique<RenderBlockRareData>();
-    return *rareData.get();
+
+    return *gRareDataMap->ensure(*this, [this] {
+        setRenderBlockHasRareData(true);
+        return makeUnique<RenderBlockRareData>();
+    }).iterator->value;
 }
 
 void RenderBlock::preparePaginationBeforeBlockLayout(bool& relayoutChildren)
@@ -2653,7 +2614,7 @@ void RenderBlock::getFirstLetter(RenderObject*& firstLetter, RenderElement*& fir
 
 RenderFragmentedFlow* RenderBlock::cachedEnclosingFragmentedFlow() const
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
 
     if (!rareData || !rareData->m_enclosingFragmentedFlow)
         return nullptr;
@@ -2663,7 +2624,7 @@ RenderFragmentedFlow* RenderBlock::cachedEnclosingFragmentedFlow() const
 
 bool RenderBlock::cachedEnclosingFragmentedFlowNeedsUpdate() const
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
 
     if (!rareData || !rareData->m_enclosingFragmentedFlow)
         return true;
@@ -2673,13 +2634,13 @@ bool RenderBlock::cachedEnclosingFragmentedFlowNeedsUpdate() const
 
 void RenderBlock::setCachedEnclosingFragmentedFlowNeedsUpdate()
 {
-    RenderBlockRareData& rareData = ensureBlockRareData(*this);
+    RenderBlockRareData& rareData = ensureBlockRareData();
     rareData.m_enclosingFragmentedFlow = std::nullopt;
 }
 
 RenderFragmentedFlow* RenderBlock::updateCachedEnclosingFragmentedFlow(RenderFragmentedFlow* fragmentedFlow) const
 {
-    RenderBlockRareData& rareData = ensureBlockRareData(*this);
+    RenderBlockRareData& rareData = const_cast<RenderBlock&>(*this).ensureBlockRareData();
     rareData.m_enclosingFragmentedFlow = fragmentedFlow;
 
     return fragmentedFlow;
@@ -2687,7 +2648,7 @@ RenderFragmentedFlow* RenderBlock::updateCachedEnclosingFragmentedFlow(RenderFra
 
 RenderFragmentedFlow* RenderBlock::locateEnclosingFragmentedFlow() const
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
     if (!rareData || !rareData->m_enclosingFragmentedFlow)
         return updateCachedEnclosingFragmentedFlow(RenderBox::locateEnclosingFragmentedFlow());
 
@@ -2708,34 +2669,34 @@ void RenderBlock::resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants(R
 
 LayoutUnit RenderBlock::paginationStrut() const
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
     return rareData ? rareData->m_paginationStrut : 0_lu;
 }
 
 LayoutUnit RenderBlock::pageLogicalOffset() const
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
     return rareData ? rareData->m_pageLogicalOffset : 0_lu;
 }
 
 void RenderBlock::setPaginationStrut(LayoutUnit strut)
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
     if (!rareData) {
         if (!strut)
             return;
-        rareData = &ensureBlockRareData(*this);
+        rareData = &ensureBlockRareData();
     }
     rareData->m_paginationStrut = strut;
 }
 
 void RenderBlock::setPageLogicalOffset(LayoutUnit logicalOffset)
 {
-    RenderBlockRareData* rareData = getBlockRareData(*this);
+    RenderBlockRareData* rareData = getBlockRareData();
     if (!rareData) {
         if (!logicalOffset)
             return;
-        rareData = &ensureBlockRareData(*this);
+        rareData = &ensureBlockRareData();
     }
     rareData->m_pageLogicalOffset = logicalOffset;
 }
@@ -3387,17 +3348,17 @@ LayoutRect RenderBlock::paintRectToClipOutFromBorder(const LayoutRect& paintRect
 
 LayoutUnit RenderBlock::intrinsicBorderForFieldset() const
 {
-    auto* rareData = getBlockRareData(*this);
+    auto* rareData = getBlockRareData();
     return rareData ? rareData->m_intrinsicBorderForFieldset : 0_lu;
 }
 
 void RenderBlock::setIntrinsicBorderForFieldset(LayoutUnit padding)
 {
-    auto* rareData = getBlockRareData(*this);
+    auto* rareData = getBlockRareData();
     if (!rareData) {
         if (!padding)
             return;
-        rareData = &ensureBlockRareData(*this);
+        rareData = &ensureBlockRareData();
     }
     rareData->m_intrinsicBorderForFieldset = padding;
 }

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -38,6 +38,7 @@ class RenderText;
 
 struct BidiRun;
 struct PaintInfo;
+struct RenderBlockRareData;
 
 using TrackedRendererListHashSet = SingleThreadWeakListHashSet<RenderBox>;
 
@@ -391,8 +392,6 @@ protected:
 
     void computeChildPreferredLogicalWidths(RenderObject&, LayoutUnit& minPreferredLogicalWidth, LayoutUnit& maxPreferredLogicalWidth) const;
 
-    void blockWillBeDestroyed();
-
     virtual void computeChildIntrinsicLogicalWidths(RenderObject&, LayoutUnit& minPreferredLogicalWidth, LayoutUnit& maxPreferredLogicalWidth) const;
 
 private:
@@ -465,11 +464,11 @@ private:
 
     void absoluteQuadsIgnoringContinuation(const FloatRect&, Vector<FloatQuad>&, bool* wasFixed) const override;
 
-private:
-    bool hasRareData() const;
-    
 protected:
     void dirtyForLayoutFromPercentageHeightDescendants();
+
+    RenderBlockRareData& ensureBlockRareData();
+    RenderBlockRareData* getBlockRareData() const;
 
 protected:
     bool recomputeLogicalWidth();

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -175,8 +175,6 @@ void RenderBlockFlow::willBeDestroyed()
     if (legacyLineLayout())
         legacyLineLayout()->lineBoxes().deleteLineBoxes();
 
-    blockWillBeDestroyed();
-
     // NOTE: This jumps down to RenderBox, bypassing RenderBlock since it would do duplicate work.
     RenderBox::willBeDestroyed();
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -608,11 +608,6 @@ public:
         return nullptr;
     }
 
-    ShapeOutsideInfo* shapeOutsideInfo() const
-    {
-        return ShapeOutsideInfo::isEnabledFor(*this) ? ShapeOutsideInfo::info(*this) : nullptr;
-    }
-
     void markShapeOutsideDependentsForLayout()
     {
         if (isFloating())
@@ -643,6 +638,8 @@ public:
     void updateFloatPainterAfterSelfPaintingLayerChange();
 
     bool computeHasTransformRelatedProperty(const RenderStyle&) const;
+
+    ShapeOutsideInfo* shapeOutsideInfo() const;
 
 protected:
     RenderBox(Type, Element&, RenderStyle&&, OptionSet<TypeFlag> = { }, TypeSpecificFlags = { });
@@ -769,6 +766,9 @@ private:
     void clipContentForBorderRadius(GraphicsContext&, const LayoutPoint&, float);
 
     void addLayoutOverflow(const LayoutRect&, const LayoutRect& flippedClientRect);
+
+    ShapeOutsideInfo& ensureShapeOutsideInfo();
+    void removeShapeOutsideInfo();
 
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -297,6 +297,9 @@ public:
 
     void clearNeedsLayoutForSkippedContent();
 
+    void setRenderBoxHasShapeOutsideInfo(bool b) { m_renderBoxHasShapeOutsideInfo = b; }
+    bool renderBoxHasShapeOutsideInfo() const { return m_renderBoxHasShapeOutsideInfo; }
+
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
     RenderElement(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
@@ -324,9 +327,11 @@ protected:
     void setRenderBlockHasMarginBeforeQuirk(bool b) { m_renderBlockHasMarginBeforeQuirk = b; }
     void setRenderBlockHasMarginAfterQuirk(bool b) { m_renderBlockHasMarginAfterQuirk = b; }
     void setRenderBlockShouldForceRelayoutChildren(bool b) { m_renderBlockShouldForceRelayoutChildren = b; }
+    void setRenderBlockHasRareData(bool b) { m_renderBlockHasRareData = b; }
     bool renderBlockHasMarginBeforeQuirk() const { return m_renderBlockHasMarginBeforeQuirk; }
     bool renderBlockHasMarginAfterQuirk() const { return m_renderBlockHasMarginAfterQuirk; }
     bool renderBlockShouldForceRelayoutChildren() const { return m_renderBlockShouldForceRelayoutChildren; }
+    bool renderBlockHasRareData() const { return m_renderBlockHasRareData; }
 
     void setRenderBlockFlowLineLayoutPath(unsigned u) { m_renderBlockFlowLineLayoutPath = u; }
     unsigned renderBlockFlowLineLayoutPath() const { return m_renderBlockFlowLineLayoutPath; }
@@ -406,12 +411,14 @@ private:
     unsigned m_renderBlockHasMarginAfterQuirk : 1;
     unsigned m_renderBlockShouldForceRelayoutChildren : 1;
     unsigned m_renderBlockFlowLineLayoutPath : 3;
+    unsigned m_renderBlockHasRareData : 1 { false };
+    unsigned m_renderBoxHasShapeOutsideInfo : 1 { false };
 
     unsigned m_isRegisteredForVisibleInViewportCallback : 1;
     unsigned m_visibleInViewportState : 2;
     unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
 
-    // 4 bits free.
+    // 2 bits free.
 
     RenderStyle m_style;
 };

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2162,6 +2162,8 @@ RenderObject::RenderObjectRareData& RenderObject::ensureRareData()
 
 void RenderObject::removeRareData()
 {
+    if (!hasRareData())
+        return;
     rareDataMap().remove(*this);
     m_stateBitfields.clearFlag(StateFlag::HasRareData);
 }

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -104,27 +104,9 @@ public:
 
     const Shape& computedShape() const;
 
-    static ShapeOutsideInfo& ensureInfo(const RenderBox& key)
-    {
-        InfoMap& infoMap = ShapeOutsideInfo::infoMap();
-        if (ShapeOutsideInfo* info = infoMap.get(key))
-            return *info;
-        auto result = infoMap.add(key, makeUnique<ShapeOutsideInfo>(key));
-        return *result.iterator->value;
-    }
-    static void removeInfo(const RenderBox& key) { infoMap().remove(key); }
-    static ShapeOutsideInfo* info(const RenderBox& key) { return infoMap().get(key); }
-
 private:
     LayoutUnit logicalTopOffset() const;
     LayoutUnit logicalLeftOffset() const;
-
-    using InfoMap = HashMap<SingleThreadWeakRef<const RenderBox>, std::unique_ptr<ShapeOutsideInfo>>;
-    static InfoMap& infoMap()
-    {
-        static NeverDestroyed<InfoMap> staticInfoMap;
-        return staticInfoMap;
-    }
 
     const RenderBox& m_renderer;
 


### PR DESCRIPTION
#### 53e6f169995e6029d4a238a424b13cf7ede55ad2
<pre>
Do not query HashMap at RenderObject destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=274192">https://bugs.webkit.org/show_bug.cgi?id=274192</a>
<a href="https://rdar.apple.com/128099684">rdar://128099684</a>

Reviewed by Alan Baradlay.

We found that a lot of HashMap lookups are used in RenderObject and its derived classes&apos; destruction.
This makes render tree teardown really costly since HashMap access is not so fast.

This patch wipes many of them by using some techniques.

1. We put m_renderBlockHasRareData and m_renderBoxHasShapeOutsideInfo flags to indicate whether these
   side data is materialized for this RenderBlock. As a result, we can skip querying to HashMap when
   this bit is not set.
2. RenderObject::removeRareData should check HasRareData flag before accessing to HashMap.
3. We are already using `HashMap&lt;SingleThreadWeakRef&lt;const T&gt;, U&gt;` much, but let&apos;s use SingleThreadWeakHashMap
   for that. As a result, for destruction, we do not need to query to this map. SingleThreadWeakHashMap will
   sweep dead ones in an amortized manner. This completely removes HashMap querying for each destruction.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::PositionedDescendantsMap::addDescendant):
(WebCore::PositionedDescendantsMap::removeDescendant):
(WebCore::PositionedDescendantsMap::removeContainingBlock):
(WebCore::PositionedDescendantsMap::positionedRenderers const):
(WebCore::RenderBlock::~RenderBlock):
(WebCore::RenderBlock::willBeDestroyed):
(WebCore::RenderBlock::getBlockRareData const):
(WebCore::RenderBlock::ensureBlockRareData):
(WebCore::RenderBlock::cachedEnclosingFragmentedFlow const):
(WebCore::RenderBlock::cachedEnclosingFragmentedFlowNeedsUpdate const):
(WebCore::RenderBlock::setCachedEnclosingFragmentedFlowNeedsUpdate):
(WebCore::RenderBlock::updateCachedEnclosingFragmentedFlow const):
(WebCore::RenderBlock::locateEnclosingFragmentedFlow const):
(WebCore::RenderBlock::paginationStrut const):
(WebCore::RenderBlock::pageLogicalOffset const):
(WebCore::RenderBlock::setPaginationStrut):
(WebCore::RenderBlock::setPageLogicalOffset):
(WebCore::RenderBlock::intrinsicBorderForFieldset const):
(WebCore::RenderBlock::setIntrinsicBorderForFieldset):
(WebCore::removeBlockFromPercentageDescendantAndContainerMaps): Deleted.
(WebCore::RenderBlock::blockWillBeDestroyed): Deleted.
(WebCore::RenderBlock::hasRareData const): Deleted.
(WebCore::RenderBlock::removeFromUpdateScrollInfoAfterLayoutTransaction): Deleted.
(WebCore::getBlockRareData): Deleted.
(WebCore::ensureBlockRareData): Deleted.
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::willBeDestroyed):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
(WebCore::RenderBox::updateShapeOutsideInfoAfterStyleChange):
(WebCore::RenderBox::overridingLogicalWidth const):
(WebCore::RenderBox::overridingLogicalHeight const):
(WebCore::RenderBox::overridingContainingBlockContentWidth const):
(WebCore::RenderBox::overridingContainingBlockContentHeight const):
(WebCore::RenderBox::overridingContainingBlockContentLogicalWidth const):
(WebCore::RenderBox::overridingContainingBlockContentLogicalHeight const):
(WebCore::RenderBox::overridingLogicalHeightLength const):
(WebCore::RenderBox::overridingLogicalWidthLength const):
(WebCore::RenderBox::imageChanged):
(WebCore::shapeOutsideInfoMap):
(WebCore::RenderBox::shapeOutsideInfo const):
(WebCore::RenderBox::ensureShapeOutsideInfo):
(WebCore::RenderBox::removeShapeOutsideInfo):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::shapeOutsideInfo const): Deleted.
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::setRenderBoxHasShapeOutsideInfo):
(WebCore::RenderElement::renderBoxHasShapeOutsideInfo const):
(WebCore::RenderElement::setRenderBlockHasRareData):
(WebCore::RenderElement::renderBlockHasRareData const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::removeRareData):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:

Canonical link: <a href="https://commits.webkit.org/278829@main">https://commits.webkit.org/278829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d49913e4ed2674397ad9412753988b4f61ab8e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42012 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1779 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56468 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49410 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48616 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28865 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7542 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->