### PR TITLE
REGRESSION (278484@main): [ iOS ] editing/selection/ios/place-selection-in-overflow-area.html is a consistent timeout

### DIFF
--- a/LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html
+++ b/LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html
@@ -41,7 +41,6 @@
 
         clickTarget.addEventListener("mousedown", event => {
             event.preventDefault();
-            setTimeout(() => testRunner.notifyDone(), 0);
         });
 
         var target = document.getElementById("target");

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7308,7 +7308,5 @@ fast/viewport/ios/viewport-fit-auto.html [ Failure ]
 fast/viewport/ios/viewport-fit-contain.html [ Failure ]
 fast/viewport/ios/viewport-fit-cover.html [ Failure ]
 
-webkit.org/b/274180 editing/selection/ios/place-selection-in-overflow-area.html [ Timeout ]
-
 # webkit.org/b/274219 (REGRESSION (278786@main): [ MacOS iOS ] 3X http/wpt/webauthn tests are consistent failures)
 http/wpt/webauthn/idl.https.html [ Failure ]

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -175,6 +175,7 @@ private:
     WebCore::Color accentColor() override;
 
     WebKitWebResourceLoadManager* webResourceLoadManager() override;
+    void didClearEditorStateAfterPageTransition() final { }
 
     // Members of PageClientImpl class
     GtkWidget* m_viewWidget;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -168,6 +168,7 @@ private:
     void selectionDidChange() override;
 
     WebKitWebResourceLoadManager* webResourceLoadManager() override;
+    void didClearEditorStateAfterPageTransition() final { }
 
     WKWPE::View& m_view;
 };

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -518,6 +518,8 @@ public:
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
 #endif
 
+    virtual void didClearEditorStateAfterPageTransition() = 0;
+
 #if PLATFORM(IOS_FAMILY)
     virtual void commitPotentialTapFailed() = 0;
     virtual void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3054,7 +3054,7 @@ void WebPageProxy::clearEditorStateAfterPageTransition(EditorStateIdentifier ide
     internals().editorState = { };
     internals().editorState.identifier = identifier;
 
-    dispatchDidUpdateEditorState();
+    protectedPageClient()->didClearEditorStateAfterPageTransition();
 }
 
 void WebPageProxy::scheduleFullEditorStateUpdate()

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -197,6 +197,7 @@ private:
     void elementDidBlur() override;
     void focusedElementDidChangeInputMode(WebCore::InputMode) override;
     void didUpdateEditorState() override;
+    void didClearEditorStateAfterPageTransition() final;
     bool isFocusingElement() override;
     void selectionDidChange() override;
     bool interpretKeyEvent(const NativeWebKeyboardEvent&, bool isCharEvent) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -713,6 +713,11 @@ void PageClientImpl::didUpdateEditorState()
     [contentView() _didUpdateEditorState];
 }
 
+void PageClientImpl::didClearEditorStateAfterPageTransition()
+{
+    [contentView() _didClearEditorStateAfterPageTransition];
+}
+
 void PageClientImpl::showPlaybackTargetPicker(bool hasVideo, const IntRect& elementRect, WebCore::RouteSharingPolicy policy, const String& contextUID)
 {
     [contentView() _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -267,7 +267,7 @@ struct WKSelectionDrawingInfo {
     enum class SelectionType { None, Plugin, Range };
     WKSelectionDrawingInfo();
     explicit WKSelectionDrawingInfo(const EditorState&);
-    SelectionType type;
+    SelectionType type { SelectionType::None };
     WebCore::IntRect caretRect;
     WebCore::Color caretColor;
     Vector<WebCore::SelectionGeometry> selectionGeometries;
@@ -743,6 +743,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_elementDidBlur;
 - (void)_didUpdateInputMode:(WebCore::InputMode)mode;
 - (void)_didUpdateEditorState;
+- (void)_didClearEditorStateAfterPageTransition;
 - (void)_hardwareKeyboardAvailabilityChanged;
 - (void)_selectionChanged;
 - (void)_updateChangedSelection;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8222,6 +8222,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         block();
 }
 
+- (void)_didClearEditorStateAfterPageTransition
+{
+    _cachedSelectedTextRange = nil;
+    _lastSelectionDrawingInfo = { };
+}
+
 - (void)_updateInitialWritingDirectionIfNecessary
 {
     if (!_page->isEditable())

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -113,6 +113,7 @@ private:
     void clearSafeBrowsingWarning() override;
     void clearSafeBrowsingWarningIfForMainFrameNavigation() override;
     bool hasSafeBrowsingWarning() const override;
+    void didClearEditorStateAfterPageTransition() final { }
     
     bool showShareSheet(const WebCore::ShareDataWithParsedURL&, WTF::CompletionHandler<void(bool)>&&) override;
         

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -164,6 +164,8 @@ private:
     UnixFileDescriptor hostFileDescriptor() override;
 #endif
 
+    void didClearEditorStateAfterPageTransition() final { }
+
     PlayStationWebView& m_view;
 };
 

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -155,6 +155,7 @@ private:
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() override { return WebCore::UserInterfaceLayoutDirection::LTR; }
 
     void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&) final;
+    void didClearEditorStateAfterPageTransition() final { }
 
     // Members of PageClientImpl class
     DefaultUndoController m_undoController;


### PR DESCRIPTION
#### 24339c7cdb4184f03fceb677a8807f6f65c754ce
<pre>
REGRESSION (278484@main): [ iOS ] editing/selection/ios/place-selection-in-overflow-area.html is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=274180">https://bugs.webkit.org/show_bug.cgi?id=274180</a>
<a href="https://rdar.apple.com/128086114">rdar://128086114</a>

Reviewed by Abrar Protyasha.

After the changes in 278484@main, this test began to intermittently fail, but only when run after
another layout test that ends with a selection rect over the tap location, `(25, 25)`. This is
because the new logic to clear out the UI-side cached editor state in `278484@main` leaves the
editor state without post-layout or visual data. This means that the `_lastSelectionDrawingInfo` on
`WKContentView` isn&apos;t updated to reflect the fact that there&apos;s no more selection after committing
the load.

Subsequently, `-_shouldToggleSelectionCommandsAfterTapAt:` returns `YES` since we (incorrectly)
think the user is still tapping a selection rect, which should toggle the edit menu instead of being
handled as a synthetic click.

To fix this, clear out the stale `_lastSelectionDrawingInfo` (along with `_cachedSelectedTextRange`)
from the previous page upon transitioning to a new page.

* LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html:

Drive-by fix: remove a redundant call to `testRunner.notifyDone()`. This test currently ends faster
than intended, since it doesn&apos;t wait for the keyboard to be dismissed.

* LayoutTests/platform/ios/TestExpectations:

Remove failing test expectations.

* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::clearEditorStateAfterPageTransition):

Add a separate client method to call out to `WKContentView` (on iOS) to invalidate selection drawing
info when transitioning to a new page.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didClearEditorStateAfterPageTransition):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _didClearEditorStateAfterPageTransition]):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/win/PageClientImpl.h:

Canonical link: <a href="https://commits.webkit.org/278902@main">https://commits.webkit.org/278902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a15f811c211b2c1f5267f079d1b9482ba5e8361

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2553 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42181 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1994 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56720 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49583 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48833 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11335 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->