### PR TITLE
[Yarr] Regex Lookbehinds differs from v8

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -232,3 +232,6 @@ testRegExp(/(?<!(ab*?))c/i, "A", null);
 testRegExp(/(?<!(AB*?))c/, "A", null);
 testRegExp(/(?<!(ab*))c/i, "A", null);
 testRegExp(/(?<!(AB*))c/, "A", null);
+
+// Test 101
+testRegExp(/(?<=Result = |<)(\w+(?:Error|Response))/, "<Result = LoadFinishedResponse>(", ["LoadFinishedResponse", "LoadFinishedResponse"]);


### PR DESCRIPTION
#### fafab41339000ed0ac0088346670e1af020dcf14
<pre>
[Yarr] Regex Lookbehinds differs from v8
<a href="https://bugs.webkit.org/show_bug.cgi?id=273254">https://bugs.webkit.org/show_bug.cgi?id=273254</a>
<a href="https://rdar.apple.com/127440248">rdar://127440248</a>

Reviewed by Yusuke Suzuki.

Updated the checked offset calculation for lookbehinds.  The count of characters we need for a lookbehind should not be
dependent of the count for the surrounding expression.  We now use the minimum checked size selected from either the already
checked characters or the parenthesis checked characters (if they are different).  The prior code would check the already checked
parenthesis count first and then the disjunction&apos;s minimum size.  Now we take the lessor of the two minimums to compute the
amount we need to check when trying to match the lookbehind.  We still need to uncheck the appropriate amount based on either
the disjunction minimum or parenthesis when we are done handling the lookbehind.  That is now handled with the new variable,
backwardUncheckAmount.

Deleted some dead code discovered while fixing this issue.

New test added.

* JSTests/stress/regexp-lookbehind.js:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::ByteCompiler::emitDisjunction):

Canonical link: <a href="https://commits.webkit.org/278863@main">https://commits.webkit.org/278863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29276852039d6f7984ae22d65babc39c2cff7fff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2434 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42096 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1888 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45084 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56601 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51247 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26863 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1851 "Found 1 new test failure: fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49499 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48733 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11322 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28997 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63567 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27837 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11997 "Passed tests") | 
<!--EWS-Status-Bubble-End-->