### PR TITLE
Changing a JSFunction's prototype property should clear allocation caches

### DIFF
--- a/JSTests/stress/bound-constructor-change-prototype-clears-cache.js
+++ b/JSTests/stress/bound-constructor-change-prototype-clears-cache.js
@@ -1,0 +1,73 @@
+function empty() {
+
+}
+
+function test1() {
+    const newTarget = (function () {}).bind();
+    newTarget.prototype = Object.prototype;
+
+    const a = Reflect.construct(Promise, [empty], newTarget);
+
+    newTarget.prototype = Array.prototype;
+
+    const b = Reflect.construct(Promise, [empty], newTarget);
+
+    if (a.__proto__ === b.__proto__)
+        throw new Error('They should be different.');
+}
+
+function test2() {
+    const newTarget = (function () {}).bind();
+    newTarget.prototype = Object.prototype;
+
+    const newTargetWrapper = Function.prototype.apply;
+    newTargetWrapper.prototype = newTarget;
+
+    class Opt extends Promise {
+        constructor() {
+            newTargetWrapper.prototype = new.target;
+            empty instanceof newTargetWrapper;
+            
+            super(empty);
+        }
+    }
+
+    for (let i = 0; i < 200000; i++) {
+        Reflect.construct(Opt, [], newTarget);
+    }
+
+    const a = Reflect.construct(Opt, [], newTarget);
+
+    newTarget.prototype = Array.prototype;
+    Reflect.construct(Object, [], newTarget);
+
+    const b = Reflect.construct(Opt, [], newTarget);
+
+    if (a.__proto__ === b.__proto__)
+        throw new Error('They should be different.');
+}
+
+function test3() {
+    const newTarget = (function () {}).bind();
+    let prototype = Object.prototype;
+    Object.defineProperty(newTarget, "prototype", { get() { return prototype; }});
+
+    const a = Reflect.construct(Promise, [empty], newTarget);
+
+    prototype = Array.prototype;
+
+    const b = Reflect.construct(Promise, [empty], newTarget);
+
+    if (a.__proto__ == b.__proto__)
+        throw new Error('They should be different.');
+}
+
+function main() {
+    test1();
+
+    test2();
+
+    test3();
+}
+
+main();

--- a/JSTests/stress/put-prototype-to-normal-function-shouldnt-be-cached.js
+++ b/JSTests/stress/put-prototype-to-normal-function-shouldnt-be-cached.js
@@ -1,0 +1,38 @@
+function opt(object, value) {
+    object.prototype = value;
+}
+
+function main() {
+    Function.prototype.__proto__ = new Proxy({}, {});
+
+    const object = {
+        nonConstructor() { }
+    };
+
+    function target() { }
+
+    Function.prototype.__proto__ = Object.prototype;
+
+    const nonConstructor = object.nonConstructor;
+
+    Object.defineProperty(nonConstructor, 'prototype', {
+        configurable: false,
+        enumerable: false,
+        writable: true,
+        value: {}
+    });
+
+    target.prototype = {};
+    Reflect.construct(Object, [], target);
+
+    opt(nonConstructor, {});
+    const newPrototype = {};
+    opt(target, newPrototype);
+
+    const result = Reflect.construct(Object, [], target);
+
+    if (result.__proto__ !== newPrototype)
+        throw new Error("Rare data of result was not cleared.");
+}
+
+main();

--- a/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
+++ b/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
@@ -135,6 +135,12 @@ ALWAYS_INLINE void ObjectAllocationProfileBase<Derived>::initializeProfile(VM& v
     // Ensure that if another thread sees the structure and prototype, it will see it properly created.
     WTF::storeStoreFence();
 
+    // The watchpoint should have been fired already but it's prudent to be safe here.
+    if (UNLIKELY(functionRareData && m_structure && m_structure.get() != structure)) {
+        ASSERT(functionRareData->allocationProfileWatchpointSet().hasBeenInvalidated());
+        functionRareData->allocationProfileWatchpointSet().fireAll(vm, "Clearing to be safe because structure has changed");
+    }
+
     m_structure.set(vm, owner, structure);
     static_cast<Derived*>(this)->setPrototype(vm, owner, prototype);
 }

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -413,22 +413,19 @@ JSC_DEFINE_JIT_OPERATION(operationCreateThis, JSCell*, (JSGlobalObject* globalOb
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (constructor->type() == JSFunctionType && jsCast<JSFunction*>(constructor)->canUseAllocationProfile()) {
-        JSObject* result;
-        {
-            DeferTermination deferScope(vm);
-            auto rareData = jsCast<JSFunction*>(constructor)->ensureRareDataAndAllocationProfile(globalObject, inlineCapacity);
-            scope.releaseAssertNoException();
-            ObjectAllocationProfileWithPrototype* allocationProfile = rareData->objectAllocationProfile();
-            Structure* structure = allocationProfile->structure();
-                result = constructEmptyObject(vm, structure);
-            if (structure->hasPolyProto()) {
-                JSObject* prototype = allocationProfile->prototype();
-                ASSERT(prototype == jsCast<JSFunction*>(constructor)->prototypeForConstruction(vm, globalObject));
-                result->putDirectOffset(vm, knownPolyProtoOffset, prototype);
-                prototype->didBecomePrototype(vm);
-                ASSERT_WITH_MESSAGE(!hasIndexedProperties(result->indexingType()), "We rely on JSFinalObject not starting out with an indexing type otherwise we would potentially need to convert to slow put storage");
-            }
+    if (constructor->type() == JSFunctionType && jsCast<JSFunction*>(constructor)->canUseAllocationProfiles()) {
+        DeferTermination deferScope(vm);
+        auto rareData = jsCast<JSFunction*>(constructor)->ensureRareDataAndObjectAllocationProfile(globalObject, inlineCapacity);
+        scope.releaseAssertNoException();
+        ObjectAllocationProfileWithPrototype* allocationProfile = rareData->objectAllocationProfile();
+        Structure* structure = allocationProfile->structure();
+        JSObject* result = constructEmptyObject(vm, structure);
+        if (structure->hasPolyProto()) {
+            JSObject* prototype = allocationProfile->prototype();
+            ASSERT(prototype == jsCast<JSFunction*>(constructor)->prototypeForConstruction(vm, globalObject));
+            result->putDirectOffset(vm, knownPolyProtoOffset, prototype);
+            prototype->didBecomePrototype(vm);
+            ASSERT_WITH_MESSAGE(!hasIndexedProperties(result->indexingType()), "We rely on JSFinalObject not starting out with an indexing type otherwise we would potentially need to convert to slow put storage");
         }
         OPERATION_RETURN(scope, result);
     }

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -152,7 +152,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_create_this)
     JSObject* result;
     JSObject* constructorAsObject = asObject(GET(bytecode.m_callee).jsValue());
     JSFunction* constructor = jsDynamicCast<JSFunction*>(constructorAsObject);
-    if (constructor && constructor->canUseAllocationProfile()) {
+    if (constructor && constructor->canUseAllocationProfiles()) {
         WriteBarrier<JSCell>& cachedCallee = bytecode.metadata(codeBlock).m_cachedCallee;
         if (!cachedCallee)
             cachedCallee.set(vm, codeBlock, constructor);
@@ -160,7 +160,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_create_this)
             cachedCallee.setWithoutWriteBarrier(JSCell::seenMultipleCalleeObjects());
 
         size_t inlineCapacity = bytecode.m_inlineCapacity;
-        ObjectAllocationProfileWithPrototype* allocationProfile = constructor->ensureRareDataAndAllocationProfile(globalObject, inlineCapacity)->objectAllocationProfile();
+        ObjectAllocationProfileWithPrototype* allocationProfile = constructor->ensureRareDataAndObjectAllocationProfile(globalObject, inlineCapacity)->objectAllocationProfile();
         CHECK_EXCEPTION();
         Structure* structure = allocationProfile->structure();
         result = constructEmptyObject(vm, structure);
@@ -204,7 +204,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_create_promise)
     }
 
     JSFunction* constructor = jsDynamicCast<JSFunction*>(constructorAsObject);
-    if (constructor && constructor->canUseAllocationProfile()) {
+    if (constructor && constructor->canUseAllocationProfiles()) {
         WriteBarrier<JSCell>& cachedCallee = bytecode.metadata(codeBlock).m_cachedCallee;
         if (!cachedCallee)
             cachedCallee.set(vm, codeBlock, constructor);
@@ -236,7 +236,7 @@ static JSClass* createInternalFieldObject(JSGlobalObject* globalObject, VM& vm, 
     JSClass* result = JSClass::create(vm, structure);
 
     JSFunction* constructor = jsDynamicCast<JSFunction*>(constructorAsObject);
-    if (constructor && constructor->canUseAllocationProfile()) {
+    if (constructor && constructor->canUseAllocationProfiles()) {
         WriteBarrier<JSCell>& cachedCallee = bytecode.metadata(codeBlock).m_cachedCallee;
         if (!cachedCallee)
             cachedCallee.set(vm, codeBlock, constructor);

--- a/Source/JavaScriptCore/runtime/FunctionRareData.h
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.h
@@ -97,7 +97,7 @@ public:
     Structure* createInternalFunctionAllocationStructureFromBase(VM& vm, JSGlobalObject* baseGlobalObject, JSObject* prototype, Structure* baseStructure)
     {
         initializeAllocationProfileWatchpointSet();
-        return m_internalFunctionAllocationProfile.createAllocationStructureFromBase(vm, baseGlobalObject, this, prototype, baseStructure);
+        return m_internalFunctionAllocationProfile.createAllocationStructureFromBase(vm, baseGlobalObject, this, prototype, baseStructure, allocationProfileWatchpointSet());
     }
     void clearInternalFunctionAllocationProfile(const char* reason)
     {

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -135,7 +135,7 @@ public:
         return bitwise_cast<FunctionRareData*>(executableOrRareData & ~rareDataTag);
     }
 
-    FunctionRareData* ensureRareDataAndAllocationProfile(JSGlobalObject*, unsigned inlineCapacity);
+    FunctionRareData* ensureRareDataAndObjectAllocationProfile(JSGlobalObject*, unsigned inlineCapacity);
 
     FunctionRareData* rareData() const
     {
@@ -156,8 +156,7 @@ public:
     // Returns the __proto__ for the |this| value if this JSFunction were to be constructed.
     JSObject* prototypeForConstruction(VM&, JSGlobalObject*);
 
-    bool canUseAllocationProfile();
-    bool canUseAllocationProfileNonInline();
+    bool canUseAllocationProfiles();
 
     enum class PropertyStatus {
         Eager,

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -227,7 +227,7 @@ inline bool JSFunction::mayHaveNonReifiedPrototype()
     return !isHostOrBuiltinFunction() && jsExecutable()->hasPrototypeProperty();
 }
 
-inline bool JSFunction::canUseAllocationProfile()
+inline bool JSFunction::canUseAllocationProfiles()
 {
     if (isHostOrBuiltinFunction()) {
         if (isHostFunction())
@@ -247,9 +247,9 @@ inline bool JSFunction::canUseAllocationProfile()
     return jsExecutable()->hasPrototypeProperty();
 }
 
-inline FunctionRareData* JSFunction::ensureRareDataAndAllocationProfile(JSGlobalObject* globalObject, unsigned inlineCapacity)
+inline FunctionRareData* JSFunction::ensureRareDataAndObjectAllocationProfile(JSGlobalObject* globalObject, unsigned inlineCapacity)
 {
-    ASSERT(canUseAllocationProfile());
+    ASSERT(canUseAllocationProfiles());
     FunctionRareData* rareData = this->rareData();
     if (!rareData)
         return allocateAndInitializeRareData(globalObject, inlineCapacity);


### PR DESCRIPTION
#### ae8102d789a8b5099ace514572f80afbcb9065d6
<pre>
Changing a JSFunction&apos;s prototype property should clear allocation caches
<a href="https://bugs.webkit.org/show_bug.cgi?id=270302">https://bugs.webkit.org/show_bug.cgi?id=270302</a>
<a href="https://rdar.apple.com/121657868">rdar://121657868</a>

Reviewed by Alexey Shvayka and Yusuke Suzuki.

Right now we only clear the allocation watchpoint if a JSFunction `mayHaveNonReifiedPrototype()` when setting
the .prototype property. This is semantically incorrect in the case of `new.target` bound functions because we will cache
the wrong value.

This patch makes it so we always file the allocation profile watchpoint when turning either of the allocation profiles.
When turning the ObjectAllocationProfile (used by op_create_this) we assert the watchpoint has already been fired as it
should&apos;ve already happened when the new .prototype value was set. When turning the InternalFunctionAllocationProfile (used
by createSubclassStructure when subclassing InternalFunction/Reflect.construct) its possible to pass the same JSFunction
to two different InternalFunctions, which will turn the profile.

* JSTests/stress/bound-constructor-change-prototype-clears-cache.js: Added.
(empty):
(test1.const.newTarget):
(test1):
(test2.const.newTarget):
(test2.Opt):
(test2):
(test3.const.newTarget):
(main):
* JSTests/stress/put-prototype-to-normal-function-shouldnt-be-cached.js: Added.
(opt):
(main.target):
(main):
* Source/JavaScriptCore/bytecode/InternalFunctionAllocationProfile.h:
(JSC::InternalFunctionAllocationProfile::createAllocationStructureFromBase):
* Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h:
(JSC::ObjectAllocationProfileBase&lt;Derived&gt;::initializeProfile):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
(JSC::createInternalFieldObject):
* Source/JavaScriptCore/runtime/FunctionRareData.h:
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::createSubclassStructure):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::prototypeForConstruction):
(JSC::JSFunction::allocateAndInitializeRareData):
(JSC::JSFunction::initializeRareData):
(JSC::JSFunction::put):
(JSC::JSFunction::defineOwnProperty):
* Source/JavaScriptCore/runtime/JSFunction.h:
* Source/JavaScriptCore/runtime/JSFunctionInlines.h:
(JSC::JSFunction::canUseAllocationProfiles):
(JSC::JSFunction::ensureRareDataAndObjectAllocationProfile):
(JSC::JSFunction::canUseAllocationProfile): Deleted.
(JSC::JSFunction::ensureRareDataAndAllocationProfile): Deleted.

Originally-landed-as: 272448.699@safari-7618-branch (96283e8a5f10). <a href="https://rdar.apple.com/128089585">rdar://128089585</a>
Canonical link: <a href="https://commits.webkit.org/278869@main">https://commits.webkit.org/278869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2740eb2c3ee08fc7ee02ec082e9ba918c85747e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2406 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42083 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1871 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45056 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56572 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49484 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44683 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48715 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28969 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63539 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7562 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27809 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11991 "Passed tests") | 
<!--EWS-Status-Bubble-End-->