### PR TITLE
Remove processing user gesture check before displaying prompt for usdz

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -289,6 +289,9 @@
 /* Title for Cancel button label in button bar */
 "Cancel button label in button bar" = "Cancel";
 
+/* Cancel USDZ file */
+"Cancel (usdz QuickLook Preview)" = "Cancel";
+
 /* Capitalize context menu item */
 "Capitalize" = "Capitalize";
 
@@ -435,6 +438,9 @@
 
 /* Undo action name */
 "Dictation (Undo action name)" = "Dictation";
+
+/* Display USDZ file */
+"Allow (usdz QuickLook Preview)" = "Allow";
 
 /* Message for requesting cross-site cookie and website data access. */
 "Do you want to allow “%@” and “%@” to use cookies and website data while browsing “%@”?" = "Do you want to allow “%@” and “%@” to use cookies and website data while browsing “%@”?";
@@ -1311,6 +1317,9 @@
 
 /* Title for Show Text action button */
 "Show Text" = "Show Text";
+
+/* Open 3D object in a new window? */
+"Open this 3D model?" = "Open this 3D model?";
 
 /* Title of the context menu item to show when PDFPlugin was used instead of a blocked plugin */
 "Show in blocked plug-in" = "Show in blocked plug-in";

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -608,7 +608,7 @@ void HTMLAnchorElement::handleClick(Event& event)
 
     SystemPreviewInfo systemPreviewInfo;
 #if USE(SYSTEM_PREVIEW)
-    systemPreviewInfo.isPreview = isSystemPreviewLink() && document->settings().systemPreviewEnabled();
+    systemPreviewInfo.isPreview = isSystemPreviewLink() && document->settings().systemPreviewEnabled() && UserGestureIndicator::processingUserGesture();
 
     if (systemPreviewInfo.isPreview) {
         systemPreviewInfo.element.elementIdentifier = identifier();

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -608,7 +608,7 @@ void HTMLAnchorElement::handleClick(Event& event)
 
     SystemPreviewInfo systemPreviewInfo;
 #if USE(SYSTEM_PREVIEW)
-    systemPreviewInfo.isPreview = isSystemPreviewLink() && document->settings().systemPreviewEnabled() && UserGestureIndicator::processingUserGesture();
+    systemPreviewInfo.isPreview = isSystemPreviewLink() && document->settings().systemPreviewEnabled();
 
     if (systemPreviewInfo.isPreview) {
         systemPreviewInfo.element.elementIdentifier = identifier();

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -393,7 +393,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    UIViewController *presentingViewController = m_webPageProxy.uiClient().presentingViewController();
+    RetainPtr<UIViewController> presentingViewController = m_webPageProxy.uiClient().presentingViewController();
 
     if (!presentingViewController)
         return completionHandler();
@@ -418,7 +418,6 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
             [dataTask setDelegate:protectedThis->m_wkSystemPreviewDataTaskDelegate.get()];
             protectedThis->takeActivityToken();
             completionHandler();
-            protectedThis->m_allowPreviewCallback = nullptr;
         });
 
         protectedThis->m_downloadURL = url;
@@ -444,13 +443,18 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         successHandler(success);
     });
     auto alert = WebKit::createUIAlertController(WEB_UI_NSSTRING(@"Open this 3D model?", "Open this 3D model?"), nil);
-    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Allow (usdz QuickLook Preview)", "Allow") style:UIAlertActionStyleDefault handler:^(UIAlertAction *) {
-        m_allowPreviewCallback.get()(true);
+    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Allow (usdz QuickLook Preview)", "Allow") style:UIAlertActionStyleDefault handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
+        if (!weakThis)
+            return;
+
+        std::exchange(weakThis->m_allowPreviewCallback, nullptr)(true);
     }];
 
-    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Cancel (usdz QuickLook Preview)", "Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction *) {
-        m_allowPreviewCallback.get()(false);
-        m_allowPreviewCallback = nullptr;
+    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Cancel (usdz QuickLook Preview)", "Cancel") style:UIAlertActionStyleCancel handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
+        if (!weakThis)
+            return;
+
+        std::exchange(weakThis->m_allowPreviewCallback, nullptr)(false);
     }];
 
     [alert addAction:doNotAllowAction];

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -29,6 +29,8 @@
 #if USE(SYSTEM_PREVIEW)
 
 #import "APIUIClient.h"
+#import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
 #import "_WKDataTaskDelegate.h"
@@ -36,13 +38,17 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <QuickLook/QuickLook.h>
 #import <UIKit/UIViewController.h>
+#import <WebCore/LocalizedStrings.h>
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/UTIUtilities.h>
 #import <pal/spi/cocoa/FoundationSPI.h>
 #import <pal/spi/ios/QuickLookSPI.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/SpanCocoa.h>
+
+#import <pal/ios/QuickLookSoftLink.h>
 
 #import <pal/ios/QuickLookSoftLink.h>
 
@@ -374,8 +380,9 @@ namespace WebKit {
 
 void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOriginData& topOrigin, const WebCore::SystemPreviewInfo& systemPreviewInfo, CompletionHandler<void()>&& completionHandler)
 {
-    if (m_state != State::Initial) {
+    if (m_state != State::Initial || m_allowPreviewCallback) {
         RELEASE_LOG(SystemPreview, "SystemPreview didn't start because an existing preview is in progress");
+        m_showPreviewDelay = std::min(30., 1. + m_showPreviewDelay * m_showPreviewDelay);
         return completionHandler();
     }
 
@@ -393,40 +400,69 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
 
     m_systemPreviewInfo = systemPreviewInfo;
 
-    RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
-
-    auto request = WebCore::ResourceRequest(url);
-    WeakPtr weakThis { *this };
-    bool shouldRunAtForegroundPriority = false;
-    m_webPageProxy.dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
-        if (!weakThis)
+    auto successHandler = [completionHandler = WTFMove(completionHandler), topOrigin, weakThis = WeakPtr { *this }, url, presentingViewController] (bool success) mutable {
+        if (!success || !weakThis)
             return completionHandler();
 
         auto protectedThis = weakThis.get();
+        RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", protectedThis->m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+        auto request = WebCore::ResourceRequest(url);
+        bool shouldRunAtForegroundPriority = false;
+        protectedThis->m_webPageProxy.dataTaskWithRequest(WTFMove(request), topOrigin, shouldRunAtForegroundPriority, [weakThis, completionHandler = WTFMove(completionHandler)] (Ref<API::DataTask>&& task) mutable {
+            if (!weakThis)
+                return completionHandler();
 
-        _WKDataTask *dataTask = wrapper(task);
-        protectedThis->m_wkSystemPreviewDataTaskDelegate = adoptNS([[_WKSystemPreviewDataTaskDelegate alloc] initWithSystemPreviewController:protectedThis]);
-        [dataTask setDelegate:protectedThis->m_wkSystemPreviewDataTaskDelegate.get()];
-        protectedThis->takeActivityToken();
-        completionHandler();
-    });
+            auto protectedThis = weakThis.get();
+            _WKDataTask *dataTask = wrapper(task);
+            protectedThis->m_wkSystemPreviewDataTaskDelegate = adoptNS([[_WKSystemPreviewDataTaskDelegate alloc] initWithSystemPreviewController:protectedThis]);
+            [dataTask setDelegate:protectedThis->m_wkSystemPreviewDataTaskDelegate.get()];
+            protectedThis->takeActivityToken();
+            completionHandler();
+            protectedThis->m_allowPreviewCallback = nullptr;
+        });
 
-    m_downloadURL = url;
-    m_fragmentIdentifier = url.fragmentIdentifier().toString();
+        protectedThis->m_downloadURL = url;
+        protectedThis->m_fragmentIdentifier = url.fragmentIdentifier().toString();
 
 #if !PLATFORM(VISION)
-    m_qlPreviewController = adoptNS([PAL::allocQLPreviewControllerInstance() init]);
+        protectedThis->m_qlPreviewController = adoptNS([PAL::allocQLPreviewControllerInstance() init]);
 
-    m_qlPreviewControllerDelegate = adoptNS([[_WKPreviewControllerDelegate alloc] initWithSystemPreviewController:this]);
-    [m_qlPreviewController setDelegate:m_qlPreviewControllerDelegate.get()];
+        protectedThis->m_qlPreviewControllerDelegate = adoptNS([[_WKPreviewControllerDelegate alloc] initWithSystemPreviewController:protectedThis]);
+        [protectedThis->m_qlPreviewController setDelegate:protectedThis->m_qlPreviewControllerDelegate.get()];
 
-    m_qlPreviewControllerDataSource = adoptNS([[_WKPreviewControllerDataSource alloc] initWithSystemPreviewController:this MIMEType:@"model/vnd.usdz+zip" originatingPageURL:url]);
-    [m_qlPreviewController setDataSource:m_qlPreviewControllerDataSource.get()];
+        protectedThis->m_qlPreviewControllerDataSource = adoptNS([[_WKPreviewControllerDataSource alloc] initWithSystemPreviewController:protectedThis MIMEType:@"model/vnd.usdz+zip" originatingPageURL:url]);
+        [protectedThis->m_qlPreviewController setDataSource:protectedThis->m_qlPreviewControllerDataSource.get()];
 
-    [presentingViewController presentViewController:m_qlPreviewController.get() animated:YES completion:nullptr];
+        [presentingViewController presentViewController:protectedThis->m_qlPreviewController.get() animated:YES completion:nullptr];
+#else
+        UNUSED_PARAM(presentingViewController);
 #endif
 
-    m_state = State::Initial;
+        protectedThis->m_state = State::Initial;
+    };
+    m_allowPreviewCallback = makeBlockPtr([successHandler = WTFMove(successHandler)](bool success) mutable {
+        successHandler(success);
+    });
+    auto alert = WebKit::createUIAlertController(WEB_UI_NSSTRING(@"Open this 3D model?", "Open this 3D model?"), nil);
+    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Allow (usdz QuickLook Preview)", "Allow") style:UIAlertActionStyleDefault handler:^(UIAlertAction *) {
+        m_allowPreviewCallback.get()(true);
+    }];
+
+    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Cancel (usdz QuickLook Preview)", "Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction *) {
+        m_allowPreviewCallback.get()(false);
+        m_allowPreviewCallback = nullptr;
+    }];
+
+    [alert addAction:doNotAllowAction];
+    [alert addAction:allowAction];
+
+    if (m_showPreviewDelay) {
+        RunLoop::main().dispatchAfter(Seconds { m_showPreviewDelay }, [alert, presentingViewController] {
+            [presentingViewController presentViewController:alert.get() animated:YES completion:nil];
+        });
+        m_showPreviewDelay = 0;
+    } else
+        [presentingViewController presentViewController:alert.get() animated:YES completion:nil];
 }
 
 void SystemPreviewController::loadStarted(const URL& localFileURL)

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -460,7 +460,9 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
     [alert addAction:doNotAllowAction];
     [alert addAction:allowAction];
 
-    if (m_showPreviewDelay) {
+    if (m_testingCallback)
+        std::exchange(m_allowPreviewCallback, nullptr)(true);
+    else if (m_showPreviewDelay) {
         RunLoop::main().dispatchAfter(Seconds { m_showPreviewDelay }, [alert, presentingViewController] {
             [presentingViewController presentViewController:alert.get() animated:YES completion:nil];
         });

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -31,6 +31,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/ResourceError.h>
+#include <wtf/BlockPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
@@ -112,6 +113,8 @@ private:
 
     std::unique_ptr<ProcessThrottler::BackgroundActivity> m_activity;
     CompletionHandler<void(bool)> m_testingCallback;
+    BlockPtr<void(bool)> m_allowPreviewCallback;
+    double m_showPreviewDelay { 0 };
 
 };
 


### PR DESCRIPTION
#### b35f3f7eba94a42a8108ea651f1de8ea4a906402
<pre>
Remove processing user gesture check before displaying prompt for usdz
<a href="https://bugs.webkit.org/show_bug.cgi?id=272321">https://bugs.webkit.org/show_bug.cgi?id=272321</a>
radar://126078233

Reviewed by Alexey Proskuryakov.

Opening a usdz blob isn&apos;t considered to be processing a user gesture,
so having the UserGestureIndicator::processingUserGesture() check results
in the download path being taken instead of the prompt and open to ARQL.

Since we already have the prompt, we can remove the user gesture check.

* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):

Originally-landed-as: 272448.918@safari-7618-branch (fe35964ae2b9). <a href="https://rdar.apple.com/128280210">rdar://128280210</a>
Canonical link: <a href="https://commits.webkit.org/279000@main">https://commits.webkit.org/279000@main</a>
</pre>
----------------------------------------------------------------------
#### f1cfd5a3139a0e18dcf0279802c0867174696beb
<pre>
Potential UAF in SystemPreviewController::begin
<a href="https://bugs.webkit.org/show_bug.cgi?id=272342">https://bugs.webkit.org/show_bug.cgi?id=272342</a>
radar://124988039

Reviewed by Aditya Keerthi.

SystemPreviewController::begin was calling functions asychronously but
directly using both an Objective-C object and a C++ object without checking
to see if their lifetime&apos;s expired.

This code also used the name &apos;protectedThis&apos; to refer to a raw C++ pointer
which seems a little confusing, so just drop the protectedThis and use this
directly after ensuring the object has not been destructed based on the result
of WeakPtr::get().

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:

Originally-landed-as: 272448.892@safari-7618-branch (b53cc7cedea8). <a href="https://rdar.apple.com/128279820">rdar://128279820</a>
Canonical link: <a href="https://commits.webkit.org/278999@main">https://commits.webkit.org/278999@main</a>
</pre>
----------------------------------------------------------------------
#### 6f6eb17ce35389deafb0be3cedfa5f9d0308ee94
<pre>
Interactionless USDZ Popups in Vision Pro
&lt;radar://122802255&gt;

Reviewed by Tim Horton.

Show a pop-up asking the user to confirm they want to
quick look preview a USDZ file in WebKit.

Add a delay if the page constantly tries to open one such
file otherwise it can be difficult to exit out of the page.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/SystemPreviewController.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):

Originally-landed-as: 272448.672@safari-7618-branch (6b6d3d3e61f6). <a href="https://rdar.apple.com/128090184">rdar://128090184</a>
Canonical link: <a href="https://commits.webkit.org/278998@main">https://commits.webkit.org/278998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91dae530544447517423b55b456f788399a9ed2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52196 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42481 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2323 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1078 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57066 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2524 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11415 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->