### PR TITLE
[Unified Text Replacement] [iOS] Add SPI to WKWebViewConfiguration to configure unified text replacement behavior

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -400,6 +400,8 @@ struct PerWebProcessState {
 - (void)_textReplacementSession:(NSUUID *)sessionUUID updateState:(WebKit::WebTextReplacementDataState)state forReplacementWithUUID:(NSUUID *)replacementUUID;
 - (void)_addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType;
 - (void)_removeTextIndicatorStyleForID:(NSUUID *)uuid;
+
+- (BOOL)_wantsCompleteUnifiedTextReplacementBehavior;
 #endif
 
 - (void)_internalDoAfterNextPresentationUpdate:(void (^)(void))updateBlock withoutWaitingForPainting:(BOOL)withoutWaitingForPainting withoutWaitingForAnimatedResize:(BOOL)withoutWaitingForAnimatedResize;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1235,6 +1235,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
 }
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+- (BOOL)_web_wantsCompleteUnifiedTextReplacementBehavior
+{
+    return [self _wantsCompleteUnifiedTextReplacementBehavior];
+}
+#endif
+
 #if ENABLE(DRAG_SUPPORT)
 
 - (WKDragDestinationAction)_web_dragDestinationActionForDraggingInfo:(id <NSDraggingInfo>)draggingInfo

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4425,7 +4425,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     if (action == @selector(_swapCharacters:))
-        return editorState.isContentRichlyEditable && [super canPerformAction:action withSender:sender];
+        return [self unifiedTextReplacementBehavior] != WebKit::WebUnifiedTextReplacementBehavior::None && [super canPerformAction:action withSender:sender];
 #endif
 
     if (action == @selector(paste:) || action == @selector(_pasteAsQuotation:) || action == @selector(_pasteAndMatchStyle:) || action == @selector(pasteAndMatchStyle:)) {
@@ -6912,6 +6912,10 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
         return _focusedElementInformation.isWritingSuggestionsEnabled;
     }();
     traits.inlinePredictionType = allowsInlinePredictions ? UITextInlinePredictionTypeDefault : UITextInlinePredictionTypeNo;
+#endif
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    [self _updateTextInputTraitsForUnifiedTextReplacement:traits];
 #endif
 
     [self _updateTextInputTraitsForInteractionTintColor];
@@ -11728,6 +11732,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 }
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+
 - (void)addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType
 {
     if (!_page->preferences().textIndicatorStylingEnabled())
@@ -11749,6 +11754,12 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
     [_textStyleManager removeTextIndicatorStyleForID:uuid];
 }
+
+- (WebKit::WebUnifiedTextReplacementBehavior)unifiedTextReplacementBehavior
+{
+    return _page->configuration().unifiedTextReplacementBehavior();
+}
+
 #endif
 
 #if HAVE(UIFINDINTERACTION)

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
@@ -31,6 +31,10 @@
 #import "WKBrowserEngineDefinitions.h"
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/UnifiedTextReplacementAdditions.h>
+#endif
+
 @interface WKExtendedTextInputTraits : NSObject
 #if USE(BROWSERENGINEKIT)
     <BEExtendedTextInputTraits>
@@ -58,6 +62,10 @@
 @property (nonatomic, strong) UIColor *insertionPointColor;
 @property (nonatomic, strong) UIColor *selectionHandleColor;
 @property (nonatomic, strong) UIColor *selectionHighlightColor;
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/WKExtendedTextInputTraitsAdditions.h>
+#endif
 
 - (void)setSelectionColorsToMatchTintColor:(UIColor *)tintColor;
 - (void)restoreDefaultValues;

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -130,7 +130,15 @@
     self.insertionPointColor = nil;
     self.selectionHandleColor = nil;
     self.selectionHighlightColor = nil;
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    [self restoreDefaultUnifiedTextReplacementBehaviorValue];
+#endif
 }
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/WKExtendedTextInputTraitsAdditions.mm>
+#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -159,6 +159,10 @@ struct TranslationContextMenuInfo;
 - (void)_didHandleAcceptedCandidate;
 - (void)_didUpdateCandidateListVisibility:(BOOL)visible;
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+- (BOOL)_web_wantsCompleteUnifiedTextReplacementBehavior;
+#endif
+
 @end
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4613,11 +4613,6 @@ void WebViewImpl::removeTextPlaceholder(NSTextPlaceholder *placeholder, bool wil
 }
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-bool WebViewImpl::wantsCompleteUnifiedTextReplacementBehavior() const
-{
-    return isEditable() || unifiedTextReplacementBehavior() == WebUnifiedTextReplacementBehavior::Complete;
-}
-
 void WebViewImpl::addTextIndicatorStyleForID(WTF::UUID uuid, WKTextIndicatorStyleType styleType)
 {
     if (!m_page->preferences().textIndicatorStylingEnabled())
@@ -6435,6 +6430,11 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
 WebUnifiedTextReplacementBehavior WebViewImpl::unifiedTextReplacementBehavior() const
 {
     return m_page->configuration().unifiedTextReplacementBehavior();
+}
+
+bool WebViewImpl::wantsCompleteUnifiedTextReplacementBehavior() const
+{
+    return [m_view _web_wantsCompleteUnifiedTextReplacementBehavior];
 }
 #endif
 


### PR DESCRIPTION
#### f0b9b35bac8074e1a3c3d7c437ba2b5d3596f9ee
<pre>
[Unified Text Replacement] [iOS] Add SPI to WKWebViewConfiguration to configure unified text replacement behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=274215">https://bugs.webkit.org/show_bug.cgi?id=274215</a>
<a href="https://rdar.apple.com/128108312">rdar://128108312</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView unifiedTextReplacementBehavior]):
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h:
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm:
(-[WKExtendedTextInputTraits restoreDefaultValues]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::wantsCompleteUnifiedTextReplacementBehavior const): Deleted.

Canonical link: <a href="https://commits.webkit.org/278901@main">https://commits.webkit.org/278901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7acfa94e18edf855a8d55504ea9033978ff66e4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51887 "Failed to checkout and rebase branch from PR 28596") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28813 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56746 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28245 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29142 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7584 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->