### PR TITLE
Further remove HashMap access in RenderObject destructions

### DIFF
--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -119,7 +119,7 @@ void RenderBoxModelObject::ContinuationChainNode::insertAfter(ContinuationChainN
     after.next = this;
 }
 
-using ContinuationChainNodeMap = HashMap<SingleThreadWeakRef<const RenderBoxModelObject>, std::unique_ptr<RenderBoxModelObject::ContinuationChainNode>>;
+using ContinuationChainNodeMap = SingleThreadWeakHashMap<const RenderBoxModelObject, std::unique_ptr<RenderBoxModelObject::ContinuationChainNode>>;
 
 static ContinuationChainNodeMap& continuationChainNodeMap()
 {
@@ -127,7 +127,7 @@ static ContinuationChainNodeMap& continuationChainNodeMap()
     return map;
 }
 
-using FirstLetterRemainingTextMap = HashMap<SingleThreadWeakRef<const RenderBoxModelObject>, SingleThreadWeakPtr<RenderTextFragment>>;
+using FirstLetterRemainingTextMap = SingleThreadWeakHashMap<const RenderBoxModelObject, SingleThreadWeakPtr<RenderTextFragment>>;
 
 static FirstLetterRemainingTextMap& firstLetterRemainingTextMap()
 {
@@ -187,12 +187,6 @@ RenderBoxModelObject::~RenderBoxModelObject()
 
 void RenderBoxModelObject::willBeDestroyed()
 {
-    if (hasContinuationChainNode())
-        removeFromContinuationChain();
-
-    if (isFirstLetter())
-        clearFirstLetterRemainingText();
-
     if (!renderTreeBeingDestroyed())
         view().imageQualityController().rendererWillBeDestroyed(*this);
 

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -298,7 +298,9 @@ public:
     void clearNeedsLayoutForSkippedContent();
 
     void setRenderBoxHasShapeOutsideInfo(bool b) { m_renderBoxHasShapeOutsideInfo = b; }
+    void setHasCachedSVGResource(bool b) { m_hasCachedSVGResource = b; }
     bool renderBoxHasShapeOutsideInfo() const { return m_renderBoxHasShapeOutsideInfo; }
+    bool hasCachedSVGResource() const { return m_hasCachedSVGResource; }
 
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
@@ -413,12 +415,13 @@ private:
     unsigned m_renderBlockFlowLineLayoutPath : 3;
     unsigned m_renderBlockHasRareData : 1 { false };
     unsigned m_renderBoxHasShapeOutsideInfo : 1 { false };
+    unsigned m_hasCachedSVGResource : 1 { false };
 
     unsigned m_isRegisteredForVisibleInViewportCallback : 1;
     unsigned m_visibleInViewportState : 2;
     unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
 
-    // 2 bits free.
+    // 1 bits free.
 
     RenderStyle m_style;
 };

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -279,6 +279,7 @@ private:
     unsigned m_useBackslashAsYenSymbol : 1 { false };
     unsigned m_originalTextDiffersFromRendered : 1 { false };
     unsigned m_hasInlineWrapperForDisplayContents : 1 { false };
+    unsigned m_hasSecureTextTimer : 1 { false };
 };
 
 String applyTextTransform(const RenderStyle&, const String&, UChar previousCharacter);


### PR DESCRIPTION
#### 03fffab5cdf7bda4716c80bbda085185e7a938da
<pre>
Further remove HashMap access in RenderObject destructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=274239">https://bugs.webkit.org/show_bug.cgi?id=274239</a>
<a href="https://rdar.apple.com/128172726">rdar://128172726</a>

Reviewed by Alan Baradlay.

This patch further removes HashMap access in RenderObject destructions.

1. SVGResourcesCache::cachedResourcesForRenderer was always looking up HashMap! This patch adds boolean flag to RenderElement to stop this behavior.
2. RenderText should have a flag whether it has SecureTextTimer.
3. We use SingleThreadWeakHashMap in ContinuationChainNodeMap and FirstLetterRemainingTextMap and wipe unregistration in RenderBoxModelObject::willBeDestroyed.

* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::willBeDestroyed):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::setHasCachedSVGResource):
(WebCore::RenderElement::hasCachedSVGResource const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::willBeDestroyed):
(WebCore::RenderText::secureText):
(WebCore::RenderText::momentarilyRevealLastTypedCharacter):
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::addResourcesFromRenderer):
(WebCore::SVGResourcesCache::removeResourcesFromRenderer):
(WebCore::SVGResourcesCache::cachedResourcesForRenderer):
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.h:

Canonical link: <a href="https://commits.webkit.org/278864@main">https://commits.webkit.org/278864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7821d25ba5f6da699aa9db15adaf9b7bdf240b23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2117 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23228 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1889 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56599 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49500 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48734 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28995 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7556 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->