### PR TITLE
[WPE][GTK] Enable fatal criticals in WebKit subprocesses

### DIFF
--- a/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
+++ b/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
@@ -36,6 +36,10 @@
 #include "unix/BreakpadExceptionHandler.h"
 #endif
 
+#if USE(GLIB)
+#include <glib.h>
+#endif
+
 namespace WebKit {
 
 AuxiliaryProcessMainCommon::AuxiliaryProcessMainCommon()
@@ -60,13 +64,22 @@ bool AuxiliaryProcessMainCommon::parseCommandLine(int argc, char** argv)
     return true;
 }
 
-void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationParameters&)
+static void ignoreSigpipe()
 {
     struct sigaction signalAction;
     memset(&signalAction, 0, sizeof(signalAction));
     RELEASE_ASSERT(!sigemptyset(&signalAction.sa_mask));
     signalAction.sa_handler = SIG_IGN;
     RELEASE_ASSERT(!sigaction(SIGPIPE, &signalAction, nullptr));
+}
+
+void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationParameters&)
+{
+    ignoreSigpipe();
+
+#if USE(GLIB)
+    g_log_set_always_fatal(G_LOG_LEVEL_CRITICAL);
+#endif
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 807cbc077ba9c62f6517e08fffba4c0470a91ef0
<pre>
[WPE][GTK] Enable fatal criticals in WebKit subprocesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=274255">https://bugs.webkit.org/show_bug.cgi?id=274255</a>

Reviewed by NOBODY (OOPS!).

Critical warnings should only be used to indicate programmer error. By
default, they are &quot;soft assertions&quot; that allow program execution to
continue even though we know the process is no lonnger operating
correctly because a bug has occurred. This is a bad default. Let&apos;s crash
instead, to make it easier to debug the problem, encourage bug reports,
and downgrade any code execution issues into denial of service.

This will significantly increase crashes in our multimedia code. I think
the rest of WebKit is more or less in good state, but there will
certainly be more crashes here and there. I&apos;m confident it will be worth
it!

We cannot do this in the UI process because that decision should be left
up to the application. Only do this for subprocesses.

* Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp:
(WebKit::ignoreSigpipe):
(WebKit::AuxiliaryProcess::platformInitialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/807cbc077ba9c62f6517e08fffba4c0470a91ef0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42122 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23252 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26001 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56629 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49523 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44747 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48763 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->