### PR TITLE
HTMLPlugInImageElement: verify that element is in same document before requesting a load

### DIFF
--- a/JSTests/wasm/stress/wasm-unreachable-br-block.js
+++ b/JSTests/wasm/stress/wasm-unreachable-br-block.js
@@ -1,0 +1,19 @@
+import * as assert from '../assert.js';
+import { instantiate } from "../wabt-wrapper.js";
+
+let wat = `
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    unreachable
+    block  ;; label = @1
+      br 1 (;@0;)
+    end)
+)
+`;
+
+async function test() {
+    await instantiate(wat);
+}
+
+assert.asyncTest(test());

--- a/LayoutTests/fast/css/repeating-conic-gradient-small-range-expected.txt
+++ b/LayoutTests/fast/css/repeating-conic-gradient-small-range-expected.txt
@@ -1,0 +1,4 @@
+This test passess if it doesn't crash.
+Repeating Gradient With Many Stops
+Repeating Gradient With Many Stops
+Repeating Gradient With Many Stops

--- a/LayoutTests/fast/css/repeating-conic-gradient-small-range.html
+++ b/LayoutTests/fast/css/repeating-conic-gradient-small-range.html
@@ -1,0 +1,19 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.repeating-gradient-with-suffix-stops {
+    background: repeating-conic-gradient(from 0deg, red 0%, green 0.0001%);
+}
+.repeating-gradient-with-prefix-stops {
+    background: repeating-conic-gradient(from 0deg, red 99.9999%, green 100%);
+}
+.repeating-gradient-with-prefix-and-suffix-stops {
+    background: repeating-conic-gradient(from 0deg, red 50%, green 50.0001%);
+}
+</style>
+<div>This test passess if it doesn't crash.</div>
+<div class="repeating-gradient-with-suffix-stops">Repeating Gradient With Many Stops</div>
+<div class="repeating-gradient-with-prefix-stops">Repeating Gradient With Many Stops</div>
+<div class="repeating-gradient-with-prefix-and-suffix-stops">Repeating Gradient With Many Stops</div>

--- a/LayoutTests/fast/css/repeating-linear-gradient-small-range-expected.txt
+++ b/LayoutTests/fast/css/repeating-linear-gradient-small-range-expected.txt
@@ -1,0 +1,4 @@
+This test passess if it doesn't crash.
+Repeating Gradient With Many Stops
+Repeating Gradient With Many Stops
+Repeating Gradient With Many Stops

--- a/LayoutTests/fast/css/repeating-linear-gradient-small-range.html
+++ b/LayoutTests/fast/css/repeating-linear-gradient-small-range.html
@@ -1,0 +1,19 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.repeating-gradient-with-suffix-stops {
+    background: repeating-linear-gradient(to right, red 0%, green 0.0001%);
+}
+.repeating-gradient-with-prefix-stops {
+    background: repeating-linear-gradient(to right, red 99.9999%, green 100%);
+}
+.repeating-gradient-with-prefix-and-suffix-stops {
+    background: repeating-linear-gradient(to right, red 50%, green 50.0001%);
+}
+</style>
+<div>This test passess if it doesn't crash.</div>
+<div class="repeating-gradient-with-suffix-stops">Repeating Gradient With Many Stops</div>
+<div class="repeating-gradient-with-prefix-stops">Repeating Gradient With Many Stops</div>
+<div class="repeating-gradient-with-prefix-and-suffix-stops">Repeating Gradient With Many Stops</div>

--- a/LayoutTests/fast/css/repeating-radial-gradient-small-range-expected.txt
+++ b/LayoutTests/fast/css/repeating-radial-gradient-small-range-expected.txt
@@ -1,0 +1,4 @@
+This test passess if it doesn't crash.
+Repeating Gradient With Many Stops
+Repeating Gradient With Many Stops
+Repeating Gradient With Many Stops

--- a/LayoutTests/fast/css/repeating-radial-gradient-small-range.html
+++ b/LayoutTests/fast/css/repeating-radial-gradient-small-range.html
@@ -1,0 +1,19 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.repeating-gradient-with-suffix-stops {
+    background: repeating-radial-gradient(circle at center, red 0%, green 0.0001%);
+}
+.repeating-gradient-with-prefix-stops {
+    background: repeating-radial-gradient(circle at center, red 99.9999%, green 100%);
+}
+.repeating-gradient-with-prefix-and-suffix-stops {
+    background: repeating-radial-gradient(circle at center, red 50%, green 50.0001%);
+}
+</style>
+<div>This test passess if it doesn't crash.</div>
+<div class="repeating-gradient-with-suffix-stops">Repeating Gradient With Many Stops</div>
+<div class="repeating-gradient-with-prefix-stops">Repeating Gradient With Many Stops</div>
+<div class="repeating-gradient-with-prefix-and-suffix-stops">Repeating Gradient With Many Stops</div>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4143,6 +4143,9 @@ imported/w3c/web-platform-tests/css/css-view-transitions/names-are-tree-scoped.h
 
 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html [ ImageOnlyFailure ]
 
+# This test hits some infinite-loop condition inside Cairo
+fast/css/repeating-conic-gradient-small-range.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/security/schedule-request-object-then-move-plugin-to-frameless-document-crash-expected.txt
+++ b/LayoutTests/security/schedule-request-object-then-move-plugin-to-frameless-document-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/security/schedule-request-object-then-move-plugin-to-frameless-document-crash.html
+++ b/LayoutTests/security/schedule-request-object-then-move-plugin-to-frameless-document-crash.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<embed id="embed"></embed>
+<iframe id="iframe"></iframe>
+<object id="object"></object>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+  doc = new DOMParser().parseFromString("foo", "text/html");
+  object.data = "x";
+  var embed = document.getElementById("embed");
+  iframe.contentDocument.adoptNode(embed);
+  embed.bar;
+  doc.body.appendChild(object);
+  document.body.replaceWith("PASS if no crash.");
+</script>

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -324,8 +324,8 @@ bool HTMLPlugInImageElement::requestObject(const String& relativeURL, const Stri
     if (ScriptDisallowedScope::InMainThread::isScriptAllowed())
         return document->frame()->loader().subframeLoader().requestObject(*this, relativeURL, getNameAttribute(), mimeType, paramNames, paramValues);
 
-    document->eventLoop().queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, relativeURL, nameAttribute = getNameAttribute(), mimeType, paramNames, paramValues]() mutable {
-        if (!isConnected())
+    document->eventLoop().queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, relativeURL, nameAttribute = getNameAttribute(), mimeType, paramNames, paramValues, document]() mutable {
+        if (!this->isConnected() || &this->document() != document.ptr())
             return;
         RefPtr frame = this->document().frame();
         if (!frame)


### PR DESCRIPTION
#### 3f5fc52ff3ea57f51b2a004ea0e47542b13ad1ae
<pre>
HTMLPlugInImageElement: verify that element is in same document before requesting a load
<a href="https://bugs.webkit.org/show_bug.cgi?id=268769">https://bugs.webkit.org/show_bug.cgi?id=268769</a>
<a href="https://rdar.apple.com/121960561">rdar://121960561</a>

Reviewed by Ryosuke Niwa.

The testcase shows a scenario where a plugin is set up to start loading the plugin contents
from an event loop, however before the event loop is started the rest of the script will run, which
moves the plugin to a different document, thus hitting an ASSERT in WebFrame::createSubframe when the load
is performed. Protect against this by returning early when this situation is detected in the event loop.

* LayoutTests/security/schedule-request-object-then-move-plugin-to-frameless-document-crash-expected.txt: Added.
* LayoutTests/security/schedule-request-object-then-move-plugin-to-frameless-document-crash.html: Added.
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::requestObject):

Originally-landed-as: 274097.9@webkit-2024.2-embargoed (f81d56c47751). <a href="https://rdar.apple.com/128089895">rdar://128089895</a>
Canonical link: <a href="https://commits.webkit.org/278884@main">https://commits.webkit.org/278884@main</a>
</pre>
----------------------------------------------------------------------
#### 72485b3a40e30c94b4394e7bac01af3159debbd6
<pre>
ASAN_ILL | WTF::Vector::expandCapacity; WTF::Vector::expandCapacity; WebCore::StyleGradientImage::computeStops
<a href="https://bugs.webkit.org/show_bug.cgi?id=264639">https://bugs.webkit.org/show_bug.cgi?id=264639</a>
<a href="https://rdar.apple.com/114069174">rdar://114069174</a>

Reviewed by Antti Koivisto.

When working with repeating gradients, more care should be put into limiting the
amount of stops that can be additionally generated. If the original gradient
range is already too small, the extra stops are not generated. Once the number
of additional stops is calculated, the generation proceeds only if that number
is below some reasonable limit. That generation is also improved slightly by
creating a separate Vector of gradient stops that then simply replaces the
original one.

* LayoutTests/fast/css/repeating-conic-gradient-small-range-expected.txt: Added.
* LayoutTests/fast/css/repeating-conic-gradient-small-range.html: Added.
* LayoutTests/fast/css/repeating-linear-gradient-small-range-expected.txt: Added.
* LayoutTests/fast/css/repeating-linear-gradient-small-range.html: Added.
* LayoutTests/fast/css/repeating-radial-gradient-small-range-expected.txt: Added.
* LayoutTests/fast/css/repeating-radial-gradient-small-range.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::computeStops const):

Originally-landed-as: 274097.8@webkit-2024.2-embargoed (efd994a148b6). <a href="https://rdar.apple.com/128090422">rdar://128090422</a>
Canonical link: <a href="https://commits.webkit.org/278883@main">https://commits.webkit.org/278883@main</a>
</pre>
----------------------------------------------------------------------
#### 96f558b446153e1417a8df780d22e338091d86a6
<pre>
WASM unreachable code validation is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=265425">https://bugs.webkit.org/show_bug.cgi?id=265425</a>
<a href="https://rdar.apple.com/103288466">rdar://103288466</a>

Reviewed by Keith Miller.

This patch fixes an assertion failure in the unreachable code parser
when the target of a br instruction is a block that was not added into
the control stack.

The code that checks the br target now takes into account the number of
unreachable blocks, if the br instruction is also unreachable. This is
similar to the solution employed by parseDelegateTarget and should
support cases when block, if, try, and loop were not added to the control
stack.

* JSTests/wasm/stress/wasm-unreachable-br-block.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBranchTarget):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Originally-landed-as: 274097.7@webkit-2024.2-embargoed (ab8e4a4470bb). <a href="https://rdar.apple.com/128090590">rdar://128090590</a>
Canonical link: <a href="https://commits.webkit.org/278882@main">https://commits.webkit.org/278882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f35bb963c3af39c9b3a4fef4d125074a888f6177

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2190 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1938 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45135 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56652 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51299 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26914 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44774 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11327 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29048 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63618 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27888 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12006 "Passed tests") | 
<!--EWS-Status-Bubble-End-->