### PR TITLE
Added default length to createGridTrackBreadth() when length is undefined

### DIFF
--- a/LayoutTests/fast/css-grid-layout/css-grid-template-rows-invalid-length-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/css-grid-template-rows-invalid-length-expected.txt
@@ -1,0 +1,2 @@
+
+This test should not crash

--- a/LayoutTests/fast/css-grid-layout/css-grid-template-rows-invalid-length.html
+++ b/LayoutTests/fast/css-grid-layout/css-grid-template-rows-invalid-length.html
@@ -1,0 +1,22 @@
+<iframe width="0" srcdoc='
+<style>
+    * { grid-template-rows: 2vh 61px; -webkit-user-modify: read-write-plaintext-only; }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+function jsfuzzer() {
+try { htmlvar00029.replaceWith("htmlvar00009"); var00145 = htmlvar00028.innerHTML; } catch(e) { }
+try { /* */ var00144 = document.execCommand("insertHTML", false, var00145); } catch(e) { }
+}
+function eventhandler3() {
+try { htmlvar00029.selectionDirection = String.fromCharCode(67, 93); } catch(e) { }
+}
+</script>
+<body onload=jsfuzzer()>
+<svg onload="eventhandler3()"></svg>
+</svg>
+<fieldset id="htmlvar00028">
+<textarea id="htmlvar00029" value=".(e;">b26</textarea>
+'></iframe>
+<div>This test should not crash</div>

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1137,7 +1137,10 @@ inline GridLength BuilderConverter::createGridTrackBreadth(const CSSPrimitiveVal
     if (primitiveValue.isFlex())
         return GridLength(primitiveValue.doubleValue());
 
-    return primitiveValue.convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion | AutoConversion>(builderState.cssToLengthConversionData());
+    auto length = primitiveValue.convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion | AutoConversion>(builderState.cssToLengthConversionData());
+    if (!length.isUndefined())
+        return length;
+    return Length(0.0, LengthType::Fixed);
 }
 
 inline GridTrackSize BuilderConverter::createGridTrackSize(const CSSValue& value, BuilderState& builderState)


### PR DESCRIPTION
#### a5ef58e83a90d4ed76c02770b5ffdd385901e847
<pre>
Added default length to createGridTrackBreadth() when length is undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=269856">https://bugs.webkit.org/show_bug.cgi?id=269856</a>
<a href="https://rdar.apple.com/119619013">rdar://119619013</a>

Reviewed by Sammy Gill.

`convertToLength` returned length undefined to `createGridTrackBreadth`
which causes an issue when creating GridLength. Added check to see if
length is undefined and if so returned a default length = 0 instead

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::createGridTrackBreadth):

Originally-landed-as: 272448.626@safari-7618-branch (0b6e28662a19). <a href="https://rdar.apple.com/128091169">rdar://128091169</a>
Canonical link: <a href="https://commits.webkit.org/278871@main">https://commits.webkit.org/278871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ebf0b54b33b7a2ea4a7906f1169e8fddb6167aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42059 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1827 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56526 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49457 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44636 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48676 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28923 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7565 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->