### PR TITLE
Fix PlayStation build following 278797@main

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -109,7 +109,7 @@ void CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyR
 size_t CanvasBase::memoryCost() const
 {
     // May be called from GC threads.
-    return m_imageBufferMemoryCost.load(std::memory_order::relaxed);
+    return m_imageBufferMemoryCost.load(std::memory_order_relaxed);
 }
 
 #if ENABLE(RESOURCE_USAGE)
@@ -259,7 +259,7 @@ RefPtr<ImageBuffer> CanvasBase::setImageBuffer(RefPtr<ImageBuffer>&& buffer) con
     RefPtr returnBuffer = std::exchange(m_imageBuffer, WTFMove(buffer));
 
     IntSize oldSize = m_size;
-    size_t oldMemoryCost = m_imageBufferMemoryCost.load(std::memory_order::relaxed);
+    size_t oldMemoryCost = m_imageBufferMemoryCost.load(std::memory_order_relaxed);
     size_t newMemoryCost = 0;
     if (m_imageBuffer) {
         m_size = m_imageBuffer->truncatedLogicalSize();
@@ -269,7 +269,7 @@ RefPtr<ImageBuffer> CanvasBase::setImageBuffer(RefPtr<ImageBuffer>&& buffer) con
         m_imageBuffer->context().setStrokeThickness(1);
         m_contextStateSaver = makeUnique<GraphicsContextStateSaver>(m_imageBuffer->context());
     }
-    m_imageBufferMemoryCost.store(newMemoryCost, std::memory_order::relaxed);
+    m_imageBufferMemoryCost.store(newMemoryCost, std::memory_order_relaxed);
     if (newMemoryCost) {
         JSC::JSLockHolder lock(scriptExecutionContext()->vm());
         scriptExecutionContext()->vm().heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), newMemoryCost);


### PR DESCRIPTION
#### ced686d42f0a56cf0854f4960775465e25136a34
<pre>
Fix PlayStation build following 278797@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=274205">https://bugs.webkit.org/show_bug.cgi?id=274205</a>

Unreviewed build fix.

C++20 makes std::memory_order an enum class, which is pretty,
but the enum itself already existed, so we can use its values directly for greater compatibility.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::memoryCost const):
(WebCore::CanvasBase::setImageBuffer const):
std::memory_order::relaxed -&gt; std::memory_order_relaxed

Canonical link: <a href="https://commits.webkit.org/278806@main">https://commits.webkit.org/278806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ef0fd23600547d39599e77cfc9a2e0b21648db5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42007 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1772 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47815 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1863 "Found 1 new test failure: imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49405 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48606 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11294 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28859 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7527 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->