### PR TITLE
Use RefPtr local variable for nextChild in insertChildrenBeforeWithoutPreInsertionValidityCheck

### DIFF
--- a/LayoutTests/fast/dom/set-attribute-and-normalize-in-event-expected.txt
+++ b/LayoutTests/fast/dom/set-attribute-and-normalize-in-event-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
+CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
+

--- a/LayoutTests/fast/dom/set-attribute-and-normalize-in-event.html
+++ b/LayoutTests/fast/dom/set-attribute-and-normalize-in-event.html
@@ -1,0 +1,17 @@
+<script>
+    function runTest() {
+        if (window.testRunner)
+            window.testRunner.dumpAsText();
+
+        marqueeElement.addEventListener("DOMSubtreeModified", () => {
+            try { hrElement.before(hrElement); } catch (e) { }
+            marqueeElement.normalize();
+        });
+
+        marqueeElement.setAttribute("a", "");
+    }
+</script>
+
+<body onload=runTest()>
+    <marquee id="marqueeElement">
+        <hr id="hrElement" width="1"></hr>


### PR DESCRIPTION
#### 0d0caf9579718608843389ad1dcf5961c5cce63e
<pre>
Use RefPtr local variable for nextChild in insertChildrenBeforeWithoutPreInsertionValidityCheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=268765">https://bugs.webkit.org/show_bug.cgi?id=268765</a>
<a href="https://rdar.apple.com/122122623">rdar://122122623</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

This patch adds a RefPtr to hold a reference to nextChild so that the
pointer stay valid through the scope of the function.

In the test case, the removeChild() call (from the before() call in the js
script) triggers a DOMSubtreeModified event, which eventually calls normalize.
The normalize() call can destroy text elements when normalizing the content of
the node if there is no one holding the reference to that node, so holding
nextChild in a RefPtr prevents us from reading an invalid pointer.

* LayoutTests/fast/dom/set-attribute-and-normalize-in-event-expected.txt: Added.
* LayoutTests/fast/dom/set-attribute-and-normalize-in-event.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::insertChildrenBeforeWithoutPreInsertionValidityCheck):

Originally-landed-as: 274097.10@webkit-2024.2-embargoed (65b1fae34533). <a href="https://rdar.apple.com/128089683">rdar://128089683</a>
Canonical link: <a href="https://commits.webkit.org/278837@main">https://commits.webkit.org/278837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8024b99cf00cc22aedf701e6028e35ef1ef7fd40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42046 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23172 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1818 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49444 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44627 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48658 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28906 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7547 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->