### PR TITLE
[Python2] Bump all module versions for a final release

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.14.1',
+    version='0.15.0',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 14, 1)
+version = Version(0, 15, 0)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.16.8',
+    version='0.17.0',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -48,7 +48,7 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(0, 16, 8)
+version = Version(0, 17, 0)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py
@@ -122,7 +122,7 @@ class TestRunner(object):
 
                 if args.log_level >= logging.WARNING and sys.stdout.isatty():
                     _, columns = Terminal.size()
-                    sys.stdout.write('\033[F\033[K' * math.ceil(chars / (columns or chars)))
+                    sys.stdout.write('\033[F\033[K' * int(math.ceil(chars / (columns or chars))))
 
         except KeyboardInterrupt:
             sys.stderr.write('\nUser interupted the program\n\n')

--- a/Tools/Scripts/libraries/webkitflaskpy/setup.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitflaskpy',
-    version='0.6.0',
+    version='0.7.0',
     description="Library supporting the WebKit Team's flask based web services.",
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
@@ -43,7 +43,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 6, 0)
+version = Version(0, 7, 0)
 
 AutoInstall.register(Package('click', Version(7, 1, 2)))
 AutoInstall.register(Package('flask', Version(1, 1, 2)))

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.8.0',
+    version='6.9.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 8, 0)
+version = Version(6, 9, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))


### PR DESCRIPTION
#### 0f65c8e1dab88eb73ce4966ae8cbef516717f0d0
<pre>
[Python2] Bump all module versions for a final release
<a href="https://bugs.webkit.org/show_bug.cgi?id=274263">https://bugs.webkit.org/show_bug.cgi?id=274263</a>
<a href="https://rdar.apple.com/128200866">rdar://128200866</a>

Reviewed by Sam Sneddon.

Before officially removing Python 2 support from these libraries, we should
release one final Python 2 compatible version of each.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/setup.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py:
(TestRunner.run): Minor Python 2 compatibility fix.
* Tools/Scripts/libraries/webkitflaskpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.

Canonical link: <a href="https://commits.webkit.org/278885@main">https://commits.webkit.org/278885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f8aaf263b49d35b97fd91bc3148655e6d786a4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42135 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23265 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51631 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26013 "4 new passes 4 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1930 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56642 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49538 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/51801 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48778 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29038 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7574 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->