### PR TITLE
Implement further enforcement of Trusted Types for Attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node-expected.txt
@@ -1,22 +1,16 @@
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 
 PASS Sanity check: Setting non-TT attributes still works.
-FAIL Set script.src via textContent assert_throws_js: function "_ => {
-      element.attributes[0].textContent = "sldkjsfldk";
-    }" did not throw
-FAIL Set script.src via nodeValue assert_throws_js: function "_ => {
-      element.attributes[0].nodeValue = "sdflkgjdlkgjdg";
-    }" did not throw
-FAIL Set iframe.srcdoc via textContent assert_throws_js: function "_ => {
-      element.attributes[0].textContent = "sldkjsfldk";
-    }" did not throw
-FAIL Set iframe.srcdoc via nodeValue assert_throws_js: function "_ => {
-      element.attributes[0].nodeValue = "sdflkgjdlkgjdg";
-    }" did not throw
-FAIL Set div.onclick via textContent assert_throws_js: function "_ => {
-      element.attributes[0].textContent = "sldkjsfldk";
-    }" did not throw
-FAIL Set div.onclick via nodeValue assert_throws_js: function "_ => {
-      element.attributes[0].nodeValue = "sdflkgjdlkgjdg";
-    }" did not throw
+PASS Set script.src via textContent
+PASS Set script.src via nodeValue
+PASS Set iframe.srcdoc via textContent
+PASS Set iframe.srcdoc via nodeValue
+PASS Set div.onclick via textContent
+PASS Set div.onclick via nodeValue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback-expected.txt
@@ -2,4 +2,7 @@
 
 PASS Ensure the right attributes are modified.
 PASS Ensure the deleted attributes is modified.
+PASS Ensure toggleAttribute results in an empty attribute.
+PASS Ensure setAttribute results in right attribute value.
+PASS Ensure setAttributeNS results in right attribute value.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <iframe id="iframe" data-x="" srcdoc="content" onmouseover=""></iframe>
+<div id="div"></div>
 <script>
   // This is a regression test for https://g-issues.chromium.org/issues/333739948
   // The test should hold true for any browser that supports Trusted Types.
@@ -16,6 +17,14 @@
     createHTML: (s, _, sink) => {
       assert_equals(sink, 'HTMLIFrameElement srcdoc');
       iframe.removeAttribute(target);
+      return s;
+    },
+    createScript: (s) => {
+      if (s == 'accepted') {
+        return s;
+      }
+
+      div.setAttribute('onmouseover', 'accepted');
       return s;
     }
   });
@@ -36,5 +45,26 @@
     iframe.setAttribute("srcdoc", "new srcdoc value");
     assert_equals(iframe.srcdoc, "new srcdoc value");
   }, "Ensure the deleted attributes is modified.");
+
+  test(t => {
+    div.toggleAttribute('onmouseover');
+    assert_equals(div.attributes.length, 2);
+    assert_equals(div.attributes.onmouseover.value, '');
+    div.removeAttribute('onmouseover');
+  }, "Ensure toggleAttribute results in an empty attribute.");
+
+  test(t => {
+    div.setAttribute('onmouseover', 'foo');
+    assert_equals(div.attributes.length, 2);
+    assert_equals(div.attributes.onmouseover.value, 'foo');
+    div.removeAttribute('onmouseover');
+  }, "Ensure setAttribute results in right attribute value.");
+
+  test(t => {
+    div.setAttributeNS(null, 'onmouseover', 'foo');
+    assert_equals(div.attributes.length, 2);
+    assert_equals(div.attributes.onmouseover.value, 'foo');
+    div.removeAttribute('onmouseover');
+  }, "Ensure setAttributeNS results in right attribute value.");
 
 </script>

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -94,17 +94,19 @@ ExceptionOr<void> Attr::setPrefix(const AtomString& prefix)
     return { };
 }
 
-void Attr::setValue(const AtomString& value)
+ExceptionOr<void> Attr::setValue(const AtomString& value)
 {
     if (RefPtr element = m_element.get())
-        element->setAttribute(qualifiedName(), value);
+        return element->setAttribute(qualifiedName(), value, true);
     else
         m_standaloneValue = value;
+
+    return { };
 }
 
-void Attr::setNodeValue(const String& value)
+ExceptionOr<void> Attr::setNodeValue(const String& value)
 {
-    setValue(value.isNull() ? emptyAtom() : AtomString(value));
+    return setValue(value.isNull() ? emptyAtom() : AtomString(value));
 }
 
 Ref<Node> Attr::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -45,7 +45,7 @@ public:
     Element* ownerElement() const { return m_element.get(); }
 
     WEBCORE_EXPORT AtomString value() const;
-    WEBCORE_EXPORT void setValue(const AtomString&);
+    WEBCORE_EXPORT ExceptionOr<void> setValue(const AtomString&);
 
     const QualifiedName& qualifiedName() const { return m_name; }
 
@@ -65,7 +65,7 @@ private:
     String nodeName() const final { return name(); }
 
     String nodeValue() const final { return value(); }
-    void setNodeValue(const String&) final;
+    ExceptionOr<void> setNodeValue(const String&) final;
 
     ExceptionOr<void> setPrefix(const AtomString&) final;
 

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -162,9 +162,10 @@ String CharacterData::nodeValue() const
     return m_data;
 }
 
-void CharacterData::setNodeValue(const String& nodeValue)
+ExceptionOr<void> CharacterData::setNodeValue(const String& nodeValue)
 {
     setData(nodeValue);
+    return { };
 }
 
 void CharacterData::setDataWithoutUpdate(const String& data)

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -65,7 +65,7 @@ protected:
 
 private:
     String nodeValue() const final;
-    void setNodeValue(const String&) final;
+    ExceptionOr<void> setNodeValue(const String&) final;
     void notifyParentAfterChange(const ContainerNode::ChildChange&);
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -166,7 +166,7 @@ public:
     AtomString getAttributeForBindings(const QualifiedName&, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
     template<typename... QualifiedNames>
     inline const AtomString& getAttribute(const QualifiedName&, const QualifiedNames&...) const;
-    WEBCORE_EXPORT void setAttribute(const QualifiedName&, const AtomString& value);
+    WEBCORE_EXPORT ExceptionOr<void> setAttribute(const QualifiedName&, const AtomString& value, bool enforceTrustedTypes = false);
     void setAttributeWithoutOverwriting(const QualifiedName&, const AtomString& value);
     WEBCORE_EXPORT void setAttributeWithoutSynchronization(const QualifiedName&, const AtomString& value);
     void setSynchronizedLazyAttribute(const QualifiedName&, const AtomString& value);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -500,9 +500,10 @@ String Node::nodeValue() const
     return String();
 }
 
-void Node::setNodeValue(const String&)
+ExceptionOr<void> Node::setNodeValue(const String&)
 {
     // By default, setting nodeValue has no effect.
+    return { };
 }
 
 RefPtr<NodeList> Node::childNodes()
@@ -1798,7 +1799,7 @@ String Node::textContent(bool convertBRsToNewlines) const
     return isNullString ? String() : content.toString();
 }
 
-void Node::setTextContent(String&& text)
+ExceptionOr<void> Node::setTextContent(String&& text)
 {           
     switch (nodeType()) {
     case ATTRIBUTE_NODE:
@@ -1806,18 +1807,19 @@ void Node::setTextContent(String&& text)
     case CDATA_SECTION_NODE:
     case COMMENT_NODE:
     case PROCESSING_INSTRUCTION_NODE:
-        setNodeValue(WTFMove(text));
-        return;
+        return setNodeValue(WTFMove(text));
     case ELEMENT_NODE:
     case DOCUMENT_FRAGMENT_NODE:
         uncheckedDowncast<ContainerNode>(*this).stringReplaceAll(WTFMove(text));
-        return;
+        return { };
     case DOCUMENT_NODE:
     case DOCUMENT_TYPE_NODE:
         // Do nothing.
-        return;
+        return { };
     }
     ASSERT_NOT_REACHED();
+
+    return { };
 }
 
 static SHA1::Digest hashPointer(const void* pointer)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -143,7 +143,7 @@ public:
     inline bool hasTagName(const SVGQualifiedName&) const;
     virtual String nodeName() const = 0;
     virtual String nodeValue() const;
-    virtual void setNodeValue(const String&);
+    virtual ExceptionOr<void> setNodeValue(const String&);
     NodeType nodeType() const { return nodeTypeFromBitFields(m_typeBitFields); }
     virtual size_t approximateMemoryCost() const { return sizeof(*this); }
     ContainerNode* parentNode() const;
@@ -208,7 +208,7 @@ public:
     WEBCORE_EXPORT const AtomString& lookupNamespaceURI(const AtomString& prefix) const;
 
     WEBCORE_EXPORT String textContent(bool convertBRsToNewlines = false) const;
-    WEBCORE_EXPORT void setTextContent(String&&);
+    WEBCORE_EXPORT ExceptionOr<void> setTextContent(String&&);
     
     Node* lastDescendant() const;
     Node* firstDescendant() const;


### PR DESCRIPTION
#### be4cdc9c602803f8505921b2c66f86aa0f392497
<pre>
Implement further enforcement of Trusted Types for Attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=274267">https://bugs.webkit.org/show_bug.cgi?id=274267</a>

Reviewed by Ryosuke Niwa.

This patch adds trusted types enforcement to Attr textContent, value and nodeValue.

It also improves error handling for mutating attributes within default policy.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
(WebCore::Attr::setNodeValue):
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::setNodeValue):
* Source/WebCore/dom/CharacterData.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::validateAttributeIndex const):
(WebCore::Element::setAttribute):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::setNodeValue):
(WebCore::Node::setTextContent):
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/279118@main">https://commits.webkit.org/279118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/312ef1fe8199709fc7851d7042576d9ed8d45a90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42603 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1990 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57259 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49993 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11477 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->