### PR TITLE
[WPE] WPE Platform: add support for tap and drag gestures

### DIFF
--- a/Source/WebKit/Shared/NativeWebWheelEvent.h
+++ b/Source/WebKit/Shared/NativeWebWheelEvent.h
@@ -68,6 +68,7 @@ public:
     NativeWebWheelEvent(struct wpe_input_axis_event*, float deviceScaleFactor, WebWheelEvent::Phase, WebWheelEvent::Phase momentumPhase);
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     explicit NativeWebWheelEvent(WPEEvent*);
+    NativeWebWheelEvent(WPEEvent*, WebWheelEvent::Phase);
 #endif
 
 #elif PLATFORM(WIN)

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.h
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.h
@@ -58,6 +58,7 @@ public:
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     static WebMouseEvent createWebMouseEvent(WPEEvent*);
     static WebWheelEvent createWebWheelEvent(WPEEvent*);
+    static WebWheelEvent createWebWheelEvent(WPEEvent*, WebWheelEvent::Phase);
     static WebKeyboardEvent createWebKeyboardEvent(WPEEvent*, const String&, bool isAutoRepeat);
 #if ENABLE(TOUCH_EVENTS)
     static WebTouchEvent createWebTouchEvent(WPEEvent*, Vector<WebPlatformTouchPoint>&&);

--- a/Source/WebKit/Shared/wpe/NativeWebWheelEventWPE.cpp
+++ b/Source/WebKit/Shared/wpe/NativeWebWheelEventWPE.cpp
@@ -37,6 +37,11 @@ NativeWebWheelEvent::NativeWebWheelEvent(WPEEvent* event)
 {
 }
 
+NativeWebWheelEvent::NativeWebWheelEvent(WPEEvent* event, WebWheelEvent::Phase phase)
+    : WebWheelEvent(WebEventFactory::createWebWheelEvent(event, phase))
+{
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -168,10 +168,15 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(WPEEvent* event)
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event)
 {
+    auto phase = wpe_event_scroll_is_stop(event) ? WebWheelEvent::Phase::PhaseEnded : WebWheelEvent::Phase::PhaseChanged;
+    return createWebWheelEvent(event, phase);
+}
+
+WebWheelEvent WebEventFactory::createWebWheelEvent(WPEEvent* event, WebWheelEvent::Phase phase)
+{
     double deltaX, deltaY;
     wpe_event_scroll_get_deltas(event, &deltaX, &deltaY);
     bool hasPreciseScrollingDeltas = wpe_event_scroll_has_precise_deltas(event);
-    auto phase = wpe_event_scroll_is_stop(event) ? WebWheelEvent::Phase::PhaseEnded : WebWheelEvent::Phase::PhaseChanged;
     auto position = positionFromEvent(event);
 
     auto wheelTicks = FloatSize(deltaX, deltaY);

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -77,6 +77,7 @@ private:
 #endif
 
     gboolean handleEvent(WPEEvent*);
+    void handleGesture(WPEEvent*);
 
     GRefPtr<WPEView> m_wpeView;
     std::unique_ptr<WebKit::AcceleratedBackingStoreDMABuf> m_backingStore;

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -26,6 +26,9 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeyUnicode.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureController.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureControllerImpl.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureDetector.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.cpp
@@ -49,6 +52,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeysyms.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureController.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEGestureController.h"
+
+/**
+ * WPEGestureController:
+ * @See_also: #WPEView
+ *
+ * A gesture controller.
+ *
+ * This interface enables implementing custom gesture detection algorithms.
+ * Objects of classes implementing this interface can be supplied to
+ * #WPEView so that they are being used instead of the default gesture detector.
+ */
+
+G_DEFINE_INTERFACE(WPEGestureController, wpe_gesture_controller, G_TYPE_OBJECT)
+
+static void wpe_gesture_controller_default_init(WPEGestureControllerInterface*)
+{
+}
+
+/**
+ * wpe_gesture_controller_handle_event:
+ * @controller: a #WPEGestureController
+ * @event: a #WPEEvent
+ *
+ * Get the gesture detected by @controller if any was detected during processing of @event.
+ */
+void wpe_gesture_controller_handle_event(WPEGestureController* controller, WPEEvent* event)
+{
+    g_return_if_fail(controller);
+    g_return_if_fail(event);
+
+    auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
+    controllerInterface->handle_event(controller, event);
+}
+
+/**
+ * wpe_gesture_controller_cancel:
+ * @controller: a #WPEGestureController
+ *
+ * Cancels ongoing gesture detection if any.
+ */
+void wpe_gesture_controller_cancel(WPEGestureController* controller)
+{
+    auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
+    controllerInterface->cancel(controller);
+}
+
+/**
+ * wpe_gesture_controller_get_gesture:
+ * @controller: a #WPEGestureController
+ *
+ * Get currently detected gesture.
+ *
+ * Returns: a #WPEGesture
+ */
+WPEGesture wpe_gesture_controller_get_gesture(WPEGestureController* controller)
+{
+    g_return_val_if_fail(controller, WPE_GESTURE_NONE);
+
+    auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
+    return controllerInterface->get_gesture(controller);
+}
+
+/**
+ * wpe_gesture_controller_get_gesture_position:
+ * @controller: a #WPEGestureController
+ * @x: (out): location to store x coordinate
+ * @y: (out): location to store y coordinate
+ *
+ * Get the position of currently detected gesture. If it doesn't have
+ * a position, %FALSE is returned.
+ *
+ * Returns: %TRUE if position is returned in @x and @y,
+ *    or %FALSE if currently detected gesture doesn't have a positon
+ */
+gboolean wpe_gesture_controller_get_gesture_position(WPEGestureController* controller, double* x, double* y)
+{
+    g_return_val_if_fail(controller, FALSE);
+    g_return_val_if_fail(x && y, FALSE);
+
+    auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
+    return controllerInterface->get_gesture_position(controller, x, y);
+}
+
+/**
+ * wpe_gesture_controller_get_gesture_delta:
+ * @controller: a #WPEGestureController
+ * @x: (out): location to store delta on x axis
+ * @y: (out): location to store delta on y axis
+ *
+ * Get the delta of currently detected gesture such as "drag" gesture.
+ * If it doesn't have a delta, %FALSE is returned.
+ *
+ * Returns: %TRUE if delta is returned in @x and @y,
+ *    or %FALSE if currently detected gesture doesn't have a delta
+ */
+gboolean wpe_gesture_controller_get_gesture_delta(WPEGestureController* controller, double* x, double* y)
+{
+    g_return_val_if_fail(controller, FALSE);
+    g_return_val_if_fail(x && y, FALSE);
+
+    auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
+    return controllerInterface->get_gesture_delta(controller, x, y);
+}
+
+/**
+ * wpe_gesture_controller_is_drag_begin:
+ * @controller: a #WPEGestureController
+ *
+ * Check if the current drag gesture is a beginning of the sequence being detected.
+ *
+ * Returns: %TRUE if current drag gesture is a beginning of the sequence being detected,
+ *    or %FALSE otherwise
+ */
+gboolean wpe_gesture_controller_is_drag_begin(WPEGestureController* controller)
+{
+    g_return_val_if_fail(controller, FALSE);
+
+    auto* controllerInterface = WPE_GESTURE_CONTROLLER_GET_IFACE(controller);
+    return controllerInterface->is_drag_begin(controller);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureController.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureController.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPEGestureController_h
+#define WPEGestureController_h
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+/**
+ * WPEGesture:
+ * @WPE_GESTURE_NONE: no gesture.
+ * @WPE_GESTURE_TAP: tap gesture that has a corresponding position.
+ * @WPE_GESTURE_DRAG: drag gesture that has a corresponding position and delta.
+ */
+typedef enum {
+    WPE_GESTURE_NONE,
+
+    WPE_GESTURE_TAP,
+    WPE_GESTURE_DRAG,
+} WPEGesture;
+
+typedef struct _WPEEvent WPEEvent;
+
+#define WPE_TYPE_GESTURE_CONTROLLER (wpe_gesture_controller_get_type())
+WPE_API G_DECLARE_INTERFACE (WPEGestureController, wpe_gesture_controller, WPE, GESTURE_CONTROLLER, GObject)
+
+struct _WPEGestureControllerInterface
+{
+    GTypeInterface parent_interface;
+
+    void        (* handle_event)         (WPEGestureController *controller,
+                                          WPEEvent             *event );
+    void        (* cancel)               (WPEGestureController *controller);
+    WPEGesture  (* get_gesture)          (WPEGestureController *controller);
+    gboolean    (* get_gesture_position) (WPEGestureController *controller,
+                                          double               *x,
+                                          double               *y);
+    gboolean    (* get_gesture_delta)    (WPEGestureController *controller,
+                                          double               *x,
+                                          double               *y);
+    gboolean    (* is_drag_begin)        (WPEGestureController *controller);
+};
+
+WPE_API void        wpe_gesture_controller_handle_event         (WPEGestureController *controller,
+                                                                 WPEEvent             *event);
+WPE_API void        wpe_gesture_controller_cancel               (WPEGestureController *controller);
+WPE_API WPEGesture  wpe_gesture_controller_get_gesture          (WPEGestureController *controller);
+WPE_API gboolean    wpe_gesture_controller_get_gesture_position (WPEGestureController *controller,
+                                                                 double               *x,
+                                                                 double               *y);
+WPE_API gboolean    wpe_gesture_controller_get_gesture_delta    (WPEGestureController *controller,
+                                                                 double               *x,
+                                                                 double               *y);
+WPE_API gboolean    wpe_gesture_controller_is_drag_begin        (WPEGestureController *controller);
+
+G_END_DECLS
+
+#endif /* WPEGestureController_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEGestureControllerImpl.h"
+
+#include "WPEGestureDetector.h"
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEGestureControllerImplPrivate {
+    WPE::GestureDetector detector;
+};
+
+static void wpe_gesture_controller_interface_init(WPEGestureControllerInterface*);
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WPEGestureControllerImpl, wpe_gesture_controller_impl, G_TYPE_OBJECT, GObject,
+    G_IMPLEMENT_INTERFACE(WPE_TYPE_GESTURE_CONTROLLER, wpe_gesture_controller_interface_init))
+
+static void wpeHandleEvent(WPEGestureController* controller, WPEEvent* event)
+{
+    WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.handleEvent(event);
+}
+
+static void wpeCancel(WPEGestureController* controller)
+{
+    WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.reset();
+}
+
+static WPEGesture wpeGetGesture(WPEGestureController* controller)
+{
+    return WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.gesture();
+}
+
+static gboolean wpeGetGesturePosition(WPEGestureController* controller, double* x, double* y)
+{
+    if (auto position = WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.position()) {
+        *x = position->x;
+        *y = position->y;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean wpeGetGestureDelta(WPEGestureController* controller, double* x, double* y)
+{
+    if (auto delta = WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.delta()) {
+        *x = delta->x;
+        *y = delta->y;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean wpeIsDragBegin(WPEGestureController* controller)
+{
+    return WPE_GESTURE_CONTROLLER_IMPL(controller)->priv->detector.dragBegin();
+}
+
+static void wpe_gesture_controller_impl_class_init(WPEGestureControllerImplClass*)
+{
+}
+
+static void wpe_gesture_controller_interface_init(WPEGestureControllerInterface* interface)
+{
+    interface->handle_event = wpeHandleEvent;
+    interface->cancel = wpeCancel;
+    interface->get_gesture = wpeGetGesture;
+    interface->get_gesture_position = wpeGetGesturePosition;
+    interface->get_gesture_delta = wpeGetGestureDelta;
+    interface->is_drag_begin = wpeIsDragBegin;
+}
+
+WPEGestureController* wpeGestureControllerImplNew()
+{
+    return WPE_GESTURE_CONTROLLER(g_object_new(WPE_TYPE_GESTURE_CONTROLLER_IMPL, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,35 +22,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#pragma once
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
+#include <glib-object.h>
 #include <wpe/WPEGestureController.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+#define WPE_TYPE_GESTURE_CONTROLLER_IMPL (wpe_gesture_controller_impl_get_type())
+G_DECLARE_FINAL_TYPE (WPEGestureControllerImpl, wpe_gesture_controller_impl, WPE, GESTURE_CONTROLLER_IMPL, GObject)
+
+WPEGestureController* wpeGestureControllerImplNew();
+
+G_END_DECLS

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEGestureDetector.h"
+
+#include <cmath>
+
+namespace WPE {
+
+void GestureDetector::handleEvent(WPEEvent* event)
+{
+    if (m_sequenceId && *m_sequenceId != wpe_event_touch_get_sequence_id(event))
+        return;
+
+    switch (wpe_event_get_event_type(event)) {
+    case WPE_EVENT_TOUCH_DOWN:
+        reset();
+        if (double x, y; wpe_event_get_position(event, &x, &y)) {
+            m_gesture = WPE_GESTURE_TAP;
+            m_position = { x, y };
+            m_sequenceId = wpe_event_touch_get_sequence_id(event);
+        }
+        break;
+    case WPE_EVENT_TOUCH_CANCEL:
+        reset();
+        break;
+    case WPE_EVENT_TOUCH_MOVE:
+        if (double x, y; wpe_event_get_position(event, &x, &y) && m_position) {
+            if (m_gesture != WPE_GESTURE_DRAG && std::hypot(x - m_position->x, y - m_position->y) > dragActivationThresholdPx) {
+                m_gesture = WPE_GESTURE_DRAG;
+                m_nextDeltaReferencePosition = m_position;
+                m_dragBegin = true;
+            } else if (m_gesture == WPE_GESTURE_DRAG)
+                m_dragBegin = false;
+            if (m_gesture == WPE_GESTURE_DRAG) {
+                m_delta = { x - m_nextDeltaReferencePosition->x, y - m_nextDeltaReferencePosition->y };
+                m_nextDeltaReferencePosition = { x, y };
+            }
+        } else
+            reset();
+        break;
+    case WPE_EVENT_TOUCH_UP:
+        if (double x, y; wpe_event_get_position(event, &x, &y) && m_position) {
+            if (m_gesture == WPE_GESTURE_DRAG)
+                m_delta = { x - m_nextDeltaReferencePosition->x, y - m_nextDeltaReferencePosition->y };
+        } else
+            reset();
+        m_sequenceId = std::nullopt; // We can accept new sequence at this point.
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+void GestureDetector::reset()
+{
+    m_gesture = WPE_GESTURE_NONE;
+    m_sequenceId = std::nullopt;
+    m_position = std::nullopt;
+    m_nextDeltaReferencePosition = std::nullopt;
+    m_delta = std::nullopt;
+    m_dragBegin = std::nullopt;
+}
+
+} // namespace WPE

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,35 +22,41 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#pragma once
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEGestureController.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include "WPEEvent.h"
+#include <optional>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+namespace WPE {
 
-#endif /* __WPE_PLATFORM_H__ */
+class GestureDetector final {
+public:
+    void handleEvent(WPEEvent*);
+    WPEGesture gesture() const { return m_gesture; }
+    void reset();
+
+    struct Position {
+        double x;
+        double y;
+    };
+    using Delta = Position;
+
+    std::optional<Position> position() const { return m_position; }
+    std::optional<Delta> delta() const { return m_delta; }
+    bool dragBegin() const { return m_dragBegin && *m_dragBegin; }
+
+private:
+    // FIXME: These ought to be either configurable or derived from system
+    //        properties, such as screen size and pixel density.
+    static constexpr uint32_t dragActivationThresholdPx { 8 };
+
+    WPEGesture m_gesture { WPE_GESTURE_NONE };
+    std::optional<uint32_t> m_sequenceId;
+    std::optional<Position> m_position;
+    std::optional<Position> m_nextDeltaReferencePosition;
+    std::optional<Delta> m_delta;
+    std::optional<bool> m_dragBegin;
+};
+
+} // namespace WPE

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -32,6 +32,7 @@
 
 #include <glib-object.h>
 #include <wpe/WPEDefines.h>
+#include <wpe/WPEGestureController.h>
 #include <wpe/WPEToplevel.h>
 
 G_BEGIN_DECLS
@@ -137,6 +138,9 @@ WPE_API WPEBufferDMABufFormats *wpe_view_get_preferred_dma_buf_formats (WPEView 
 WPE_API void                    wpe_view_set_opaque_rectangles         (WPEView            *view,
                                                                         WPERectangle       *rects,
                                                                         guint               n_rects);
+WPE_API void                    wpe_view_set_gesture_controller        (WPEView            *view,
+                                                                        WPEGestureController *controller);
+WPE_API WPEGestureController   *wpe_view_get_gesture_controller        (WPEView            *view);
 
 G_END_DECLS
 


### PR DESCRIPTION
#### 23d6925f4d0973911cea79158805b5e555a6a0de
<pre>
[WPE] WPE Platform: add support for tap and drag gestures
<a href="https://bugs.webkit.org/show_bug.cgi?id=265637">https://bugs.webkit.org/show_bug.cgi?id=265637</a>

Reviewed by Carlos Garcia Campos.

This change extends the WPE platform API by introducing:
 - WPEGestureController - an interface (with default cross-WPE-platform implementation) that is used to process touch events in order to detect gestures.
This change also provides a code that:
 - Feeds WPEGestureController provided by WPE platform with events.
 - Handles events detected by WPEGestureController:
   - Tap gesture is handled as a mouse click.
   - Drag gesture is handled as a mouse wheel scroll.

* Source/WebKit/Shared/NativeWebWheelEvent.h:
* Source/WebKit/Shared/libwpe/WebEventFactory.h:
* Source/WebKit/Shared/wpe/NativeWebWheelEventWPE.cpp:
(WebKit::NativeWebWheelEvent::NativeWebWheelEvent):
* Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithTouchEvent):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::ViewPlatform):
(WKWPE::ViewPlatform::handleGesture):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h:
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEGestureController.cpp: Added.
(wpe_gesture_controller_default_init):
(wpe_gesture_controller_handle_event):
(wpe_gesture_controller_cancel):
(wpe_gesture_controller_get_gesture):
(wpe_gesture_controller_get_gesture_position):
(wpe_gesture_controller_get_gesture_delta):
(wpe_gesture_controller_is_drag_begin):
* Source/WebKit/WPEPlatform/wpe/WPEGestureController.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.cpp: Added.
(wpeHandleEvent):
(wpeCancel):
(wpeGetGesture):
(wpeGetGesturePosition):
(wpeGetGestureDelta):
(wpeIsDragBegin):
(wpe_gesture_controller_impl_class_init):
(wpe_gesture_controller_interface_init):
(wpeGestureControllerImplNew):
* Source/WebKit/WPEPlatform/wpe/WPEGestureControllerImpl.h: Copied from Source/WebKit/WPEPlatform/wpe/wpe-platform.h.
* Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp: Added.
(WPE::GestureDetector::handleEvent):
(WPE::GestureDetector::reset):
* Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h: Copied from Source/WebKit/WPEPlatform/wpe/wpe-platform.h.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_set_gesture_controller):
(wpe_view_get_gesture_controller):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:

Canonical link: <a href="https://commits.webkit.org/280661@main">https://commits.webkit.org/280661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c95c4d8891b3127c0a71766489a7e5ad98f05243

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60750 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7573 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46263 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5332 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59160 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34227 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31007 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53524 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53584 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/884 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8538 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32287 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->