### PR TITLE
Implement `field-sizing: content` minimum width for text caret

### DIFF
--- a/LayoutTests/fast/forms/text/text-field-sizing-caret-expected.txt
+++ b/LayoutTests/fast/forms/text/text-field-sizing-caret-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS The width of an empty text input should be same as the caret width
+PASS The width of an empty search input should be same as the caret width
+PASS The width of an empty number input should be same as the caret width
+

--- a/LayoutTests/fast/forms/text/text-field-sizing-caret.html
+++ b/LayoutTests/fast/forms/text/text-field-sizing-caret.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+input {
+  border: none;
+  padding: 0px;
+  field-sizing: content;
+}
+input::-webkit-search-cancel-button {
+  display: none;
+}
+input::-webkit-inner-spin-button {
+  display: none;
+}
+</style>
+<input id="text">
+<input id="search" type="search">
+<input id="number" type="number">
+<script>
+text.focus();
+finalCaretRect = internals.absoluteCaretBounds();
+
+test(() => {
+  assert_equals(document.querySelector('#text').offsetWidth, finalCaretRect.width);
+}, 'The width of an empty text input should be same as the caret width');
+test(() => {
+  assert_equals(document.querySelector('#search').offsetWidth, finalCaretRect.width);
+}, 'The width of an empty search input should be same as the caret width');
+test(() => {
+  assert_equals(document.querySelector('#number').offsetWidth, finalCaretRect.width);
+}, 'The width of an empty number input should be same as the caret width');
+</script>

--- a/LayoutTests/fast/forms/textarea/textarea-field-sizing-caret-expected.txt
+++ b/LayoutTests/fast/forms/textarea/textarea-field-sizing-caret-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS The width of an empty textarea should be same as the caret width
+PASS The height of an empty textarea should be same as the caret height in a vertical writing-mode
+

--- a/LayoutTests/fast/forms/textarea/textarea-field-sizing-caret.html
+++ b/LayoutTests/fast/forms/textarea/textarea-field-sizing-caret.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+textarea {
+  border: none;
+  padding: 0px;
+  field-sizing: content;
+}
+</style>
+<textarea id="textarea"></textarea>
+<textarea style="writing-mode:vertical-rl"></textarea>
+<script>
+textarea.focus();
+finalCaretRect = internals.absoluteCaretBounds();
+test(() => {
+  assert_equals(document.querySelector('textarea').offsetWidth, finalCaretRect.width);
+}, 'The width of an empty textarea should be same as the caret width');
+test(() => {
+  assert_equals(document.querySelectorAll('textarea')[1].offsetHeight, finalCaretRect.width);
+}, 'The height of an empty textarea should be same as the caret height in a vertical writing-mode');
+</script>

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -908,6 +908,9 @@ void HTMLTextFormControlElement::adjustInnerTextStyle(const RenderStyle& parentS
         }
     }
 
+    if (parentStyle.fieldSizing() == FieldSizing::Content)
+        textBlockStyle.setLogicalMinWidth(Length { caretWidth(), LengthType::Fixed });
+
 #if PLATFORM(IOS_FAMILY)
     if (textBlockStyle.textSecurity() != TextSecurity::None && !textBlockStyle.isLeftToRightDirection()) {
         // Preserve the alignment but force the direction to LTR so that the last-typed, unmasked character


### PR DESCRIPTION
#### c2e64ba96fbed90353cfdea4b0c20a855a6c40bb
<pre>
Implement `field-sizing: content` minimum width for text caret
<a href="https://bugs.webkit.org/show_bug.cgi?id=269128">https://bugs.webkit.org/show_bug.cgi?id=269128</a>

Reviewed by Darin Adler.

Updates text control computed style to include a minimum sizing so the caret shows.

* LayoutTests/fast/forms/text/text-field-sizing-caret-expected.txt: Added.
* LayoutTests/fast/forms/text/text-field-sizing-caret.html: Added.
* LayoutTests/fast/forms/textarea/textarea-field-sizing-caret-expected.txt: Added.
* LayoutTests/fast/forms/textarea/textarea-field-sizing-caret.html: Added.
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::adjustInnerTextStyle const):

Canonical link: <a href="https://commits.webkit.org/279115@main">https://commits.webkit.org/279115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b272fbe30ecf4d20b1685066fc8f9196c8912c8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42504 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1896 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2355 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57097 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2556 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45199 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->