### PR TITLE
"targetavailabilitychanged" event fired even when media element has disabledRemotePlayback = true

### DIFF
--- a/LayoutTests/media/airplay-target-availability-disableremoteplayback-expected.txt
+++ b/LayoutTests/media/airplay-target-availability-disableremoteplayback-expected.txt
@@ -1,0 +1,37 @@
+Test that a webkitplaybacktargetavailabilitychanged is not fired when adding an event listener to a media element with disableRemotePlayback set
+RUN(video = document.body.appendChild(document.createElement('video')))
+RUN(video.disableRemotePlayback = true)
+Promise rejected correctly OK
+Correctly failed to receive targetavailabilitychanged event OK
+Test completed OK
+
+Test that a webkitplaybacktargetavailabilitychanged is fired when setting disableRemotePlayback on an element with an event listener
+RUN(video = document.body.appendChild(document.createElement('video')))
+EVENT(webkitplaybacktargetavailabilitychanged)
+EXPECTED (event.availability == 'available') OK
+RUN(video.disableRemotePlayback = true)
+EVENT(webkitplaybacktargetavailabilitychanged)
+EXPECTED (event.availability == 'not-available') OK
+Test completed OK
+
+Test that a webkitplaybacktargetavailabilitychanged is fired when clearing disableRemotePlayback on an element with an event listener
+RUN(video = document.body.appendChild(document.createElement('video')))
+RUN(video.disableRemotePlayback = true)
+Promise rejected correctly OK
+Correctly failed to receive targetavailabilitychanged event OK
+RUN(video.disableRemotePlayback = false)
+EVENT(webkitplaybacktargetavailabilitychanged)
+EXPECTED (event.availability == 'available') OK
+Test completed OK
+
+Test that a webkitplaybacktargetavailabilitychanged is not received when setting disableRemotePlayback, when no targets were previously available
+RUN(video = document.body.appendChild(document.createElement('video')))
+EVENT(webkitplaybacktargetavailabilitychanged)
+EXPECTED (event.availability == 'not-available') OK
+RUN(video.disableRemotePlayback = true)
+Promise rejected correctly OK
+Correctly failed to receive targetavailabilitychanged event OK
+Test completed OK
+
+END OF TEST
+

--- a/LayoutTests/media/airplay-target-availability-disableremoteplayback.html
+++ b/LayoutTests/media/airplay-target-availability-disableremoteplayback.html
@@ -1,0 +1,134 @@
+<html>
+<head>
+    <script src='media-file.js'></script>
+    <script src='video-test.js'></script>
+    <script>
+    window.addEventListener('load', async event => {
+        await runTest().then(endTest).catch(failTest);
+    });
+
+    function waitForTargetAvailableToBecome(element, state, duration, message) {
+        return new Promise(async (resolve, reject) => {
+            var timeout;
+            var listener;
+
+            let cleanup = () => {
+                clearTimeout(timeout);
+                element.removeEventListener('webkitplaybacktargetavailabilitychanged', listener);
+            };
+
+            listener = event => {
+                if (event.availability !== state)
+                    return;
+                consoleWrite(`EVENT(${event.type})`);
+                resolve(event);
+                cleanup();
+            };
+            element.addEventListener('webkitplaybacktargetavailabilitychanged', listener);
+
+            timeout = setTimeout(() => {
+                reject(new Error(message));
+                cleanup();
+            }, duration);
+        });
+    }
+
+    async function runTest() {
+        const tenSeconds = 10000;
+        let tests = [
+            async function() {
+                consoleWrite('Test that a webkitplaybacktargetavailabilitychanged is not fired when adding an event listener to a media element with disableRemotePlayback set');
+
+                if (window.internals)
+                    internals.setMockMediaPlaybackTargetPickerState('Sleepy TV', 'DeviceAvailable');
+
+                run(`video = document.body.appendChild(document.createElement('video'))`);
+                run(`video.disableRemotePlayback = true`);
+
+                await shouldReject(waitForEventWithTimeout(video, 'webkitplaybacktargetavailabilitychanged', 100));
+                logResult(Success, 'Correctly failed to receive targetavailabilitychanged event')
+            },
+            async function() {
+                consoleWrite('Test that a webkitplaybacktargetavailabilitychanged is fired when setting disableRemotePlayback on an element with an event listener');
+
+                if (window.internals)
+                    internals.setMockMediaPlaybackTargetPickerState('Sleepy TV', 'DeviceAvailable');
+
+                run(`video = document.body.appendChild(document.createElement('video'))`);
+
+                event = await waitForTargetAvailableToBecome(video, 'available', tenSeconds, 'Failed to receive targetavailabilitychanged event');
+                testExpected('event.availability', 'available');
+
+                let eventPromise = waitForTargetAvailableToBecome(video, 'not-available', tenSeconds, 'Failed to receive targetavailabilitychanged event');
+                run(`video.disableRemotePlayback = true`);
+
+                event = await eventPromise;
+                testExpected('event.availability', 'not-available');
+            },
+            async function() {
+                consoleWrite('Test that a webkitplaybacktargetavailabilitychanged is fired when clearing disableRemotePlayback on an element with an event listener');
+
+                if (window.internals)
+                    internals.setMockMediaPlaybackTargetPickerState('Sleepy TV', 'DeviceAvailable');
+
+                run(`video = document.body.appendChild(document.createElement('video'))`);
+                run(`video.disableRemotePlayback = true`);
+
+                await shouldReject(waitForEventWithTimeout(video, 'webkitplaybacktargetavailabilitychanged', tenSeconds));
+                logResult(Success, 'Correctly failed to receive targetavailabilitychanged event')
+
+                let eventPromise = waitForTargetAvailableToBecome(video, 'available', tenSeconds, 'Failed to receive targetavailabilitychanged event');
+                run(`video.disableRemotePlayback = false`);
+
+                event = await eventPromise;
+                testExpected('event.availability', 'available');
+            },
+            async function() {
+                consoleWrite('Test that a webkitplaybacktargetavailabilitychanged is not received when setting disableRemotePlayback, when no targets were previously available');
+
+                if (window.internals)
+                    internals.setMockMediaPlaybackTargetPickerState('Sleepy TV', 'DeviceUnavailable');
+
+                run(`video = document.body.appendChild(document.createElement('video'))`);
+
+                event = await waitForTargetAvailableToBecome(video, 'not-available', tenSeconds);
+                testExpected('event.availability', 'not-available');
+
+                run(`video.disableRemotePlayback = true`);
+
+                await shouldReject(waitForEventWithTimeout(video, 'webkitplaybacktargetavailabilitychanged', tenSeconds));
+                logResult(Success, 'Correctly failed to receive targetavailabilitychanged event')
+            },
+        ];
+
+        if (window.internals)
+            internals.setMockMediaPlaybackTargetPickerEnabled(true);
+
+        for (var test of tests) {
+            try {
+                await test();
+                logResult(Success, 'Test completed');
+            } catch(e) {
+                logResult(Failed, `ERROR: ${e.message}`);
+            } finally {
+                if (window.internals)
+                    internals.setMockMediaPlaybackTargetPickerState('Sleepy TV', 'DeviceUnavailable');
+                video.src = '';
+                video.load();
+                document.body.removeChild(video);
+                consoleWrite('');
+            }
+        }
+
+        if (window.internals) {
+            internals.setMockMediaPlaybackTargetPickerState('Sleepy TV', 'DeviceUnavailable');
+            internals.setMockMediaPlaybackTargetPickerEnabled(false);
+        }
+    }
+
+    </script>
+</head>
+
+<body>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2585,6 +2585,7 @@ platform/ios/media/video-interruption-suspendunderlock.html [ Skip ]
 media/airplay-allows-buffering.html
 media/airplay-autoplay.html
 media/airplay-target-availability.html
+media/airplay-target-availability-disableremoteplayback.html
 
 # needs enhanced eventSender.contextMenu() return value
 webkit.org/b/116651 media/context-menu-actions.html

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -461,10 +461,14 @@ public:
     void playbackTargetPickerWasDismissed() override;
     bool hasWirelessPlaybackTargetAlternative() const;
     bool isWirelessPlaybackTargetDisabled() const;
+    void isWirelessPlaybackTargetDisabledChanged();
+    bool hasTargetAvailabilityListeners();
+    bool hasEnabledTargetAvailabilityListeners();
 #endif
 
     bool isPlayingToWirelessPlaybackTarget() const override { return m_isPlayingToWirelessTarget; };
     void setIsPlayingToWirelessTarget(bool);
+
     bool webkitCurrentPlaybackTargetIsWireless() const;
 
     void setPlayingOnSecondScreen(bool value);
@@ -1342,6 +1346,7 @@ private:
 
     std::optional<RemotePlaybackConfiguration> m_remotePlaybackConfiguration;
 
+    bool m_wirelessPlaybackTargetDisabled { false };
     bool m_isPlayingToWirelessTarget { false };
     bool m_playingOnSecondScreen { false };
     bool m_removedBehaviorRestrictionsAfterFirstUserGesture { false };


### PR DESCRIPTION
#### 7eb36e38f352976b39cc87c1483937c58129a01d
<pre>
&quot;targetavailabilitychanged&quot; event fired even when media element has disabledRemotePlayback = true
<a href="https://bugs.webkit.org/show_bug.cgi?id=274220">https://bugs.webkit.org/show_bug.cgi?id=274220</a>
<a href="https://rdar.apple.com/128137977">rdar://128137977</a>

Reviewed by Eric Carlson.

The expectation is that `disableRemotePlayback = true` should cause all remote playback
events to not fire. Instead, disabling remote playback seems to have no effect on disabling
these events, and default media controls remote playback buttons still appear.

Add some utility methods to HTMLMediaElement to make it a bit cheaper to check whether
remote playback is disabled, and whether remote playback event listeners exist.

When changing the state of `disableRemotePlayback`, ensure that an event is fired saying
no remote playback targets exist, which cause media controls (including the native ones)
to hide the remote playback button.

* LayoutTests/media/airplay-target-availability-disableremoteplayback-expected.txt: Added.
* LayoutTests/media/airplay-target-availability-disableremoteplayback.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::clearMediaPlayer):
(WebCore::HTMLMediaElement::wirelessRoutesAvailableDidChange):
(WebCore::HTMLMediaElement::enqueuePlaybackTargetAvailabilityChangedEvent):
(WebCore::HTMLMediaElement::remoteHasAvailabilityCallbacksChanged):
(WebCore::HTMLMediaElement::hasTargetAvailabilityListeners):
(WebCore::HTMLMediaElement::hasEnabledTargetAvailabilityListeners):
(WebCore::HTMLMediaElement::isWirelessPlaybackTargetDisabledChanged):
(WebCore::HTMLMediaElement::isWirelessPlaybackTargetDisabled const):
(WebCore::HTMLMediaElement::addEventListener):
(WebCore::HTMLMediaElement::removeEventListener):
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/278933@main">https://commits.webkit.org/278933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e9854a8900f1bd757ecccf5125e06b49e1e1596

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55271 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2417 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/1738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28948 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23401 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48130 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27113 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11374 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->