### PR TITLE
Ensure that the SWServerWorker is in the correct state before finishing installation

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -200,7 +200,10 @@ void SWServerWorker::scriptContextStarted(const std::optional<ServiceWorkerJobDa
 
 void SWServerWorker::didFinishInstall(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, bool wasSuccessful)
 {
-    ASSERT(m_server && this->state() == ServiceWorkerState::Installing);
+    auto state = this->state();
+
+    ASSERT(m_server);
+    ASSERT(state == ServiceWorkerState::Installing);
     if (RefPtr server = m_server.get())
         server->didFinishInstall(jobDataIdentifier, *this, wasSuccessful);
 }


### PR DESCRIPTION
#### 0c63d2dc08e5fdee297ea17c88431ea387b2ca39
<pre>
Ensure that the SWServerWorker is in the correct state before finishing installation
<a href="https://rdar.apple.com/121429889">rdar://121429889</a>

Reviewed by Youenn Fablet.

Ensure that the SWServerWorker is in the expected state and bail if this method is triggered on a SWServerWorker in a different state. This method is callable over CoreIPC passing a ServiceWorkerIdentifier. Passing the ID of a service worker in any other state will reach the RELEASE_ASSERT

* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::didFinishInstall):

Originally-landed-as: 272448.701@safari-7618-branch (be630dbb12c9). rdar://128089504
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c63d2dc08e5fdee297ea17c88431ea387b2ca39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52820 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32157 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5307 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56099 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3543 "Hash 0c63d2dc for PR 28626 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55125 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38877 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3268 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/56099 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/3543 "Hash 0c63d2dc for PR 28626 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54918 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/38877 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/5307 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/56099 "Hash 0c63d2dc for PR 28626 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/38877 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/5307 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1702 "Hash 0c63d2dc for PR 28626 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/38877 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/5307 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57692 "Hash 0c63d2dc for PR 28626 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27961 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/57692 "Hash 0c63d2dc for PR 28626 does not build (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/5307 "Hash 0c63d2dc for PR 28626 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/57692 "Hash 0c63d2dc for PR 28626 does not build (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28935 "Hash 0c63d2dc for PR 28626 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->