### PR TITLE
[WebGL] Log KHR_debug messages to system console

### DIFF
--- a/LayoutTests/fast/canvas/webgl/debug-messages-to-console-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/debug-messages-to-console-expected.txt
@@ -1,0 +1,12 @@
+CONSOLE MESSAGE: WebGL: INVALID_VALUE: Insufficient buffer size.
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: Texture is immutable.
+CONSOLE MESSAGE: WebGL: INVALID_ENUM: Invalid enum provided.
+Test that messages output via KHR_debug extension are displayed in the JS console
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/debug-messages-to-console.html
+++ b/LayoutTests/fast/canvas/webgl/debug-messages-to-console.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<canvas></canvas>
+<script>
+jsTestIsAsync = true;
+description("Test that messages output via KHR_debug extension are displayed in the JS console");
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+internals.settings.setWebGLErrorsToConsoleEnabled(true);
+
+const canvas = document.querySelector("canvas");
+const gl = canvas.getContext("webgl2");
+
+const b = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, b);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, 32, gl.STREAM_DRAW);
+// CONSOLE MESSAGE: WebGL: INVALID_VALUE: Insufficient buffer size.
+gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 24, new ArrayBuffer(16));
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+
+// Invalid to respecify an immutable texture
+const texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, 32, 32);
+// CONSOLE MESSAGE: WebGL: INVALID_OPERATION: Texture is immutable.
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+// CONSOLE MESSAGE: WebGL: INVALID_ENUM: Invalid enum provided.
+gl.drawElements(0, 0, 0, 0);
+
+while (gl.getError() != 0)
+    /* empty */;
+setTimeout(() => { finishJSTest(); }, 50);
+</script>
+<body>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/index-validation-with-subsequent-draws.html
+++ b/LayoutTests/fast/canvas/webgl/index-validation-with-subsequent-draws.html
@@ -13,6 +13,9 @@
 if (window.testRunner)
     testRunner.dumpAsText();
 
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 // Boilerplate set-up.
 let canvas = document.getElementById('canvas1');
 let gl = canvas.getContext('webgl');

--- a/LayoutTests/fast/canvas/webgl/invalid-UTF-16.html
+++ b/LayoutTests/fast/canvas/webgl/invalid-UTF-16.html
@@ -12,6 +12,9 @@
 <script>
 description('This test verifies that the internal conversion from UTF16 to UTF8 is robust to invalid inputs. Any DOM entry point which converts an incoming string to UTF8 could be used for this test.');
 
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 var array = [];
 array.push(String.fromCharCode(0x48)); // H
 array.push(String.fromCharCode(0x69)); // i

--- a/LayoutTests/fast/canvas/webgl/largeBuffer-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/largeBuffer-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: WebGL: INVALID_VALUE: bufferData: size more than 32-bits
 PASS gl.getError() is 0
 PASS gl.getError() is 1281
 PASS size is 0

--- a/LayoutTests/fast/canvas/webgl/largeBuffer.html
+++ b/LayoutTests/fast/canvas/webgl/largeBuffer.html
@@ -4,6 +4,9 @@
 <body>
 <canvas></canvas>
 <script>
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 const canvas = document.querySelector("canvas");
 const gl = canvas.getContext("webgl");
 

--- a/LayoutTests/fast/canvas/webgl/webgl2-texStorage.html
+++ b/LayoutTests/fast/canvas/webgl/webgl2-texStorage.html
@@ -6,6 +6,9 @@
 <body>
 <canvas id="canvas" width="40" height="40"></canvas>
 <script>
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 description("Test that texStorage2D() works.");
 
 var canvas = document.getElementById("canvas");

--- a/LayoutTests/fast/canvas/webgl/webgl2-texture-upload-enums.html
+++ b/LayoutTests/fast/canvas/webgl/webgl2-texture-upload-enums.html
@@ -8,6 +8,9 @@
 <script>
 description("Test that glTexImage2D and glTexSubImage2D accept new WebGL 2 enum values");
 
+if (window.internal)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 var canvas = document.getElementById("canvas");
 var width = canvas.width;
 var height = canvas.height;

--- a/LayoutTests/http/wpt/webxr/resources/webxr_util.js
+++ b/LayoutTests/http/wpt/webxr/resources/webxr_util.js
@@ -232,6 +232,11 @@ async function loadChromiumResources() {
 }
 
 function setupWebKitWebXRTestAPI() {
+  // Disable output of WebGL errors to the JS console as these affect the
+  // expected results
+  if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
   // WebKit setup. The internals object is used by the WebKit test runner
   // to provide JS access to internal APIs. In this case it's used to
   // ensure that XRTest is only exposed to wpt tests.

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/resources/webxr_util.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/resources/webxr_util.js
@@ -232,6 +232,11 @@ async function loadChromiumResources() {
 }
 
 function setupWebKitWebXRTestAPI() {
+  // Disable output of WebGL errors to the JS console as these affect the
+  // expected results
+  if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
   // WebKit setup. The internals object is used by the WebKit test runner
   // to provide JS access to internal APIs. In this case it's used to
   // ensure that XRTest is only exposed to wpt tests.

--- a/LayoutTests/platform/wpe/fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies-expected.txt
+++ b/LayoutTests/platform/wpe/fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: Element value exceeds maximum element index.
 PASS: MAX_UINT index was unable to be simulated
 PASS: MAX_UINT index did not crash
 FAIL: Huge index did not fail validation

--- a/LayoutTests/webgl/webgl-allow-shared-expected.txt
+++ b/LayoutTests/webgl/webgl-allow-shared-expected.txt
@@ -1,13 +1,3 @@
-CONSOLE MESSAGE: WebGL: INVALID_ENUM: texImage2D: invalid texture type
-CONSOLE MESSAGE: WebGL: INVALID_ENUM: texSubImage2D: invalid texture type
-CONSOLE MESSAGE: WebGL: INVALID_ENUM: compressedTexImage2D: invalid format
-CONSOLE MESSAGE: WebGL: INVALID_ENUM: compressedTexSubImage2D: invalid format
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage3D: no texture bound to target
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage3D: no texture bound to target
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage3D: no texture bound to target
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: compressedTexImage3D: no texture bound to target
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: compressedTexSubImage3D: no texture bound to target
-CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage2D: ArrayBufferView not big enough for request
 
 
 PASS WebGL AllowShared

--- a/LayoutTests/webgl/webgl-allow-shared.html
+++ b/LayoutTests/webgl/webgl-allow-shared.html
@@ -9,6 +9,9 @@
 <canvas width="100" height="100"></canvas>
 <canvas width="100" height="100"></canvas>
 <script>
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 test(() => {
     const canvas = document.querySelectorAll('canvas')[0];
     const gl = canvas.getContext("webgl");

--- a/LayoutTests/webgl/webgl-multi-draw-noop.html
+++ b/LayoutTests/webgl/webgl-multi-draw-noop.html
@@ -9,6 +9,10 @@ if (window.testRunner) {
   testRunner.waitUntilDone();
   window.testRunner.dumpAsText();
 }
+
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
 let canvas = document.createElement('canvas');
 let ctx = canvas.getContext('webgl');
 let multiDraw = ctx.getExtension('WEBGL_multi_draw');

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -458,7 +458,8 @@ public:
     void vertexAttribDivisor(GCGLuint index, GCGLuint divisor);
 
     // GraphicsContextGL::Client
-    void forceContextLost() override;
+    void forceContextLost() final;
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const String&) final;
 
     void recycleContext();
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -950,6 +950,22 @@ public:
     static constexpr GCGLenum VARIABLE_RASTERIZATION_RATE_ANGLE = 0x96BC;
     static constexpr GCGLenum METAL_RASTERIZATION_RATE_MAP_BINDING_ANGLE = 0x96BD;
 
+    // GL_KHR_debug
+    static constexpr GCGLenum DEBUG_OUTPUT = 0x92E0;
+    static constexpr GCGLenum DEBUG_OUTPUT_SYNCHRONOUS = 0x8242;
+    static constexpr GCGLenum DEBUG_TYPE_ERROR = 0x824C;
+    static constexpr GCGLenum DEBUG_TYPE_DEPRECATED_BEHAVIOR = 0x824D;
+    static constexpr GCGLenum DEBUG_TYPE_UNDEFINED_BEHAVIOR = 0x824E;
+    static constexpr GCGLenum DEBUG_TYPE_PORTABILITY = 0x824F;
+    static constexpr GCGLenum DEBUG_TYPE_PERFORMANCE = 0x8250;
+    static constexpr GCGLenum DEBUG_TYPE_OTHER = 0x8251;
+    static constexpr GCGLenum DEBUG_TYPE_MARKER = 0x8268;
+    static constexpr GCGLenum DEBUG_SEVERITY_HIGH = 0x9146;
+    static constexpr GCGLenum DEBUG_SEVERITY_MEDIUM = 0x9147;
+    static constexpr GCGLenum DEBUG_SEVERITY_LOW = 0x9148;
+    static constexpr GCGLenum DEBUG_SEVERITY_NOTIFICATION = 0x826B;
+    static constexpr GCGLenum DEBUG_SOURCE_API = 0x8246;
+
     // Attempt to enumerate all possible native image formats to
     // reduce the amount of temporary allocations during texture
     // uploading. This enum must be public because it is accessed
@@ -1193,6 +1209,7 @@ public:
         WEBCORE_EXPORT Client();
         WEBCORE_EXPORT virtual ~Client();
         virtual void forceContextLost() = 0;
+        virtual void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const String&) = 0;
     };
 
     WEBCORE_EXPORT GraphicsContextGL(GraphicsContextGLAttributes);

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -401,6 +401,7 @@ bool GraphicsContextGLCocoa::platformInitialize()
 GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
 {
     if (makeContextCurrent()) {
+        GL_Disable(DEBUG_OUTPUT);
         if (m_texture)
             GL_DeleteTextures(1, &m_texture);
         if (m_multisampleColorBuffer)

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -65,6 +65,8 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
     if (!makeContextCurrent())
         return;
 
+    GL_Disable(DEBUG_OUTPUT);
+
     if (m_texture)
         GL_DeleteTextures(1, &m_texture);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -166,6 +166,12 @@ void RemoteGraphicsContextGL::forceContextLost()
     send(Messages::RemoteGraphicsContextGLProxy::WasLost());
 }
 
+void RemoteGraphicsContextGL::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const String& message)
+{
+    assertIsCurrent(workQueue());
+    send(Messages::RemoteGraphicsContextGLProxy::addDebugMessage(type, id, severity, message));
+}
+
 void RemoteGraphicsContextGL::reshape(int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -106,6 +106,7 @@ protected:
 
     // GraphicsContextGL::Client overrides.
     void forceContextLost() final;
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const String&) final;
 
     // Messages to be received.
     void ensureExtensionEnabled(String&&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -437,7 +437,14 @@ void RemoteGraphicsContextGLProxy::wasLost()
     if (isContextLost())
         return;
     markContextLost();
+}
 
+void RemoteGraphicsContextGLProxy::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, String&& message)
+{
+    if (isContextLost())
+        return;
+    if (m_client)
+        m_client->addDebugMessage(type, id, severity, WTFMove(message));
 }
 
 void RemoteGraphicsContextGLProxy::markContextLost()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -404,6 +404,7 @@ private:
     // Messages to be received.
     void wasCreated(IPC::Semaphore&&, IPC::Semaphore&&, std::optional<RemoteGraphicsContextGLInitializationState>&&);
     void wasLost();
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, String&&);
 
     void readPixelsSharedMemory(WebCore::IntRect, GCGLenum format, GCGLenum type, std::span<uint8_t> data);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
@@ -25,6 +25,7 @@
 messages -> RemoteGraphicsContextGLProxy NotRefCounted {
     void WasCreated(IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore, std::optional<WebKit::RemoteGraphicsContextGLInitializationState> initializationState) CanDispatchOutOfOrder
     void WasLost()
+    void addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, String message) CanDispatchOutOfOrder
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -44,6 +44,7 @@ namespace {
 class MockGraphicsContextGLClient final : public WebCore::GraphicsContextGL::Client {
 public:
     void forceContextLost() final { ++m_contextLostCalls; }
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const String&) final { }
 
     int contextLostCalls() { return m_contextLostCalls; }
 private:


### PR DESCRIPTION
#### 8e4c281fd16129e538ce75fa7c6bf0f427ed882d
<pre>
[WebGL] Log KHR_debug messages to system console
<a href="https://bugs.webkit.org/show_bug.cgi?id=274197">https://bugs.webkit.org/show_bug.cgi?id=274197</a>
<a href="https://rdar.apple.com/128107146">rdar://128107146</a>

Reviewed by Kimmo Kinnunen and Mike Wyrzykowski.

To aid debugging WebGL apps, surface debug messages generated by the KHR_debug
extension for the GL_DEBUG_SOURCE_API message source to the system
console. Errors are formatted in the same manner as other errors resulting from
WebGL operations, where as all other message types are formatted as informational.

* LayoutTests/fast/canvas/webgl/debug-messages-to-console-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/debug-messages-to-console.html: Added.
* LayoutTests/fast/canvas/webgl/index-validation-with-subsequent-draws.html:
* LayoutTests/fast/canvas/webgl/invalid-UTF-16.html:
* LayoutTests/fast/canvas/webgl/largeBuffer.html:
* LayoutTests/fast/canvas/webgl/webgl2-texStorage.html:
* LayoutTests/webgl/webgl-allow-shared.html:
* LayoutTests/webgl/webgl-multi-draw-noop.html:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::glEnumToErrorCode):
(WebCore::resolveGraphicsContextGLAttributes):
(WebCore::debugMessageTypeToString):
(WebCore::debugMessageSeverityToString):
(WebCore::WebGLRenderingContextBase::addDebugMessage):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::addDebugMessage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::wasLost):
(WebKit::RemoteGraphicsContextGLProxy::addDebugMessage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/279786@main">https://commits.webkit.org/279786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d115a6cc047fa1a3a65de1f757b91cfddb57e36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44102 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3484 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4499 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3339 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59335 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4873 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51527 "Found 1 new test failure: imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50897 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31831 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8070 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->