### PR TITLE
Do not delay getUserMedia promise resolution on VPIO unit prewarming

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -93,6 +93,21 @@ void BaseAudioSharedUnit::startProducingData()
     if (++m_producingCount != 1)
         return;
 
+#if PLATFORM(MAC)
+    prewarmAudioUnitCreation([weakThis = WeakPtr { *this }] {
+        if (weakThis)
+            weakThis->continueStartProducingData();
+    });
+#else
+    continueStartProducingData();
+#endif
+}
+
+void BaseAudioSharedUnit::continueStartProducingData()
+{
+    if (!m_producingCount)
+        return;
+
     if (isProducingData())
         return;
 

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -102,6 +102,7 @@ public:
 protected:
     void forEachClient(const Function<void(CoreAudioCaptureSource&)>&) const;
     void captureFailed();
+    void continueStartProducingData();
 
     virtual void cleanupAudioUnit() = 0;
     virtual OSStatus startInternal() = 0;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -343,15 +343,6 @@ void CoreAudioCaptureSource::setIsInBackground(bool value)
 }
 #endif
 
-#if PLATFORM(MAC)
-void CoreAudioCaptureSource::whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback)
-{
-    unit().prewarmAudioUnitCreation([callback = WTFMove(callback)] () mutable {
-        callback({ });
-    });
-}
-#endif
-
 void CoreAudioCaptureSource::audioUnitWillStart()
 {
     forEachObserver([](auto& observer) {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -88,9 +88,6 @@ private:
 #if PLATFORM(IOS_FAMILY)
     void setIsInBackground(bool) final;
 #endif
-#if PLATFORM(MAC)
-    void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
-#endif
 
     std::optional<Vector<int>> discreteSampleRates() const final { return { { 8000, 16000, 32000, 44100, 48000, 96000 } }; }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -713,17 +713,24 @@ bool CoreAudioSharedUnit::migrateToNewDefaultDevice(const CaptureDevice& capture
 
 void CoreAudioSharedUnit::prewarmAudioUnitCreation(CompletionHandler<void()>&& callback)
 {
-    if (!m_audioUnitCreationWarmupPromise) {
-        m_audioUnitCreationWarmupPromise = invokeAsync(WorkQueue::create("CoreAudioSharedUnit AudioUnit creation"_s).get(), [] {
-            return createAudioUnit(true);
-        })->whenSettled(RunLoop::main(), [weakThis = WeakPtr { *this }] (auto&& vpioUnitOrError) {
-            if (weakThis && vpioUnitOrError.has_value())
-                weakThis->setStoredVPIOUnit(WTFMove(vpioUnitOrError.value()));
-            return GenericNonExclusivePromise::createAndResolve();
-        });
+    if (m_audioUnitCreationWarmupPromise) {
+        m_audioUnitCreationWarmupPromise->whenSettled(RunLoop::main(), WTFMove(callback));
+        return;
     }
 
-    m_audioUnitCreationWarmupPromise->whenSettled(RunLoop::main(), WTFMove(callback));
+    if (!enableEchoCancellation()) {
+        callback();
+        return;
+    }
+
+    m_audioUnitCreationWarmupPromise = invokeAsync(WorkQueue::create("CoreAudioSharedUnit AudioUnit creation"_s).get(), [] {
+        return createAudioUnit(true);
+    })->whenSettled(RunLoop::main(), [weakThis = WeakPtr { *this }, callback = WTFMove(callback)] (auto&& vpioUnitOrError) mutable {
+        if (weakThis && vpioUnitOrError.has_value())
+            weakThis->setStoredVPIOUnit(WTFMove(vpioUnitOrError.value()));
+        callback();
+        return GenericNonExclusivePromise::createAndResolve();
+    });
 }
 
 void CoreAudioSharedUnit::deallocateStoredVPIOUnit()

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -153,6 +153,7 @@
 #endif
 
 #if ENABLE(MEDIA_STREAM)
+#include <WebCore/CoreAudioSharedUnit.h>
 #include <WebCore/SecurityOrigin.h>
 #endif
 
@@ -1107,6 +1108,11 @@ void GPUConnectionToWebProcess::setOrientationForMediaCapture(IntDegrees orienta
 
 void GPUConnectionToWebProcess::updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture)
 {
+#if PLATFORM(MAC) && ENABLE(MEDIA_STREAM)
+    if (allowAudioCapture)
+        CoreAudioSharedUnit::singleton().prewarmAudioUnitCreation([] { });
+#endif
+
     m_allowsAudioCapture |= allowAudioCapture;
     m_allowsVideoCapture |= allowVideoCapture;
     m_allowsDisplayCapture |= allowDisplayCapture;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -552,13 +552,7 @@ void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstrai
             return;
         }
 
-        proxy->source().whenReady([completionHandler = WTFMove(completionHandler), proxy = WeakPtr { *proxy }] (auto&& error) mutable {
-            if (!!error || !proxy) {
-                completionHandler(error, { }, { });
-                return;
-            }
-            completionHandler({ }, proxy->settings(), proxy->source().capabilities());
-        });
+        completionHandler({ }, proxy->settings(), proxy->source().capabilities());
         m_proxies.add(id, WTFMove(proxy));
     };
 


### PR DESCRIPTION
#### 4238f637a2833b0e91b07bacbf786517df549a7d
<pre>
Do not delay getUserMedia promise resolution on VPIO unit prewarming
<a href="https://bugs.webkit.org/show_bug.cgi?id=274203">https://bugs.webkit.org/show_bug.cgi?id=274203</a>
<a href="https://rdar.apple.com/128112002">rdar://128112002</a>

Reviewed by Eric Carlson.

Before this patch, we were delaying the resolution of the getUserMedia promise upon VPIO creation prewarming.
This was ensuring that there would be no freeze and audio capture would start right away.
But this delays the web page processing.

We are now doing the following when starting capture:
- Prewarm the VPIO unit when GPU process is instructed that it will start audio capture soon.
- Create sources in GPU process, do not wait for warming up to finish..
- Resolve getUserMedia promise.
- Start the sources. When starting microphone capture, complete the prewarming if needed before starting the VPIO unit.

This change allows the web page to manipulate the getUserMedia tracks sooner.
It can then use the tracks to set up a VC call for instance, in parallel to the prewarming of the VPIO unit.
We keep prewarming of the VPIO unit as fast as we can.

Manually tested on macOS, should be a no op on iOS.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::startProducingData):
(WebCore::BaseAudioSharedUnit::prepareForNewCapture):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::whenReady): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::prewarmAudioUnitCreation):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):

Canonical link: <a href="https://commits.webkit.org/278860@main">https://commits.webkit.org/278860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98b8728760864f75089b7e1df39233b7b6ea20f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42110 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53861 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1911 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56621 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1877 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->