### PR TITLE
AVVideoCaptureSource is slower due to resolution reconfiguration happening when session is running

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -182,7 +182,6 @@ private:
     bool m_interrupted { false };
     bool m_isRunning { false };
     bool m_hasBegunConfigurationForConstraints { false };
-    bool m_needsResolutionReconfiguration { false };
     bool m_needsTorchReconfiguration { false };
     bool m_needsWhiteBalanceReconfiguration { false };
 

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -833,11 +833,6 @@ void AVVideoCaptureSource::setSessionSizeFrameRateAndZoom()
 
     ASSERT(m_currentPreset->format());
 
-    if (!m_isRunning) {
-        m_needsResolutionReconfiguration = true;
-        return;
-    }
-
     if (!lockForConfiguration())
         return;
 
@@ -1192,13 +1187,10 @@ void AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto(RetainPtr<AVCap
 
 void AVVideoCaptureSource::reconfigureIfNeeded()
 {
-    if (!m_isRunning || (!m_needsResolutionReconfiguration && !m_needsTorchReconfiguration && !m_needsWhiteBalanceReconfiguration))
+    if (!m_isRunning || (!m_needsTorchReconfiguration && !m_needsWhiteBalanceReconfiguration))
         return;
 
     beginConfiguration();
-
-    if (std::exchange(m_needsResolutionReconfiguration, false))
-        setSessionSizeFrameRateAndZoom();
 
     if (std::exchange(m_needsTorchReconfiguration, false))
         updateTorch();


### PR DESCRIPTION
#### 87d9f26a3a2ea1b59dbbeef61603a21972757f76
<pre>
AVVideoCaptureSource is slower due to resolution reconfiguration happening when session is running
<a href="https://bugs.webkit.org/show_bug.cgi?id=274206">https://bugs.webkit.org/show_bug.cgi?id=274206</a>
<a href="https://rdar.apple.com/128113983">rdar://128113983</a>

Reviewed by Eric Carlson.

Before <a href="https://commits.webkit.org/276773@main">https://commits.webkit.org/276773@main</a>, we were configuring the session before running it.
This caused issues with torch, so we decided to configure once the session was running.
This is triggering a perf issue as configuring the resolution takes time, 0.5 seconds on macOS.
To go back to a good start time, we partially revert <a href="https://commits.webkit.org/276773@main">https://commits.webkit.org/276773@main</a>,
by configuring the resolution and frame rate before starting the session.
We continue to configure once the session is running for torch and white balance.

Manually tested.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setSessionSizeFrameRateAndZoom):
(WebCore::AVVideoCaptureSource::reconfigureIfNeeded):

Canonical link: <a href="https://commits.webkit.org/278853@main">https://commits.webkit.org/278853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d44ffa202d5c5244a353fe3b525aa83dcc73b60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1982 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42010 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/nosniff/parsing-nosniff.window.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1778 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56467 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48612 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->