### PR TITLE
Leaked 2D contexts might consume all OS global GPU resources

### DIFF
--- a/LayoutTests/fast/canvas/image-buffer-backend-count-limit-expected.txt
+++ b/LayoutTests/fast/canvas/image-buffer-backend-count-limit-expected.txt
@@ -1,0 +1,10 @@
+Test creates many 2D contexts and checks when they are not created accelerated anymore
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Effective rendering mode switches to Unaccelerated at instance: 1000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/image-buffer-backend-count-limit.html
+++ b/LayoutTests/fast/canvas/image-buffer-backend-count-limit.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Test creates many 2D contexts and checks when they are not created accelerated anymore")
+
+function pixelsEqual(a, b) {
+    for (let i = 0; i < 4; ++i) {
+        if (a[i] != b[i])
+            return false;
+    }
+    return true;
+}
+
+var transparentBlack = [0, 0, 0, 0];
+var lime = [0, 255, 0, 255];
+var imageData;
+var context;
+function runTest() {
+    if (typeof CanvasRenderingContext2D.prototype.getEffectiveRenderingModeForTesting === "undefined") {
+        testFailed("Need effective rendering mode API");
+        return;
+    }
+    let canvases = [];
+    for (let i = 0; i < 15000; ++i) {
+        let canvas = document.createElement('canvas');
+        canvases.push(canvas)
+        canvas.height = 100;
+        canvas.width = 100;
+        context = canvas.getContext("2d");
+        if (!context) {
+            testFailed(`Context ${i} not created`);
+            return;
+        }
+        context.fillStyle = "lime";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        imageData = context.getImageData(0, 0, 1, 1);
+        if (!imageData) {
+            testFailed("Context failed to allocate imageData");
+            return;
+        } else if (pixelsEqual(imageData.data, transparentBlack)) {
+            testFailed("Context was lost");
+            return;
+        } else if (!pixelsEqual(imageData.data, lime)) {
+            shouldBe("imageData.data", "lime");
+            return;
+        }
+        let renderingMode = context.getEffectiveRenderingModeForTesting();
+        if (renderingMode != "Accelerated") {
+            testPassed(`Effective rendering mode switches to ${renderingMode} at instance: ${i}`);
+            canvases.length = 0;
+            delete context;
+            delete canvas;
+            gc();
+            return;
+        }
+    }
+    testFailed(`All ${i} contexts accelerated. Currently unexpected`);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3974,6 +3974,9 @@ webkit.org/b/156148 svg/text/text-vkern.svg [ Failure ]
 webkit.org/b/156148 svg/W3C-SVG-1.1/text-text-05-t.svg [ Failure ]
 webkit.org/b/156148 svg/W3C-SVG-1.1/text-text-06-t.svg [ Failure ]
 
+# Accelerated canvases not implemented.
+fast/canvas/image-buffer-backend-count-limit.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2803,3 +2803,5 @@ webkit.org/b/260883 inspector/timeline/timeline-recording.html [ Skip ]
 webkit.org/b/274409 imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html [ Pass Failure ]
 
 webkit.org/b/274792 compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint.html [ Pass Failure ]
+# Limiting accelerated canvases not implemented for WK1
+fast/canvas/image-buffer-backend-count-limit.html [ Skip ]

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -416,6 +416,9 @@ webgl/webgl-worker.html [ Skip ]
 # Accelerated canvas isn't supported yet
 fast/canvas/canvas-will-read-frequently.html [ Skip ]
 
+# Limiting accelerated canvases not implemented for WinCairo.
+fast/canvas/image-buffer-backend-count-limit.html [ Skip ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # These areas are not implemented well on WinCairo
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -29,6 +29,7 @@
 
 #include "MessageReceiver.h"
 #include "RemoteSerializedImageBufferIdentifier.h"
+#include "ScopedRenderingResourcesRequest.h"
 #include "ThreadSafeObjectHeap.h"
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/ProcessIdentity.h>
@@ -44,7 +45,8 @@
 namespace WebKit {
 
 class GPUConnectionToWebProcess;
-// Class holding GPU process resources per Web Process.
+
+// Class holding GPU process resources per WebContent process.
 // Thread-safe.
 class RemoteSharedResourceCache final : public ThreadSafeRefCounted<RemoteSharedResourceCache>, IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -54,6 +56,11 @@ public:
 
     void addSerializedImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>);
     RefPtr<WebCore::ImageBuffer> takeSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
+
+    Ref<ResourceCounter> acceleratedImageBufferCounter() const;
+    Ref<ResourceCounter> globalAcceleratedImageBufferCounter() const;
+
+    WebCore::RenderingMode adjustAcceleratedImageBufferRenderingMode(WebCore::RenderingPurpose) const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -72,12 +79,12 @@ private:
     void releaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
 
     IPC::ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<WebCore::ImageBuffer>> m_serializedImageBuffers;
+    Ref<ResourceCounter> m_acceleratedImageBufferCounter;
     WebCore::ProcessIdentity m_resourceOwner;
 #if HAVE(IOSURFACE)
     Ref<WebCore::IOSurfacePool> m_ioSurfacePool;
 #endif
 };
-
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -31,6 +31,7 @@
 #include "IPCSemaphore.h"
 #include "RemoteImageBufferMessages.h"
 #include "RemoteRenderingBackend.h"
+#include "RemoteSharedResourceCache.h"
 #include "StreamConnectionWorkQueue.h"
 #include <WebCore/GraphicsContext.h>
 
@@ -54,6 +55,11 @@ RemoteImageBuffer::RemoteImageBuffer(Ref<WebCore::ImageBuffer> imageBuffer, Remo
     : m_backend(&backend)
     , m_imageBuffer(WTFMove(imageBuffer))
 {
+    if (m_imageBuffer->renderingMode() == RenderingMode::Accelerated) {
+        auto& sharedResourceCache = backend.sharedResourceCache();
+        m_sharedCacheAcceleratedCounter = sharedResourceCache.acceleratedImageBufferCounter();
+        m_globalAcceleratedCounter = sharedResourceCache.globalAcceleratedImageBufferCounter();
+    }
 }
 
 RemoteImageBuffer::~RemoteImageBuffer()

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -80,6 +80,8 @@ private:
     RefPtr<RemoteRenderingBackend> m_backend;
     Ref<WebCore::ImageBuffer> m_imageBuffer;
     ScopedRenderingResourcesRequest m_renderingResourcesRequest { ScopedRenderingResourcesRequest::acquire() };
+    RefPtr<ResourceCounter> m_sharedCacheAcceleratedCounter;
+    RefPtr<ResourceCounter> m_globalAcceleratedCounter;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequest.h
+++ b/Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequest.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <utility>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebKit {
 
@@ -81,5 +82,10 @@ inline bool hasOutstandingRenderingResourceUsage()
 {
     return ScopedRenderingResourcesRequest::s_requests;
 }
+
+class ResourceCounter : public ThreadSafeRefCounted<ResourceCounter> {
+public:
+    size_t count() const { return refCount() - 1; }
+};
 
 }


### PR DESCRIPTION
#### c2df703f594d1328979a7b87d50ce96770867313
<pre>
Leaked 2D contexts might consume all OS global GPU resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=273326">https://bugs.webkit.org/show_bug.cgi?id=273326</a>
<a href="https://rdar.apple.com/95930955">rdar://95930955</a>

Reviewed by NOBODY (OOPS!).

Limit all the GPUP accelerated image buffers to certain numbers:
 - 30000 total limit
 - 3000 layer tile, 2D Context backing stores limit per WP
 - 1000 2D Context backing stores limit per WP

Store the per-WP limit to the RemoteSharedResourceCache. This is shared
with all the RemoteRenderingBackend instances of a particular WP:
main thread rendering and Web Worker rendering.

If GPUP allocates unlimited amount of accelerated image buffers, the
allocations cause all of system IOSurface handles. The failures are
handled ok in GPUP code, but might cause problems in other parts of the
WebKit as well as in other processes. The underlying CGContexts will
also run into per-process Metal object count limits.

Reland:
Implement the counters via ThreadSafeRefCounted objects with no content.
The refcount acts as the counter. This ensures the shared and global
counters get decremented when destroying the whole
RemoteRenderingBackend with RemoteImageBuffers.

* LayoutTests/fast/canvas/image-buffer-backend-count-limit-expected.txt: Added.
* LayoutTests/fast/canvas/image-buffer-backend-count-limit.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp:
(WebKit::globalAcceleratedImageBufferCounter):
(WebKit::RemoteSharedResourceCache::RemoteSharedResourceCache):
(WebKit::RemoteSharedResourceCache::acceleratedImageBufferCounter const):
(WebKit::RemoteSharedResourceCache::globalAcceleratedImageBufferCounter const):
(WebKit::RemoteSharedResourceCache::adjustAcceleratedImageBufferRenderingMode const):
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
(WebKit::RemoteRenderingBackend::releaseImageBuffer):
(WebKit::RemoteRenderingBackend::takeImageBuffer):
* Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequest.h:
(WebKit::ResourceCounter::count const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2df703f594d1328979a7b87d50ce96770867313

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43379 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2780 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50778 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50118 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->