### PR TITLE
Reduce VPIO destruction timer delay to the delay applied to capture indicators

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -263,7 +263,7 @@ void CoreAudioSharedUnit::setStoredVPIOUnit(StoredAudioUnit&& unit)
 {
     RELEASE_LOG(WebRTC, "CoreAudioSharedUnit::setStoredVPIOUnit");
 
-    static constexpr Seconds delayBeforeStoredVPIOUnitDeallocation = 60_s;
+    static constexpr Seconds delayBeforeStoredVPIOUnitDeallocation = 3_s;
     m_storedVPIOUnit = WTFMove(unit);
     m_storedVPIOUnitDeallocationTimer.startOneShot(delayBeforeStoredVPIOUnitDeallocation);
 }


### PR DESCRIPTION
#### a6b4a4b6fc0ee708c282a831b4f87a171c69063a
<pre>
Reduce VPIO destruction timer delay to the delay applied to capture indicators
<a href="https://bugs.webkit.org/show_bug.cgi?id=274201">https://bugs.webkit.org/show_bug.cgi?id=274201</a>
<a href="https://rdar.apple.com/128111934">rdar://128111934</a>

Reviewed by Eric Carlson.

We keep VPIO unit to reuse it in case page stops capture and restarts capture very quickly.
We do not need a long timer of 60 seconds, we reduce it to 3 seconds, which is the equivalent delay when capture indicator goes from live to not capturing.
This will further reduce the drawback of having an allocated but unused VPIO unit.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::setStoredVPIOUnit):

Canonical link: <a href="https://commits.webkit.org/278850@main">https://commits.webkit.org/278850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa9f63c034f47b9d745b67ab8c5968754ca21768

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42003 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1768 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56461 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1733 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49401 "Found 7 new test failures: imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https.html?client, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rg32f-rg-float.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r16f-red-float.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r16f-red-half_float.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rg16f-rg-float.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rg8ui-rg_integer-unsigned_byte.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rgb565-rgb-unsigned_short_5_6_5.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48602 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->