### PR TITLE
`field-sizing: content` should disable relayout boundaries for text controls

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<body>
+<input id="inputa" style="field-sizing: content" type="number" value="12345"><input type="number">
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<body>
+<input id="inputa" style="field-sizing: content" type="number" value="12345"><input type="number">
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<link rel=match href="field-sizing-input-number-relayout-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<body>
+<input id="inputa" style="field-sizing: content" type="number"><input type="number">
+<script>
+requestAnimationFrame(() => {
+  inputa.value = '';
+  requestAnimationFrame(() => {
+    inputa.value = 12345;
+    takeScreenshot();
+  });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<body>
+<input id="inputa" style="field-sizing: content" value="12345"><input>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<body>
+<input id="inputa" style="field-sizing: content" value="12345"><input>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<link rel=match href="field-sizing-input-text-relayout-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<body>
+<input id="inputa" style="field-sizing: content" value=""><input>
+<script>
+requestAnimationFrame(() => {
+  inputa.value = '';
+  requestAnimationFrame(() => {
+    inputa.value = '12345';
+    takeScreenshot();
+  });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<body>
+<textarea style="field-sizing: content">12345</textarea><textarea></textarea>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<body>
+<textarea style="field-sizing: content">12345</textarea><textarea></textarea>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<link rel=match href="field-sizing-textarea-relayout-ref.html">
+<meta name="fuzzy" content="maxDifference=153; totalPixels=2" />
+<script src="/common/reftest-wait.js"></script>
+<body>
+<textarea id="textarea" style="field-sizing: content"></textarea><textarea></textarea>
+<script>
+requestAnimationFrame(() => {
+  textarea.value = '';
+  requestAnimationFrame(() => {
+    textarea.value = '12345';
+    takeScreenshot();
+  });
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -542,7 +542,7 @@ static inline bool objectIsRelayoutBoundary(const RenderElement* object)
         return true;
 
     if (auto* textControl = dynamicDowncast<RenderTextControl>(*object)) {
-        if (!textControl->isFlexItem() && !textControl->isGridItem()) {
+        if (!textControl->isFlexItem() && !textControl->isGridItem() && object->style().fieldSizing() != FieldSizing::Content) {
             // Flexing type of layout systems may compute different size than what input's preferred width is which won't happen unless they run their layout as well.
             return true;
         }


### PR DESCRIPTION
#### 1cdfa78d9cbae06b3dcc568882cd7e51655e1749
<pre>
`field-sizing: content` should disable relayout boundaries for text controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=270219">https://bugs.webkit.org/show_bug.cgi?id=270219</a>

Reviewed by Darin Adler.

Updates objectIsRelayoutBoundary to account for field-sizing property value.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number-relayout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-relayout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-relayout.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::objectIsRelayoutBoundary):

Canonical link: <a href="https://commits.webkit.org/291783@main">https://commits.webkit.org/291783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f543e58fbf9ec7800968688d839c79dbb78ca84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67389 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25128 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47709 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33885 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37048 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75392 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19736 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14118 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->