### PR TITLE
[iOS] Camera track is sometimes muted/unmuted when starting to capture

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -138,6 +138,9 @@ private:
 
     void updateVerifyCapturingTimer();
     void verifyIsCapturing();
+#if PLATFORM(IOS_FAMILY)
+    void startupTimerFired();
+#endif
 
     std::optional<double> computeMinZoom() const;
     std::optional<double> computeMaxZoom(AVCaptureDeviceFormat*) const;
@@ -188,6 +191,10 @@ private:
     static constexpr Seconds verifyCaptureInterval = 30_s;
     static const uint64_t framesToDropWhenStarting = 4;
 
+#if PLATFORM(IOS_FAMILY)
+    bool m_shouldCallNotifyMutedChange { false };
+    Timer m_startupTimer;
+#endif
     Timer m_verifyCapturingTimer;
     uint64_t m_framesCount { 0 };
     uint64_t m_lastFramesCount { 0 };


### PR DESCRIPTION
#### da808677339de833db3e1d36ca34dda8464b4638
<pre>
[iOS] Camera track is sometimes muted/unmuted when starting to capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=274211">https://bugs.webkit.org/show_bug.cgi?id=274211</a>
<a href="https://rdar.apple.com/125475254">rdar://125475254</a>

Reviewed by Eric Carlson.

There is a race condition below WebKit between media endowment activation and camera start-u.
This sometimes triggers spurious notification of being muted on iOS.
We add a timer that will delay mute notifications at startup time for 1 second.

Manually tested.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::AVVideoCaptureSource):
(WebCore::AVVideoCaptureSource::startupTimerFired):
(WebCore::AVVideoCaptureSource::startProducingData):
(WebCore::AVVideoCaptureSource::captureSessionIsRunningDidChange):

Canonical link: <a href="https://commits.webkit.org/278952@main">https://commits.webkit.org/278952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/487705fc95ade9997d88320f043a92f5b7da7c42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4294 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55193 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2334 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/55193 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28901 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44797 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/55193 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26225 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2067 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 7 pre-existing failure based on results-db; Running upload-test-results") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/812 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48074 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2156 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56784 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27047 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2109 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/56784 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28284 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/56784 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11391 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29185 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->