### PR TITLE
[WGSL] Add type checking for compound assignment

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/compound-assignment.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/compound-assignment.wgsl
@@ -1,0 +1,16 @@
+// RUN: %not %wgslc | %check
+
+@compute
+fn main() {
+  {
+    // CHECK-L: no matching overload for operator +(ref<function, i32, read_write>, f32)
+    var x = 1;
+    x += 1f;
+  }
+
+  {
+    // CHECK-L: cannot assign to a value of type 'i32'
+    let x = 1;
+    x += 1;
+  }
+}

--- a/Source/WebGPU/WGSL/tests/valid/fuzz-127229681.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fuzz-127229681.wgsl
@@ -47,76 +47,76 @@ fn f() -> u32 {
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ = x[0];
         _ =& x[-1];
      ;
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ =& x[-1];
      ;
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ =& x[-1];
      ;
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
     { let x = (zptr);
  _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ = x[0];
         _ =& x[-1];
      ;
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ =& x[-1];
      ;
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ =& x[-1];
      ;
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
-        _ = x[0];
-        _ = x[0];
-        _ =& x[-1];
-     ;
-y/=*(zptr);
-        _ = x[0];
-    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
- }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ = x[0];
         _ =& x[-1];
      ;
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y.x[0]/=(*(zptr))[0].x[0];
+        _ = x[0];
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
         _ = x[0];
     { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
  }
-y/=*(zptr);
+y.x[0]/=(*(zptr))[0].x[0];
         _ = x[0];
     return x1 +2;
     return x1 +2;

--- a/Source/WebGPU/WGSL/tests/valid/pack-unpack.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pack-unpack.wgsl
@@ -1,4 +1,5 @@
-// RUN: %metal-compile main 2>&1| %check
+// RUN: %metal-compile main
+// RUN: %metal main | %check
 
 @compute @workgroup_size(1)
 fn main()


### PR DESCRIPTION
#### 47944ff1d4a0313a1e1581a58e11b1a3a067735c
<pre>
[WGSL] Add type checking for compound assignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=274212">https://bugs.webkit.org/show_bug.cgi?id=274212</a>
<a href="https://rdar.apple.com/128064852">rdar://128064852</a>

Reviewed by Mike Wyrzykowski.

Resolve a long standing fixme and add type checking for the compound assignments
by sharing the code with binary expressions.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::binaryExpression):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/tests/invalid/compound-assignment.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/fuzz-127229681.wgsl:
* Source/WebGPU/WGSL/tests/valid/pack-unpack.wgsl:

Canonical link: <a href="https://commits.webkit.org/278848@main">https://commits.webkit.org/278848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc8fd9755f5a3321fb056dab11243ef2b12c3c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2325 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42032 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23158 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25893 "Found unexpected failure with change (failure)") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56491 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49433 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11312 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->