### PR TITLE
[JSC] B3::EliminateCommonSubexpression shouldn't remove reads info after processing each block

### DIFF
--- a/JSTests/stress/ecs-store-with-loop.js
+++ b/JSTests/stress/ecs-store-with-loop.js
@@ -1,0 +1,24 @@
+//@ runDefault("--jitPolicyScale=0")
+let var1 = 0x80000000;
+
+function foo() {
+    for (let i = 0; i < 7; i++) {
+        var1 = var1 << i;
+        var1 = var1 - 1;
+    }
+    var1 >>= 8;
+    return var1;
+}
+noInline(foo);
+
+function main() {
+    let ret = undefined;
+    foo();
+    let expected = foo();
+    for (let i = 0; i < 1e3; i++) {
+        ret = foo();
+        if (expected != ret)
+            throw new Error();
+    }
+}
+main();

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -278,6 +278,12 @@ private:
         
         if (memory)
             processMemoryAfterClobber(memory);
+
+        // The reads info should be updated even the block is processed
+        // since the dominated store nodes may dependent on the data
+        // read from the processed block. Note that there is no need to
+        // update reads info if the node is deleted.
+        m_data.reads.add(m_value->effects().reads);
     }
 
     // Return true if we got rid of the operation. If you changed IR in this function, you have to

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1204,6 +1204,8 @@ void addTupleTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 
 bool shouldRun(const TestConfig*, const char* testName);
 
+void testCSEStoreWithLoop();
+
 void testLoadPreIndex32();
 void testLoadPreIndex64();
 void testLoadPostIndex32();


### PR DESCRIPTION
#### 1abeda3a23f182f79a5eb5a7cb82f1e82b42eed3
<pre>
[JSC] B3::EliminateCommonSubexpression shouldn&apos;t remove reads info after processing each block
<a href="https://bugs.webkit.org/show_bug.cgi?id=265426">https://bugs.webkit.org/show_bug.cgi?id=265426</a>
<a href="https://rdar.apple.com/118832222">rdar://118832222</a>

Reviewed by Yusuke Suzuki.

Eliminate common subexpressions in B3 is used to remove redundant B3 nodes.
Current algorithm removes block reads info after processing each block. This is wrong
since some B3 nodes may be deleted erroneously due to the missing reads info from
the processed blocks. To fix this issue, we should update block reads info after
processing each node.

* JSTests/stress/ecs-store-with-loop.js: Added.
(foo):
(main):
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testCSEStoreWithLoop):
(addShrTests):

Originally-landed-as: 272448.698@safari-7618-branch (e6aa0aa96d51). <a href="https://rdar.apple.com/128089690">rdar://128089690</a>
Canonical link: <a href="https://commits.webkit.org/278865@main">https://commits.webkit.org/278865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd51f34e17934baa8b567f23d6566ace383a66d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42065 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1843 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45025 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56541 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51188 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49467 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44653 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48693 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28938 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63508 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7557 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27778 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11985 "Passed tests") | 
<!--EWS-Status-Bubble-End-->