### PR TITLE
Add bytes() to Blob and PushMessageData

### DIFF
--- a/LayoutTests/http/wpt/push-api/pushEvent.any.js
+++ b/LayoutTests/http/wpt/push-api/pushEvent.any.js
@@ -27,8 +27,12 @@ test(() => {
         assert_true(data instanceof PushMessageData);
         assert_equals(data.text(), stringValue);
         assert_true(data.blob() instanceof Blob);
+        assert_true(data.bytes() instanceof Uint8Array);
         assert_equals(data.json().test, 1);
         assert_equals(data.arrayBuffer().byteLength, stringValue.length);
+        assert_equals(data.bytes().length, stringValue.length);
+        assert_not_equals(data.bytes().buffer, data.arrayBuffer());
+        assert_not_equals(data.bytes(), data.bytes());
     }
 }, "PushEvent with data");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame-expected.txt
@@ -2,5 +2,6 @@
 PASS slice()
 PASS text()
 PASS arrayBuffer()
+PASS bytes()
 PASS stream()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html
@@ -27,6 +27,7 @@ promise_test(async () => {
 
     assert_equals(await slicedBlob.text(), "oo");
     assert_equals(charCodeBufferToString(await slicedBlob.arrayBuffer()), "oo");
+    assert_equals(charCodeArrayToString(await slicedBlob.bytes()), "oo");
 
     const reader = slicedBlob.stream().getReader();
     const { value } = await reader.read();
@@ -47,6 +48,14 @@ promise_test(async () => {
     const charCodeBuffer = await arrayBuffer.call(blob);
     assert_equals(charCodeBufferToString(charCodeBuffer), "bar");
 }, "arrayBuffer()");
+
+promise_test(async () => {
+    const { bytes } = await BlobPrototypeFromDetachedFramePromise;
+    const blob = new Blob(["bar"]);
+
+    const charCodeBytes = await bytes.call(blob);
+    assert_equals(charCodeArrayToString(charCodeBytes), "bar");
+}, "bytes()");
 
 promise_test(async () => {
     const { stream } = await BlobPrototypeFromDetachedFramePromise;

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Blob.bytes()
+PASS Blob.bytes() empty Blob data
+PASS Blob.bytes() non-ascii input
+PASS Blob.bytes() non-unicode input
+PASS Blob.bytes() concurrent reads
+

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.js
@@ -1,0 +1,45 @@
+// META: title=Blob bytes()
+// META: script=../support/Blob.js
+'use strict';
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("PASS");
+  const blob = new Blob([input_arr]);
+  const uint8array = await blob.bytes();
+  assert_true(uint8array instanceof Uint8Array);
+  assert_equals_typed_array(uint8array, input_arr);
+}, "Blob.bytes()")
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("");
+  const blob = new Blob([input_arr]);
+  const uint8array = await blob.bytes();
+  assert_true(uint8array instanceof Uint8Array);
+  assert_equals_typed_array(uint8array, input_arr);
+}, "Blob.bytes() empty Blob data")
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("\u08B8\u000a");
+  const blob = new Blob([input_arr]);
+  const uint8array = await blob.bytes();
+  assert_equals_typed_array(uint8array, input_arr);
+}, "Blob.bytes() non-ascii input")
+
+promise_test(async () => {
+  const input_arr = [8, 241, 48, 123, 151];
+  const typed_arr = new Uint8Array(input_arr);
+  const blob = new Blob([typed_arr]);
+  const uint8array = await blob.bytes();
+  assert_equals_typed_array(uint8array, typed_arr);
+}, "Blob.bytes() non-unicode input")
+
+promise_test(async () => {
+  const input_arr = new TextEncoder().encode("PASS");
+  const blob = new Blob([input_arr]);
+  const uint8array_results = await Promise.all([blob.bytes(),
+      blob.bytes(), blob.bytes()]);
+  for (let uint8array of uint8array_results) {
+    assert_true(uint8array instanceof Uint8Array);
+    assert_equals_typed_array(uint8array, input_arr);
+  }
+}, "Blob.bytes() concurrent reads")

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Blob.bytes()
+PASS Blob.bytes() empty Blob data
+PASS Blob.bytes() non-ascii input
+PASS Blob.bytes() non-unicode input
+PASS Blob.bytes() concurrent reads
+

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.js
+/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.js
 /LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.js
 /LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html
 /LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.js

--- a/Source/WebCore/Modules/push-api/PushMessageData.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(PushMessageData);
 
 ExceptionOr<RefPtr<JSC::ArrayBuffer>> PushMessageData::arrayBuffer()
 {
-    auto buffer = ArrayBuffer::tryCreate(m_data.data(), m_data.size());
+    auto buffer = ArrayBuffer::tryCreate(m_data.span());
     if (!buffer)
         return Exception { ExceptionCode::OutOfMemoryError };
     return buffer;
@@ -49,6 +49,14 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> PushMessageData::arrayBuffer()
 RefPtr<Blob> PushMessageData::blob(ScriptExecutionContext& context)
 {
     return Blob::create(&context, Vector<uint8_t> { m_data }, { });
+}
+
+ExceptionOr<RefPtr<JSC::Uint8Array>> PushMessageData::bytes()
+{
+    auto view = Uint8Array::tryCreate(m_data.span());
+    if (!view)
+        return Exception { ExceptionCode::OutOfMemoryError };
+    return view;
 }
 
 ExceptionOr<JSC::JSValue> PushMessageData::json(JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/Modules/push-api/PushMessageData.h
+++ b/Source/WebCore/Modules/push-api/PushMessageData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "ExceptionOr.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/Uint8Array.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/Vector.h>
 
@@ -44,6 +45,7 @@ public:
 
     ExceptionOr<RefPtr<JSC::ArrayBuffer>> arrayBuffer();
     RefPtr<Blob> blob(ScriptExecutionContext&);
+    ExceptionOr<RefPtr<JSC::Uint8Array>> bytes();
     ExceptionOr<JSC::JSValue> json(JSDOMGlobalObject&);
     String text();
 

--- a/Source/WebCore/Modules/push-api/PushMessageData.idl
+++ b/Source/WebCore/Modules/push-api/PushMessageData.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 ] interface PushMessageData {
     ArrayBuffer arrayBuffer();
     [CallWith=CurrentScriptExecutionContext] Blob blob();
+    Uint8Array bytes();
     [CallWith=CurrentGlobalObject] any json();
     USVString text();
 };

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -58,6 +58,9 @@ class ScriptExecutionContext;
 class FragmentedSharedBuffer;
 class WebCoreOpaqueRoot;
 
+struct IDLArrayBuffer;
+
+template<typename> class DOMPromiseDeferred;
 template<typename> class ExceptionOr;
 
 using BlobPartVariant = std::variant<RefPtr<JSC::ArrayBufferView>, RefPtr<JSC::ArrayBuffer>, RefPtr<Blob>, String>;
@@ -121,7 +124,8 @@ public:
     Ref<Blob> slice(long long start, long long end, const String& contentType) const;
 
     void text(Ref<DeferredPromise>&&);
-    void arrayBuffer(Ref<DeferredPromise>&&);
+    void arrayBuffer(DOMPromiseDeferred<IDLArrayBuffer>&&);
+    void bytes(Ref<DeferredPromise>&&);
     ExceptionOr<Ref<ReadableStream>> stream();
 
     size_t memoryCost() const { return m_memoryCost; }

--- a/Source/WebCore/fileapi/Blob.idl
+++ b/Source/WebCore/fileapi/Blob.idl
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -48,4 +49,5 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     [NewObject] ReadableStream stream();
     [NewObject] Promise<USVString> text();
     [NewObject] Promise<ArrayBuffer> arrayBuffer();
+    [NewObject] Promise<Uint8Array> bytes();
 };


### PR DESCRIPTION
#### d35627646eb3b30079f2ec5bbbc75b02b2eb4e2b
<pre>
Add bytes() to Blob and PushMessageData
<a href="https://bugs.webkit.org/show_bug.cgi?id=274119">https://bugs.webkit.org/show_bug.cgi?id=274119</a>
<a href="https://rdar.apple.com/128418858">rdar://128418858</a>

Reviewed by Youenn Fablet.

This implements <a href="https://github.com/w3c/FileAPI/pull/198">https://github.com/w3c/FileAPI/pull/198</a> and
<a href="https://github.com/w3c/push-api/pull/370">https://github.com/w3c/push-api/pull/370</a> creating parity for these
APIs with Fetch&apos;s Body.

This incorporates the tests from
<a href="https://github.com/web-platform-tests/wpt/pull/46232">https://github.com/web-platform-tests/wpt/pull/46232</a> modulo a typo fix.
PushMessageData test coverage is done through a local test that would
be good to upstream at some point.

* LayoutTests/http/wpt/push-api/pushEvent.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html:
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.js: Added.
(string_appeared_here.promise_test.async const):
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/w3c-import.log:
* Source/WebCore/Modules/push-api/PushMessageData.cpp:
(WebCore::PushMessageData::arrayBuffer):
(WebCore::PushMessageData::bytes):
* Source/WebCore/Modules/push-api/PushMessageData.h:
* Source/WebCore/Modules/push-api/PushMessageData.idl:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::arrayBuffer):
(WebCore::Blob::bytes):
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/Blob.idl:

Canonical link: <a href="https://commits.webkit.org/279263@main">https://commits.webkit.org/279263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/841b7d4dd8c1fcacf53234c6ce7759865cf009d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42964 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24088 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1844 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57836 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3159 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45935 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11560 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->