### PR TITLE
[Writing Suggestions] Prediction sometimes appears at the end of the document in Mail compose

### DIFF
--- a/LayoutTests/editing/input/mac/writing-suggestions-in-anonymous-renderer-expected.html
+++ b/LayoutTests/editing/input/mac/writing-suggestions-in-anonymous-renderer-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    font-size: 16px;
+    width: 300px;
+    height: 300px;
+    caret-color: transparent;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    getSelection().setPosition(document.body.childNodes[0], 4);
+    if (!window.testRunner)
+        return;
+    testRunner.waitUntilDone();
+    await UIHelper.setInlinePrediction("Hello", 4);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.notifyDone();
+});
+</script>
+</head>
+<body contenteditable>Hell<div></div></body>
+</html>

--- a/LayoutTests/editing/input/mac/writing-suggestions-in-anonymous-renderer.html
+++ b/LayoutTests/editing/input/mac/writing-suggestions-in-anonymous-renderer.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    font-size: 16px;
+    width: 300px;
+    height: 300px;
+    caret-color: transparent;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    getSelection().setPosition(document.body.childNodes[0], 1);
+    if (!window.testRunner)
+        return;
+    testRunner.waitUntilDone();
+    await UIHelper.setInlinePrediction("Hello", 4);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.notifyDone();
+});
+</script>
+</head>
+<body contenteditable><span>Hell</span><div></div></body>
+</html>


### PR DESCRIPTION
#### 316776c063a7e94ad008c5c9db5fa78b801d7824
<pre>
[Writing Suggestions] Prediction sometimes appears at the end of the document in Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=274223">https://bugs.webkit.org/show_bug.cgi?id=274223</a>
<a href="https://rdar.apple.com/128109513">rdar://128109513</a>

Reviewed by Richard Robinson.

Writing suggestions are still sometimes inserted in the wrong place in the render tree. This happens
under these conditions:

1.  The text node before the caret selection is inside of an anonymous renderer.
2.  There are one or more renderers that come after the text node&apos;s renderer in tree order, that are
    descendants of the element that contains the text node.

This is one concrete example, wherein an anonymous block-level renderer is added to contain a single
text node directly underneath the `body`:

```
&lt;body renderer&gt;
    &lt;anonymous renderer&gt;
        &lt;text renderer&gt; // this is the node before suggestions
        * // writing suggestions are supposed to be inserted here
    &lt;any other renderer&gt;
    …
    * // writing suggestions are inserted here instead
```

To fix this, we simply adjust the logic in `updateWritingSuggestionsRenderer` to insert the
generated writing suggestions renderer inside of the text node&apos;s parent, such that it&apos;s always
the next sibling of the text node.

* LayoutTests/editing/input/mac/writing-suggestions-in-anonymous-renderer-expected.html: Added.
* LayoutTests/editing/input/mac/writing-suggestions-in-anonymous-renderer.html: Added.

Add another layout test to exercise this change.

* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer):

Canonical link: <a href="https://commits.webkit.org/278833@main">https://commits.webkit.org/278833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0938257bbd1bb3aae4a81838137485f64666c445

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2359 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1829 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1798 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44638 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11306 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->