### PR TITLE
Use more smart pointers for members

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -212,7 +212,7 @@ private:
         ~CanBeAcceleratedMutationScope();
 
     private:
-        KeyframeEffect* m_effect;
+        RefPtr<KeyframeEffect> m_effect;
         bool m_couldOriginallyPreventAcceleration;
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
         bool m_couldOriginallyBeAccelerated;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3404,7 +3404,7 @@ void Document::setVisuallyOrdered()
 Ref<DocumentParser> Document::createParser()
 {
     // FIXME: this should probably pass the frame instead
-    return XMLDocumentParser::create(*this, protectedView().get(), m_parserContentPolicy);
+    return XMLDocumentParser::create(*this, view() ? XMLDocumentParser::IsInFrameView::Yes : XMLDocumentParser::IsInFrameView::No, m_parserContentPolicy);
 }
 
 bool Document::hasHighlight() const

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -87,13 +87,13 @@ public:
         : m_root(root)
     {
         if (m_root)
-            disabledSubtreeRoots().add(m_root);
+            disabledSubtreeRoots().add(m_root.get());
     }
 
     ~SubframeLoadingDisabler()
     {
         if (m_root)
-            disabledSubtreeRoots().remove(m_root);
+            disabledSubtreeRoots().remove(m_root.get());
     }
 
     static bool canLoadFrame(HTMLFrameOwnerElement&);
@@ -105,7 +105,7 @@ private:
         return nodes;
     }
 
-    ContainerNode* m_root;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_root;
 };
 
 inline HTMLFrameOwnerElement* Frame::ownerElement() const

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -42,8 +42,6 @@ const double HTMLProgressElement::InvalidPosition = -2;
 
 HTMLProgressElement::HTMLProgressElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
-    , m_value(0)
-    , m_isDeterminate(false)
 {
     ASSERT(hasTagName(progressTag));
 }

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -65,7 +65,7 @@ private:
 
     bool canContainRangeEndPoint() const final { return false; }
 
-    ProgressValueElement* m_value;
+    WeakPtr<ProgressValueElement, WeakPtrImplWithEventTargetData> m_value;
     bool m_isDeterminate { false };
 };
 

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -74,7 +74,6 @@ inline HTMLTrackElement::HTMLTrackElement(const QualifiedName& tagName, Document
 
 HTMLTrackElement::~HTMLTrackElement()
 {
-    m_track->clearElement();
     m_track->clearClient(*this);
 }
 
@@ -166,7 +165,7 @@ bool HTMLTrackElement::isDefault() const
 
 TextTrack& HTMLTrackElement::track()
 {
-    return m_track;
+    return m_track.get();
 }
 
 bool HTMLTrackElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -47,6 +47,9 @@ public:
     void deref() const final { HTMLElement::deref(); }
 
     using HTMLElement::scriptExecutionContext;
+    using HTMLElement::weakPtrFactory;
+    using HTMLElement::WeakValueType;
+    using HTMLElement::WeakPtrImplType;
 
     const AtomString& kind();
     void setKind(const AtomString&);

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -30,7 +30,6 @@
 #if ENABLE(VIDEO)
 
 #include "ElementInlines.h"
-#include "HTMLTrackElement.h"
 #include "ScriptExecutionContext.h"
 #include "TextTrackCueList.h"
 #include "VTTCue.h"
@@ -44,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LoadableTextTrack);
 
 LoadableTextTrack::LoadableTextTrack(HTMLTrackElement& track, const AtomString& kind, const AtomString& label, const AtomString& language)
     : TextTrack(track.scriptExecutionContext(), kind, emptyAtom(), label, language, TrackElement)
-    , m_trackElement(&track)
+    , m_trackElement(track)
 {
 }
 
@@ -155,7 +154,7 @@ size_t LoadableTextTrack::trackElementIndex()
     for (RefPtr<Node> node = m_trackElement->parentNode()->firstChild(); node; node = node->nextSibling()) {
         if (!node->hasTagName(trackTag) || !node->parentNode())
             continue;
-        if (node == m_trackElement)
+        if (node.get() == m_trackElement.get())
             return index;
         ++index;
     }

--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -28,12 +28,11 @@
 
 #if ENABLE(VIDEO)
 
+#include "HTMLTrackElement.h"
 #include "TextTrack.h"
 #include "TextTrackLoader.h"
 
 namespace WebCore {
-
-class HTMLTrackElement;
 
 class LoadableTextTrack final : public TextTrack, private TextTrackLoaderClient {
     WTF_MAKE_ISO_ALLOCATED(LoadableTextTrack);
@@ -43,8 +42,7 @@ public:
     void scheduleLoad(const URL&);
 
     size_t trackElementIndex();
-    HTMLTrackElement* trackElement() const { return m_trackElement; }
-    void clearElement() { m_trackElement = nullptr; }
+    HTMLTrackElement* trackElement() const { return m_trackElement.get(); }
 
 private:
     LoadableTextTrack(HTMLTrackElement&, const AtomString& kind, const AtomString& label, const AtomString& language);
@@ -63,7 +61,7 @@ private:
     ASCIILiteral logClassName() const override { return "LoadableTextTrack"_s; }
 #endif
 
-    HTMLTrackElement* m_trackElement;
+    WeakPtr<HTMLTrackElement, WeakPtrImplWithEventTargetData> m_trackElement;
     std::unique_ptr<TextTrackLoader> m_loader;
     URL m_url;
     bool m_loadPending { false };

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -88,7 +88,7 @@ void DOMPatchSupport::patchDocument(const String& markup)
     if (newDocument->isHTMLDocument())
         parser = HTMLDocumentParser::create(static_cast<HTMLDocument&>(*newDocument));
     else
-        parser = XMLDocumentParser::create(*newDocument, nullptr);
+        parser = XMLDocumentParser::create(*newDocument, XMLDocumentParser::IsInFrameView::No);
     parser->insert(markup); // Use insert() so that the parser will not yield.
     parser->finish();
     parser->detach();

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -74,8 +74,8 @@ public:
 
     float zoomFactor() const;
 
-    LocalFrameView& frameView() const { return m_frameView; }
-    Ref<LocalFrameView> protectedFrameView() const { return m_frameView; }
+    LocalFrameView& frameView() const { return m_frameView.get(); }
+    Ref<LocalFrameView> protectedFrameView() const { return m_frameView.get(); }
 
     Layout::InitialContainingBlock& initialContainingBlock() { return m_initialContainingBlock.get(); }
     const Layout::InitialContainingBlock& initialContainingBlock() const { return m_initialContainingBlock.get(); }
@@ -235,7 +235,7 @@ private:
 
     void updateInitialContainingBlockSize();
 
-    LocalFrameView& m_frameView;
+    CheckedRef<LocalFrameView> m_frameView;
 
     // Include this RenderView.
     uint64_t m_rendererCount { 1 };

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -107,9 +107,9 @@ static ContainerNode* findRenderingRoot(ContainerNode& node)
 
 void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
 {
-    ASSERT(&m_document == &styleUpdate->document());
+    ASSERT(m_document.ptr() == &styleUpdate->document());
 
-    if (!m_document.shouldCreateRenderers() || !m_document.renderView())
+    if (!m_document->shouldCreateRenderers() || !m_document->renderView())
         return;
 
     TraceScope scope(RenderTreeBuildStart, RenderTreeBuildEnd);
@@ -121,7 +121,7 @@ void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
     updateRenderViewStyle();
 
     for (auto& root : m_styleUpdate->roots()) {
-        if (&root->document() != &m_document)
+        if (&root->document() != m_document.ptr())
             continue;
         auto* renderingRoot = findRenderingRoot(*root);
         if (!renderingRoot)
@@ -469,9 +469,9 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
         if (!hasDisplayContentsOrNone) {
             auto* box = element.renderBox();
             if (box && box->style().hasAutoLengthContainIntrinsicSize() && !box->isSkippedContentRoot())
-                m_document.observeForContainIntrinsicSize(element);
+                m_document->observeForContainIntrinsicSize(element);
             else
-                m_document.unobserveForContainIntrinsicSize(element);
+                m_document->unobserveForContainIntrinsicSize(element);
         }
     });
 
@@ -532,11 +532,11 @@ void RenderTreeUpdater::createRenderer(Element& element, RenderStyle&& style)
 
     m_builder.attach(insertionPosition.parent(), WTFMove(newRenderer), insertionPosition.nextSibling());
 
-    auto* textManipulationController = m_document.textManipulationControllerIfExists();
+    auto* textManipulationController = m_document->textManipulationControllerIfExists();
     if (UNLIKELY(textManipulationController))
         textManipulationController->didAddOrCreateRendererForNode(element);
 
-    if (auto* cache = m_document.axObjectCache())
+    if (auto* cache = m_document->axObjectCache())
         cache->onRendererCreated(element);
 }
 
@@ -609,7 +609,7 @@ void RenderTreeUpdater::createTextRenderer(Text& textNode, const Style::TextUpda
 
     m_builder.attach(renderTreePosition.parent(), WTFMove(textRenderer), renderTreePosition.nextSibling());
 
-    auto* textManipulationController = m_document.textManipulationControllerIfExists();
+    auto* textManipulationController = m_document->textManipulationControllerIfExists();
     if (UNLIKELY(textManipulationController))
         textManipulationController->didAddOrCreateRendererForNode(textNode);
 }
@@ -657,7 +657,7 @@ void RenderTreeUpdater::storePreviousRenderer(Node& node)
 void RenderTreeUpdater::updateRenderViewStyle()
 {
     if (m_styleUpdate->initialContainingBlockUpdate())
-        m_document.renderView()->setStyle(RenderStyle::clone(*m_styleUpdate->initialContainingBlockUpdate()));
+        m_document->renderView()->setStyle(RenderStyle::clone(*m_styleUpdate->initialContainingBlockUpdate()));
 }
 
 static void invalidateRebuildRootIfNeeded(Node& node)
@@ -914,7 +914,7 @@ void RenderTreeUpdater::tearDownLeftoverChildrenOfComposedTree(Element& element,
 
 RenderView& RenderTreeUpdater::renderView()
 {
-    return *m_document.renderView();
+    return *m_document->renderView();
 }
 
 }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -106,7 +106,7 @@ private:
 
     RenderView& renderView();
 
-    Document& m_document;
+    Ref<Document> m_document;
     std::unique_ptr<Style::Update> m_styleUpdate;
 
     Vector<Parent> m_parentStack;

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "LocalFrameView.h"
 #include "ParserContentPolicy.h"
 #include "PendingScriptClient.h"
 #include "ScriptableDocumentParser.h"
@@ -42,7 +43,6 @@ class ContainerNode;
 class CachedResourceLoader;
 class DocumentFragment;
 class Element;
-class LocalFrameView;
 class PendingCallbacks;
 class Text;
 
@@ -66,9 +66,10 @@ class XMLDocumentParser final : public ScriptableDocumentParser, public PendingS
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLDocumentParser);
 public:
-    static Ref<XMLDocumentParser> create(Document& document, LocalFrameView* view, OptionSet<ParserContentPolicy> policy = DefaultParserContentPolicy)
+    enum class IsInFrameView : bool { No, Yes };
+    static Ref<XMLDocumentParser> create(Document& document, IsInFrameView isInFrameView, OptionSet<ParserContentPolicy> policy = DefaultParserContentPolicy)
     {
-        return adoptRef(*new XMLDocumentParser(document, view, policy));
+        return adoptRef(*new XMLDocumentParser(document, isInFrameView, policy));
     }
     static Ref<XMLDocumentParser> create(DocumentFragment& fragment, HashMap<AtomString, AtomString>&& prefixToNamespaceMap, const AtomString& defaultNamespaceURI, OptionSet<ParserContentPolicy> parserContentPolicy)
     {
@@ -92,7 +93,7 @@ public:
     static bool supportsXMLVersion(const String&);
 
 private:
-    explicit XMLDocumentParser(Document&, LocalFrameView*, OptionSet<ParserContentPolicy>);
+    explicit XMLDocumentParser(Document&, IsInFrameView, OptionSet<ParserContentPolicy>);
     XMLDocumentParser(DocumentFragment&, HashMap<AtomString, AtomString>&&, const AtomString&, OptionSet<ParserContentPolicy>);
 
     // CheckedPtr interface
@@ -153,7 +154,7 @@ private:
 
     xmlParserCtxtPtr context() const { return m_context ? m_context->context() : nullptr; };
 
-    LocalFrameView* m_view { nullptr };
+    IsInFrameView m_isInFrameView { IsInFrameView::No };
 
     SegmentedString m_originalSourceForTransform;
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -623,9 +623,9 @@ bool XMLDocumentParser::supportsXMLVersion(const String& version)
     return version == "1.0"_s;
 }
 
-XMLDocumentParser::XMLDocumentParser(Document& document, LocalFrameView* frameView, OptionSet<ParserContentPolicy> policy)
+XMLDocumentParser::XMLDocumentParser(Document& document, IsInFrameView isInFrameView, OptionSet<ParserContentPolicy> policy)
     : ScriptableDocumentParser(document, policy)
-    , m_view(frameView)
+    , m_isInFrameView(isInFrameView)
     , m_pendingCallbacks(makeUnique<PendingCallbacks>())
     , m_currentNode(&document)
     , m_scriptStartPosition(TextPosition::belowRangePosition())
@@ -885,7 +885,7 @@ void XMLDocumentParser::endElementNs()
         return;
     }
 
-    if (!element || !m_view) {
+    if (!element || m_isInFrameView == IsInFrameView::No) {
         popCurrentNode();
         return;
     }


### PR DESCRIPTION
#### d827195d613f685f3af939eeae5c779c27dee3ac
<pre>
Use more smart pointers for members
<a href="https://bugs.webkit.org/show_bug.cgi?id=274252">https://bugs.webkit.org/show_bug.cgi?id=274252</a>

Reviewed by Chris Dumez.

Use more smart pointers for members to address [clang-analyzer-webkit.NoUncountedMemberChecker] warnings.

* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createParser):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::SubframeLoadingDisabler::SubframeLoadingDisabler):
(WebCore::SubframeLoadingDisabler::~SubframeLoadingDisabler):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::HTMLProgressElement):
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::~HTMLTrackElement):
(WebCore::HTMLTrackElement::track):
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/track/LoadableTextTrack.cpp:
(WebCore::LoadableTextTrack::LoadableTextTrack):
(WebCore::LoadableTextTrack::trackElementIndex):
* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::DOMPatchSupport::patchDocument):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::commit):
(WebCore::RenderTreeUpdater::updateElementRenderer):
(WebCore::RenderTreeUpdater::createRenderer):
(WebCore::RenderTreeUpdater::createTextRenderer):
(WebCore::RenderTreeUpdater::updateRenderViewStyle):
(WebCore::RenderTreeUpdater::renderView):
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::XMLDocumentParser):
(WebCore::XMLDocumentParser::endElementNs):

Canonical link: <a href="https://commits.webkit.org/281261@main">https://commits.webkit.org/281261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c19b530b4c87b3a6fb2a688d610e27080139ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48118 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6901 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64910 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55589 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13134 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2638 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34392 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35475 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->