### PR TITLE
Block "setMediaOverridesForTesting" media IPC endpoints when not testing

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -43,7 +43,7 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     CreateVisibilityPropagationContextForPage(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, bool canShowWhileLocked);
     DestroyVisibilityPropagationContextForPage(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID);
 #endif
-    SetMediaOverridesForTesting(struct WebKit::MediaOverridesForTesting configuration)
+    [EnabledIf='allowTestOnlyIPC()'] SetMediaOverridesForTesting(struct WebKit::MediaOverridesForTesting configuration)
     CreateAudioHardwareListener(WebKit::RemoteAudioHardwareListenerIdentifier identifier)
     ReleaseAudioHardwareListener(WebKit::RemoteAudioHardwareListenerIdentifier identifier)
     CreateRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)


### PR DESCRIPTION
#### e60b1b001ab4aa1bc777205fbc8217e75ad9b391
<pre>
Block &quot;setMediaOverridesForTesting&quot; media IPC endpoints when not testing
<a href="https://rdar.apple.com/107918233">rdar://107918233</a>

Reviewed by Youenn Fablet.

This is a continuation of 260935@main, adding the setMediaOverridesForTesting to the list
of blocked IPC endpoints.

All involved tests already contains the required keywords.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:

Originally-landed-as: 272448.445@safari-7618-branch (b60b2da0516d). rdar://128086276
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e60b1b001ab4aa1bc777205fbc8217e75ad9b391

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2350 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42054 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25919 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26779 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1942 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/accessibility-node-reparent.html, accessibility/accessibility-object-detached.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/aria-combobox-no-owns.html, accessibility/combobox/aria-combobox.html, accessibility/combobox/combobox-active-element-selected-children.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49460 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28016 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48684 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->