### PR TITLE
GetWebAssemblyInstanceExports nodes should not be blindly hoisted

### DIFF
--- a/JSTests/stress/hoist-get-wasm-exports.js
+++ b/JSTests/stress/hoist-get-wasm-exports.js
@@ -1,0 +1,30 @@
+function opt(access, instance, transition) {
+    let result;
+    instance.x;
+
+    for (let i = 0; i < 2; i++) {
+        transition.y = 1;
+
+        if (access) {
+            result = instance.exports;
+        }
+    }
+
+    return result;
+}
+
+function main() {
+    const emptyModule = new WebAssembly.Module(new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]));
+    const instance = new WebAssembly.Instance(emptyModule, {});
+    instance.x = 1;
+
+    const object = {x: 1, p1: 1, p2: 1, p3: 1, p4: 0x1234};
+
+    for (let i = 0; i < 100000; i++) {
+        opt(/* access */ true, instance, {});
+        opt(/* access */ false, object, {});
+    }
+}
+
+if (typeof WebAssembly === "object")
+    main();

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -326,7 +326,6 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case DataViewGetInt:
     case DataViewGetFloat:
     case ResolveRope:
-    case GetWebAssemblyInstanceExports:
     case NumberIsNaN:
     case StringIndexOf:
         return true;
@@ -437,6 +436,22 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
             if (checkOffset != desiredOffset || !(attributes & PropertyAttribute::Accessor))
                 return false;
         }
+        return true;
+    }
+
+    case GetWebAssemblyInstanceExports: {
+        if (!state.forNode(node->child1()).isType(SpecCell))
+            return false;
+
+        StructureAbstractValue& value = state.forNode(node->child1()).m_structure;
+        if (value.isInfinite())
+            return false;
+        for (unsigned i = value.size(); i--;) {
+            Structure* structure = value[i].get();
+            if (structure->typeInfo().type() != WebAssemblyInstanceType)
+                return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
#### fc8a911ed08115172c50eac41b9ced4e3415d234
<pre>
GetWebAssemblyInstanceExports nodes should not be blindly hoisted
<a href="https://bugs.webkit.org/show_bug.cgi?id=270259">https://bugs.webkit.org/show_bug.cgi?id=270259</a>
<a href="https://rdar.apple.com/123617167">rdar://123617167</a>

Reviewed by Alexey Shvayka.

GetWebAssemblyInstanceExports nodes should not be blindly hoisted above
their structure check.

```
case WebAssemblyInstanceExportsIntrinsic:
    ...
    addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(variant.structureSet())), thisNode);
    set(result, addToGraph(GetWebAssemblyInstanceExports, Edge(thisNode, KnownCellUse)));
```

Similar to GetByOffset, we should only hoist this node if we have proven
that the child has the structure of a WebAssembly Instance.

* JSTests/stress/hoist-get-wasm-exports.js: Added.
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):

Originally-landed-as: 272448.653@safari-7618-branch (f6e2c3bb0a72). <a href="https://rdar.apple.com/128090197">rdar://128090197</a>
Canonical link: <a href="https://commits.webkit.org/278866@main">https://commits.webkit.org/278866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bef0593fe0bbe94e380849e82bd2104fcb9fa3b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2381 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42070 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1848 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45031 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56547 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51194 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48703 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28944 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63514 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7558 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27784 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11987 "Passed tests") | 
<!--EWS-Status-Bubble-End-->