### PR TITLE
Add entitlement related to notifyd blocking to WebContent Development

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -198,37 +198,40 @@ function webcontent_sandbox_entitlements()
 function notify_entitlements()
 {
     plistbuddy Add :com.apple.developer.web-browser-engine.restrict.notifyd bool YES
-    plistbuddy Add :com.apple.private.darwin-notification.introspect array
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:0 string com.apple.CFPreferences._domainsChangedExternally
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:1 string com.apple.WebKit.LibraryPathDiagnostics
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:2 string com.apple.WebKit.deleteAllCode
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:3 string com.apple.WebKit.fullGC
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:4 string com.apple.accessibility.cache.app.ax
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:5 string com.apple.accessibility.cache.ax
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:6 string com.apple.accessibility.cache.enhance.text.legibility
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:7 string com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:8 string com.apple.accessibility.cache.guided.access.via.mdm
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:9 string com.apple.accessibility.cache.invert.colors
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:10 string com.apple.accessibility.cache.invert.colorscom.apple.WebKit.WebContent
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:11 string com.apple.accessibility.cache.vot
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:12 string com.apple.accessibility.cache.zoom
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:13 string com.apple.language.changed
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:14 string com.apple.mediaaccessibility.captionAppearanceSettingsChanged
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:15 string com.apple.powerlog.state_changed
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:16 string com.apple.system.logging.prefschanged
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:17 string com.apple.system.lowpowermode
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:18 string com.apple.system.timezone
-    plistbuddy Add :com.apple.private.darwin-notification.introspect:19 string com.apple.zoomwindow
-    if [[ "${WK_PLATFORM_NAME}" == macosx ]]
+    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:20 string com.apple.system.DirectoryService.InvalidateCache
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:21 string com.apple.system.DirectoryService.InvalidateCache.group
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:22 string com.apple.system.DirectoryService.InvalidateCache.host
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:23 string com.apple.system.DirectoryService.InvalidateCache.service
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:24 string com.apple.system.DirectoryService.InvalidateCache.user
-    else
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:20 string com.apple.mobile.usermanagerd.foregrounduser_changed
-        plistbuddy Add :com.apple.private.darwin-notification.introspect:21 string com.apple.mobile.keybagd.user_changed
+        plistbuddy Add :com.apple.private.darwin-notification.introspect array
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:0 string com.apple.CFPreferences._domainsChangedExternally
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:1 string com.apple.WebKit.LibraryPathDiagnostics
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:2 string com.apple.WebKit.deleteAllCode
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:3 string com.apple.WebKit.fullGC
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:4 string com.apple.accessibility.cache.app.ax
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:5 string com.apple.accessibility.cache.ax
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:6 string com.apple.accessibility.cache.enhance.text.legibility
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:7 string com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:8 string com.apple.accessibility.cache.guided.access.via.mdm
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:9 string com.apple.accessibility.cache.invert.colors
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:10 string com.apple.accessibility.cache.invert.colorscom.apple.WebKit.WebContent
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:11 string com.apple.accessibility.cache.vot
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:12 string com.apple.accessibility.cache.zoom
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:13 string com.apple.language.changed
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:14 string com.apple.mediaaccessibility.captionAppearanceSettingsChanged
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:15 string com.apple.powerlog.state_changed
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:16 string com.apple.system.logging.prefschanged
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:17 string com.apple.system.lowpowermode
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:18 string com.apple.system.timezone
+        plistbuddy Add :com.apple.private.darwin-notification.introspect:19 string com.apple.zoomwindow
+        if [[ "${WK_PLATFORM_NAME}" == macosx ]]
+        then
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:20 string com.apple.system.DirectoryService.InvalidateCache
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:21 string com.apple.system.DirectoryService.InvalidateCache.group
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:22 string com.apple.system.DirectoryService.InvalidateCache.host
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:23 string com.apple.system.DirectoryService.InvalidateCache.service
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:24 string com.apple.system.DirectoryService.InvalidateCache.user
+        else
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:20 string com.apple.mobile.usermanagerd.foregrounduser_changed
+            plistbuddy Add :com.apple.private.darwin-notification.introspect:21 string com.apple.mobile.keybagd.user_changed
+        fi
     fi
 }
 
@@ -254,11 +257,6 @@ function mac_process_webcontent_shared_entitlements()
             plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
         fi
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" > 140000 ))
-        then
-            notify_entitlements
-        fi
-
         if [[ "${WK_WEBCONTENT_SERVICE_NEEDS_XPC_DOMAIN_EXTENSION_ENTITLEMENT}" == YES ]]
         then
             plistbuddy Add :com.apple.private.xpc.domain-extension bool YES
@@ -268,6 +266,11 @@ function mac_process_webcontent_shared_entitlements()
     if [[ "${WK_XPC_SERVICE_VARIANT}" == Development ]]
     then
         plistbuddy Add :com.apple.security.cs.disable-library-validation bool YES
+    fi
+
+    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" > 140000 ))
+    then
+        notify_entitlements
     fi
 }
 


### PR DESCRIPTION
#### 693ae98c2146edd20bf2bb087eda06c9dc1ce48f
<pre>
Add entitlement related to notifyd blocking to WebContent Development
<a href="https://bugs.webkit.org/show_bug.cgi?id=274265">https://bugs.webkit.org/show_bug.cgi?id=274265</a>
<a href="https://rdar.apple.com/128139234">rdar://128139234</a>

Reviewed by Sihui Liu.

Add entitlement related to notifyd blocking to the WebContent Development XPC service, since it is also required there.
Without this entitlement, we can get into a notification loop state where notifications are continously being reposted
by the WebContent process. With this entitlement, notifyd will be blocked in the sandbox, preventing this loop.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/278899@main">https://commits.webkit.org/278899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15166573f0ad21a37bc85c668e081ab7c7a6b138

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2536 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42170 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23303 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51692 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26054 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49573 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44815 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48823 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11331 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29099 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7583 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->