### PR TITLE
REGRESSION (272448.703@safari-7618-branch): [iOS] <input type=file> camera capture instantly dismisses

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PickerDismissalReason.h
+++ b/Source/WebKit/UIProcess/Cocoa/PickerDismissalReason.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,36 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "WKAPICast.h"
-
-#if PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-
-@class WKWebView;
-@protocol WKShareSheetDelegate;
-
-namespace WebCore {
-struct ShareDataWithParsedURL;
-}
+#pragma once
 
 namespace WebKit {
-enum class PickerDismissalReason : uint8_t;
-}
 
-@interface WKShareSheet : NSObject
+enum class PickerDismissalReason : uint8_t {
+    ResetState,
+    ViewRemoved,
+    ProcessExited,
+    Testing,
+};
 
-- (instancetype)initWithView:(WKWebView *)view;
-
-- (void)presentWithParameters:(const WebCore::ShareDataWithParsedURL&)data inRect:(std::optional<WebCore::FloatRect>)rect completionHandler:(WTF::CompletionHandler<void(bool)>&&)completionHandler;
-
-- (BOOL)dismissIfNeededWithReason:(WebKit::PickerDismissalReason)reason;
-
-@property (nonatomic, weak) id <WKShareSheetDelegate> delegate;
-@end
-
-@protocol WKShareSheetDelegate <NSObject>
-@optional
-- (void)shareSheetDidDismiss:(WKShareSheet *)shareSheet;
-- (void)shareSheet:(WKShareSheet *)shareSheet willShowActivityItems:(NSArray *)activityItems;
-@end
-
-#endif // PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.h
@@ -38,13 +38,17 @@ struct ContactInfo;
 struct ContactsRequestData;
 }
 
+namespace WebKit {
+enum class PickerDismissalReason : uint8_t;
+}
+
 @interface WKContactPicker : NSObject
 
 - (instancetype)initWithView:(WKWebView *)view;
 
 - (void)presentWithRequestData:(const WebCore::ContactsRequestData&)requestData completionHandler:(WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&)completionHandler;
 
-- (void)dismiss;
+- (BOOL)dismissIfNeededWithReason:(WebKit::PickerDismissalReason)reason;
 
 @property (nonatomic, weak) id<WKContactPickerDelegate> delegate;
 

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -29,6 +29,7 @@
 #if HAVE(CONTACTSUI)
 
 #import "ContactsUISPI.h"
+#import "PickerDismissalReason.h"
 #import <Contacts/Contacts.h>
 #import <WebCore/ContactInfo.h>
 #import <WebCore/ContactsRequestData.h>
@@ -182,6 +183,22 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 - (void)dismiss
 {
     [self dismissWithContacts:nil];
+}
+
+- (BOOL)dismissIfNeededWithReason:(WebKit::PickerDismissalReason)reason
+{
+#if HAVE(CNCONTACTPICKERVIEWCONTROLLER)
+    if (reason == WebKit::PickerDismissalReason::ViewRemoved) {
+        if ([_contactPickerViewController _wk_isInFullscreenPresentation])
+            return NO;
+    }
+#endif
+
+    if (reason == WebKit::PickerDismissalReason::ProcessExited || reason == WebKit::PickerDismissalReason::ViewRemoved)
+        [self setDelegate:nil];
+
+    [self dismiss];
+    return YES;
 }
 
 #pragma mark - Completion

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 
+#import "PickerDismissalReason.h"
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
 #import <WebCore/NSURLUtilities.h>
@@ -423,6 +424,22 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
         _presentationViewController = nil;
     }];
 #endif
+}
+
+- (BOOL)dismissIfNeededWithReason:(WebKit::PickerDismissalReason)reason
+{
+#if PLATFORM(IOS_FAMILY)
+    if (reason == WebKit::PickerDismissalReason::ViewRemoved) {
+        if ([_shareSheetViewController _wk_isInFullscreenPresentation])
+            return NO;
+    }
+#endif
+
+    if (reason == WebKit::PickerDismissalReason::ProcessExited || reason == WebKit::PickerDismissalReason::ViewRemoved)
+        [self setDelegate:nil];
+
+    [self dismiss];
+    return YES;
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -56,6 +56,10 @@
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
 @end
 
+@interface UIViewController (WebKitInternal)
+@property (nonatomic, readonly) BOOL _wk_isInFullscreenPresentation;
+@end
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message);

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -230,6 +230,15 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 @end
 
+@implementation UIViewController (WebKitInternal)
+
+- (BOOL)_wk_isInFullscreenPresentation
+{
+    return self.activePresentationController && self.modalPresentationStyle == UIModalPresentationFullScreen;
+}
+
+@end
+
 @implementation UIGestureRecognizer (WebKitInternal)
 
 - (BOOL)_wk_isTextInteractionLoupeGesture

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -36,6 +36,7 @@
 #import "Logging.h"
 #import "ModelProcessProxy.h"
 #import "PageClientImplIOS.h"
+#import "PickerDismissalReason.h"
 #import "PrintInfo.h"
 #import "RemoteLayerTreeDrawingAreaProxyIOS.h"
 #import "SmartMagnificationController.h"
@@ -524,7 +525,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     }
 
     if (window && !newWindow)
-        [self dismissPickers];
+        [self dismissPickersIfNeededWithReason:WebKit::PickerDismissalReason::ViewRemoved];
 }
 
 - (void)didMoveToWindow

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -116,6 +116,7 @@ class NativeWebTouchEvent;
 class SmartMagnificationController;
 class WebOpenPanelResultListenerProxy;
 class WebPageProxy;
+enum class PickerDismissalReason : uint8_t;
 }
 
 @class AVPlayerViewController;
@@ -681,7 +682,7 @@ struct ImageAnalysisContextMenuActionData {
 - (void)cleanUpInteraction;
 - (void)cleanUpInteractionPreviewContainers;
 
-- (void)dismissPickers;
+- (void)dismissPickersIfNeededWithReason:(WebKit::PickerDismissalReason)reason;
 
 - (void)scrollViewWillStartPanOrPinchGesture;
 

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -31,6 +31,7 @@
 #import "APIUIClient.h"
 #import "FindClient.h"
 #import "PDFKitSPI.h"
+#import "PickerDismissalReason.h"
 #import "UIKitSPI.h"
 #import "WKActionSheetAssistant.h"
 #import "WKKeyboardScrollingAnimator.h"
@@ -145,8 +146,7 @@
 - (void)dealloc
 {
     if (_shareSheet) {
-        [_shareSheet setDelegate:nil];
-        [_shareSheet dismiss];
+        [_shareSheet dismissIfNeededWithReason:WebKit::PickerDismissalReason::ProcessExited];
         _shareSheet = nil;
     }
     [_actionSheetAssistant cleanupSheet];
@@ -671,7 +671,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     shareData.url = { url };
     shareData.originator = WebCore::ShareDataOriginator::User;
     
-    [_shareSheet dismiss];
+    [_shareSheet dismissIfNeededWithReason:WebKit::PickerDismissalReason::ResetState];
 
     _shareSheet = adoptNS([[WKShareSheet alloc] initWithView:webView]);
     [_shareSheet setDelegate:self];

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
@@ -36,13 +36,15 @@ class OpenPanelParameters;
 
 namespace WebKit {
 class WebOpenPanelResultListenerProxy;
+enum class PickerDismissalReason : uint8_t;
 }
 
 @interface WKFileUploadPanel : UIViewController
 @property (nonatomic, weak) id <WKFileUploadPanelDelegate> delegate;
 - (instancetype)initWithView:(WKContentView *)view;
 - (void)presentWithParameters:(API::OpenPanelParameters*)parameters resultListener:(WebKit::WebOpenPanelResultListenerProxy*)listener;
-- (void)dismiss;
+
+- (BOOL)dismissIfNeededWithReason:(WebKit::PickerDismissalReason)reason;
 
 #if USE(UICONTEXTMENU)
 - (void)repositionContextMenuIfNeeded;

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -34,6 +34,7 @@
 #import "APIString.h"
 #import "CompactContextMenuPresenter.h"
 #import "PhotosUISPI.h"
+#import "PickerDismissalReason.h"
 #import "UIKitUtilities.h"
 #import "WKContentViewInteraction.h"
 #import "WKData.h"
@@ -550,6 +551,28 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _presentationViewController = nil;
 
     [self _cancel];
+}
+
+- (BOOL)dismissIfNeededWithReason:(WebKit::PickerDismissalReason)reason
+{
+    if (reason == WebKit::PickerDismissalReason::ViewRemoved) {
+        if ([_documentPickerController _wk_isInFullscreenPresentation])
+            return NO;
+
+#if HAVE(PHOTOS_UI)
+        if ([_photoPicker _wk_isInFullscreenPresentation])
+            return NO;
+#endif
+
+        if ([_cameraPicker _wk_isInFullscreenPresentation])
+            return NO;
+    }
+
+    if (reason == WebKit::PickerDismissalReason::ProcessExited || reason == WebKit::PickerDismissalReason::ViewRemoved)
+        [self setDelegate:nil];
+
+    [self dismiss];
+    return YES;
 }
 
 - (void)_dismissDisplayAnimated:(BOOL)animated

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -44,6 +44,7 @@
 #import "PageClient.h"
 #import "PageClientImplMac.h"
 #import "PasteboardTypes.h"
+#import "PickerDismissalReason.h"
 #import "PlatformFontInfo.h"
 #import "PlaybackSessionManagerProxy.h"
 #import "RemoteLayerTreeDrawingAreaProxyMac.h"
@@ -2812,7 +2813,7 @@ void WebViewImpl::selectionDidChange()
 void WebViewImpl::showShareSheet(const WebCore::ShareDataWithParsedURL& data, WTF::CompletionHandler<void(bool)>&& completionHandler, WKWebView *view)
 {
     if (_shareSheet)
-        [_shareSheet dismiss];
+        [_shareSheet dismissIfNeededWithReason:WebKit::PickerDismissalReason::ResetState];
 
     ASSERT([view respondsToSelector:@selector(shareSheetDidDismiss:)]);
     _shareSheet = adoptNS([[WKShareSheet alloc] initWithView:view]);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2465,6 +2465,7 @@
 		E568B91F20A3AB2F00E3C856 /* WebDataListSuggestionsDropdown.h in Headers */ = {isa = PBXBuildFile; fileRef = E568B91E20A3AB2F00E3C856 /* WebDataListSuggestionsDropdown.h */; };
 		E568B92220A3AC6A00E3C856 /* WebDataListSuggestionsDropdownMac.h in Headers */ = {isa = PBXBuildFile; fileRef = E568B92020A3AC6A00E3C856 /* WebDataListSuggestionsDropdownMac.h */; };
 		E596DD6A251E71D400C275A7 /* WKContactPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = E596DD68251E71D300C275A7 /* WKContactPicker.h */; };
+		E5AF80FD2BB4F05F00726F63 /* PickerDismissalReason.h in Headers */ = {isa = PBXBuildFile; fileRef = E5AF80FC2BB4F00A00726F63 /* PickerDismissalReason.h */; };
 		E5BEF6822130C48000F31111 /* WebDataListSuggestionsDropdownIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */; };
 		E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */; };
 		E5CBA76427A318E100DF7858 /* UnifiedSource120.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA75F27A3187800DF7858 /* UnifiedSource120.cpp */; };
@@ -8078,6 +8079,7 @@
 		E568B92120A3AC6A00E3C856 /* WebDataListSuggestionsDropdownMac.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = WebDataListSuggestionsDropdownMac.mm; sourceTree = "<group>"; };
 		E596DD68251E71D300C275A7 /* WKContactPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContactPicker.h; sourceTree = "<group>"; };
 		E596DD69251E71D400C275A7 /* WKContactPicker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKContactPicker.mm; sourceTree = "<group>"; };
+		E5AF80FC2BB4F00A00726F63 /* PickerDismissalReason.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PickerDismissalReason.h; sourceTree = "<group>"; };
 		E5BEF6802130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebDataListSuggestionsDropdownIOS.h; path = ios/WebDataListSuggestionsDropdownIOS.h; sourceTree = "<group>"; };
 		E5BEF6812130C47F00F31111 /* WebDataListSuggestionsDropdownIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebDataListSuggestionsDropdownIOS.mm; path = ios/WebDataListSuggestionsDropdownIOS.mm; sourceTree = "<group>"; };
 		E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormColorControl.h; path = ios/forms/WKFormColorControl.h; sourceTree = "<group>"; };
@@ -9492,6 +9494,7 @@
 				1ABC3DF31899E437004F0626 /* NavigationState.mm */,
 				5C6CE6D31F59EA350007C6CB /* PageClientImplCocoa.h */,
 				5C6CE6D01F59BC460007C6CB /* PageClientImplCocoa.mm */,
+				E5AF80FC2BB4F00A00726F63 /* PickerDismissalReason.h */,
 				1185025E2673B0A700A6425E /* PlatformXRCoordinator.mm */,
 				CDA29A1E1CBEB5FB00901CCF /* PlaybackSessionManagerProxy.h */,
 				CDA29A221CBEB61A00901CCF /* PlaybackSessionManagerProxy.messages.in */,
@@ -16515,6 +16518,7 @@
 				832ED18C1E2FE157006BA64A /* PerActivityStateCPUUsageSampler.h in Headers */,
 				7AFBD36F21E546F8005DBACB /* PersistencyUtils.h in Headers */,
 				E5DEFA6826F8F42600AB68DB /* PhotosUISPI.h in Headers */,
+				E5AF80FD2BB4F05F00726F63 /* PickerDismissalReason.h in Headers */,
 				5CE85B201C88E64B0070BFCE /* PingLoad.h in Headers */,
 				0F5E200418E77051003EC3E5 /* PlatformCAAnimationRemote.h in Headers */,
 				46D246262AFE956500F24C94 /* PlatformCAAnimationRemoteProperties.h in Headers */,


### PR DESCRIPTION
#### 1358c81b18526a7f44d21b66983c82e59ba44056
<pre>
REGRESSION (272448.703@safari-7618-branch): [iOS] &lt;input type=file&gt; camera capture instantly dismisses
<a href="https://rdar.apple.com/125046135">rdar://125046135</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

272448.703@safari-7618-branch added logic to dismiss presented pickers, such as
the file upload panel, when the `WKWebView` was removed from the hierarchy. The
behavior is necessary to avoid scenarios where a picker can be displayed over a
site that&apos;s unrelated to the one requesting the information.

While that solution is correct for modal presentations, it is incorrect for
fullscreen presentations, which remove views from the hierarchy following
presentation. The camera view controller uses a fullscreen presentation.
Consequently, once it gets presented, the web view is removed from the
hierarchy, and following 272448.703@safari-7618-branch, it is instantly
dismissed.

To fix, reduce the scope of the previous fix to exclude fullscreen presentations.
In this case, there is no need to dismiss presented view controllers, as the
web view content is already hidden.

Note that there is no way to detect whether a view was removed from the hierarchy
due to a fullscreen presentation. Consequently, the solution checks the status
of various presented pickers.

* Source/WebKit/UIProcess/Cocoa/PickerDismissalReason.h:

Introduce `PickerDismissalReason`s to control the dimissal behavior.

In particular, `ViewRemoved` now checks for fullscreen presentations, to avoid
instant dismissal.

* Source/WebKit/UIProcess/Cocoa/WKContactPicker.h:
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker dismissIfNeededWithReason:]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.h:
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet dismissIfNeededWithReason:]):
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIViewController _wk_isInFullscreenPresentation]):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView willMoveToWindow:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView dismissFilePicker]):
(-[WKContentView _showShareSheet:inRect:completionHandler:]):
(-[WKContentView dismissPickersIfNeededWithReason:]):
(-[WKContentView dismissPickers]): Deleted.
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView dealloc]):

`ProcessExited` is used here, since it has the desired semantics.

In effect, the remote process of the host view controller is exited here.

(-[WKPDFView actionSheetAssistant:shareElementWithURL:rect:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel dismissIfNeededWithReason:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::showShareSheet):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Originally-landed-as: 272448.818@safari-7618-branch (1db2f6a6a042). <a href="https://rdar.apple.com/128086989">rdar://128086989</a>
Canonical link: <a href="https://commits.webkit.org/278827@main">https://commits.webkit.org/278827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8cfdedc0fee4580166b0d2ba99154b6325f2008

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2338 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/37374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23175 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25907 "4 new passes 1 flakes") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56504 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1783 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48656 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28901 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7541 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->