### PR TITLE
Rename CoreAudioSharedInternalUnit::m_ioUnit to m_audioUnit

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -88,7 +88,7 @@ private:
     OSStatus defaultInputDevice(uint32_t*) final;
     OSStatus defaultOutputDevice(uint32_t*) final;
 
-    CoreAudioSharedUnit::StoredAudioUnit m_ioUnit;
+    CoreAudioSharedUnit::StoredAudioUnit m_audioUnit;
     bool m_shouldUseVPIO { false };
 };
 
@@ -152,8 +152,8 @@ Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioShared
     return result;
 }
 
-CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit(CoreAudioSharedUnit::StoredAudioUnit&& ioUnit, bool shouldUseVPIO)
-    : m_ioUnit(WTFMove(ioUnit))
+CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit(CoreAudioSharedUnit::StoredAudioUnit&& audioUnit, bool shouldUseVPIO)
+    : m_audioUnit(WTFMove(audioUnit))
     , m_shouldUseVPIO(shouldUseVPIO)
 {
 }
@@ -162,43 +162,43 @@ CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit()
 {
 #if PLATFORM(MAC)
     if (m_shouldUseVPIO)
-        CoreAudioSharedUnit::unit().setStoredVPIOUnit(std::exchange(m_ioUnit, { }));
+        CoreAudioSharedUnit::unit().setStoredVPIOUnit(std::exchange(m_audioUnit, { }));
 #endif
 }
 
 OSStatus CoreAudioSharedInternalUnit::initialize()
 {
-    return PAL::AudioUnitInitialize(m_ioUnit.get());
+    return PAL::AudioUnitInitialize(m_audioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::uninitialize()
 {
-    return PAL::AudioUnitUninitialize(m_ioUnit.get());
+    return PAL::AudioUnitUninitialize(m_audioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::start()
 {
-    return PAL::AudioOutputUnitStart(m_ioUnit.get());
+    return PAL::AudioOutputUnitStart(m_audioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::stop()
 {
-    return PAL::AudioOutputUnitStop(m_ioUnit.get());
+    return PAL::AudioOutputUnitStop(m_audioUnit.get());
 }
 
 OSStatus CoreAudioSharedInternalUnit::set(AudioUnitPropertyID propertyID, AudioUnitScope scope, AudioUnitElement element, const void* value, UInt32 size)
 {
-    return PAL::AudioUnitSetProperty(m_ioUnit.get(), propertyID, scope, element, value, size);
+    return PAL::AudioUnitSetProperty(m_audioUnit.get(), propertyID, scope, element, value, size);
 }
 
 OSStatus CoreAudioSharedInternalUnit::get(AudioUnitPropertyID propertyID, AudioUnitScope scope, AudioUnitElement element, void* value, UInt32* size)
 {
-    return PAL::AudioUnitGetProperty(m_ioUnit.get(), propertyID, scope, element, value, size);
+    return PAL::AudioUnitGetProperty(m_audioUnit.get(), propertyID, scope, element, value, size);
 }
 
 OSStatus CoreAudioSharedInternalUnit::render(AudioUnitRenderActionFlags* ioActionFlags, const AudioTimeStamp* inTimeStamp, UInt32 inOutputBusNumber, UInt32 inNumberFrames, AudioBufferList* list)
 {
-    return PAL::AudioUnitRender(m_ioUnit.get(), ioActionFlags, inTimeStamp, inOutputBusNumber, inNumberFrames, list);
+    return PAL::AudioUnitRender(m_audioUnit.get(), ioActionFlags, inTimeStamp, inOutputBusNumber, inNumberFrames, list);
 }
 
 OSStatus CoreAudioSharedInternalUnit::defaultInputDevice(uint32_t* deviceID)


### PR DESCRIPTION
#### db277866eade69b4c06fcb17b61dc3aeb679cba9
<pre>
Rename CoreAudioSharedInternalUnit::m_ioUnit to m_audioUnit
<a href="https://bugs.webkit.org/show_bug.cgi?id=274200">https://bugs.webkit.org/show_bug.cgi?id=274200</a>
<a href="https://rdar.apple.com/128111716">rdar://128111716</a>

Reviewed by Eric Carlson.

CoreAudioSharedInternalUnit::m_ioUnit is conflicting with CoreAudioSharedUnit:m_ioUnit which makes the code less easy to read/search.
Renaming CoreAudioSharedInternalUnit::m_ioUnit to CoreAudioSharedInternalUnit::m_audioUnit instead.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedInternalUnit::initialize):
(WebCore::CoreAudioSharedInternalUnit::uninitialize):
(WebCore::CoreAudioSharedInternalUnit::start):
(WebCore::CoreAudioSharedInternalUnit::stop):
(WebCore::CoreAudioSharedInternalUnit::set):
(WebCore::CoreAudioSharedInternalUnit::get):
(WebCore::CoreAudioSharedInternalUnit::render):

Canonical link: <a href="https://commits.webkit.org/278852@main">https://commits.webkit.org/278852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24411473e4133625fca78e062eaf558a647a95bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23130 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25851 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1767 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56459 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48601 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11313 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->