### PR TITLE
Difference in semantics between jsTypeStringForValueWithConcurrency and buildTypeOf

### DIFF
--- a/JSTests/stress/getter-setter-ai.js
+++ b/JSTests/stress/getter-setter-ai.js
@@ -1,0 +1,61 @@
+//@runDefault("--useConcurrentJIT=false", "--validateAbstractInterpreterState=true", "--validateAbstractInterpreterStateProbability=1.0")
+function opt(inline, callTypeOf, object, transition) {
+    let result;
+
+    object.p1;
+
+    for (let i = 0; i < 2; i++) {
+        if (inline) {
+            object();
+
+            result = object.p2;
+        }
+
+        if (callTypeOf) {
+            transition.x = 1;
+
+            result = typeof(object.p3);
+        }
+    }
+
+
+    return result;
+}
+
+function watchP3(object) {
+    function cache() {
+        return object.p3;
+    }
+
+    for (let i = 0; i < 100; i++) {
+        cache();
+    }
+}
+
+function main() {
+    noDFG(main);
+
+    let object1 = function () {};
+    object1.p1 = 1;
+    object1.p2 = 1;
+    object1.__defineGetter__('p3', () => {});
+
+    let object2 = function () {};
+    object2.p1 = 2;
+    object2.p2 = 1;
+    object2.p3 = 1;
+
+    watchP3(object1);
+
+    for (let i = 0; i < 100; i++) {
+        opt(/* inline */ false, /* callTypeOf */ true, object2, {});
+    }
+
+    for (let i = 0; i < 10000; i++) {
+        opt(/* inline */ true, /* callTypeOf */ false, object1, {});
+    }
+
+    opt(/* inline */ false, /* callTypeOf */ false, object1, {});
+}
+
+main();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -20149,7 +20149,9 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock stringCase = m_out.newBlock();
         LBasicBlock notStringCase = m_out.newBlock();
         LBasicBlock bigIntCase = m_out.newBlock();
+        LBasicBlock notBigIntCase = m_out.newBlock();
         LBasicBlock symbolCase = m_out.newBlock();
+        LBasicBlock notSymbolCase = m_out.newBlock();
         LBasicBlock notCellCase = m_out.newBlock();
         LBasicBlock numberCase = m_out.newBlock();
         LBasicBlock notNumberCase = m_out.newBlock();
@@ -20209,13 +20211,24 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(notStringCase, bigIntCase);
         m_out.branch(
             isHeapBigInt(value, provenType(child) & (SpecCell - SpecObject - SpecString)),
-            unsure(bigIntCase), unsure(symbolCase));
+            unsure(bigIntCase), unsure(notBigIntCase));
 
-        m_out.appendTo(bigIntCase, symbolCase);
+        m_out.appendTo(bigIntCase, notBigIntCase);
         functor(TypeofType::BigInt);
 
-        m_out.appendTo(symbolCase, notCellCase);
+        m_out.appendTo(notBigIntCase, symbolCase);
+        m_out.branch(
+            isSymbol(value, provenType(child) & (SpecCell - SpecObject - SpecString - SpecBigInt)),
+            unsure(symbolCase), unsure(notSymbolCase));
+
+        m_out.appendTo(symbolCase, notSymbolCase);
         functor(TypeofType::Symbol);
+
+        m_out.appendTo(notSymbolCase, notCellCase);
+        // This case can happen for internal objects like GetterSetter too, that
+        // can be exposed to this function by transformations like LICM blind hoisting.
+        // The actual result shouldn't matter, as long as it matches jsTypeStringForValueWithConcurrency.
+        functor(TypeofType::Object);
 
         m_out.appendTo(notCellCase, numberCase);
         m_out.branch(

--- a/Source/JavaScriptCore/runtime/Operations.cpp
+++ b/Source/JavaScriptCore/runtime/Operations.cpp
@@ -109,6 +109,9 @@ JSString* jsTypeStringForValueWithConcurrency(VM& vm, JSGlobalObject* globalObje
             return nullptr;
         }
     }
+    // This case can happen for internal objects like GetterSetter, that
+    // can be exposed to this function by transformations like LICM blind hoisting.
+    // The actual result shouldn't matter, as long as it matches buildTypeOf.
     return vm.smallStrings.objectString();
 }
 


### PR DESCRIPTION
#### 31319e7a0b96c61cd61e17377adc648e4b8b5692
<pre>
Difference in semantics between jsTypeStringForValueWithConcurrency and buildTypeOf
<a href="https://bugs.webkit.org/show_bug.cgi?id=270659">https://bugs.webkit.org/show_bug.cgi?id=270659</a>
<a href="https://rdar.apple.com/124116542">rdar://124116542</a>

Reviewed by Yusuke Suzuki.

Consider the given test case:

Object1: 0x30000bba0 %DL (should never getByOffset p3 of this, it is a GetterSetter)
Object2: 0x30000bc10 %DS (p3 is fine)

 Before LICM:
32  0 40:   D@26:&lt;!0:-&gt; FilterGetByStatus(Check:Untyped:D@7, MustGen, (Simple, &lt;id=&apos;uid:(p1)&apos;, [0x30000bc10:[0xbc10/48144, Function, (0/0, 3/4){p1:64, p2:65, p3:66}, NonArray, Proto:0x11706ddc8, Leaf (Watched)], 0x30000bba0:[0xbba0/48032, Function, (0/0, 3/4){p1:64, p2:65, p3:66}, NonArray, Proto:0x11706ddc8, Leaf (Watched)]], [], offset = 64&gt;, seenInJIT = true), W:SideState, bc#4, ExitValid)
33  0 40:   D@15:&lt;!0:-&gt; AssertNotEmpty(Check:Untyped:D@7, MustGen, W:SideState, Exits, bc#4, ExitValid)
34  0 40:   D@28:&lt;!0:-&gt; CheckStructure(Cell:D@7, MustGen, [%DS:Function, %DL:Function], R:JSCell_structureID, Exits, bc#4, ExitValid)
35  0 40:   D@29:&lt; 2:-&gt; GetButterfly(Cell:D@7, Storage|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, Other, R:JSObject_butterfly, bc#4, ExitValid)
36  0 40:   D@30:&lt; 1:-&gt; GetByOffset(Check:Untyped:D@29, KnownCell:D@7, JS|PureInt, Int32, id0{p1}, 64, R:NamedProperties(0), bc#4, ExitValid)  predicting Int32

... branching

6  7 40:   D@87:&lt;!0:-&gt;  FilterGetByStatus(Check:Untyped:D@7, MustGen, (Simple, &lt;id=&apos;uid:(p3)&apos;, [0x30000bc10:[0xbc10/48144, Function, (0/0, 3/4){p1:64, p2:65, p3:66}, NonArray, Proto:0x11706ddc8, Leaf (Watched)]], [], offset = 66&gt;, seenInJIT = true), W:SideState, bc#45, ExitValid)
7  7 40:   D@89:&lt;!0:-&gt;  CheckStructure(Cell:D@7, MustGen, [%DS:Function], R:JSCell_structureID, Exits, bc#45, ExitValid)
8  7 40:   D@91:&lt; 2:-&gt;  GetByOffset(Check:Untyped:D@29, KnownCell:D@7, JS|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, BoolInt32, id3{p3}, 66, R:NamedProperties(3), bc#45, ExitValid)  predicting BoolInt32
11  7 40:   D@94:&lt; 2:-&gt; TypeOf(Check:Untyped:Kill:D@91, JS|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, StringIdent, Exits, bc#51, ExitValid)

Note that we never get p3 of DL

After LICM blind hoist:
 34  0 41:   D@28:&lt;!0:-&gt;        CheckStructure(Cell:D@7, MustGen, [%DS:Function, %DL:Function], R:JSCell_structureID, Exits, bc#4, ExitValid)
 35  0 41:   D@29:&lt; 2:-&gt;        GetButterfly(Cell:D@7, Storage|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, Other, R:JSObject_butterfly, bc#4, ExitValid)
 36  0 41:   D@30:&lt; 1:-&gt;        GetByOffset(Check:Untyped:D@29, KnownCell:D@7, JS|PureInt, Int32, id0{p1}, 64, R:NamedProperties(0), bc#4, ExitValid)  predicting Int32
 44  0 41:   D@48:&lt;!0:-&gt;        CheckIsConstant(Cell:D@7, MustGen, &lt;0x13908f140, Function&gt;, object1#B5FU55/&lt;nogen&gt;:[0x13909da00], Exits, bc#25, exit: bc#17, ExitValid, WasHoisted)
 45  0 41:   D@91:&lt; 2:-&gt;        GetByOffset(Check:Untyped:D@29, KnownCell:D@7, JS|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, BoolInt32, id3{p3}, 66, R:NamedProperties(3), bc#45, exit: bc#17, ExitValid)  predicting BoolInt32
 46  0 41:   D@94:&lt; 2:-&gt;        TypeOf(Check:Untyped:Kill:D@91, JS|PureNum|NeedsNegZero|NeedsNaNOrInfinity|UseAsOther, StringIdent, Exits, bc#51, exit: bc#17, ExitValid, WasHoisted)

The GetByOffset is hoisted without its guarding CheckStructure, and it accesses p3 unexpectedly. SafeToExecute says it is
safe because it won&apos;t crash or produce a malformed JSValue. Honestly, fair.

This patch fixes the semantic difference between AI and runtime for GetterSetter objects.
Stopping the GetterSetter from being hoisted may be too costly and restrictive, and it
doesn&apos;t get leaked anyway.

The string result (which was [object] but is now [symbol]) doesn&apos;t really matter, it should
never leak to user code anyway. Even if it does, it is just a string.

* JSTests/stress/getter-setter-ai.js: Added.
(opt):
(watchP3.cache):
(watchP3):
(main.let.object1):
(main.let.object2):
(main):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Operations.cpp:
(JSC::jsTypeStringForValueWithConcurrency):

Originally-landed-as: 272448.708@safari-7618-branch (b42cc4168b71). <a href="https://rdar.apple.com/128089110">rdar://128089110</a>
Canonical link: <a href="https://commits.webkit.org/278868@main">https://commits.webkit.org/278868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23917898dd476feb7ab6c8ff993042231b302af6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42076 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1862 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45047 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56563 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51210 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49481 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48713 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28960 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63530 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7561 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27800 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11989 "Passed tests") | 
<!--EWS-Status-Bubble-End-->