### PR TITLE
[CSS] Fix bug when using a coalesced CSSValuePair with Typed OM

### DIFF
--- a/LayoutTests/fast/css/css-typed-om-typeerror-coalescing-pair-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om-typeerror-coalescing-pair-expected.txt
@@ -1,0 +1,17 @@
+This test checks that we throw error when using Typed OM set() with a coalesced pair of values.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS () => {
+      var element = document.getElementById("element");
+      element.attributeStyleMap.set('width', CSSStyleValue.parse('border-bottom-left-radius', '30px'))
+    } threw exception NotSupportedError: Invalid values.
+PASS () => {
+      var element2 = document.getElementById("element2");
+      element2.attributeStyleMap.set('width', CSSStyleValue.parse('border-bottom-left-radius', '30px 10px'))
+    } threw exception TypeError: Invalid values.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-typed-om-typeerror-coalescing-pair.html
+++ b/LayoutTests/fast/css/css-typed-om-typeerror-coalescing-pair.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+
+<div id="element">
+</div>
+<div id="element2">
+</div>
+
+<script>
+description('This test checks that we throw error when using Typed OM set() with a coalesced pair of values.')
+shouldThrow(
+    () => { 
+      var element = document.getElementById("element");
+      element.attributeStyleMap.set('width', CSSStyleValue.parse('border-bottom-left-radius', '30px'))
+    }, "'NotSupportedError: Invalid values'");
+shouldThrow(
+    () => { 
+      var element2 = document.getElementById("element2");
+      element2.attributeStyleMap.set('width', CSSStyleValue.parse('border-bottom-left-radius', '30px 10px'))
+    }, "'TypeError: Invalid values'");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -55,6 +55,11 @@ Ref<CSSValuePair> CSSValuePair::createNoncoalescing(Ref<CSSValue> first, Ref<CSS
     return adoptRef(*new CSSValuePair(SpaceSeparator, WTFMove(first), WTFMove(second), IdenticalValueSerialization::DoNotCoalesce));
 }
 
+bool CSSValuePair::canBeCoalesced() const
+{
+    return m_coalesceIdenticalValues && m_first->equals(m_second);
+}
+
 String CSSValuePair::customCSSText() const
 {
     String first = m_first->cssText();

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -43,6 +43,7 @@ public:
 
     String customCSSText() const;
     bool equals(const CSSValuePair&) const;
+    bool canBeCoalesced() const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -82,7 +82,9 @@
 namespace WebCore {
 namespace Style {
 
-// Note that we assume the CSS parser only allows valid CSSValue types.
+// FIXME: Some of those functions assume the CSS parser only allows valid CSSValue types.
+// This might not be true if we pass the CSSValue from js via CSS Typed OM.
+
 class BuilderConverter {
 public:
     static Length convertLength(const BuilderState&, const CSSValue&);
@@ -306,7 +308,7 @@ inline Length BuilderConverter::convertLengthSizing(const BuilderState& builderS
         return Length(LengthType::Content);
     default:
         ASSERT_NOT_REACHED();
-        return Length();
+        return { };
     }
 }
 


### PR DESCRIPTION
#### c467c1a956e52767b38eeb9a171e8856a28be94f
<pre>
[CSS] Fix bug when using a coalesced CSSValuePair with Typed OM
<a href="https://rdar.apple.com/115346002">rdar://115346002</a>

Reviewed by Chris Dumez.

We use the CSSParser and the serialization of CSSValue to validate the input of Typed OM set().
Unfortunately, sometimes a CSSValuePair serializes to a single value while it
actually contains two values: this confuses the StyleBuilder.

If the pair has the same values twice &quot;10px 10px&quot;, it serializes to only &quot;10px&quot;,
thus pass our string-based check (inside setProperty), but then crash when the actual value is a
pair of length instead of a simple length.

The more frequent case when the two values are distincts, such as &quot;10px 30px&quot;, is
already prevented by the string-based check.

A proper fix would be to have validation method which doesn&apos;t work
on the serialized string value but on the actual typed CSSValue.

For the moment, we avoid crashing and warn the user with an error.

* LayoutTests/fast/css/css-typed-om-typeerror-coalescing-pair-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om-typeerror-coalescing-pair.html: Added.
* Source/WebCore/css/CSSValuePair.cpp:
(WebCore::CSSValuePair::canBeCoalesced const):
* Source/WebCore/css/CSSValuePair.h:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLengthSizing):

Originally-landed-as: 272448.627@safari-7618-branch (51293a58e9dd). <a href="https://rdar.apple.com/128090952">rdar://128090952</a>
Canonical link: <a href="https://commits.webkit.org/278891@main">https://commits.webkit.org/278891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/960775eb630dcbdf15f8826d99a2e78f75872a21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42142 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23272 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1939 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56653 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49544 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48788 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29049 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7578 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->