### PR TITLE
WebGL fails to compile shaders with out variables that are arrays and start with underscore

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLTest.cpp
@@ -19201,36 +19201,6 @@ void main()
     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
 }
 
-// Test that struct declarations are introduced into the correct scope.
-TEST_P(GLSLTest, NestedReturnedStructs)
-{
-    const char kFragmentShader[] = R"(precision mediump float;
-struct Foo { float v; } foo(float bar);
-
-void main()
-{
-    gl_FragColor = vec4(1, 0, 0, 1);
-    float v = foo(foo(0.5).v).v;
-    if (v == 0.5)
-    {
-        gl_FragColor = vec4(0, 1, 0, 1);
-    }
-}
-
-Foo foo(float bar)
-{
-    Foo f;
-    f.v = bar;
-    return f;
-})";
-
-    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), kFragmentShader);
-    glUseProgram(program);
-
-    drawQuad(program, essl1_shaders::PositionAttrib(), 0.5f, 1.0f, true);
-    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
-}
-
 // Test that underscores in array names work with out arrays.
 TEST_P(GLSLTest_ES3, UnderscoresWorkWithOutArrays)
 {


### PR DESCRIPTION
#### d3ad1d842868cafb05b7fca1a058fa83d00855d2
<pre>
WebGL fails to compile shaders with out variables that are arrays and start with underscore
<a href="https://rdar.apple.com/126944294">rdar://126944294</a>

Reviewed by Chris Dumez.

Integrates upstream commit:
commit e0e91b8cbb2e096d2d009cd0d1fbe20d785f2263
Author: Kimmo Kinnunen &lt;kkinnunen@apple.com&gt;
Date:   Mon Apr 22 18:11:30 2024 -0700
Metal: Fix rewritten out variables with underscores

Fix compilation in case of output variables start with underscores.
Make name emission always emit MSL name ANGLE_{name}, so that GLSL `_e`
and `e` cannot clash. This regressed in angleproject:8558.

Bug: b/335744344
Change-Id: Ibae4dba4a24888acc1461582e69d48218ba11176

Originally-landed-as: bce91c8033e3. <a href="https://rdar.apple.com/128091308">rdar://128091308</a>
Canonical link: <a href="https://commits.webkit.org/278880@main">https://commits.webkit.org/278880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e70eab1d5efb34ff9c2c888df6533ae04b6c232

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2418 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1880 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49491 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48724 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28981 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7572 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->