### PR TITLE
[git-webkit] Reduce radar requests in clone

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -208,6 +208,8 @@ class RadarModel(object):
         return [self.client.parent.keywords[keyword] for keyword in self._issue.get('keywords', [])]
 
     def commit_changes(self):
+        self.client.parent.request_count += 1
+
         self.client.parent.issues[self.id]['comments'] = [
             Issue.Comment(
                 user=self.client.parent.users[entry.addedBy.email],
@@ -293,12 +295,16 @@ class RadarClient(object):
         self.authentication_strategy = authentication_strategy
 
     def radar_for_id(self, problem_id, additional_fields=None):
+        self.parent.request_count += 1
+
         found = self.parent.issues.get(problem_id)
         if not found:
             return None
         return RadarModel(self, found, additional_fields=additional_fields)
 
     def find_radars(self, query, return_find_results_directly=False):
+        self.parent.request_count += 1
+
         result = []
         for issue in self.parent.issues.values():
             r = RadarModel(self, issue)
@@ -317,9 +323,12 @@ class RadarClient(object):
         return result
 
     def milestones_for_component(self, component, include_access_groups=False):
+        self.parent.request_count += 1
         return list(self.parent.milestones.values())
 
     def find_components(self, request_data):
+        self.parent.request_count += 1
+
         filters = []
         for key in ('name', 'version'):
             if key in request_data:
@@ -347,6 +356,8 @@ class RadarClient(object):
         return result
 
     def create_radar(self, request_data):
+        self.parent.request_count += 1
+
         if not all((
             request_data.get('title'), request_data.get('description'), request_data.get('component'),
             request_data.get('classification'), request_data.get('reproducible'),
@@ -391,6 +402,8 @@ class RadarClient(object):
         return self.radar_for_id(id)
 
     def clone_radar(self, problem_id, reason_text, component=None):
+        self.parent.request_count += 1
+
         original = self.radar_for_id(problem_id)
         if not original:
             raise Radar.exceptions.UnsuccessfulResponseException("'{}' does not match a known radar".format(problem_id))
@@ -412,6 +425,8 @@ class RadarClient(object):
         ))
 
     def keywords_for_name(self, keyword_name):
+        self.parent.request_count += 1
+
         return [
             keyword for name, keyword in self.parent.keywords.items()
             if name.startswith(keyword_name)
@@ -558,6 +573,8 @@ class Radar(Base, ContextStack):
 
         from mock import patch
         self.patches.append(patch('webkitbugspy.radar.Tracker.radarclient', new=lambda s=None: self))
+
+        self.request_count = 0
 
 
 class NoRadar(ContextStack):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -54,12 +54,13 @@ class TestClone(testing.PathTestCase):
             issues=bmocks.ISSUES,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
             self.assertEqual(255, program.main(
                 args=('clone', 'rdar://1'),
                 path=self.path,
             ))
+            self.assertEqual(2, mock_radar.request_count)
 
         self.assertEqual(
             captured.stderr.getvalue(),
@@ -71,12 +72,14 @@ class TestClone(testing.PathTestCase):
             issues=bmocks.ISSUES,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
             self.assertEqual(0, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for a future branch', '--milestone', 'Future'),
                 path=self.path,
             ))
+            self.assertEqual(22, mock_radar.request_count)
+
             tracker = radar.Tracker()
             raw_issue = tracker.client.radar_for_id(4)
 
@@ -97,12 +100,13 @@ class TestClone(testing.PathTestCase):
             issues=bmocks.ISSUES,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
             self.assertEqual(255, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--no-prompt'),
                 path=self.path,
             ))
+            self.assertEqual(5, mock_radar.request_count)
 
         self.assertEqual(
             captured.stderr.getvalue(),
@@ -116,12 +120,14 @@ class TestClone(testing.PathTestCase):
             issues=bmocks.ISSUES,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), MockTerminal.input('2'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, MockTerminal.input('2'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
             self.assertEqual(0, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--prompt'),
                 path=self.path,
             ))
+            self.assertEqual(22, mock_radar.request_count)
+
             tracker = radar.Tracker()
             raw_issue = tracker.client.radar_for_id(4)
 
@@ -182,11 +188,12 @@ class TestClone(testing.PathTestCase):
             issues=issues,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
             self.assertEqual(255, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--merge-back'),
                 path=self.path,
             ))
+            self.assertEqual(11, mock_radar.request_count)
 
         self.assertEqual(
             captured.stderr.getvalue(),
@@ -216,11 +223,13 @@ class TestClone(testing.PathTestCase):
             issues=issues,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
             self.assertEqual(0, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--merge-back'),
                 path=self.path,
             ))
+            self.assertEqual(42, mock_radar.request_count)
+
             tracker = radar.Tracker()
             raw_issue = tracker.client.radar_for_id(5)
 
@@ -261,7 +270,7 @@ class TestClone(testing.PathTestCase):
             issues=issues,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), MockTerminal.input('y', '1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ) as mock_radar, MockTerminal.input('y', '1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
             tracker = radar.Tracker()
             tracker.issue(1).add_comment('Committed 1234.10@some-branch (12345678) to some-branch referencing this bug')
 
@@ -269,6 +278,8 @@ class TestClone(testing.PathTestCase):
                 args=('clone', 'rdar://1', '--milestone', 'October'),
                 path=self.path,
             ))
+            self.assertEqual(49, mock_radar.request_count)
+
             raw_issue = tracker.client.radar_for_id(5)
 
             self.assertEqual(raw_issue.milestone.name, 'Internal Tools - October')


### PR DESCRIPTION
#### b1a07690232ffd27093173e2fd66cf65aa0ed777
<pre>
[git-webkit] Reduce radar requests in clone
<a href="https://bugs.webkit.org/show_bug.cgi?id=274216">https://bugs.webkit.org/show_bug.cgi?id=274216</a>
<a href="https://rdar.apple.com/128135181">rdar://128135181</a>

Reviewed by Dewei Zhu.

Attempt to batch update requests on cloned radar, falling back to smaller updates if the
larger one fails.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.commit_changes): Increment network call counter.
(RadarClient.radar_for_id): Ditto
(RadarClient.find_radars): Ditto
(RadarClient.milestones_for_component): Ditto
(RadarClient.find_components): Ditto
(RadarClient.create_radar): Ditto
(RadarClient.clone_radar): Ditto
(RadarClient.keywords_for_name): Ditto
(Radar.__init__): Keep track of function calls that result in network requests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py:
(Clone.main): Attempt to batch all radar updates into a single request, falling back to smaller
updates if the batched update fails.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py:
(TestClone.test_no_reason): Check the number of radar network requests made during the program.
(TestClone.test_basic): Ditto.
(TestClone.test_no_prompt): Ditto.
(TestClone.test_prompt): Ditto.
(TestClone.test_merge_back_no_parent): Ditto.
(TestClone.test_merge_back): Ditto.
(TestClone.test_infer_merge_back): Ditto.

Canonical link: <a href="https://commits.webkit.org/279019@main">https://commits.webkit.org/279019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5fcf2781cb7a1776289f49de31efe59edce743a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42036 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23162 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51484 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56494 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26757 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1771 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49435 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/51654 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48646 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28891 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7654 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->