### PR TITLE
Calling evaluateJavaScript enables back-button hijacking

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8451,8 +8451,12 @@ bool Document::hasRecentUserInteractionForNavigationFromJS() const
     if (UserGestureIndicator::processingUserGesture(this))
         return true;
 
-    static constexpr Seconds maximumItervalForUserGestureForwarding { 10_s };
-    return (MonotonicTime::now() - lastHandledUserGestureTimestamp()) <= maximumItervalForUserGestureForwarding;
+    RefPtr window = domWindow();
+    if (!window || window->lastActivationTimestamp().isInfinity())
+        return false;
+
+    static constexpr Seconds maximumIntervalForUserActivationForwarding { 10_s };
+    return (MonotonicTime::now() - window->lastActivationTimestamp()) <= maximumIntervalForUserActivationForwarding;
 }
 
 void Document::startTrackingStyleRecalcs()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -569,6 +569,20 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragmen
     });
 }
 
+TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushStateAfterEvaluateJS)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
+        // Do a call to evaluateJavaScript (with user gesture) *BEFORE* the pushState and make sure it doesn't count
+        // as a user gesture for the pushState().
+        __block bool didRunScript = false;
+        [webView evaluateJavaScript:@"window.foo = 1;" completionHandler:^(id, NSError *) {
+            didRunScript = true;
+        }];
+        TestWebKitAPI::Util::run(&didRunScript);
+        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s) completionHandler:nil];
+    });
+}
+
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureSubframe)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 26dd802ebb28b5acb59ea16b46c85f83fa243cd3
<pre>
Calling evaluateJavaScript enables back-button hijacking
<a href="https://bugs.webkit.org/show_bug.cgi?id=261611">https://bugs.webkit.org/show_bug.cgi?id=261611</a>
<a href="https://rdar.apple.com/115561250">rdar://115561250</a>

Reviewed by Ben Nham.

In 253405@main, I updated our back/forward list hijacking prevention logic by
treating history items added by JS (e.g. via &apos;history.pushState()`) as having
a user gesture if a user gesture had occurred in the last 10 seconds. This was
needed for backward compatibility with some legit sites.

The issue now is that if the client app has called evaluateJavaScript on the
WKWebView in the last 10 seconds, the JS will be able to hijack the back/forward
list again.

In 265168@main, we did some hardening so that the transient activation gets
consumed after the evaluateJavaScript call has completed. However, it didn&apos;t
fix the back/forward list hijacking prevention logic because it relies on
user gesture and not transient activation.

To address the issue, I updated out back/forward list hijacking prevention logic
to rely on transient user activation rather than whether or not there was a
user gesture in the last 10 minutes.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hasRecentUserInteractionForNavigationFromJS const):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST):

Originally-landed-as: 272448.685@safari-7618-branch (028628cff473). <a href="https://rdar.apple.com/128089980">rdar://128089980</a>
Canonical link: <a href="https://commits.webkit.org/278881@main">https://commits.webkit.org/278881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e708fc8f14923352a607993b7f9a37f81a9e232

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23194 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1845 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56543 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49469 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48696 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28940 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7573 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->