### PR TITLE
[webkitcorepy] Add mutually exclusive groups to TaskPool (Follow-up)

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -465,7 +465,7 @@ class TaskPool(object):
     def do(self, function, *args, **kwargs):
         callback = kwargs.pop('callback', None)
         group = kwargs.pop('group', None)
-        if group and group not in self._group_queues:
+        if group and group not in self.mutually_exclusive_groups:
             raise ValueError("'{}' is not a recognized group".format(group))
 
         if not self.queue:

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py
@@ -202,6 +202,26 @@ class TaskPoolUnittest(unittest.TestCase):
                 ]
             )
 
+        def test_mutually_exclusive_group_single_worker(self):
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=1, mutually_exclusive_groups=['group']) as pool:
+                    for character in self.alphabet:
+                        pool.do(
+                            action, character,
+                            include_worker=True,
+                            group='group' if character in ('a', 'b', 'c', 'd') else None,
+                        )
+                    pool.wait()
+
+            self.assertEqual(
+                sorted(captured.stdout.getvalue().splitlines())[:4], [
+                    'worker/0 action(a)',
+                    'worker/0 action(b)',
+                    'worker/0 action(c)',
+                    'worker/0 action(d)',
+                ]
+            )
+
         def test_mutually_exclusive_groups(self):
             with OutputCapture(level=logging.INFO) as captured:
                 with TaskPool(workers=4, mutually_exclusive_groups=[
@@ -258,7 +278,7 @@ class TaskPoolUnittest(unittest.TestCase):
 
         def test_invalid_group(self):
             with OutputCapture(level=logging.INFO) as captured:
-                with TaskPool(workers=1) as pool:
+                with TaskPool(workers=2) as pool:
                     with self.assertRaises(ValueError):
                         pool.do(action, 'a', group='invalid')
                     pool.wait()


### PR DESCRIPTION
#### 0db49f66f9ad5769a05b5a947f3555c25f0ea48b
<pre>
[webkitcorepy] Add mutually exclusive groups to TaskPool (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273695">https://bugs.webkit.org/show_bug.cgi?id=273695</a>
<a href="https://rdar.apple.com/127503729">rdar://127503729</a>

Unreviewed follow-up fix.

Fix group existence check for a single worker.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
(TaskPool.do): Don&apos;t base group check on queues, that breaks single workers.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py:
(TaskPoolUnittest.test_mutually_exclusive_group_single_worker):
(TaskPoolUnittest.test_invalid_group):

Canonical link: <a href="https://commits.webkit.org/278822@main">https://commits.webkit.org/278822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e3551160f62e7c93e787d6a188e7aa159bc9af5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/51656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4017 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/53959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/54922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44552 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51504 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56514 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/51674 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44621 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7535 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->