### PR TITLE
Special case treatment of out-of-flow RenderLineBreak

### DIFF
--- a/LayoutTests/fast/css/line-break-fixed-position-container-expected.txt
+++ b/LayoutTests/fast/css/line-break-fixed-position-container-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/css/line-break-fixed-position-container.html
+++ b/LayoutTests/fast/css/line-break-fixed-position-container.html
@@ -1,0 +1,36 @@
+<html>
+<head>
+<style>
+/* Fixed position for the line break should be ignored. */
+br { position: fixed; }
+
+/* Only function of this styling is forcing style invalidation
+ * on the line break renderer. */
+br::first-line { color: blue; }
+</style>
+<script>
+function test() {
+    if (window.testRunner) {
+        window.testRunner.dumpAsText();
+        window.testRunner.waitUntilDone();
+    }
+
+    setTimeout(function() {
+        // Only function of this event listener is invalidating event regions
+        // for the Document and subsequently triggering a complete style rebuild
+        // which is necessary to exhibit the problem.
+        window.addEventListener('wheel', function() { });
+
+        setTimeout(function() {
+            if (window.testRunner)
+                window.testRunner.notifyDone();
+        });
+    });
+}
+</script>
+</head>
+<body onload="test()">
+This test passes if it doesn't crash.
+<br/>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -747,7 +747,8 @@ RenderBlock* RenderObject::containingBlockForPositionType(PositionType positionT
 
 RenderBlock* RenderObject::containingBlock() const
 {
-    if (is<RenderText>(*this))
+    // FIXME: See https://bugs.webkit.org/show_bug.cgi?id=270977 for RenderLineBreak special treatment.
+    if (is<RenderText>(*this) || is<RenderLineBreak>(*this))
         return containingBlockForPositionType(PositionType::Static, *this);
 
     auto containingBlockForRenderer = [](const auto& renderer) -> RenderBlock* {
@@ -1702,9 +1703,15 @@ static inline RenderElement* containerForElement(const RenderObject& renderer, c
     // (2) For absolute positioned elements, it will return a relative positioned inline, while
     // containingBlock() skips to the non-anonymous containing block.
     // This does mean that computePositionedLogicalWidth and computePositionedLogicalHeight have to use container().
-    auto* renderElement = dynamicDowncast<RenderElement>(renderer);
-    if (!renderElement)
+    // FIXME: See https://bugs.webkit.org/show_bug.cgi?id=270977 for RenderLineBreak special treatment.
+    if (!is<RenderElement>(renderer) || is<RenderText>(renderer) || is<RenderLineBreak>(renderer))
         return renderer.parent();
+
+    auto* renderElement = dynamicDowncast<RenderElement>(renderer);
+    if (!renderElement) {
+        ASSERT_NOT_REACHED();
+        return renderer.parent();
+    }
     auto updateRepaintContainerSkippedFlagIfApplicable = [&] {
         if (!repaintContainerSkipped)
             return;


### PR DESCRIPTION
#### cfbedad2b912fe2910a7de269bf055bbc60fcc00
<pre>
Special case treatment of out-of-flow RenderLineBreak
<a href="https://bugs.webkit.org/show_bug.cgi?id=264631">https://bugs.webkit.org/show_bug.cgi?id=264631</a>
<a href="https://rdar.apple.com/114719845">rdar://114719845</a>

Reviewed by Alan Baradlay.

Out-of-flow RenderLineBreaks have problems when relying on default out-of-flow support of the render
tree, see <a href="https://bugs.webkit.org/show_bug.cgi?id=270977.">https://bugs.webkit.org/show_bug.cgi?id=270977.</a>

To fix the problem we change containerForElement and containingBlock to treat RenderLineBreak that are out-of-flow as
if they have position: static.

* LayoutTests/fast/css/line-break-fixed-position-container-expected.txt: Added.
* LayoutTests/fast/css/line-break-fixed-position-container.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::containingBlock const):
(WebCore::containerForElement):

Originally-landed-as: 274097.12@webkit-2024.2-embargoed (5bd3a1c2b0ac). <a href="https://rdar.apple.com/128088216">rdar://128088216</a>
Canonical link: <a href="https://commits.webkit.org/278867@main">https://commits.webkit.org/278867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55bd640158af27733641e7e3aade020f42e986c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42073 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1857 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56555 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49476 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48705 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28952 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7560 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->