### PR TITLE
Trusted Types fails to protect against a script edited mid-parse

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5513,6 +5513,7 @@ webkit.org/b/272196 imported/w3c/web-platform-tests/trusted-types/trusted-types-
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
+webkit.org/b/274519 imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-in-xhtml-document.tentative.https.xhtml [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Pass Failure ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation.html [ Pass Failure ]
 webkit.org/b/274088 imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-internal-slot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-internal-slot-expected.txt
@@ -1,8 +1,8 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
-
-FAIL Test TT application when manipulating <script> elements during loading. promise_test: Unhandled rejection with value: "First message should have been blocked: first script element executed"
+PASS Test TT application when manipulating <script> elements during loading.
 PASS Script set via .textContent executes on a connected HTMLScriptElement.
 PASS Script set via .textContent executes on an unconnected HTMLScriptElement.
 PASS Script set via .innerText executes on a connected HTMLScriptElement.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-internal-slot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-internal-slot.html
@@ -7,24 +7,17 @@
 </head>
 <body>
 <script>
+  // This policy allows document.write to work as that's not relevant to what's actually being tested here.
+  trustedTypes.createPolicy('default', {createHTML: s => s});
   promise_test(t => {
-    // Setup: We create an <iframe> and trigger loading the document. We use
-    // WPTserve's ?pipe functionality to make sure it gets delivered in chunks
-    // and that parsing will be deferred.
-    var frame = document.createElement("iframe");
-    document.body.appendChild(frame);
-    frame.src = "support/HTMLScriptElement-internal-slot-support.html?pipe=trickle(200:d1)";
-
-    // This function tries to find the first <script> element in our iframe and
-    // manipulated it with DOM APIs (appendChild + createTextNode). If it
-    // doesn't find the script element then it'll just enqueue itself again
-    // in 100ms.
+    document.write(`<script>window.postMessage("first script element executed", "*");`);
     var manipulator = _ => {
-      let script = frame.contentDocument.getElementsByTagName("script")[0];
+      let script = document.body.getElementsByTagName("script")[1];
       if (script) {
-        script.appendChild(frame.contentDocument.createTextNode("/*byapi*/"));
+        script.appendChild(document.createTextNode('/*byapi*/'));
+        document.write('<\/script><script>window.parent.postMessage("second script element executed", "*");<\/script>');
       } else {
-        t.step_timeout(manipulator, 100);
+        t.step_timeout(manipulator, 50);
       }
     }
     manipulator();

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/SVGScriptElement-internal-slot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/SVGScriptElement-internal-slot-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
-Harness Error (TIMEOUT), message = null
-
+PASS Test TT application when manipulating <script> elements during loading.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/SVGScriptElement-internal-slot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/SVGScriptElement-internal-slot.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<script>
+  // This policy allows document.write to work as that's not relevant to what's actually being tested here.
+  trustedTypes.createPolicy('default', {createHTML: s => s});
+  promise_test(t => {
+    document.write(`<svg><script>window.postMessage("first script element executed", "*");`);
+    var manipulator = _ => {
+      let script = document.body.getElementsByTagName("script")[1];
+      if (script) {
+        script.appendChild(document.createTextNode('/*byapi*/'));
+        document.write('<\/script><script>window.parent.postMessage("second script element executed", "*");<\/script><\/svg>');
+      } else {
+        t.step_timeout(manipulator, 50);
+      }
+    }
+    manipulator();
+
+    // Now we'll wait for the postMessages to arrive. We expect the iframe's
+    // first message to be blocked by Trusted Types, since the manipulator
+    // above should have manipulated it (while loading). The second one should
+    // pass.
+    return new Promise((resolve, reject) => {
+      window.addEventListener("message", e => {
+        if (e.data.includes("first")) {
+          reject("First message should have been blocked: " + e.data);
+        } else if (e.data.includes("second")) {
+          resolve();
+        } else {
+          reject("Unknown message: " + e.data);
+        }
+      });
+    });
+  }, "Test TT application when manipulating <script> elements during loading.");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -94,11 +94,15 @@ void ScriptElement::childrenChanged(const ContainerNode::ChildChange& childChang
 {
     if (m_parserInserted == ParserInserted::No && childChange.isInsertion() && element().isConnected())
         prepareScript(); // FIXME: Provide a real starting line number here.
+
+    if (childChange.source == ContainerNode::ChildChange::Source::API)
+        m_childrenChangedByAPI = true;
 }
 
 void ScriptElement::finishParsingChildren()
 {
-    m_trustedScriptText = scriptContent();
+    if (!m_childrenChangedByAPI)
+        m_trustedScriptText = scriptContent();
 }
 
 void ScriptElement::handleSourceAttribute(const String& sourceURL)

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -144,6 +144,7 @@ private:
     bool m_willExecuteWhenDocumentFinishedParsing : 1 { false };
     bool m_forceAsync : 1;
     bool m_willExecuteInOrder : 1 { false };
+    bool m_childrenChangedByAPI : 1 { false };
     ScriptType m_scriptType : bitWidthOfScriptType { ScriptType::Classic };
     String m_characterEncoding;
     String m_fallbackCharacterEncoding;


### PR DESCRIPTION
#### c31d9c40707d3ec58faee43f7446ac3fbd6c4531
<pre>
Trusted Types fails to protect against a script edited mid-parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=274253">https://bugs.webkit.org/show_bug.cgi?id=274253</a>

Reviewed by Darin Adler.

This patch adds a new flag to script elements that is triggered if their children are changed by API.
This flag is then used to decide whether to accept parsed script elements as trusted.

This patch stops parsed scripts working in XHTML documents when TT is enforced. A follow up patch will address that.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-in-xhtml-document.tentative.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-internal-slot-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-internal-slot.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/SVGScriptElement-internal-slot-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/SVGScriptElement-internal-slot.html: Added.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::childrenChanged):
(WebCore::ScriptElement::finishParsingChildren):
* Source/WebCore/dom/ScriptElement.h:

Canonical link: <a href="https://commits.webkit.org/279225@main">https://commits.webkit.org/279225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/783b9e7d36e149de140dda4fb150458e6c7e2d48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42846 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23959 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1664 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57652 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50243 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11544 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->