### PR TITLE
Resuming audio playing of HTMLMediaElement via AudioContext does not work if user switched from tab

### DIFF
--- a/LayoutTests/webaudio/audiomix-bufferingpolicy-expected.txt
+++ b/LayoutTests/webaudio/audiomix-bufferingpolicy-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Validate that web audio media element source is working when moving out of MakeResourcesPurgeable buffering policy
+

--- a/LayoutTests/webaudio/audiomix-bufferingpolicy.html
+++ b/LayoutTests/webaudio/audiomix-bufferingpolicy.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <audio id=audioIn controls loop autoplay></audio>
+    <audio id=audioOut controls autoplay></audio>
+    <script>
+promise_test(async () => {
+    audioIn.src = "resources/media/128kbps-44khz.mp3";
+    audioIn.load();
+
+    const audioContext = new AudioContext();
+    const audioSourceNode = audioContext.createMediaElementSource(audioIn);
+    const mediaStreamDestination = audioContext.createMediaStreamDestination();
+    audioSourceNode.connect(mediaStreamDestination);
+
+    audioOut.srcObject = mediaStreamDestination.stream;
+
+     audioContext.resume();
+     await audioIn.play();
+     await audioOut.play();
+
+     await new Promise(resolve => audioIn.ontimeupdate = resolve);
+
+     audioIn.pause();
+     audioOut.pause();
+
+     await new Promise(resolve => setTimeout(resolve, 50));
+
+     if (window.internals) {
+          // change buffering policy
+          const policy = internals.elementBufferingPolicy(audioIn);
+          internals.setMediaElementBufferingPolicy(audioIn, "MakeResourcesPurgeable");
+          internals.setMediaElementBufferingPolicy(audioIn, policy);
+     }
+
+     audioContext.resume();
+     await audioIn.play();
+     await audioOut.play();
+
+     let counter = 0;
+     return new Promise((resolve, reject) => {
+         setTimeout(() => reject("ontimeupdate event test timed out"), 5000);
+         audioIn.ontimeupdate = () => {
+             if (counter++ > 5)
+                 resolve();
+         }
+     });
+}, "Validate that web audio media element source is working when moving out of MakeResourcesPurgeable buffering policy");
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -311,7 +311,7 @@ public:
 #endif
 
     using HTMLMediaElementEnums::BufferingPolicy;
-    void setBufferingPolicy(BufferingPolicy);
+    WEBCORE_EXPORT void setBufferingPolicy(BufferingPolicy);
     WEBCORE_EXPORT BufferingPolicy bufferingPolicy() const;
     WEBCORE_EXPORT void purgeBufferedDataIfPossible();
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -67,6 +67,8 @@ public:
     using ConfigureAudioStorageCallback = Function<std::unique_ptr<CARingBuffer>(const CAAudioStreamDescription&, size_t frameCount)>;
     WEBCORE_EXPORT void setConfigureAudioStorageCallback(ConfigureAudioStorageCallback&&);
 
+    void recreateAudioMixIfNeeded();
+
 private:
     AudioSourceProviderAVFObjC(AVPlayerItem *);
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -175,6 +175,15 @@ void AudioSourceProviderAVFObjC::setAudioTrack(AVAssetTrack *avAssetTrack)
     createMixIfNeeded();
 }
 
+void AudioSourceProviderAVFObjC::recreateAudioMixIfNeeded()
+{
+    if (!m_avAudioMix)
+        return;
+
+    destroyMixIfNeeded();
+    createMixIfNeeded();
+}
+
 void AudioSourceProviderAVFObjC::destroyMixIfNeeded()
 {
     if (!m_avAudioMix)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4433,6 +4433,27 @@ String Internals::elementBufferingPolicy(HTMLMediaElement& element)
     return "UNKNOWN"_s;
 }
 
+void Internals::setMediaElementBufferingPolicy(HTMLMediaElement& element, const String& policy)
+{
+    if (policy == "Default"_s) {
+        element.setBufferingPolicy(MediaPlayer::BufferingPolicy::Default);
+        return;
+    }
+    if (policy == "LimitReadAhead"_s) {
+        element.setBufferingPolicy(MediaPlayer::BufferingPolicy::LimitReadAhead);
+        return;
+    }
+    if (policy == "MakeResourcesPurgeable"_s) {
+        element.setBufferingPolicy(MediaPlayer::BufferingPolicy::MakeResourcesPurgeable);
+        return;
+    }
+    if (policy == "PurgeResources"_s) {
+        element.setBufferingPolicy(MediaPlayer::BufferingPolicy::PurgeResources);
+        return;
+    }
+    ASSERT_NOT_REACHED();
+}
+
 ExceptionOr<void> Internals::setOverridePreferredDynamicRangeMode(HTMLMediaElement& element, const String& modeString)
 {
     DynamicRangeMode mode;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -765,6 +765,7 @@ public:
 
     bool elementShouldBufferData(HTMLMediaElement&);
     String elementBufferingPolicy(HTMLMediaElement&);
+    void setMediaElementBufferingPolicy(HTMLMediaElement&, const String&);
     double privatePlayerVolume(const HTMLMediaElement&);
     bool privatePlayerMuted(const HTMLMediaElement&);
     bool isMediaElementHidden(const HTMLMediaElement&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -897,6 +897,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     [Conditional=VIDEO] boolean elementShouldBufferData(HTMLMediaElement media);
     [Conditional=VIDEO] DOMString elementBufferingPolicy(HTMLMediaElement media);
+    [Conditional=VIDEO] undefined setMediaElementBufferingPolicy(HTMLMediaElement element, DOMString policy);
     [Conditional=VIDEO] double privatePlayerVolume(HTMLMediaElement media);
     [Conditional=VIDEO] boolean privatePlayerMuted(HTMLMediaElement media);
     [Conditional=VIDEO] boolean isMediaElementHidden(HTMLMediaElement media);


### PR DESCRIPTION
#### b1479358ffa916a136356f5ded70b22f22a1b7c2
<pre>
Resuming audio playing of HTMLMediaElement via AudioContext does not work if user switched from tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=270352">https://bugs.webkit.org/show_bug.cgi?id=270352</a>
<a href="https://rdar.apple.com/123901202">rdar://123901202</a>

Reviewed by Eric Carlson.

When switching from one tab to the other, we are setting AVPlayer resourceConservationLevelWhilePaused to AVPlayerResourceConservationLevelReuseActivePlayerResources.
When getting back to the tab, we set it back to AVPlayerResourceConservationLevelNone.
But the AVPlayer audio mix is not functional anymore.

We implement a workaround at WebKit level by recreating the audio mix if needed whenever moving out of AVPlayerResourceConservationLevelReuseActivePlayerResources.

Covered by added test.

* LayoutTests/webaudio/audiomix-bufferingpolicy-expected.txt: Added.
* LayoutTests/webaudio/audiomix-bufferingpolicy.html: Added.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::recreateAudioMixIfNeeded):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::setBufferingPolicy):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setMediaElementelementBufferingPolicy):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/278859@main">https://commits.webkit.org/278859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35249ce46caa61b99df3087f269eb4c30c071476

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2146 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23245 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1909 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56620 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1876 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49517 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44737 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11318 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->