### PR TITLE
[WebGPU] RGBA16Float canvas context isn't created correctly

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2117,6 +2117,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273578.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273585.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273585.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274270.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274270.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274270-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274270-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274270.html
+++ b/LayoutTests/fast/webgpu/fuzz-274270.html
@@ -1,0 +1,28613 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u16c2\u08cf\u0aff\ue303\ua7f5\u197f\u85e4\u0ab1\u3e25\u2c03\ud139',
+  requiredLimits: {
+    maxBindGroups: 5,
+    maxColorAttachmentBytesPerSample: 52,
+    maxVertexBufferArrayStride: 46088,
+    maxStorageTexturesPerShaderStage: 27,
+    maxStorageBuffersPerShaderStage: 35,
+    maxDynamicStorageBuffersPerPipelineLayout: 44856,
+    maxDynamicUniformBuffersPerPipelineLayout: 21428,
+    maxBindingsPerBindGroup: 8844,
+    maxTextureArrayLayers: 355,
+    maxTextureDimension1D: 11835,
+    maxTextureDimension2D: 10525,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 227719939,
+    maxUniformBuffersPerShaderStage: 38,
+    maxSampledTexturesPerShaderStage: 20,
+    maxInterStageShaderVariables: 60,
+    maxInterStageShaderComponents: 90,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u00dc\ubb25'});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 2912});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\ud3ef\u470f\u{1f7bb}\u0b4f\u04d0\u07e6\u2076\ucee6\u09c5'});
+let img0 = await imageWithData(152, 72, '#966cb4e7', '#47a77110');
+let commandEncoder1 = device0.createCommandEncoder({label: '\u{1f66c}\u{1f84a}\u{1fc73}\u080f'});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\ud359\u0cf5\ufa74\u{1fbe9}',
+  entries: [
+    {
+      binding: 1133,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer0 = device0.createBuffer({
+  label: '\u70b6\ue461\u{1fdbb}\ub755\u292b',
+  size: 310796,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let computePassEncoder1 = commandEncoder1.beginComputePass({label: '\u{1fd3d}\u2c3e\u2d58\u288f\u0427\u{1fcb0}\u{1f67a}\u{1fe45}\u019b\u{1f9e5}'});
+let commandEncoder2 = device0.createCommandEncoder({});
+let texture0 = device0.createTexture({
+  label: '\u{1fb3b}\u0723\u02cd\u{1fe94}\u032f',
+  size: [80, 1, 180],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView0 = texture0.createView({label: '\u7c79\u6644', dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 9, arrayLayerCount: 56});
+gc();
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u0e23\u87cc\u0c0d\u{1fdb9}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder3 = device0.createCommandEncoder({label: '\ue830\ua157\u{1ff3b}\u{1fb73}\u{1f858}\u911e\u015b\u{1f929}\u601c\u4b4b\u4a1a'});
+let textureView1 = texture0.createView({
+  label: '\u02d7\u32ec\u0c81\u0dfe\u099e\u0989\u0b7b\u005d\u{1fd63}',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 86,
+  arrayLayerCount: 49,
+});
+let querySet1 = device0.createQuerySet({label: '\u96ba\u03de\u134e\u3415\ubd71\u0892', type: 'occlusion', count: 2387});
+let textureView2 = texture0.createView({
+  label: '\ua6c2\u0f7b\u10be\u6dea\udb58\ub735',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  baseArrayLayer: 85,
+  arrayLayerCount: 30,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1f86d}\ue18a\u{1f677}\ubea8\u4328\u3cd5\u8da6\ud436\uf9e6\u4904',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let sampler0 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.96,
+  lodMaxClamp: 55.35,
+  maxAnisotropy: 14,
+});
+gc();
+let commandBuffer0 = commandEncoder3.finish({label: '\ufc82\u0c9b\u4582\u0bd0\u5669'});
+let texture1 = device0.createTexture({
+  label: '\u{1f97a}\u0ca3\u{1fae4}\u{1f75d}\u9e49\u8c53\ued42\u{1fcd4}\u339d\u{1ff21}',
+  size: {width: 576, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+});
+let textureView3 = texture0.createView({
+  label: '\u0194\u4de5\u070d\u8881\u0844\uc680\u95f1\u92b3\uca52\u0630',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 67,
+  arrayLayerCount: 14,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1fa31}\ue9d5\ubee4\u75cc\u6776\u68e8\ua997\ueaa2\u0257'});
+try {
+buffer0.destroy();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(956, 309);
+let commandEncoder4 = device0.createCommandEncoder({label: '\u091a\u{1ff3f}\u41d3'});
+let textureView4 = texture0.createView({
+  label: '\u{1f77a}\uf95b\uf58c\u3238\u{1f6d4}\u5065',
+  mipLevelCount: 3,
+  baseArrayLayer: 94,
+  arrayLayerCount: 58,
+});
+let textureView5 = texture0.createView({dimension: '2d', baseMipLevel: 3, mipLevelCount: 3, baseArrayLayer: 53, arrayLayerCount: 1});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u0068\u7b21\u{1fd26}\u0053\u1c46\u{1fbd7}\u065f',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\u3c95\u{1fe60}\u023e', source: videoFrame0, colorSpace: 'srgb'});
+let img1 = await imageWithData(6, 136, '#8ddd0848', '#03ff3336');
+let renderBundle1 = renderBundleEncoder0.finish();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u0dce\ub2d8\ue802\u2956',
+  code: `@group(2) @binding(1133)
+var<storage, read_write> n0: array<u32>;
+@group(3) @binding(1133)
+var<storage, read_write> field0: array<u32>;
+@group(4) @binding(1133)
+var<storage, read_write> n1: array<u32>;
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: i32,
+  @location(2) f1: vec4<i32>,
+  @location(6) f2: vec4<f32>,
+  @location(3) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec4<f32>,
+  @location(1) f6: vec4<f32>,
+  @location(4) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(31) a0: vec4<u32>, @location(13) a1: vec3<f32>, @builtin(position) a2: vec4<f32>, @location(20) a3: vec4<i32>, @location(1) a4: vec4<f16>, @location(38) a5: i32, @location(57) a6: vec3<u32>, @location(12) a7: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(57) f0: vec3<u32>,
+  @location(1) f1: vec4<f16>,
+  @location(16) f2: f16,
+  @location(7) f3: vec4<u32>,
+  @location(45) f4: vec3<u32>,
+  @location(48) f5: vec2<i32>,
+  @location(13) f6: vec3<f32>,
+  @location(56) f7: f32,
+  @location(24) f8: vec4<f16>,
+  @location(49) f9: vec2<i32>,
+  @location(40) f10: vec3<f32>,
+  @location(31) f11: vec4<u32>,
+  @location(12) f12: vec4<f16>,
+  @location(3) f13: vec2<f32>,
+  @location(32) f14: vec2<i32>,
+  @location(51) f15: vec2<u32>,
+  @location(50) f16: vec2<i32>,
+  @location(36) f17: vec2<f16>,
+  @location(42) f18: vec4<u32>,
+  @location(38) f19: i32,
+  @location(39) f20: vec2<u32>,
+  @location(15) f21: f32,
+  @location(27) f22: i32,
+  @location(46) f23: vec4<f16>,
+  @location(25) f24: vec2<f32>,
+  @location(21) f25: vec4<u32>,
+  @location(28) f26: vec3<i32>,
+  @location(54) f27: vec4<f16>,
+  @location(47) f28: vec4<i32>,
+  @location(20) f29: vec4<i32>,
+  @builtin(position) f30: vec4<f32>,
+  @location(11) f31: vec3<u32>,
+  @location(29) f32: vec4<i32>,
+  @location(10) f33: u32
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u6078\u6512\u4bf6\u0293\u{1f996}\uf145\ufbf3\u0298',
+  entries: [{binding: 5340, visibility: 0, externalTexture: {}}],
+});
+let textureView6 = texture0.createView({
+  label: '\uae06\u{1f6ba}\u20b0\u7310\u00e3\u{1ffb9}\u0b26',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+  baseArrayLayer: 43,
+  arrayLayerCount: 41,
+});
+let externalTexture1 = device0.importExternalTexture({label: '\u02aa\u822d\u2ac5\ucb46', source: videoFrame0, colorSpace: 'srgb'});
+try {
+commandEncoder2.resolveQuerySet(querySet0, 2877, 35, buffer0, 200448);
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({
+  label: '\u03b3\ucdfe\u0aa2',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let texture2 = device0.createTexture({
+  label: '\ua976\u99b9',
+  size: [320],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView7 = texture0.createView({
+  label: '\u{1f859}\u09cf\u05fd\u0544\u{1fea6}\u9b51\ua742\u0b3b',
+  format: 'r32sint',
+  baseMipLevel: 4,
+  baseArrayLayer: 177,
+  arrayLayerCount: 2,
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({label: '\u61d9\udc2b\ucb7d\u0fdf\ud1cd\u4d3a\u5f15\uf196\u{1f649}\u{1f67f}\u64f8'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0871\u0ab5\u0310\u027f\u4318\udeb2\u{1f72a}\u0e82\u7c2c\u210a',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle2 = renderBundleEncoder2.finish({label: '\u0ad3\u05f7\ua38e\u9f0e\uceae\u0909\ub183'});
+let pipeline1 = device0.createComputePipeline({
+  label: '\u003c\u8ad9\ue7fd\u7a88\u0426\u0137\u{1fc25}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+document.body.prepend(img1);
+let imageBitmap0 = await createImageBitmap(videoFrame0);
+let shaderModule1 = device0.createShaderModule({
+  label: '\u2505\u{1fdf9}\u174d\u0ca1\u{1f7b4}\u0242\u0c6e\ud489\u082e',
+  code: `@group(4) @binding(1133)
+var<storage, read_write> type0: array<u32>;
+@group(3) @binding(1133)
+var<storage, read_write> global0: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> field1: array<u32>;
+@group(2) @binding(1133)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(1133)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(12) f0: vec4<u32>,
+  @location(41) f1: i32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>,
+  @location(4) f4: vec4<i32>,
+  @location(5) f5: vec2<i32>,
+  @location(1) f6: vec4<f32>,
+  @location(6) f7: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @location(53) a2: vec2<f32>, a3: S1, @location(38) a4: f16, @location(56) a5: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(7) f0: vec3<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(12) f2: vec3<u32>,
+  @location(13) f3: f16,
+  @location(15) f4: vec3<i32>,
+  @location(11) f5: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(53) f34: vec2<f32>,
+  @location(56) f35: vec2<i32>,
+  @builtin(position) f36: vec4<f32>,
+  @location(12) f37: vec4<u32>,
+  @location(38) f38: f16,
+  @location(41) f39: i32
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<u32>, @location(3) a1: vec4<f16>, @location(8) a2: vec3<i32>, a3: S0, @builtin(instance_index) a4: u32, @builtin(vertex_index) a5: u32, @location(9) a6: vec3<u32>, @location(0) a7: vec2<f16>, @location(5) a8: f32, @location(4) a9: i32, @location(6) a10: vec2<f16>, @location(14) a11: vec3<i32>, @location(10) a12: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout2 = pipeline1.getBindGroupLayout(3);
+let buffer1 = device0.createBuffer({
+  label: '\u{1fbf0}\u5dc1\u{1f875}',
+  size: 704628,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1f7cf}\uc5d7\u9b6b\u0674\u3007\ube44\u1d47'});
+let textureView8 = texture1.createView({
+  label: '\u{1f71c}\u0187\u{1fc0d}\u{1fbb2}\u0d1f\u085d\ub3ad\u1a80\u066b\uc4de\u04ef',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(9796, undefined, 0, 401770805);
+} catch {}
+gc();
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u5951\ud866\u{1fae7}\u0e7f\ub481',
+  entries: [
+    {
+      binding: 5687,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 3807});
+let textureView9 = texture0.createView({
+  label: '\u{1fc5a}\u{1fd88}\u0ca1\uce24',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 124,
+  arrayLayerCount: 47,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u000b\u8ddd',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+try {
+commandEncoder5.resolveQuerySet(querySet2, 1913, 786, buffer1, 634368);
+} catch {}
+try {
+adapter0.label = '\u1105\u{1fef8}';
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  label: '\uba6b\u0684\u{1f725}\u0f63\u165a\u0179',
+  layout: bindGroupLayout1,
+  entries: [{binding: 5340, resource: externalTexture1}],
+});
+let textureView10 = texture0.createView({
+  label: '\u{1fc8a}\u{1fbbc}\u13a8\u1f4a\u{1fe45}\ubb3b\u{1fd1f}\uca58\u{1f9a8}\u5d2a\u042d',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 28,
+  arrayLayerCount: 149,
+});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 172, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(24)), /* required buffer size: 672 */
+{offset: 672}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet3 = device0.createQuerySet({label: '\u05ff\u{1f699}\u0d3c\u03aa', type: 'occlusion', count: 2624});
+let textureView11 = texture2.createView({label: '\u0376\u0df5\uc705\u468f\u{1fdc1}'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup0, []);
+} catch {}
+offscreenCanvas0.width = 429;
+let video0 = await videoWithData();
+let commandEncoder6 = device0.createCommandEncoder();
+let sampler1 = device0.createSampler({
+  label: '\u{1f676}\u32e8\u{1feaa}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.795,
+  lodMaxClamp: 41.42,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u6156\u060f\u{1fc21}\u35a7\u05c6\u0a1e', source: video0, colorSpace: 'srgb'});
+let adapter1 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u{1f74f}\u0ac8'});
+let commandBuffer1 = commandEncoder6.finish({label: '\u{1ffa8}\u0014'});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 83 */
+{offset: 83}, {width: 240, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.width = 230;
+let offscreenCanvas1 = new OffscreenCanvas(194, 914);
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u{1fa87}\u0b24\u{1fe42}\ua8e2\u4171\u{1ff96}\u05e4\u2313\u03ac',
+  bindGroupLayouts: [bindGroupLayout3],
+});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u1137\u0883\u8a8d\u{1fa30}\u9b84\u49a0\u{1ff45}\u08af\u0705\udd7a'});
+let commandBuffer2 = commandEncoder8.finish();
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u3542\u727a\u0fe0',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let sampler2 = device0.createSampler({
+  label: '\u5074\u{1fe9c}\u{1fcd8}\uc725\u0488\u0fb5\ua06a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.43,
+  lodMaxClamp: 89.74,
+  compare: 'less',
+});
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(471), /* required buffer size: 471 */
+{offset: 471}, {width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(950, 676);
+let pipelineLayout2 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout2, bindGroupLayout2, bindGroupLayout2, bindGroupLayout2],
+});
+let textureView12 = texture2.createView({label: '\u09af\u09fc\u{1fd40}'});
+let renderBundle3 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder3.insertDebugMarker('\u6574');
+} catch {}
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u56e1\u{1fc5d}',
+  size: 66528,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder9 = device0.createCommandEncoder({label: '\uf50f\u4995\u01f6\u0a07'});
+let texture3 = device0.createTexture({
+  label: '\udea5\u{1f754}',
+  size: {width: 1152, height: 1, depthOrArrayLayers: 218},
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView13 = texture2.createView({
+  label: '\u63c9\ued09\u5d54\udc0a\u6005\u2252\u0412\u0645\u092e',
+  format: 'rgba32float',
+  mipLevelCount: 1,
+});
+let pipeline2 = await device0.createComputePipelineAsync({
+  label: '\u740f\u4b76\u0682\u{1faeb}\u980e\u{1fa65}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup1 = device0.createBindGroup({label: '\u00d5\u031b\u375e', layout: bindGroupLayout3, entries: [{binding: 5687, resource: sampler0}]});
+let commandEncoder10 = device0.createCommandEncoder({});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+  label: '\u333a\u0edf\u0835\u0e27\u5a60\u40e2\u{1f812}\u2911\uf15f\u0089\u{1f9e6}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+  },
+}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'less', failOp: 'keep'},
+    stencilReadMask: 2408641943,
+    stencilWriteMask: 4177907319,
+    depthBias: -1255177569,
+    depthBiasClamp: 564.8807503236717,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 23076,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 4784, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 2876, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 14048, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 7444, shaderLocation: 5},
+          {format: 'sint32', offset: 5116, shaderLocation: 8},
+          {format: 'sint32x4', offset: 4820, shaderLocation: 4},
+          {format: 'float32x2', offset: 5284, shaderLocation: 0},
+          {format: 'uint32x4', offset: 4104, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 12600, shaderLocation: 11},
+          {format: 'float32x4', offset: 2736, shaderLocation: 3},
+          {format: 'float16x2', offset: 6984, shaderLocation: 6},
+          {format: 'sint32x2', offset: 21900, shaderLocation: 7},
+          {format: 'uint8x4', offset: 1452, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 7384, attributes: [{format: 'sint8x4', offset: 1904, shaderLocation: 14}]},
+      {arrayStride: 15752, attributes: [{format: 'uint32x3', offset: 5144, shaderLocation: 1}]},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7104,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 2124, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+let bindGroup2 = device0.createBindGroup({
+  label: '\u1beb\uc4ca\ue609\u96eb\u2b99\ue14f\u2843\u{1f9bb}\u6250',
+  layout: bindGroupLayout3,
+  entries: [{binding: 5687, resource: sampler1}],
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({
+  label: '\u4183\ua9d4\u90ed\u{1fde7}\uc9fd\u0add\u02a5\u0e7b\u4bdb\ud857\u420a',
+  type: 'occlusion',
+  count: 2288,
+});
+let texture4 = device0.createTexture({
+  size: [320, 1, 1],
+  mipLevelCount: 9,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8sint'],
+});
+let textureView14 = texture0.createView({
+  label: '\u53cc\u080d\u0b51\u9d28\u056c\u{1fcd6}\uceed\ude96\uc046\ud657\u090a',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 15,
+  arrayLayerCount: 24,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u179f\u18ba\u{1f7c1}\ufe6e',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup2, new Uint32Array(4416), 2590, 0);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet4, 957, 207, buffer0, 115712);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  label: '\u0324\u1875\u{1fe4f}\u{1fdcc}',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3652, attributes: []},
+      {
+        arrayStride: 13148,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 1152, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  label: '\u1445\u{1f9a1}\u{1fc9d}\u{1f601}\ud6d6',
+  size: [160, 1, 1],
+  mipLevelCount: 5,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(9852), 3750, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(540), 340, 0);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline5 = device0.createComputePipeline({
+  label: '\uc504\u{1fff9}\uedcb',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let offscreenCanvas3 = new OffscreenCanvas(322, 778);
+let shaderModule2 = device0.createShaderModule({
+  label: '\u7aea\ud1f6\u{1fa6e}\ucf7d\u{1fe58}\u{1fddb}\u9a6a\u{1f8c8}\u045a\ud942\u678e',
+  code: `@group(0) @binding(1133)
+var<storage, read_write> field2: array<u32>;
+@group(4) @binding(1133)
+var<storage, read_write> global1: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> global2: array<u32>;
+@group(2) @binding(1133)
+var<storage, read_write> parameter0: array<u32>;
+@group(3) @binding(1133)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(5) f1: vec2<i32>,
+  @location(4) f2: vec4<i32>,
+  @location(6) f3: vec2<f32>,
+  @location(3) f4: vec4<f32>,
+  @location(2) f5: vec4<i32>,
+  @location(0) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(35) a0: vec4<f32>, @location(6) a1: u32, @location(12) a2: f16, @location(3) a3: i32, @location(37) a4: u32, @location(27) a5: u32, @location(13) a6: vec2<f32>, @location(10) a7: u32, @location(7) a8: u32, @location(29) a9: i32, @location(55) a10: vec2<f16>, @location(36) a11: vec2<i32>, @location(44) a12: vec2<f32>, @location(9) a13: vec3<u32>, @location(19) a14: vec2<u32>, @location(8) a15: vec2<f32>, @location(5) a16: f16, @location(20) a17: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(31) f40: i32,
+  @location(35) f41: vec4<f32>,
+  @location(46) f42: vec2<i32>,
+  @location(28) f43: i32,
+  @location(23) f44: vec4<f32>,
+  @location(32) f45: i32,
+  @location(10) f46: u32,
+  @location(5) f47: f16,
+  @location(0) f48: vec3<f32>,
+  @location(27) f49: u32,
+  @location(55) f50: vec2<f16>,
+  @location(19) f51: vec2<u32>,
+  @location(22) f52: vec2<f16>,
+  @location(3) f53: i32,
+  @location(36) f54: vec2<i32>,
+  @location(57) f55: vec2<f16>,
+  @location(6) f56: u32,
+  @location(42) f57: i32,
+  @location(44) f58: vec2<f32>,
+  @location(25) f59: u32,
+  @location(20) f60: u32,
+  @location(40) f61: vec3<u32>,
+  @location(7) f62: u32,
+  @location(1) f63: vec3<u32>,
+  @location(8) f64: vec2<f32>,
+  @location(54) f65: vec4<f32>,
+  @location(30) f66: f16,
+  @location(39) f67: f32,
+  @location(37) f68: u32,
+  @location(9) f69: vec3<u32>,
+  @location(29) f70: i32,
+  @location(52) f71: vec2<f32>,
+  @location(18) f72: vec3<f16>,
+  @location(12) f73: f16,
+  @location(17) f74: vec3<f16>,
+  @location(2) f75: vec3<u32>,
+  @location(24) f76: vec3<i32>,
+  @builtin(position) f77: vec4<f32>,
+  @location(13) f78: vec2<f32>,
+  @location(16) f79: vec2<f32>,
+  @location(58) f80: vec3<f32>,
+  @location(48) f81: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec4<u32>, @builtin(instance_index) a1: u32, @location(5) a2: vec3<f32>, @builtin(vertex_index) a3: u32, @location(15) a4: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u86c3\u08ec\uceb4\u{1fbf1}',
+  entries: [
+    {
+      binding: 4793,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 280702, hasDynamicOffset: true },
+    },
+    {
+      binding: 5489,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 2759,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let textureView15 = texture3.createView({aspect: 'all', mipLevelCount: 4});
+let renderBundle4 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet4, 443, 1248, buffer1, 689152);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas3.getContext('webgpu');
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1836});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(203), 85, 0);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet5, 1696, 133, buffer0, 42496);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 10, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({
+  label: '\udc84\u5390\u2555\u8b2b\u9e86\u121a\u509c\u6c51\uc772',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u01ea\u0991\u{1fdcc}',
+  entries: [
+    {binding: 152, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 8535,
+      visibility: 0,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 7505,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u{1ff9d}\u{1f6ed}\u{1feb3}'});
+let textureView16 = texture0.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 3, baseArrayLayer: 125});
+try {
+renderBundleEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(56)), /* required buffer size: 193 */
+{offset: 193}, {width: 28, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u1e72\udc7e\uaf21\ue262\u5053\u04c4\u0584\udb93\u30b8',
+  entries: [
+    {
+      binding: 3330,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView17 = texture3.createView({label: '\u1b5c\u8289\uffd7\u1178\u9c24\u349b\u98cd', baseMipLevel: 6, mipLevelCount: 4});
+let renderBundle5 = renderBundleEncoder1.finish({label: '\u{1f67e}\u12e4\u3061\u{1f95b}\u19dd\u2b8a\u1721'});
+let sampler3 = device0.createSampler({
+  label: '\uaef9\u0e15',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.29,
+  lodMaxClamp: 77.01,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.submit([commandBuffer2, commandBuffer0]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let computePassEncoder3 = commandEncoder10.beginComputePass({label: '\u0d69\u923a\u{1f708}'});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync({
+  label: '\u0687\u8169\u2f91\u707c\u0048\u16b6\u0221\u09f3',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 3860, attributes: [{format: 'snorm16x2', offset: 188, shaderLocation: 2}]}],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw'},
+});
+let buffer3 = device0.createBuffer({size: 43254, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder14 = device0.createCommandEncoder({});
+let computePassEncoder4 = commandEncoder5.beginComputePass({label: '\u{1fd6b}\ua9e2\ueaaa\u714d\u5774\u{1ff0c}\u0176\u6caf\u6d0b\u{1fdb0}\u055e'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise0 = device0.createRenderPipelineAsync({
+  label: '\u{1f702}\u{1fb7d}\u23a4\ud5f9\u03e3\uc260',
+  layout: 'auto',
+  multisample: {mask: 0x4a7b1426},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: GPUColorWrite.RED}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'never', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'zero'},
+    stencilReadMask: 3553245355,
+    stencilWriteMask: 1384660674,
+    depthBiasClamp: 237.36404470130606,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 35844,
+        attributes: [
+          {format: 'sint32', offset: 30284, shaderLocation: 15},
+          {format: 'float16x2', offset: 7064, shaderLocation: 13},
+          {format: 'uint16x4', offset: 6560, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 2920, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 226, shaderLocation: 3},
+          {format: 'uint32x3', offset: 6288, shaderLocation: 1},
+          {format: 'sint32x4', offset: 2360, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 14082, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 624, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 10932, shaderLocation: 0},
+          {format: 'sint8x4', offset: 8720, shaderLocation: 7},
+          {format: 'sint8x2', offset: 1316, shaderLocation: 8},
+          {format: 'uint16x4', offset: 1628, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 216, shaderLocation: 11},
+          {format: 'uint32', offset: 3640, shaderLocation: 9},
+          {format: 'sint32x2', offset: 1388, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let textureView18 = texture1.createView({
+  label: '\u0d4a\u{1fecf}\u4222\u814d\u0d75\uc711\u0a83\ud96d',
+  format: 'bgra8unorm',
+  baseMipLevel: 3,
+  baseArrayLayer: 0,
+});
+let sampler4 = device0.createSampler({
+  label: '\u32cd\ua7fd\u0752\u{1fda9}\u3c0b\u8007\u00aa\u3bf0\ub8f3',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.44,
+  lodMaxClamp: 77.35,
+});
+try {
+renderBundleEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16304 */
+  offset: 16304,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet4, 1189, 371, buffer3, 28672);
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({
+  label: '\u56f8\u0543\u8d82\u4544\u8fb7',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule3 = device0.createShaderModule({
+  label: '\u3f20\u0f11\u0db1\u69e4',
+  code: `
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: vec2<i32>,
+  @location(2) f2: vec4<i32>,
+  @location(5) f3: vec4<i32>,
+  @builtin(sample_mask) f4: u32,
+  @location(6) f5: vec4<f32>,
+  @location(3) f6: vec4<f32>,
+  @location(1) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(6) a1: vec2<i32>, @location(15) a2: vec4<u32>, @builtin(vertex_index) a3: u32, @location(2) a4: vec2<u32>, @location(13) a5: vec4<i32>, @location(1) a6: vec3<u32>, @location(8) a7: i32, @location(10) a8: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder15 = device0.createCommandEncoder();
+let textureView19 = texture2.createView({label: '\u5fcd\u{1faa3}\u{1f69f}\ud163\u1628\u029a\u300c\u0b91\uc997'});
+let computePassEncoder5 = commandEncoder15.beginComputePass();
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\ud001');
+} catch {}
+let imageBitmap1 = await createImageBitmap(img0);
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3127,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 942,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandBuffer3 = commandEncoder11.finish();
+let texture6 = device0.createTexture({
+  size: [144],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let textureView20 = texture5.createView({label: '\u09e1\u692f\uc4d4\u739e\u0a39\u3469\u0cdc', format: 'rgba8unorm', mipLevelCount: 1});
+let externalTexture3 = device0.importExternalTexture({label: '\u818b\u{1f808}\u{1fc34}', source: video0, colorSpace: 'display-p3'});
+try {
+commandEncoder7.resolveQuerySet(querySet1, 2379, 8, buffer0, 161792);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(8)), /* required buffer size: 888 */
+{offset: 888}, {width: 131, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView21 = texture6.createView({label: '\ueef4\u{1fd33}\u09fd', arrayLayerCount: 1});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f78a}\u{1fa5e}\u049c\ue347\ub30d\u{1fcb5}\u02fc',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle6 = renderBundleEncoder3.finish({label: '\ubc36\u8940\u7662\u0235\u{1fed3}\u7cf9\uc01b\u0ff6\u{1fb2b}\u0f46\ue118'});
+try {
+renderBundleEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet2, 1820, 1761, buffer3, 3328);
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({
+  label: '\ucfc6\ufb51\u115b\u052e\ue303\u{1fb43}\u02f4\u{1fa03}\u0281\u37fd\ud620',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let video1 = await videoWithData();
+let imageData0 = new ImageData(72, 144);
+let textureView22 = texture3.createView({label: '\u3848\u528c\uc824\u9a45\u{1fea8}\u0e75', baseMipLevel: 5, mipLevelCount: 3});
+try {
+commandEncoder2.resolveQuerySet(querySet1, 209, 1504, buffer0, 267776);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let querySet6 = device0.createQuerySet({label: '\u2ed9\u05cc\u1f41\ucec2\u0631\u{1fd92}\ud5f8', type: 'occlusion', count: 1372});
+try {
+computePassEncoder4.setBindGroup(4, bindGroup1, new Uint32Array(6721), 6676, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(7603, undefined, 3738805452, 69200424);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 61, y: 103 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData1 = new ImageData(20, 40);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let querySet7 = device0.createQuerySet({label: '\ucb59\u01b1\u2f1e\u2e35\u018e\u{1fb1f}', type: 'occlusion', count: 225});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u5251\ufbde\u{1f85e}\u1bb6\ue251\u{1fd0a}\u2843\u{1fa21}\u55a4\u5b49\ue170',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3700, undefined);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(0, 52828);
+try {
+commandEncoder2.resolveQuerySet(querySet5, 1472, 242, buffer1, 323840);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 280, y: 285 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = device0.createRenderPipeline({
+  label: '\ubdbf\u6263\u7c57\ua434\u2232\u36be',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst-alpha'},
+  },
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-wrap',
+    },
+    stencilReadMask: 3002385757,
+    stencilWriteMask: 1131014568,
+    depthBias: -824462206,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 688, attributes: [{format: 'uint32x2', offset: 0, shaderLocation: 15}]},
+      {
+        arrayStride: 336,
+        attributes: [
+          {format: 'sint16x4', offset: 52, shaderLocation: 13},
+          {format: 'uint32x3', offset: 36, shaderLocation: 2},
+          {format: 'uint32x3', offset: 12, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 6476, attributes: [{format: 'float32x3', offset: 1128, shaderLocation: 10}]},
+      {arrayStride: 10740, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2552,
+        attributes: [
+          {format: 'sint16x2', offset: 324, shaderLocation: 8},
+          {format: 'sint32x3', offset: 456, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(video1);
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u066d\u0334\u4e47\u{1f92e}\u{1f70b}\u{1f889}',
+  entries: [
+    {
+      binding: 4481,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 7721,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 13, y: 69 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  label: '\uf4d3\u05e2\uf3a4\uabbd\u83da',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x9742d83b},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb'}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 1448234032,
+    stencilWriteMask: 3189904115,
+    depthBias: 194973709,
+    depthBiasSlopeScale: 775.847445738911,
+    depthBiasClamp: 142.12374055628334,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2084,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 316, shaderLocation: 15},
+          {format: 'sint32', offset: 456, shaderLocation: 8},
+          {format: 'float16x4', offset: 216, shaderLocation: 10},
+          {format: 'uint8x4', offset: 432, shaderLocation: 9},
+          {format: 'float32x2', offset: 432, shaderLocation: 0},
+          {format: 'uint16x4', offset: 1256, shaderLocation: 2},
+          {format: 'sint8x4', offset: 1304, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 460, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 22656,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 2856, shaderLocation: 6},
+          {format: 'uint32x3', offset: 4516, shaderLocation: 12},
+          {format: 'float32x3', offset: 5456, shaderLocation: 5},
+          {format: 'float32x2', offset: 4724, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x3', offset: 812, shaderLocation: 13},
+          {format: 'sint32x4', offset: 10592, shaderLocation: 14},
+          {format: 'sint32x3', offset: 4164, shaderLocation: 7},
+          {format: 'uint16x4', offset: 5276, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder16 = device0.createCommandEncoder();
+let texture7 = device0.createTexture({
+  label: '\u{1f9ca}\u{1fb30}\u{1fd2d}\u{1f8c1}',
+  size: [288],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView23 = texture5.createView({
+  label: '\u{1f882}\u9965',
+  dimension: '2d',
+  format: 'rgba8unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+try {
+buffer2.destroy();
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let canvas0 = document.createElement('canvas');
+let commandEncoder17 = device0.createCommandEncoder({});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u606f\u{1f6f5}\u209c\u395d\u{1f9cc}\u6732\u3002\u879c\ubd3e\u0da3\u{1fe21}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle7 = renderBundleEncoder6.finish({label: '\u{1fe58}\u53a6\u2fa1\u0a54\u{1fdc2}\u0ef7'});
+try {
+computePassEncoder4.insertDebugMarker('\u0960');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 148, y: 50 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule3, entryPoint: 'compute0'}});
+offscreenCanvas0.height = 882;
+let img2 = await imageWithData(284, 299, '#3a91f5ec', '#70262303');
+try {
+adapter0.label = '\u07a7\ufb14\ua55c\u068b\u{1fd9e}\u013f\ufbb3\u0ba4\u{1fd7c}\u{1fb6e}';
+} catch {}
+let querySet8 = device0.createQuerySet({label: '\ud4a8\u{1fe99}\u5dc1\u3d27\u3896\uea61\u04c6', type: 'occlusion', count: 3862});
+let texture8 = device0.createTexture({
+  label: '\u0d47\u{1fe01}\uca24\u065e\u43fb\u{1f820}\uc685\u0a0c\u021e',
+  size: [80],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture4.createView({aspect: 'all', baseMipLevel: 2, mipLevelCount: 4, baseArrayLayer: 0});
+let renderBundle8 = renderBundleEncoder5.finish({label: '\u7b8d\ud94a\u{1fc6c}\u3aba'});
+let sampler5 = device0.createSampler({
+  label: '\u3cda\u9041\u8481\u76c8',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.23,
+  lodMaxClamp: 92.75,
+  compare: 'greater-equal',
+  maxAnisotropy: 19,
+});
+let externalTexture4 = device0.importExternalTexture({
+  label: '\u631d\u0a6f\u2b0c\u001e\u0076\uc39b\u6661\u12ba\u73ef\u{1f84f}',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 524 widthInBlocks: 131 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 29332 */
+  offset: 29332,
+  rowsPerImage: 118,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 131, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let promise1 = device0.createRenderPipelineAsync({
+  label: '\u{1fe6c}\u0154\u0963\u7fcf\u06eb\u9fdf\u{1f942}\u03b3\ue346\u2734',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3952, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7744,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 568, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let gpuCanvasContext3 = canvas0.getContext('webgpu');
+let commandEncoder18 = device0.createCommandEncoder({label: '\u2bd1\u4302\u7a46\ub670\uc2ee\u{1f87a}\u3c80\ub60f\u{1f795}\u75f9\u4140'});
+let textureView25 = texture2.createView({});
+let computePassEncoder6 = commandEncoder2.beginComputePass({label: '\u{1f774}\u02b4\u5185\u3f2b\u02d6\u012f\u6af4\u0a7f'});
+let renderBundle9 = renderBundleEncoder1.finish({label: '\ueec5\u0328\u0c30\u5b08\u0553\u{1f905}'});
+try {
+computePassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 172 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2168 */
+  offset: 2168,
+  rowsPerImage: 233,
+  buffer: buffer3,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let textureView26 = texture2.createView({});
+let computePassEncoder7 = commandEncoder7.beginComputePass();
+let renderBundle10 = renderBundleEncoder0.finish({label: '\u{1fd9b}\u{1fbab}\u{1fbd5}\u083e\ue22f\u5f60\u7402\u74dc\u{1ffef}\u0605'});
+let externalTexture5 = device0.importExternalTexture({label: '\ued00\u05ae\u191f\u038b\u74f0\u9ab7\ubb56', source: video0});
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet1, 885, 319, buffer1, 456448);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({entries: []});
+let pipelineLayout3 = device0.createPipelineLayout({label: '\u3c12\udc9f\ubd38\u0fcb\udbd7\u0a3d\ua779\u7109\u4cc9', bindGroupLayouts: []});
+let commandEncoder19 = device0.createCommandEncoder();
+let textureView27 = texture5.createView({label: '\u007e\u0918\u9a19\u0056\ub6d7\u{1fd61}\u8643\uaff2', dimension: '2d-array', mipLevelCount: 2});
+let renderBundle11 = renderBundleEncoder4.finish({label: '\u0ad1\u5b2f\uf614\u{1ff47}\uea54'});
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer0), /* required buffer size: 934 */
+{offset: 734}, {width: 50, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img3 = await imageWithData(234, 152, '#fc70bda1', '#5e222276');
+let commandEncoder20 = device0.createCommandEncoder({label: '\u5acf\u{1fd17}'});
+let querySet9 = device0.createQuerySet({label: '\ud40c\ue1f9\u868a\u8893\u{1fd9f}\u6434\ub078', type: 'occlusion', count: 2260});
+let textureView28 = texture4.createView({
+  label: '\u0a5a\u{1f96a}\u0c5b',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u9092\u9bd5\u6d2c\u07fc\u041b\ue6c7\u0635',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup0, new Uint32Array(7474), 1507, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  label: '\u{1fa17}\u{1fd6f}\u0b05\u{1f616}\u0170\u66ed\ua62b\uc877\ude7b\u07f9',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL}, {format: 'r32sint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 1641595003,
+    stencilWriteMask: 1438308129,
+    depthBias: 1892190654,
+    depthBiasSlopeScale: 160.60298135357215,
+    depthBiasClamp: 866.74438683514,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 38392,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 4422, shaderLocation: 5}],
+      },
+      {
+        arrayStride: 27048,
+        attributes: [
+          {format: 'float32x2', offset: 12576, shaderLocation: 15},
+          {format: 'uint8x2', offset: 7184, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+});
+let sampler6 = device0.createSampler({label: '\u1fa2\u{1fe0c}', addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 50.10});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3768 */
+  offset: 3768,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({label: '\u0878\u{1ff3a}\u2c62\u4c17\u0320\u{1fb12}\u7773\u{1fb91}'});
+let texture9 = device0.createTexture({
+  label: '\u8e0a\ua456\u0ea1\u13c8\u{1f9c8}\u568f\u0299\u086e\u0e3b',
+  size: [144, 1, 1],
+  mipLevelCount: 5,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView29 = texture5.createView({
+  label: '\u0c01\ua7cf\ubb19\u{1fc74}\u3783\u1fd2\u{1f999}\u0b4a',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 3,
+});
+try {
+renderBundleEncoder9.setVertexBuffer(884, undefined, 0, 237287045);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2544 */
+  offset: 2544,
+  buffer: buffer2,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let textureView30 = texture4.createView({baseMipLevel: 5, mipLevelCount: 3});
+let computePassEncoder8 = commandEncoder13.beginComputePass({label: '\u{1fea0}\u4806\ud781\u018f\u09aa\u06ad\u02f4'});
+let pipeline14 = device0.createComputePipeline({
+  label: '\u3ca9\u56ce\u51e1\u1707\u3f08\ubbb1\u1a54\uf729\u3479\u0629\u{1fe78}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas1.height = 1907;
+let commandEncoder22 = device0.createCommandEncoder({label: '\ud663\ub418'});
+let commandBuffer4 = commandEncoder21.finish({label: '\u0758\u078f\u09af\u31ed\uff37\u0b4a\u020c'});
+let sampler7 = device0.createSampler({
+  label: '\uf7f9\u0443\u0385\ud276\u{1fd88}\u63c8\u0744\u325f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 3.641,
+  lodMaxClamp: 78.86,
+});
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(4, bindGroup0, new Uint32Array(8005), 23, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 107, y: 69 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createRenderPipeline({
+  label: '\u{1f6c4}\u01d0\u5d90',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x78600437},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'r8sint', writeMask: GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 3923506396,
+    stencilWriteMask: 3888997488,
+    depthBias: -1161657922,
+    depthBiasSlopeScale: 384.38904113549097,
+    depthBiasClamp: 401.17403562250496,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 620, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2788,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 312, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 216, shaderLocation: 15},
+          {format: 'uint32x3', offset: 412, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'none'},
+});
+let offscreenCanvas4 = new OffscreenCanvas(254, 204);
+let commandEncoder23 = device0.createCommandEncoder({label: '\u009d\u{1f7d9}\u08bd\u{1f6b5}\u07d8\u8807\u{1fc8f}\u043d\u{1f61b}\uf3ea'});
+let texture10 = device0.createTexture({size: {width: 576}, dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView31 = texture4.createView({dimension: '2d', baseMipLevel: 8});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u02ce\u3660\u0f8d\u0f13\u93fc\u0026\u504c\u{1f973}\u84ca\u8b64',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet7, 126, 11, buffer0, 119296);
+} catch {}
+let pipeline16 = device0.createComputePipeline({
+  label: '\u0fb3\u7482',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img4 = await imageWithData(300, 181, '#78d0625b', '#8f40f681');
+let sampler8 = device0.createSampler({
+  label: '\uc60e\u{1ff15}\u0230\u08bf\u{1fe07}\u{1f919}\u{1f8d0}\ucb90',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 73.93,
+  lodMaxClamp: 93.62,
+});
+try {
+computePassEncoder8.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 18, y: 31 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let bindGroupLayout10 = device0.createBindGroupLayout({label: '\ub2ee\ue4a3\ue5f5\u{1fdb4}\u0e74\u4aaa\u{1f970}\u9466', entries: []});
+let commandEncoder24 = device0.createCommandEncoder({label: '\ua627\ufcea\u9562\u1563\ue787\u{1ff45}\u{1ffbb}\u0140\u05b1\u8000\u577d'});
+let commandBuffer5 = commandEncoder14.finish({});
+let textureView32 = texture10.createView({format: 'r8sint'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 19, y: 240 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl2');
+} catch {}
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture11 = device0.createTexture({
+  size: {width: 160},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+let textureView33 = texture3.createView({label: '\u02af\u0b0c', baseMipLevel: 10, baseArrayLayer: 0});
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 702,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup3 = device0.createBindGroup({
+  label: '\u0794\ua80d\u1f4f\ubf01\u{1f86c}\uca00\u{1ff94}\u{1f80a}\u0df7\ubb53\ub4cf',
+  layout: bindGroupLayout10,
+  entries: [],
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u0099\u7536\u0f82\u{1fcfc}\u02ed\u2412\u{1fe31}\ucfce\ua4f5'});
+let querySet10 = device0.createQuerySet({label: '\u6c81\u5552\u0e93\uebcc\u9f6a', type: 'occlusion', count: 3032});
+let texture12 = device0.createTexture({
+  size: {width: 320, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+try {
+renderBundleEncoder9.setPipeline(pipeline7);
+} catch {}
+let pipeline17 = device0.createComputePipeline({
+  label: '\udad7\u06e6\u3df7\ucfe2\u0eab\uc52a\u2380\u{1feb5}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let sampler9 = device0.createSampler({
+  label: '\u{1fd8b}\u1c1a\u{1fde8}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(7210, undefined, 0, 3128519077);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let textureView34 = texture7.createView({baseArrayLayer: 0});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 3424 widthInBlocks: 214 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 10784 */
+  offset: 7360,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 214, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 77, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 877 */
+{offset: 877}, {width: 309, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u6217\u0753\u05a2\u08f4\u672f\u0674\u0547',
+  code: `@group(1) @binding(1133)
+var<storage, read_write> type1: array<u32>;
+@group(3) @binding(1133)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(1133)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(1, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @builtin(front_facing) f0: bool
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec2<i32>,
+  @location(2) f1: vec4<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(5) f4: i32,
+  @location(6) f5: f32,
+  @location(3) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec3<i32>, @location(40) a1: vec4<u32>, @location(29) a2: vec4<f32>, @location(32) a3: vec3<f32>, @location(55) a4: u32, @location(33) a5: f32, @location(35) a6: vec3<f16>, @location(21) a7: u32, @location(16) a8: vec2<f32>, a9: S2, @location(48) a10: f32, @location(20) a11: u32, @location(52) a12: vec4<f16>, @location(58) a13: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(16) f82: vec2<f32>,
+  @location(6) f83: u32,
+  @location(11) f84: vec4<i32>,
+  @location(35) f85: vec3<f16>,
+  @location(45) f86: vec4<f16>,
+  @location(38) f87: vec3<u32>,
+  @location(5) f88: u32,
+  @location(20) f89: u32,
+  @location(3) f90: f16,
+  @location(54) f91: vec2<f16>,
+  @location(33) f92: f32,
+  @location(59) f93: vec3<i32>,
+  @location(40) f94: vec4<u32>,
+  @location(49) f95: vec4<f16>,
+  @location(17) f96: vec3<i32>,
+  @location(14) f97: vec2<u32>,
+  @location(58) f98: f16,
+  @builtin(position) f99: vec4<f32>,
+  @location(7) f100: vec4<i32>,
+  @location(55) f101: u32,
+  @location(36) f102: u32,
+  @location(1) f103: vec4<i32>,
+  @location(41) f104: vec2<u32>,
+  @location(21) f105: u32,
+  @location(43) f106: f32,
+  @location(24) f107: u32,
+  @location(48) f108: f32,
+  @location(8) f109: u32,
+  @location(44) f110: i32,
+  @location(0) f111: u32,
+  @location(52) f112: vec4<f16>,
+  @location(32) f113: vec3<f32>,
+  @location(42) f114: vec4<u32>,
+  @location(34) f115: vec4<f32>,
+  @location(29) f116: vec4<f32>,
+  @location(30) f117: vec4<u32>,
+  @location(27) f118: vec3<u32>,
+  @location(2) f119: vec3<i32>,
+  @location(47) f120: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: i32, @location(1) a1: vec2<f32>, @location(15) a2: vec4<u32>, @location(0) a3: vec3<u32>, @location(5) a4: f32, @location(12) a5: vec2<f16>, @location(13) a6: i32, @location(4) a7: vec4<f32>, @location(7) a8: vec3<f32>, @location(2) a9: f32, @location(9) a10: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer4 = device0.createBuffer({
+  label: '\u{1fa50}\u1702\uba50\udf60\u{1fa77}\u{1fcd9}\u{1f949}\u{1f88f}\ub4a9\u1a7c\u7c56',
+  size: 369000,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet11 = device0.createQuerySet({
+  label: '\u0735\u03de\u3cd2\u{1f7f1}\u05e2\u4155\u{1f66d}\u782b\u767a\u5a57',
+  type: 'occlusion',
+  count: 3766,
+});
+let textureView35 = texture4.createView({
+  label: '\u{1fd98}\u8529\uff77\u{1fb6d}\ubde3\u{1fe68}',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\ud473\u7586\u{1fbc4}\u0ff8\u{1fec1}\ube82\uaf68\u0c13\u562a\u1efb\u1209',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder11.finish({label: '\u486d\u02b7\u0193\u06e6\u{1fd91}'});
+try {
+computePassEncoder0.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer2, 41972, buffer4, 153344, 23932);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(141), /* required buffer size: 141 */
+{offset: 141}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img5 = await imageWithData(88, 207, '#6dea406b', '#50b20fc3');
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder();
+let renderBundle13 = renderBundleEncoder0.finish({});
+try {
+commandEncoder27.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+renderBundleEncoder10.pushDebugGroup('\u5d01');
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({label: '\u037f\u10da\u7d04\u07ae\u08e9\udef2'});
+let querySet12 = device0.createQuerySet({
+  label: '\u{1f70b}\u{1fd31}\ua1d7\u{1fea5}\ue4dc\ufecf\u06bb\u0878\u484c',
+  type: 'occlusion',
+  count: 1527,
+});
+let textureView36 = texture8.createView({label: '\u0840\u6040\u0fa3', arrayLayerCount: 1});
+try {
+commandEncoder17.copyBufferToBuffer(buffer2, 48816, buffer4, 29996, 15752);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1508 widthInBlocks: 377 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18536 */
+  offset: 17028,
+  rowsPerImage: 269,
+  buffer: buffer4,
+}, {width: 377, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet5, 995, 7, buffer3, 27136);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 13, y: 299 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}}});
+let imageData2 = new ImageData(4, 136);
+let texture13 = device0.createTexture({
+  size: [320, 1, 40],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let textureView37 = texture5.createView({
+  label: '\uc476\u5326\u{1f9ea}\uf884\u0566\u807c\ucae7\u{1fd35}\ufe1c\ue074\u0552',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 296 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 42160 */
+  offset: 41864,
+  buffer: buffer4,
+}, {width: 74, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({label: '\u049d\uffec\u062d\u{1fb3f}'});
+let textureView38 = texture7.createView({label: '\ucf35\uf261\u{1f6b9}\uf620\u0c5a\u02d4\u0004\u{1f989}'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u{1fcde}\u9350\u1ca3\ue55c\u3601\u4435\u8f0c\u{1fb6e}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+let renderBundle14 = renderBundleEncoder7.finish({label: '\u594a\u7348\u4a40'});
+try {
+computePassEncoder6.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet11, 2644, 1082, buffer1, 151552);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 124 */
+{offset: 124}, {width: 54, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet13 = device0.createQuerySet({label: '\u790d\u7514', type: 'occlusion', count: 3642});
+let textureView39 = texture6.createView({label: '\u06ea\uc2cd\u0101\u05cd\ude30\u0652\u{1fe22}', mipLevelCount: 1});
+let renderBundle15 = renderBundleEncoder8.finish({label: '\uc4c9\u0d3c\u0d4d\u3d8a\u42e2\u{1fc8a}\ued35\u2064\u0649'});
+try {
+renderBundleEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 188 widthInBlocks: 47 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36532 */
+  offset: 36344,
+  buffer: buffer4,
+}, {width: 47, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 23572, new Float32Array(62444));
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 104 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+  label: '\u{1f9e9}\u096f',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\ubef2\u{1fba6}\u7995\u0ea6\u888d',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout2, bindGroupLayout9, bindGroupLayout6, bindGroupLayout8],
+});
+let querySet14 = device0.createQuerySet({
+  label: '\u0d49\u0eeb\u0c8c\u{1ff8f}\ud908\u{1f676}\ud86c\u4089\u259b\u44c7',
+  type: 'occlusion',
+  count: 3634,
+});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 54, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder7.pushDebugGroup('\u{1f801}');
+} catch {}
+try {
+renderBundleEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 109540, new BigUint64Array(54822), 25971);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(985), /* required buffer size: 985 */
+{offset: 985}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer5 = device0.createBuffer({
+  label: '\u0b0d\ub126\u8bb5\uf1e0\u7a4f',
+  size: 99620,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+});
+let querySet15 = device0.createQuerySet({
+  label: '\u9e61\u29c0\u2380\u{1fb70}\udfae\u0312\u{1fb11}\ue1c4\u{1fe74}\u{1f626}\u76b9',
+  type: 'occlusion',
+  count: 3295,
+});
+let textureView40 = texture13.createView({label: '\u{1ff32}\u0d85', format: 'rgba32float', baseMipLevel: 1, baseArrayLayer: 0});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u587e\ue71d\u6394\u0735\u0464\u{1f9af}\ua858\ude59\u0588',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle16 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6239, undefined, 1116480597, 861995879);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet5, 109, 622, buffer1, 184832);
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 107, y: 193 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline20 = device0.createComputePipeline({
+  label: '\ubc84\u0dfe\u0944\u0bd7\u5f85\u80c2\u54b2\u8f6d\u4116\udb78',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let computePassEncoder9 = commandEncoder19.beginComputePass({label: '\u2256\u69f7\u3d7d\u071c'});
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(3497, undefined, 0, 862074060);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet11, 2508, 641, buffer3, 9984);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 218 */
+{offset: 218}, {width: 60, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({
+  label: '\u031e\u575e\u{1fc08}\u3d20\ube4d\u1257\u21cb\u01f5\u2e07\u067f',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas5 = new OffscreenCanvas(433, 853);
+let imageData3 = new ImageData(16, 116);
+let texture14 = device0.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 219},
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u4738\u1b43\u0112\u0a0e\u064e\u0615\u{1feaa}\u7e88',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle17 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet6, 707, 18, buffer1, 609536);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 308 */
+{offset: 308, rowsPerImage: 11}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 14 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 2, y: 1, z: 88},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline22 = await device0.createRenderPipelineAsync({
+  label: '\u00bf\u0022\u044e\u97b5',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x4aa8a3de},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 231385349,
+    depthBias: 1886524859,
+    depthBiasSlopeScale: 290.89740614687844,
+    depthBiasClamp: 495.02443759709513,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 8820, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 5372, attributes: []},
+      {
+        arrayStride: 6260,
+        attributes: [
+          {format: 'uint32x2', offset: 628, shaderLocation: 1},
+          {format: 'uint8x2', offset: 1854, shaderLocation: 2},
+          {format: 'sint16x2', offset: 128, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 90, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 20000, stepMode: 'instance', attributes: []},
+      {arrayStride: 6816, attributes: [{format: 'sint32x3', offset: 1336, shaderLocation: 13}]},
+      {
+        arrayStride: 10656,
+        attributes: [
+          {format: 'sint32x4', offset: 628, shaderLocation: 6},
+          {format: 'uint8x4', offset: 1092, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder30 = device0.createCommandEncoder({label: '\uef1d\u68c5\ubb6d\u{1fec0}\u00fe'});
+let texture15 = device0.createTexture({
+  label: '\u954e\uee96\u0f8c\u9fa7\u{1fd56}\u4fdf\u06d8',
+  size: {width: 288},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView41 = texture15.createView({format: 'r8sint'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet5, 724, 438, buffer1, 296448);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 287 */
+{offset: 287}, {width: 276, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4638,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 5740,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 876,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u718d\u0711\u00da\u800f\ub273\u{1f782}\u0521\ufcb8\u0247'});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 1824});
+let textureView42 = texture10.createView({});
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet14, 3586, 46, buffer0, 102400);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer0), /* required buffer size: 671 */
+{offset: 671, bytesPerRow: 28}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+  label: '\u1dbc\u{1fedf}\u0eb5\u{1fdfe}\u{1ffc8}\u459e\ubb7c',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder32 = device0.createCommandEncoder({label: '\u{1f968}\u38c3'});
+let computePassEncoder10 = commandEncoder20.beginComputePass({label: '\u{1fd31}\u0084\u3b51\u{1faee}\uf4be\u5bc3'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u9947\u0558\u8240\u5ab7\u9577\u5e21\u{1f715}\ud928',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+let renderBundle18 = renderBundleEncoder2.finish();
+try {
+querySet4.destroy();
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder27.resolveQuerySet(querySet4, 229, 1717, buffer0, 164608);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 26, y: 14 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(1011, 946);
+let imageBitmap2 = await createImageBitmap(offscreenCanvas5);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u{1fea6}\ub661\ub9c8\uc596\ue5fc',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 7 */
+{offset: 7}, {width: 67, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline24 = device0.createRenderPipeline({
+  label: '\ue614\ua1c6\u4401\u{1fecf}\u02ea',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x80233be3},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: 0}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {
+      compare: 'greater',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'equal', passOp: 'decrement-wrap'},
+    stencilReadMask: 350914868,
+    stencilWriteMask: 2173222508,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2524,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 2516, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 100, shaderLocation: 10},
+          {format: 'uint32', offset: 376, shaderLocation: 2},
+          {format: 'sint8x2', offset: 378, shaderLocation: 6},
+          {format: 'uint32x4', offset: 372, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 16044, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 2740,
+        attributes: [
+          {format: 'sint32', offset: 348, shaderLocation: 8},
+          {format: 'sint32', offset: 496, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let querySet17 = device0.createQuerySet({
+  label: '\u0b62\u{1fc37}\u0ffe\uec3b\ud7d7\u12ea\u{1fa32}\u93c5\u088f\u20ae',
+  type: 'occlusion',
+  count: 2790,
+});
+let textureView43 = texture4.createView({
+  label: '\u0ccd\u8e45\u77f5\u5e8a\ua048\u3cda\u029a\uabd6\u33e6\u{1f8e3}\u76f9',
+  dimension: '2d-array',
+  baseMipLevel: 8,
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder12.pushDebugGroup('\ue9bf');
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\ue354');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+video0.height = 164;
+let imageData4 = new ImageData(112, 240);
+let commandEncoder34 = device0.createCommandEncoder({label: '\ub2f1\u07c5\u{1f77c}\u51ea\uaffb\u7f28\u4874\u{1fc12}\u04d9'});
+let renderBundle19 = renderBundleEncoder15.finish();
+try {
+computePassEncoder9.setBindGroup(0, bindGroup2, new Uint32Array(5298), 1008, 0);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+let textureView44 = texture9.createView({label: '\u{1ff6c}\u02ac\u803b\u{1fdbb}\u6287', dimension: '2d-array', baseMipLevel: 2});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup2, new Uint32Array(8249), 1846, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4468, undefined, 3871955670);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 125, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas5.getContext('2d');
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u41c6\u1429\u7621\u018d\u55c0\u{1fce5}\u{1fb2b}',
+  entries: [
+    {binding: 8842, visibility: 0, externalTexture: {}},
+    {binding: 1629, visibility: 0, externalTexture: {}},
+    {binding: 1640, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder23.beginComputePass();
+let renderBundle20 = renderBundleEncoder12.finish({label: '\u5383\uf86c\u{1f883}\u097e\u074d\u728a\u2b5a\u0376\u01c5\u0e1f'});
+try {
+computePassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 1600 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 28912 */
+  offset: 28912,
+  buffer: buffer2,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 100, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 38 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet18 = device0.createQuerySet({label: '\ud9d8\u7a33\u00d5', type: 'occlusion', count: 2364});
+let textureView45 = texture5.createView({label: '\u3393\u9617', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+let renderBundle21 = renderBundleEncoder5.finish({label: '\u8d1d\uea79\u{1fdf7}\u49cd'});
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline4);
+} catch {}
+let promise4 = device0.popErrorScope();
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 339 */
+{offset: 339, bytesPerRow: 433}, {width: 60, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture16 = device0.createTexture({
+  size: {width: 160},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17152 */
+  offset: 17132,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+canvas0.height = 531;
+let buffer6 = device0.createBuffer({
+  label: '\u0b4e\u86b0\uaf41\u05fb',
+  size: 186028,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView46 = texture12.createView({
+  label: '\u5be0\ue312\u{1fef2}\u{1fd86}\uccb1\u06c2',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup2, new Uint32Array(4704), 2381, 0);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 47700 */
+  offset: 47700,
+  buffer: buffer2,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundle5.label = '\udbcc\u1d0d\u0eb2\udddd\u817e';
+} catch {}
+let commandBuffer6 = commandEncoder32.finish();
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 119, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder();
+let texture17 = device0.createTexture({
+  label: '\ue0ef\u01b4\u58b8\u9c7e\u2e5e',
+  size: {width: 1152},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let renderBundle22 = renderBundleEncoder14.finish({label: '\u{1fbea}\ub003\u{1fbcc}\ua63c'});
+let externalTexture6 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup2, new Uint32Array(1927), 516, 0);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer3, 18116, buffer6, 152612, 24580);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 810 */
+{offset: 654}, {width: 39, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video0);
+let video2 = await videoWithData();
+let commandEncoder37 = device0.createCommandEncoder({label: '\u{1fb2e}\u{1fea0}\u0167\u5923\u{1f7c1}\u61a4\u1a21\u01b5\uee3f\u9792'});
+let commandBuffer7 = commandEncoder33.finish({label: '\u{1ff20}\u{1f6c0}\ue0aa\u0cc4\ud921\ud756\u0201\u{1ff05}\u0aeb'});
+let textureView47 = texture14.createView({
+  label: '\u0d56\ub620\u670b\u0acd\uc635\u51a3\u9562',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 114,
+  arrayLayerCount: 17,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u0457\u028b\u8655\u0801\u0e9c\u765a',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup1, new Uint32Array(8831), 4122, 0);
+} catch {}
+document.body.prepend(canvas0);
+let promise6 = adapter1.requestDevice({
+  label: '\u5b2a\u{1fa2c}',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 56,
+    maxVertexAttributes: 29,
+    maxVertexBufferArrayStride: 16869,
+    maxStorageTexturesPerShaderStage: 9,
+    maxStorageBuffersPerShaderStage: 9,
+    maxDynamicStorageBuffersPerPipelineLayout: 34234,
+    maxDynamicUniformBuffersPerPipelineLayout: 47197,
+    maxBindingsPerBindGroup: 8101,
+    maxTextureArrayLayers: 762,
+    maxTextureDimension1D: 8263,
+    maxTextureDimension2D: 12517,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 166321607,
+    maxUniformBuffersPerShaderStage: 32,
+    maxSampledTexturesPerShaderStage: 22,
+    maxInterStageShaderVariables: 40,
+    maxInterStageShaderComponents: 100,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let buffer7 = device0.createBuffer({
+  label: '\uf83b\ub18c\ufd08',
+  size: 188571,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler10 = device0.createSampler({
+  label: '\u8b88\udc73\uaa6d\u1c88\u0716\ud58c\u05da\ua4c6\u92ef\u88db\u0ebe',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.410,
+});
+let externalTexture7 = device0.importExternalTexture({
+  label: '\u4af1\u07bd\u7676\u7f90\u8515\uddf3\u{1fc9d}\ucb10\u0fe5',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup2, new Uint32Array(3490), 976, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer7, 124712, 990);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1972 widthInBlocks: 493 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 55920 */
+  offset: 55920,
+  buffer: buffer4,
+}, {width: 493, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 72, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder12.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 1659314 */
+{offset: 586, bytesPerRow: 352, rowsPerImage: 152}, {width: 26, height: 1, depthOrArrayLayers: 32});
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  multisample: {mask: 0x4322b1ad},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8sint'}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'constant'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 3700680426,
+    stencilWriteMask: 2834506838,
+    depthBias: 1700323536,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 241.5012837899729,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 7258, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'front'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({label: '\u91fb\u0f08\uab8d\u{1fe1c}\u0a31\u0845\ufb9d\u56c6\u5208\u{1fe67}\ufc5e'});
+let texture18 = device0.createTexture({
+  label: '\u1f1c\u0957\u{1fdff}\u{1fcb7}\uab0f\u55e9',
+  size: {width: 40},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView48 = texture2.createView({});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u0746\ub595\u0f39\u5760\u1fd6\uaab8\u0004\u767a',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 107544, new Float32Array(20873), 20790);
+} catch {}
+let promise7 = device0.createComputePipelineAsync({
+  label: '\u6078\u904e\u02e8\ua23b\u{1ffc9}\u0891\u8808\u177a\u3ad2',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline26 = device0.createRenderPipeline({
+  label: '\ufb42\u0ac7\u07aa\u04c4\u5d27\u{1f9dc}\u{1ffa4}',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 2914213026,
+    stencilWriteMask: 1102230524,
+    depthBiasSlopeScale: 427.5214827829577,
+    depthBiasClamp: -39.44405931951477,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 39392, attributes: [{format: 'snorm8x2', offset: 426, shaderLocation: 12}]},
+      {
+        arrayStride: 6728,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 552, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 5660, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 8472,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 5032, shaderLocation: 1},
+          {format: 'sint16x4', offset: 196, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 1080, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 27120, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 13536,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 6760, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 702, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 8948,
+        attributes: [
+          {format: 'uint16x2', offset: 8944, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 7492, shaderLocation: 5},
+          {format: 'uint8x2', offset: 388, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\u88a0\uf2e1\u04b0'});
+let textureView49 = texture10.createView({label: '\u6367\u{1f727}\ud0c6\uec31\u{1ffda}', arrayLayerCount: 1});
+let sampler11 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.60,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4540 */
+  offset: 4464,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let promise8 = adapter0.requestAdapterInfo();
+let commandEncoder40 = device0.createCommandEncoder({label: '\ub118\u0263'});
+let sampler12 = device0.createSampler({
+  label: '\u95e1\u1d45\u078e',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.99,
+  lodMaxClamp: 80.90,
+});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\u3086\u05ef\u637a\u{1fda0}\u3a03\ueb18\ua2e7\u7123\u0610',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer2, 22556, buffer4, 51784, 31464);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 234, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let computePassEncoder12 = commandEncoder24.beginComputePass({label: '\u{1fa6c}\ua43a\u0d43'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\uf31b\u{1f752}\u9252',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(9, buffer7);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer2, 18140, buffer4, 323784, 7944);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline27 = device0.createComputePipeline({
+  label: '\ua020\ufc1e',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline28 = device0.createRenderPipeline({
+  label: '\u5a69\ufc07\u573c\u93f1\u0762\u{1f6b0}\ufe9a\u{1fd5d}\uef12',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint', writeMask: 0}, {format: 'r32sint', writeMask: 0}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 100, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 790, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 1192, shaderLocation: 6},
+          {format: 'sint32', offset: 428, shaderLocation: 7},
+          {format: 'uint16x2', offset: 320, shaderLocation: 9},
+          {format: 'uint32x3', offset: 4640, shaderLocation: 12},
+          {format: 'sint32x3', offset: 0, shaderLocation: 14},
+          {format: 'uint32x2', offset: 68, shaderLocation: 2},
+          {format: 'sint8x4', offset: 2472, shaderLocation: 15},
+          {format: 'float32', offset: 932, shaderLocation: 5},
+          {format: 'sint16x2', offset: 964, shaderLocation: 8},
+          {format: 'uint32', offset: 1916, shaderLocation: 1},
+          {format: 'sint32', offset: 464, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 3716, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 22276,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 22272, shaderLocation: 0},
+          {format: 'float32', offset: 3116, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 88, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip'},
+});
+try {
+  await promise2;
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({label: '\u0dcc\u2f11\u{1ffe5}\u09ed\ud561'});
+try {
+computePassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1, commandBuffer6]);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync({
+  label: '\ud8cc\u{1fb33}\ufbc5\uc64f\u4722\u{1f60e}\u1bbb\u{1f7ec}\u0c9b',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout12, bindGroupLayout7, bindGroupLayout11]});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 2024});
+let texture19 = device0.createTexture({
+  size: [1152, 1, 1589],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView50 = texture12.createView({label: '\uf950\u5de6\u0e58', dimension: '2d-array', baseMipLevel: 2});
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 205},
+  aspect: 'all',
+},
+{width: 391, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = await promise0;
+let imageBitmap3 = await createImageBitmap(imageData1);
+let videoFrame1 = new VideoFrame(img4, {timestamp: 0});
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u{1fd05}\u9195', bindGroupLayouts: [bindGroupLayout6, bindGroupLayout13, bindGroupLayout3]});
+let commandEncoder42 = device0.createCommandEncoder({label: '\ufac3\u7492\u{1fe38}\u0918\u4eea\u{1fc2d}\u8e2f\ub514\u45da'});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(7004), 2534, 0);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer2, 6824, buffer4, 362760, 5616);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 7, y: 14 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(canvas0, {timestamp: 0});
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1084,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let buffer8 = device0.createBuffer({
+  label: '\u6e05\uff2b\ude0f\u9e8d\u{1fcc9}\u0352\ua078',
+  size: 1449,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u214e\u18fb\u{1fc0f}\u07b7\u5989\u0771\u9b6b',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer5, 11412, buffer6, 171476, 3100);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder22.resolveQuerySet(querySet0, 1746, 154, buffer7, 101120);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u0b48');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 1021 */
+{offset: 893}, {width: 32, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: imageData0,
+  origin: { x: 44, y: 13 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({label: '\ua9f0\u{1fd26}\u{1fcbb}\ua713\u0d33\u4264'});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u3f0d\u2121\u0ccd\u0f37\u6eb2\u5c2a\ue999\u{1ff69}\u9956',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer7, 153900, 30390);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer4, 259848);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet13, 3168, 122, buffer0, 48128);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 62, y: 97 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 99},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({label: '\u{1fc6a}\u72b1\u{1ff9e}\u{1fb57}\u7f48\u04a7\u4ba9\ucff5\u3de8\u1ca5'});
+let texture20 = device0.createTexture({
+  label: '\u990f\u6fd3\u2658\ua0bb\u{1f78b}',
+  size: {width: 80, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView51 = texture3.createView({label: '\u27eb\u97e4\uc2cf\u0b11', baseMipLevel: 10});
+try {
+computePassEncoder2.setBindGroup(4, bindGroup0, new Uint32Array(5275), 3836, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer7, 0, 153133);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: img2,
+  origin: { x: 90, y: 62 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture21 = device0.createTexture({
+  label: '\u{1fec9}\u1bd3\u{1faa6}',
+  size: {width: 1152},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint'],
+});
+try {
+computePassEncoder7.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(5, buffer7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 5, y: 8 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u5480\u0a40\u057a\u4284\u5096\u{1fda1}\u{1f813}\u8608',
+  code: `@group(2) @binding(1133)
+var<storage, read_write> type2: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> n3: array<u32>;
+@group(4) @binding(1133)
+var<storage, read_write> type3: array<u32>;
+@group(3) @binding(1133)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(5687)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @builtin(sample_mask) f1: u32,
+  @location(6) f2: vec4<f32>,
+  @location(4) f3: vec2<i32>,
+  @location(0) f4: vec4<f32>,
+  @location(1) f5: vec4<f32>,
+  @location(5) f6: vec4<i32>,
+  @location(3) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(5) f0: vec2<u32>,
+  @builtin(instance_index) f1: u32,
+  @location(1) f2: f32,
+  @location(3) f3: u32,
+  @location(10) f4: vec2<f32>,
+  @location(14) f5: vec2<i32>,
+  @location(2) f6: vec3<f16>,
+  @location(9) f7: vec2<i32>,
+  @location(6) f8: f16,
+  @location(11) f9: vec2<i32>,
+  @location(7) f10: vec4<u32>,
+  @location(13) f11: u32,
+  @location(4) f12: vec2<i32>
+}
+
+@vertex
+fn vertex0(a0: S3, @location(12) a1: u32, @location(0) a2: vec3<u32>, @location(8) a3: u32, @location(15) a4: vec4<f32>, @builtin(vertex_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder45 = device0.createCommandEncoder({label: '\uabf9\u{1f859}\u532a\u0a2b\u9116\u0dae\ue736\u01df\u{1f7d1}\uf7ac'});
+let querySet20 = device0.createQuerySet({label: '\u01e7\u0388\u54e4\ue340\u6296', type: 'occlusion', count: 1099});
+let computePassEncoder13 = commandEncoder26.beginComputePass({label: '\u{1fb0d}\u{1fbfc}\uf320\u0ecc\u742c\uef51\u514b\u48fb\u678b\u073b\u09d2'});
+try {
+commandEncoder5.clearBuffer(buffer4, 145808);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 74456, new DataView(new ArrayBuffer(11182)), 367, 6292);
+} catch {}
+document.body.prepend(canvas0);
+let offscreenCanvas7 = new OffscreenCanvas(221, 479);
+let imageData5 = new ImageData(84, 248);
+let commandEncoder46 = device0.createCommandEncoder();
+let textureView52 = texture19.createView({label: '\udaee\uc417\u9192\udd5f\u0e94\ubd06\u105f\u67a8\u{1fb99}\ub826\u{1fe3f}', mipLevelCount: 2});
+try {
+renderBundleEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 248 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27576 */
+  offset: 27576,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 62, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet4, 240, 1372, buffer7, 126208);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 90288, new BigUint64Array(27802), 26450);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u{1fc32}\u0b97\uba36\ucdc4\u0de2\u0a0e\u{1fe9f}\u07ff\u0af9\u0f4c\u0826',
+  entries: [
+    {
+      binding: 56,
+      visibility: 0,
+      buffer: { type: 'storage', minBindingSize: 664434, hasDynamicOffset: false },
+    },
+    {
+      binding: 2129,
+      visibility: 0,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 3674,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1f78f}\u0e2e\u4937\u006f'});
+let texture22 = device0.createTexture({
+  label: '\u{1f9c9}\u{1f9de}\u0bbd\u07f1\ucb40\u3c3a\u8cbe',
+  size: {width: 288, height: 1, depthOrArrayLayers: 108},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let textureView53 = texture18.createView({mipLevelCount: 1});
+try {
+computePassEncoder12.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline28);
+} catch {}
+document.body.prepend(img2);
+let querySet21 = device0.createQuerySet({
+  label: '\u{1ff74}\u{1fb00}\ub037\u{1f74f}\u0827\u00d1\u0ac6\u4ae1\u35b2\u08a6',
+  type: 'occlusion',
+  count: 1557,
+});
+let commandBuffer8 = commandEncoder34.finish({label: '\u{1f95a}\u07ed\u{1f8d7}\uded3\u96ed\u{1f905}\ucf1e\u68f8\u040e\u6181'});
+let renderBundle23 = renderBundleEncoder21.finish();
+let sampler13 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.77,
+  lodMaxClamp: 94.42,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(10, buffer7, 36232, 68634);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.READ);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas7.getContext('webgpu');
+let commandEncoder48 = device0.createCommandEncoder({label: '\u059f\u2d20'});
+let texture23 = device0.createTexture({
+  size: {width: 1152},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder14 = commandEncoder37.beginComputePass({label: '\u{1fc74}\u02f7\u{1f698}\u21e0\u{1fd82}\u1361\u568e'});
+let externalTexture9 = device0.importExternalTexture({
+  label: '\ufe3a\u428f\u01a1\u081b\u0ede\u0250\uda4e\u{1f814}',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer7, 0, 94566);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 71 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1341 */
+  offset: 1341,
+  buffer: buffer5,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 71, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet4, 195, 863, buffer3, 12288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(40)), /* required buffer size: 407 */
+{offset: 407, rowsPerImage: 237}, {width: 64, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline31 = device0.createComputePipeline({
+  label: '\uc0fc\u398b',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder49 = device0.createCommandEncoder({label: '\u{1fb44}\u696d\u0534\u{1f89a}'});
+let computePassEncoder15 = commandEncoder20.beginComputePass();
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(9, buffer7, 0, 49046);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 49, y: 27 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet22 = device0.createQuerySet({label: '\u{1fde7}\u983c\u{1fb3a}', type: 'occlusion', count: 3311});
+let textureView54 = texture16.createView({});
+let computePassEncoder16 = commandEncoder23.beginComputePass({label: '\u0d5c\uc2f3\u0d0f\u20d8\u{1feef}\ud08f\ud677'});
+try {
+commandEncoder27.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let video3 = await videoWithData();
+let imageData6 = new ImageData(100, 120);
+let shaderModule6 = device0.createShaderModule({
+  label: '\ua18f\ue458\u{1f68c}\u6fda\u0a05\ub9a5\u8375\u0477\u6b18\u3968\u06a4',
+  code: `@group(1) @binding(1640)
+var<storage, read_write> type4: array<u32>;
+@group(0) @binding(3330)
+var<storage, read_write> local1: array<u32>;
+@group(2) @binding(5687)
+var<storage, read_write> n4: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @location(41) f0: vec3<f16>,
+  @location(32) f1: vec3<f16>,
+  @builtin(front_facing) f2: bool,
+  @location(5) f3: vec3<f32>,
+  @location(40) f4: vec2<f16>,
+  @location(7) f5: f32,
+  @location(52) f6: vec3<i32>,
+  @location(36) f7: vec3<f32>,
+  @location(31) f8: vec2<f16>,
+  @location(20) f9: vec3<f32>,
+  @location(56) f10: vec4<f16>,
+  @location(8) f11: vec4<u32>,
+  @location(45) f12: vec4<u32>,
+  @location(18) f13: f32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(6) f1: f32,
+  @location(1) f2: vec4<f32>,
+  @location(2) f3: vec4<i32>,
+  @location(3) f4: vec4<f32>,
+  @location(4) f5: vec2<i32>,
+  @location(5) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(48) a0: f16, @location(57) a1: vec4<u32>, @location(25) a2: vec2<f16>, @location(30) a3: f32, a4: S4, @builtin(sample_mask) a5: u32, @builtin(sample_index) a6: u32, @builtin(position) a7: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(52) f121: vec3<i32>,
+  @location(40) f122: vec2<f16>,
+  @location(18) f123: f32,
+  @location(5) f124: vec3<f32>,
+  @location(30) f125: f32,
+  @builtin(position) f126: vec4<f32>,
+  @location(56) f127: vec4<f16>,
+  @location(7) f128: f32,
+  @location(45) f129: vec4<u32>,
+  @location(48) f130: f16,
+  @location(57) f131: vec4<u32>,
+  @location(32) f132: vec3<f16>,
+  @location(20) f133: vec3<f32>,
+  @location(8) f134: vec4<u32>,
+  @location(41) f135: vec3<f16>,
+  @location(25) f136: vec2<f16>,
+  @location(31) f137: vec2<f16>,
+  @location(36) f138: vec3<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(5) a1: vec3<f16>, @location(2) a2: vec4<i32>, @location(11) a3: vec3<u32>, @location(0) a4: vec2<u32>, @location(13) a5: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup3, new Uint32Array(7363), 532, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer7, 120156, 45898);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 128 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 85564 */
+  offset: 85564,
+  buffer: buffer5,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 27, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 126176, new Float32Array(15343), 15268);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\ua566\u5e98\u015b\ud5b6\u{1fa6c}\u6eb6\ucd65\u0edd',
+  code: `@group(4) @binding(7721)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(4481)
+var<storage, read_write> local2: array<u32>;
+@group(4) @binding(4481)
+var<storage, read_write> function3: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> global4: array<u32>;
+@group(0) @binding(7721)
+var<storage, read_write> parameter2: array<u32>;
+@group(3) @binding(3330)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(6, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(5) f2: vec4<i32>,
+  @location(2) f3: vec4<i32>,
+  @location(6) f4: vec3<f32>,
+  @location(4) f5: vec3<i32>,
+  @location(1) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(0) a0: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer9 = device0.createBuffer({
+  label: '\u1460\u{1f994}\ucf2c\ucf3e\u56f9\u8a3e\u94a8\u085c\u75c5',
+  size: 130912,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandBuffer9 = commandEncoder25.finish({label: '\u{1f8e2}\u0f5b\u1440'});
+let textureView55 = texture18.createView({label: '\u01cf\ub85d\u2d92\u0915\u053e\u{1f938}\u{1f864}\u63b6\ueb5a\u{1f856}', aspect: 'all'});
+let renderBundle24 = renderBundleEncoder13.finish();
+try {
+computePassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 101, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet1, 1734, 361, buffer7, 158976);
+} catch {}
+let img6 = await imageWithData(211, 246, '#ef6df4d3', '#7936afca');
+let textureView56 = texture21.createView({label: '\u12a8\u{1f7ba}\u7c2c'});
+let externalTexture10 = device0.importExternalTexture({label: '\ue2dc\uef51', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 695 */
+  offset: 695,
+  rowsPerImage: 111,
+  buffer: buffer3,
+}, {
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4496 widthInBlocks: 281 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 32 */
+  offset: 32,
+  buffer: buffer6,
+}, {width: 281, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}}});
+offscreenCanvas7.height = 3983;
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5, bindGroupLayout14, bindGroupLayout7]});
+let textureView57 = texture13.createView({baseMipLevel: 0});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 36, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 82, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 33928, new Int16Array(2108));
+} catch {}
+let pipeline33 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+let commandEncoder50 = device0.createCommandEncoder({label: '\u4237\u21db\u6e00\u03e7\u3f4f\u9afb\u994c\u{1fcd6}\u08c2\u2472'});
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 194, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2156 widthInBlocks: 539 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28792 */
+  offset: 26636,
+  bytesPerRow: 2560,
+  buffer: buffer6,
+}, {width: 539, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 45200, new DataView(new ArrayBuffer(22686)), 15992, 1200);
+} catch {}
+let pipeline34 = await promise1;
+gc();
+let imageData7 = new ImageData(128, 128);
+let textureView58 = texture6.createView({label: '\u02e5\ud7d6\u0cbf', format: 'rgba8sint', mipLevelCount: 1});
+let computePassEncoder17 = commandEncoder44.beginComputePass({label: '\u{1fcd8}\ud2ef\ued12'});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u{1f731}\u0892\ufdb9\uccfe\u190d\u{1f8a2}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle25 = renderBundleEncoder9.finish({});
+try {
+commandEncoder49.resolveQuerySet(querySet2, 823, 2284, buffer0, 11264);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 507 */
+{offset: 507}, {width: 33, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: img6,
+  origin: { x: 68, y: 181 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let commandEncoder51 = device0.createCommandEncoder();
+let textureView59 = texture11.createView({
+  label: '\u{1fe73}\u00b6\u8023\u3bf4\u{1ffa5}\u664d\u01d0\u05ef\u36dd',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let externalTexture11 = device0.importExternalTexture({label: '\u{1ff87}\u6529\u0cdf\u{1fa39}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder2.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer7, 'uint16');
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(2, buffer9, 0, 103677);
+} catch {}
+let arrayBuffer1 = buffer4.getMappedRange(46672, 137548);
+try {
+commandEncoder40.copyBufferToBuffer(buffer8, 580, buffer4, 256364, 680);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 32, y: 0, z: 22},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 68, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(32)), /* required buffer size: 557 */
+{offset: 557}, {width: 240, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline35 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'invert', passOp: 'increment-wrap'},
+    stencilWriteMask: 93229180,
+    depthBias: 781411601,
+    depthBiasClamp: 315.7382421016539,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5204,
+        attributes: [
+          {format: 'sint32x2', offset: 956, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 1232, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 28, shaderLocation: 1},
+          {format: 'uint8x2', offset: 90, shaderLocation: 0},
+          {format: 'sint8x2', offset: 962, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 60, shaderLocation: 15},
+          {format: 'sint8x2', offset: 4824, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 1268, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 552, shaderLocation: 6},
+          {format: 'uint32x3', offset: 228, shaderLocation: 12},
+          {format: 'sint16x2', offset: 1684, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 8828, attributes: [{format: 'uint16x2', offset: 1108, shaderLocation: 7}]},
+      {
+        arrayStride: 2608,
+        attributes: [{format: 'uint32', offset: 184, shaderLocation: 8}, {format: 'uint32', offset: 156, shaderLocation: 5}],
+      },
+      {arrayStride: 11404, stepMode: 'vertex', attributes: []},
+      {arrayStride: 6068, attributes: [{format: 'uint16x2', offset: 0, shaderLocation: 13}]},
+      {
+        arrayStride: 12164,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 3032, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+let bindGroupLayout16 = device0.createBindGroupLayout({label: '\u1be8\u03c6\u718e\uf09a\u0ce0\u{1fd5e}\ub81e', entries: []});
+let commandBuffer10 = commandEncoder43.finish();
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+try {
+renderBundleEncoder16.draw(552203546, 405879780, 1125707454, 648153059);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(717561908, 250380807, 904611117);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder49.copyBufferToBuffer(buffer8, 352, buffer6, 72032, 296);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 236, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 39, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet15, 296, 1689, buffer1, 54272);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let pipeline36 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xa6699db0},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.ALL}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7848,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 1572, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 244, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 9652, stepMode: 'instance', attributes: []},
+      {arrayStride: 17340, attributes: []},
+      {
+        arrayStride: 25228,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x4', offset: 256, shaderLocation: 4}],
+      },
+    ],
+  },
+});
+let bindGroup4 = device0.createBindGroup({
+  label: '\u{1fae5}\u039b\u0024\u{1f939}\u4a75\ucb99\u0222\u{1f621}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 5340, resource: externalTexture11}],
+});
+let commandEncoder52 = device0.createCommandEncoder({label: '\u58b3\u5476\u508d\u33a9\u{1f92b}\u73ce\u2f8c\u9dd7\u{1fc87}\uc03e'});
+let commandBuffer11 = commandEncoder50.finish();
+let texture24 = device0.createTexture({
+  label: '\u{1fa95}\u{1fbec}\u94ab',
+  size: {width: 144, height: 1, depthOrArrayLayers: 200},
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView60 = texture2.createView({label: '\u8bd5\u{1fe61}\u{1f945}'});
+let computePassEncoder18 = commandEncoder17.beginComputePass({label: '\u5b43\u6af8\u0aa8\u0d05\u535c\u{1fc4c}\u{1fc39}\u4a94\u{1ff66}\u969a\u072e'});
+let sampler14 = device0.createSampler({
+  label: '\u10c0\u0e1a\ufd45\u38b8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 39.23,
+  compare: 'equal',
+  maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.draw(288683226, 1203677288, 716609021, 457887306);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(1030299711, 282126392, 1141748846, -920391828, 68155817);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 12424);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer8, 'uint16', 356, 174);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer3, 19592, buffer4, 358516, 7112);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 8, y: 94 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup5 = device0.createBindGroup({layout: bindGroupLayout16, entries: []});
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  label: '\uc9a2\u2c90',
+  size: {width: 160, height: 1, depthOrArrayLayers: 1820},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+});
+let renderBundle26 = renderBundleEncoder14.finish({label: '\u0eea\u08a7\ued3b\u0d1d\u00f2\u0d84\u8d7d'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer9, 'uint16');
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer8, 960, buffer4, 31704, 460);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 488 widthInBlocks: 122 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2188 */
+  offset: 1700,
+  buffer: buffer6,
+}, {width: 122, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 600 */
+{offset: 600}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: img2,
+  origin: { x: 101, y: 51 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 79},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', passOp: 'invert'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2332872856,
+    depthBiasSlopeScale: 172.1836992358525,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3660,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 580, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 6},
+          {format: 'sint8x4', offset: 16, shaderLocation: 15},
+          {format: 'uint32x2', offset: 900, shaderLocation: 12},
+          {format: 'uint16x2', offset: 220, shaderLocation: 9},
+          {format: 'sint32', offset: 64, shaderLocation: 14},
+          {format: 'sint8x2', offset: 688, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 11048,
+        attributes: [
+          {format: 'sint16x4', offset: 348, shaderLocation: 7},
+          {format: 'float16x4', offset: 700, shaderLocation: 13},
+          {format: 'float32x2', offset: 24, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 1028,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 444, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 12, shaderLocation: 10},
+          {format: 'uint32', offset: 288, shaderLocation: 1},
+          {format: 'uint32x3', offset: 724, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 172, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 548, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+});
+try {
+renderBundleEncoder10.setVertexBuffer(8, buffer9, 68772, 18897);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 38, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\ua9b9');
+} catch {}
+try {
+renderBundleEncoder16.insertDebugMarker('\u09e7');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 18712150 */
+{offset: 712, bytesPerRow: 4058, rowsPerImage: 159}, {width: 235, height: 0, depthOrArrayLayers: 30});
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb'}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 1177221328,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 192, shaderLocation: 13},
+          {format: 'float32x2', offset: 1544, shaderLocation: 1},
+          {format: 'uint32x3', offset: 1144, shaderLocation: 0},
+          {format: 'sint32x3', offset: 8468, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 1698, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 1230, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 1152, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 452, shaderLocation: 12},
+          {format: 'uint32x4', offset: 580, shaderLocation: 9},
+          {format: 'float32', offset: 484, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 4808, attributes: [{format: 'uint16x2', offset: 3772, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+offscreenCanvas2.width = 23;
+let querySet23 = device0.createQuerySet({label: '\u0b88\u000a\ud307', type: 'occlusion', count: 1527});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle27 = renderBundleEncoder20.finish({label: '\ubf39\u{1fd46}\uc445\u8c84\u063f\u4fa7\uf4c1\uafcb\uac4b\u{1f88e}'});
+try {
+renderBundleEncoder16.draw(728328053, 755256514, 919306123);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 23404);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 100088, new Float32Array(58739), 31338, 2612);
+} catch {}
+let pipeline39 = device0.createComputePipeline({
+  label: '\ue38b\u7ff8\u069f\u581b\u1781\ub6e7\u0347\u{1fcd3}\u4452',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline40 = device0.createRenderPipeline({
+  label: '\u{1fae9}\u0e8e',
+  layout: pipelineLayout3,
+  multisample: {count: 1, mask: 0x99fb57cc},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: 0}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'r8sint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2461373657,
+    stencilWriteMask: 1640859254,
+    depthBiasSlopeScale: 480.7390136865465,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18260,
+        attributes: [
+          {format: 'snorm8x4', offset: 176, shaderLocation: 4},
+          {format: 'uint32x4', offset: 5864, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 7712, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8444,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 5368, shaderLocation: 5},
+          {format: 'uint8x4', offset: 1736, shaderLocation: 15},
+          {format: 'sint32x2', offset: 3720, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 19804,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 292, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 692,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 36, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 396, shaderLocation: 1},
+          {format: 'float16x2', offset: 32, shaderLocation: 2},
+          {format: 'sint8x2', offset: 58, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 160, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let img7 = await imageWithData(94, 264, '#991800d4', '#c47a3a1c');
+let shaderModule8 = device0.createShaderModule({
+  label: '\u0f75\u065e\u866b\u{1fa43}\u9d9f\u0910\u0995\u{1f927}',
+  code: `@group(2) @binding(5687)
+var<storage, read_write> local3: array<u32>;
+@group(1) @binding(1629)
+var<storage, read_write> function5: array<u32>;
+@group(0) @binding(3330)
+var<storage, read_write> n5: array<u32>;
+@group(1) @binding(1640)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(8842)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(28) f0: vec3<f16>,
+  @location(42) f1: f32,
+  @location(32) f2: vec4<i32>,
+  @location(33) f3: vec3<f16>,
+  @location(15) f4: vec2<f32>,
+  @location(7) f5: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(6) f2: vec2<f32>,
+  @location(2) f3: vec4<i32>,
+  @location(5) f4: vec3<i32>,
+  @location(1) f5: vec4<f32>,
+  @location(4) f6: i32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(21) a1: vec2<u32>, a2: S5, @location(29) a3: u32, @location(57) a4: vec3<i32>, @location(51) a5: vec2<f16>, @location(0) a6: vec4<u32>, @location(53) a7: vec4<u32>, @location(56) a8: vec3<f32>, @location(47) a9: vec3<u32>, @location(20) a10: vec4<f32>, @location(36) a11: vec4<f16>, @location(26) a12: vec4<u32>, @location(22) a13: vec3<i32>, @location(11) a14: f32, @location(1) a15: vec3<f16>, @location(23) a16: u32, @location(48) a17: vec4<f16>, @location(6) a18: vec3<f16>, @location(54) a19: vec4<i32>, @location(25) a20: vec3<i32>, @location(37) a21: vec4<u32>, @location(55) a22: vec3<u32>, @location(34) a23: i32, @location(24) a24: vec2<f16>, @location(43) a25: vec2<u32>, @location(17) a26: vec3<f32>, @location(31) a27: vec3<f16>, @location(2) a28: f16, @builtin(sample_mask) a29: u32, @builtin(position) a30: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(55) f139: vec3<u32>,
+  @location(53) f140: vec4<u32>,
+  @location(2) f141: f16,
+  @location(6) f142: vec3<f16>,
+  @location(17) f143: vec3<f32>,
+  @builtin(position) f144: vec4<f32>,
+  @location(15) f145: vec2<f32>,
+  @location(31) f146: vec3<f16>,
+  @location(22) f147: vec3<i32>,
+  @location(43) f148: vec2<u32>,
+  @location(29) f149: u32,
+  @location(0) f150: vec4<u32>,
+  @location(32) f151: vec4<i32>,
+  @location(33) f152: vec3<f16>,
+  @location(42) f153: f32,
+  @location(36) f154: vec4<f16>,
+  @location(23) f155: u32,
+  @location(57) f156: vec3<i32>,
+  @location(7) f157: vec2<f16>,
+  @location(1) f158: vec3<f16>,
+  @location(25) f159: vec3<i32>,
+  @location(26) f160: vec4<u32>,
+  @location(24) f161: vec2<f16>,
+  @location(37) f162: vec4<u32>,
+  @location(28) f163: vec3<f16>,
+  @location(11) f164: f32,
+  @location(51) f165: vec2<f16>,
+  @location(47) f166: vec3<u32>,
+  @location(48) f167: vec4<f16>,
+  @location(56) f168: vec3<f32>,
+  @location(34) f169: i32,
+  @location(20) f170: vec4<f32>,
+  @location(21) f171: vec2<u32>,
+  @location(54) f172: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let querySet24 = device0.createQuerySet({
+  label: '\u9a22\u7225\u8ac8\u{1f6c7}\u30ea\u92f4\u{1f81e}\u006a\uabbd\u3928\u02d2',
+  type: 'occlusion',
+  count: 3001,
+});
+let textureView61 = texture13.createView({baseMipLevel: 1});
+let renderBundle28 = renderBundleEncoder2.finish({label: '\u{1f6e2}\u{1fa7c}\u4d15\u{1ff88}\u6307\u2a00\u4564\u46e3\u5702\ufcc2\u0972'});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame2});
+try {
+renderBundleEncoder16.setIndexBuffer(buffer7, 'uint32', 64500, 86057);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 608 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 13104 */
+  offset: 13104,
+  buffer: buffer6,
+}, {width: 38, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet20, 95, 894, buffer0, 173312);
+} catch {}
+let promise10 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x46bb93c8},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3896, attributes: [{format: 'uint8x4', offset: 1668, shaderLocation: 15}]},
+      {
+        arrayStride: 18784,
+        attributes: [
+          {format: 'float32x4', offset: 7928, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 12856, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 28436,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 2008, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 4504, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 96, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 3916, shaderLocation: 12},
+          {format: 'float32', offset: 24844, shaderLocation: 4},
+          {format: 'sint32', offset: 2976, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 34516,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 28340, shaderLocation: 0}],
+      },
+      {arrayStride: 8076, stepMode: 'instance', attributes: []},
+      {arrayStride: 15652, attributes: []},
+      {arrayStride: 22012, attributes: []},
+      {arrayStride: 9148, stepMode: 'vertex', attributes: []},
+      {arrayStride: 28004, stepMode: 'instance', attributes: []},
+      {arrayStride: 15904, attributes: []},
+      {arrayStride: 10140, attributes: [{format: 'sint32', offset: 4780, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let video4 = await videoWithData();
+let imageData8 = new ImageData(60, 84);
+let bindGroup6 = device0.createBindGroup({
+  label: '\ud3a9\ud229\u27b6\ue24e\u06b7\u7cfd\u4319\u{1fe80}\u97b4\u0e9c\u1f93',
+  layout: bindGroupLayout1,
+  entries: [{binding: 5340, resource: externalTexture3}],
+});
+let querySet25 = device0.createQuerySet({
+  label: '\ubb30\u9f37\u{1fe68}\u3ece\u0f04\u1bf6\u067a\u9b5f\u0448\u8053\u0fdd',
+  type: 'occlusion',
+  count: 3356,
+});
+let commandBuffer12 = commandEncoder5.finish();
+let textureView62 = texture14.createView({label: '\u5cb3\u504c\u01af\u6a0f', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 83});
+let renderBundle29 = renderBundleEncoder3.finish({label: '\u{1fcc2}\u0e86\u{1f96f}\u805c\u{1fa80}\u43cc\u03d6\u04ee'});
+let sampler15 = device0.createSampler({
+  label: '\u{1fa9d}\u6106\u9d80\u0051\ude4d\uc12e\u{1fec7}\u802c\uca58\ub748\ue1d0',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 78.59,
+  lodMaxClamp: 97.78,
+});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\uffdc\u3673\ub139\u0bf2\ud056\ucf39\u0b84\u06e9\u378a\ub89d',
+  source: video4,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder5.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup1, new Uint32Array(4418), 503, 0);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(1202275900);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 1040);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline28);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let texture26 = device0.createTexture({
+  label: '\u0515\u{1fb5b}\uff28\u{1fbbd}\u0f27\uc501\u019d\udcbe\uf67d\uabc9',
+  size: {width: 320},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u0adb\u0370\u{1f987}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder17.setBindGroup(4, bindGroup0, new Uint32Array(1182), 1049, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer7, 'uint32', 140132, 30472);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 244 widthInBlocks: 61 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 35688 */
+  offset: 35688,
+  buffer: buffer6,
+}, {width: 61, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 57312, new BigUint64Array(22663), 7406);
+} catch {}
+let pipeline41 = device0.createRenderPipeline({
+  label: '\uca6e\u0b7b\udd90\u0f48\ud35a\u{1f91d}\u{1f637}\uaad8',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: 0}, {format: 'rgba8sint'}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 324, stepMode: 'instance', attributes: []},
+      {arrayStride: 22604, stepMode: 'instance', attributes: []},
+      {arrayStride: 6284, stepMode: 'instance', attributes: []},
+      {arrayStride: 5864, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 35352, attributes: []},
+      {arrayStride: 5972, attributes: [{format: 'sint32', offset: 52, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw'},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+window.someLabel = textureView23.label;
+} catch {}
+let texture27 = device0.createTexture({
+  label: '\u85da\u{1feb2}\u0b77\uccb6\u00b5\u089f\u4fff\u8522\u8dd2\uf7b1',
+  size: [80, 1, 83],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView63 = texture25.createView({
+  label: '\u8149\uf53f\u0f1a\u04aa\u78d0\u{1feae}\u13d4\u2287\u{1fe0a}',
+  dimension: '3d',
+  format: 'bgra8unorm',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let computePassEncoder19 = commandEncoder18.beginComputePass({});
+let sampler16 = device0.createSampler({
+  label: '\u5794\u798e\ucc7e\ucde2\u2e2d\u{1fa3e}\u07fa\u5d51\u{1f73f}\u0441\u8b90',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 26.17,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup4, new Uint32Array(9926), 7493, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(6, buffer9, 37580, 8492);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer8, 860, buffer4, 361924, 492);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 22680, new Int16Array(19579), 13316, 588);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 989 */
+{offset: 677, bytesPerRow: 327}, {width: 78, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet26 = device0.createQuerySet({label: '\uc107\u29a0\u0fab\u5fe5\u00da\u{1f7f0}\ub8a0\u18ca', type: 'occlusion', count: 1790});
+let computePassEncoder20 = commandEncoder22.beginComputePass();
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 95.43,
+  lodMaxClamp: 96.60,
+});
+let externalTexture14 = device0.importExternalTexture({label: '\u5353\u3f9a\u0cfe', source: video2, colorSpace: 'srgb'});
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 2064 widthInBlocks: 516 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8772 */
+  offset: 8772,
+  buffer: buffer2,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 516, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet21, 169, 593, buffer7, 124928);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 19376, new Float32Array(59822), 5556, 4504);
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+  label: '\ubc34\ufd75\ucd92\u0b37\u1ff8\ua077\u5159\u1d8a',
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0x1c761e21},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.GREEN}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 1034837398,
+    stencilWriteMask: 4294967295,
+    depthBiasSlopeScale: 943.103490049142,
+    depthBiasClamp: 266.45281824445124,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [{arrayStride: 3136, attributes: [{format: 'sint32x4', offset: 812, shaderLocation: 15}]}],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder54 = device0.createCommandEncoder({label: '\ub6f2\u8afb\u0d11\u0a6f\u90e0'});
+let textureView64 = texture10.createView({label: '\u86d6\u06f8\u{1ff3b}\u{1fe6b}\u03c2\u43d0\u{1fbe7}'});
+let bindGroup7 = device0.createBindGroup({layout: bindGroupLayout9, entries: []});
+try {
+renderBundleEncoder25.setIndexBuffer(buffer8, 'uint16', 1072, 164);
+} catch {}
+let arrayBuffer2 = buffer9.getMappedRange(113328, 15984);
+try {
+commandEncoder38.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet11, 1229, 1636, buffer9, 69120);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 86, y: 467 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame3 = new VideoFrame(img3, {timestamp: 0});
+let commandBuffer13 = commandEncoder30.finish({label: '\u046a\u{1fd30}'});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u8cb7\u{1fcba}\u0c90\u0fbb\u2a8f\u{1f806}\u0327\u4719\u2914',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 592 */
+  offset: 592,
+  buffer: buffer5,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 46, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline43 = await promise10;
+let img8 = await imageWithData(115, 255, '#284abe23', '#f6f7af6f');
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\ue346\u{1febb}\u7a6f\u{1fedc}\u{1fe13}\u071c\udb52\u1507',
+  entries: [{binding: 6817, visibility: 0, externalTexture: {}}],
+});
+let bindGroupLayout18 = pipeline41.getBindGroupLayout(1);
+try {
+commandEncoder27.copyBufferToBuffer(buffer3, 10732, buffer4, 333660, 18028);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let renderBundle30 = renderBundleEncoder20.finish();
+let sampler18 = device0.createSampler({
+  label: '\u{1fd55}\u0d8a\u002e',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.08,
+  maxAnisotropy: 6,
+});
+try {
+commandEncoder41.copyBufferToBuffer(buffer3, 64, buffer6, 10988, 27960);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet5, 612, 1032, buffer1, 94720);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 50484, new BigUint64Array(35584), 31787);
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+  label: '\u194b\u{1fce8}\u99d6\ue58d\u00ab\u{1f9fa}\u7b1a\u0366\u0fbd\u0675\u{1fe11}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter1.label = '\u3eba\u{1fe80}\ucbc2';
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\ud791\u{1f7d6}\u582a\u{1f727}\u0cb4\u082c\u0662\u{1fbe7}\u{1f704}',
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 1629, resource: externalTexture12},
+    {binding: 1640, resource: externalTexture10},
+    {binding: 8842, resource: externalTexture3},
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u{1febd}\u2f92\u{1f91c}\u{1f77b}\u0096\u315d\u{1febf}\u{1fa3a}\u381c\u0c0b',
+  bindGroupLayouts: [bindGroupLayout14, bindGroupLayout18, bindGroupLayout4],
+});
+let commandEncoder55 = device0.createCommandEncoder({label: '\u7d26\uc019\u0bab\u9a82\u0aef\u0216\uffb1'});
+let commandBuffer14 = commandEncoder27.finish();
+let textureView65 = texture23.createView({label: '\u{1f872}\u20ac\u8da2\u6eb2\ue0a3\u5841\u{1fbf5}\ub341'});
+let renderBundle31 = renderBundleEncoder8.finish({label: '\u{1fd5d}\ub993\u6141'});
+let arrayBuffer3 = buffer9.getMappedRange(130560, 148);
+try {
+commandEncoder29.resolveQuerySet(querySet13, 141, 2375, buffer9, 48128);
+} catch {}
+let textureView66 = texture19.createView({
+  label: '\u858c\u2913\u05d8\u{1fd69}\u{1f85d}\uc235\uc87f\u802a\u{1f67a}\u5658',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderBundleEncoder10.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(10, buffer9, 121880, 4526);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 11, y: 1 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 54},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let bindGroup9 = device0.createBindGroup({label: '\u0420\u08a1\u{1f769}\u04f7\u2ba3\u{1fb5a}', layout: bindGroupLayout10, entries: []});
+let commandEncoder56 = device0.createCommandEncoder({label: '\u8232\u{1f6a6}\u{1f9bd}'});
+let textureView67 = texture7.createView({label: '\uf823\u63a5\uabc0\u88e6\u61c7\u0c20\uec6d\u0f44\uf099\u6228'});
+let renderBundle32 = renderBundleEncoder23.finish({label: '\u0c6d\ua634\u0fcf\u0179\ucfc6\u519e'});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer5, 9732, buffer6, 169000, 6468);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 13},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 9104922 */
+{offset: 682, bytesPerRow: 4144, rowsPerImage: 183}, {width: 251, height: 1, depthOrArrayLayers: 13});
+} catch {}
+let pipeline45 = await device0.createRenderPipelineAsync({
+  label: '\u{1fd01}\ue41c\u{1fcac}\ue4f7\uc5d7\ub1d5\u{1fb60}\u08da\u0266',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 2045270437,
+    stencilWriteMask: 23735995,
+    depthBiasClamp: 532.8277366768098,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 21028, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 72, shaderLocation: 5},
+          {format: 'sint16x2', offset: 8388, shaderLocation: 2},
+          {format: 'uint16x4', offset: 46080, shaderLocation: 11},
+          {format: 'uint32x4', offset: 1876, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 2192,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm16x2', offset: 356, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+canvas1.width = 1264;
+try {
+externalTexture5.label = '\u302c\u2a02\u0701\u0fff\u076f\u4a4b\uae18\ue6d3\u{1f6e7}\u{1f630}\u0a82';
+} catch {}
+let texture28 = device0.createTexture({
+  label: '\u5d2b\uac17\ubc66\u{1fbab}\u46df\u9854\u2ee6\u{1f879}\u{1fbc7}\u059b',
+  size: [40],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView68 = texture13.createView({label: '\u57b1\u08ef', baseMipLevel: 1, arrayLayerCount: 1});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u{1f706}\u19e1\u0a06\u46fc\u40b2\u{1fa26}\u4577\u{1fa1c}\u{1fbac}\ufc87\u3831',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: false,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline46 = device0.createComputePipeline({
+  label: '\u{1fe45}\ud167\u0f32\u{1f9ba}\u8074\u081d',
+  layout: 'auto',
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let pipeline47 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilReadMask: 2874713367,
+    stencilWriteMask: 4294888053,
+    depthBiasSlopeScale: 794.0795404716756,
+    depthBiasClamp: 224.47006461451645,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 10676, attributes: []},
+      {arrayStride: 41012, attributes: [{format: 'snorm16x4', offset: 7296, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let sampler19 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 9.830,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+querySet25.destroy();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(998, 965);
+let shaderModule9 = device0.createShaderModule({
+  code: `@group(0) @binding(4481)
+var<storage, read_write> field4: array<u32>;
+@group(4) @binding(4481)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(7721)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> n6: array<u32>;
+@group(4) @binding(7721)
+var<storage, read_write> function6: array<u32>;
+@group(3) @binding(3330)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(5) f1: i32,
+  @location(2) f2: vec4<i32>,
+  @location(6) f3: vec4<f32>,
+  @location(4) f4: vec4<i32>,
+  @location(1) f5: vec4<f32>,
+  @location(3) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(52) a1: vec2<i32>, @location(13) a2: vec4<f32>, @location(20) a3: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(16) f173: f32,
+  @location(10) f174: f32,
+  @location(39) f175: vec2<i32>,
+  @location(44) f176: vec3<i32>,
+  @location(27) f177: vec4<f16>,
+  @location(34) f178: i32,
+  @location(20) f179: vec4<f16>,
+  @location(21) f180: vec2<i32>,
+  @location(19) f181: vec2<f32>,
+  @location(54) f182: f16,
+  @location(4) f183: vec4<i32>,
+  @location(18) f184: vec4<f16>,
+  @location(52) f185: vec2<i32>,
+  @location(33) f186: f32,
+  @location(59) f187: vec3<u32>,
+  @location(40) f188: vec3<u32>,
+  @location(0) f189: vec2<f32>,
+  @location(13) f190: vec4<f32>,
+  @location(36) f191: vec4<u32>,
+  @location(41) f192: vec2<u32>,
+  @location(58) f193: vec3<f32>,
+  @location(12) f194: f32,
+  @location(29) f195: vec2<u32>,
+  @location(25) f196: u32,
+  @location(47) f197: vec4<f32>,
+  @location(22) f198: vec2<u32>,
+  @location(1) f199: vec4<u32>,
+  @location(8) f200: vec4<i32>,
+  @location(31) f201: vec4<f32>,
+  @builtin(position) f202: vec4<f32>,
+  @location(55) f203: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<f16>, @location(12) a1: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer10 = device0.createBuffer({size: 93415, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let querySet27 = device0.createQuerySet({label: '\u602b\u0977\u004c\uf7be\u{1fc3c}\u037d\u{1f9b5}', type: 'occlusion', count: 2035});
+let texture29 = device0.createTexture({
+  label: '\u04b3\u0e8a\u0d39\u01c0\u3adc\u{1f867}\u{1fc4d}',
+  size: {width: 160, height: 1, depthOrArrayLayers: 124},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u13e7\ue9de\u49d4\u2fab\ue47e\u0bba\u2753\u{1fb3e}\u018c',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+let renderBundle33 = renderBundleEncoder22.finish();
+let sampler20 = device0.createSampler({
+  label: '\u0ec6\ufcd2\u9a65\ubdb4',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.98,
+  lodMaxClamp: 86.37,
+});
+try {
+renderBundleEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13176 */
+  offset: 13176,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 140212, new Float32Array(5348));
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+externalTexture13.label = '\uaec1\u{1f836}';
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u0979\u0b18\ud574\ua718\u{1f9e3}\u09c9\u{1fb01}\u9f2c\ua0c9\u003b\ud3e9',
+  bindGroupLayouts: [],
+});
+let querySet28 = device0.createQuerySet({label: '\u63ba\u{1fce1}\u26de\ud16b\u{1f9e2}\u5747', type: 'occlusion', count: 2404});
+let texture30 = device0.createTexture({
+  label: '\u{1fef5}\u03fb\u8263\ud0f7\u4490\u0bb1\ue7a0\u{1faec}\u{1fc77}\u09cd',
+  size: {width: 160, height: 1, depthOrArrayLayers: 48},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.47,
+  lodMaxClamp: 53.63,
+});
+try {
+computePassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 177868, new Float32Array(35048), 19570, 128);
+} catch {}
+try {
+canvas2.getContext('webgpu');
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder();
+try {
+computePassEncoder9.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 190 widthInBlocks: 95 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3340 */
+  offset: 3340,
+  rowsPerImage: 80,
+  buffer: buffer5,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 260, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 95, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline48 = await device0.createRenderPipelineAsync({
+  label: '\u587c\u{1f6bd}\ue591\u0302\u0ca5\u83fe\u{1fbe1}',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x43cdfa89},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+  },
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', depthFailOp: 'invert'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 22836911,
+    stencilWriteMask: 2007667269,
+    depthBias: -1257311720,
+    depthBiasSlopeScale: 191.31393418115908,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2968, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 10096,
+        attributes: [
+          {format: 'unorm16x2', offset: 1028, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 2456, shaderLocation: 15},
+          {format: 'uint16x4', offset: 1416, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let gpuCanvasContext5 = offscreenCanvas8.getContext('webgpu');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let img9 = await imageWithData(260, 99, '#3edf6121', '#a2942e78');
+let buffer11 = device0.createBuffer({
+  label: '\uefc5\u{1fa6f}\u89d9\u0e8f\u0a9d\u7ac4\ucff3\u8f35\u{1fe14}\u3908',
+  size: 313014,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture31 = device0.createTexture({
+  label: '\ucbb2\u4a79\u1feb',
+  size: [288, 1, 844],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView69 = texture17.createView({aspect: 'all'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u0a63\u0c1f\u4c09\u04ee\u{1fc17}\u0511\u7997\u052a\ue4f9\u60c6\u{1fe52}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let externalTexture16 = device0.importExternalTexture({label: '\ub4a6\ubf45', source: video3, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup9, new Uint32Array(9067), 7905, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer9, 78272, 38198);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 145468, new Int16Array(6461), 3727);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise9;
+} catch {}
+let canvas3 = document.createElement('canvas');
+let buffer12 = device0.createBuffer({
+  label: '\u07b0\u0aeb\u054f\u0e3d\u7dcd\u{1fbe3}\u8792\ud601\u48bf\u3f40',
+  size: 23692,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView70 = texture6.createView({label: '\ueae5\uea58\u3ed2\u03c0\udcda\u0cb0\ue587\u1ca3\u{1ff0d}\u1ab8\uc5f1', baseArrayLayer: 0});
+let computePassEncoder21 = commandEncoder46.beginComputePass({label: '\ufb97\u0b30\u043e\ufad6\u44b4\u0af0'});
+try {
+renderBundleEncoder16.setPipeline(pipeline41);
+} catch {}
+let promise11 = buffer11.mapAsync(GPUMapMode.WRITE, 0, 267084);
+let pipeline49 = device0.createComputePipeline({
+  label: '\u{1fd07}\u0344\u5b89\u0296',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline50 = await device0.createRenderPipelineAsync({
+  label: '\u44ab\u{1f900}\u1dde',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r8sint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7452,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1084, shaderLocation: 1},
+          {format: 'float32x3', offset: 780, shaderLocation: 10},
+          {format: 'sint8x2', offset: 4414, shaderLocation: 15},
+          {format: 'sint16x2', offset: 2768, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 10776,
+        attributes: [
+          {format: 'unorm8x4', offset: 1640, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 1576, shaderLocation: 0},
+          {format: 'uint32', offset: 64, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 2112, shaderLocation: 13},
+          {format: 'uint32', offset: 588, shaderLocation: 2},
+          {format: 'uint32x4', offset: 84, shaderLocation: 9},
+          {format: 'float16x4', offset: 120, shaderLocation: 3},
+          {format: 'sint32x2', offset: 2688, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 512, shaderLocation: 6},
+          {format: 'sint8x2', offset: 1004, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 15420,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 7256, shaderLocation: 5},
+          {format: 'sint32x2', offset: 1964, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', cullMode: 'front'},
+});
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 5687, resource: sampler1}]});
+let sampler22 = device0.createSampler({
+  label: '\u1e65\u0ed0\u{1f852}\u{1ff72}\u{1fd22}\ude4b\u0311\u2d70',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 94.53,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup10, new Uint32Array(6099), 2876, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet13, 3298, 206, buffer9, 104960);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 9 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup11 = device0.createBindGroup({label: '\u5200\u{1f95f}', layout: bindGroupLayout3, entries: [{binding: 5687, resource: sampler6}]});
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 49712 */
+  offset: 49712,
+  buffer: buffer6,
+}, {width: 59, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(1014, 838);
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\ubec5\u4578\u0517\u731d\u{1fd2a}\u0bfb\u{1ffd7}\u0471\ua017',
+  entries: [
+    {
+      binding: 6464,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let textureView71 = texture13.createView({label: '\u9446\u0ae9', baseMipLevel: 1});
+let computePassEncoder22 = commandEncoder38.beginComputePass({label: '\uce68\ua2a3\u0cbf\u52e0\u0378\u0710\u{1ffd5}'});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let sampler23 = device0.createSampler({
+  label: '\u9e3d\u02b4\uef65\u{1f768}\u0aac\u0455\udfa6\ub50b\u0690',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 35.38,
+  lodMaxClamp: 91.98,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup10, new Uint32Array(2112), 1196, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer9, 'uint32', 42924, 73529);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer11, 175656, buffer4, 173208, 18792);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet13, 1666, 331, buffer3, 23296);
+} catch {}
+gc();
+let video5 = await videoWithData();
+let buffer13 = device0.createBuffer({
+  label: '\u8a6e\uc27e\u6dfa\ub34e\u0d00\u4f5b\uf881',
+  size: 419452,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder58 = device0.createCommandEncoder({label: '\u0f99\u70ad\ua7c6\ub1ea\u{1fc0a}'});
+let renderBundle34 = renderBundleEncoder26.finish({label: '\u6b53\u{1fb74}\u5d6a\uae63\u0657\u6c71\uc8ce\u791e\u{1f9d5}\u0545'});
+try {
+canvas1.getContext('2d');
+} catch {}
+let bindGroup12 = device0.createBindGroup({label: '\u037d\u{1fa08}', layout: bindGroupLayout9, entries: []});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u3f85\u99fb\u4a74\u0c29\u2ce6'});
+let querySet29 = device0.createQuerySet({label: '\u{1f8d1}\u0c90\u6b9e', type: 'occlusion', count: 720});
+let textureView72 = texture13.createView({
+  label: '\u00d7\u{1fa57}\u040f\u5036\u{1fd5a}\ubb6d\u040f\u{1faa8}\uee70\u04d7\u099d',
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder18.setPipeline(pipeline41);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer10, 61824, buffer4, 214720, 9752);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder42.insertDebugMarker('\u{1fb74}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 2, y: 46 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let shaderModule10 = device0.createShaderModule({
+  label: '\u{1f669}\u74ad\u5c1a\u41b2\u027d\u{1f735}',
+  code: `@group(0) @binding(8535)
+var<storage, read_write> parameter6: array<u32>;
+@group(2) @binding(3127)
+var<storage, read_write> parameter7: array<u32>;
+@group(1) @binding(1084)
+var<storage, read_write> function7: array<u32>;
+@group(0) @binding(152)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(7, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(2) f2: vec4<i32>,
+  @location(4) f3: vec4<i32>,
+  @location(5) f4: vec4<i32>,
+  @location(3) f5: vec4<f32>,
+  @location(6) f6: f32
+}
+
+@fragment
+fn fragment0(@location(54) a0: vec2<f16>, @builtin(sample_index) a1: u32, @location(41) a2: vec3<i32>, @location(44) a3: vec4<u32>, @builtin(position) a4: vec4<f32>, @builtin(front_facing) a5: bool, @builtin(sample_mask) a6: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(2) f0: f32,
+  @location(3) f1: vec3<u32>,
+  @location(14) f2: vec2<i32>,
+  @location(10) f3: f32,
+  @location(0) f4: vec4<f32>,
+  @location(7) f5: vec2<i32>
+}
+struct VertexOutput0 {
+  @builtin(position) f204: vec4<f32>,
+  @location(41) f205: vec3<i32>,
+  @location(54) f206: vec2<f16>,
+  @location(44) f207: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec3<f32>, @location(11) a1: vec4<i32>, @location(5) a2: vec2<i32>, @location(6) a3: vec2<f16>, @location(15) a4: vec3<u32>, @location(9) a5: vec4<u32>, @location(13) a6: vec3<u32>, @location(4) a7: vec2<i32>, @location(8) a8: vec4<u32>, a9: S6, @location(12) a10: vec2<f32>, @builtin(instance_index) a11: u32, @builtin(vertex_index) a12: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder60 = device0.createCommandEncoder({label: '\ua8ed\u3eca\u5d93\u{1ff21}\ua2fa\u0189\u0a71\u0218'});
+let querySet30 = device0.createQuerySet({label: '\u06cf\u2672\u{1fcf9}\u74e5\u{1fe60}\uf369\u0d80\u6b2f', type: 'occlusion', count: 1629});
+let renderBundle35 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder18.draw(426142843);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer5, 53380);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer5, 22252);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer6, 668);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 7940, new BigUint64Array(10993), 9755);
+} catch {}
+let buffer14 = device0.createBuffer({label: '\u5732\uf36b\u{1ffb7}\u62d4\u0455\u8b6e', size: 9490, usage: GPUBufferUsage.STORAGE});
+let commandEncoder61 = device0.createCommandEncoder();
+try {
+renderBundleEncoder18.drawIndexed(1075964318);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet11, 1333, 1187, buffer9, 64256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 16052, new BigUint64Array(48568), 22927, 840);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas5 = document.createElement('canvas');
+let imageData9 = new ImageData(204, 8);
+let commandEncoder62 = device0.createCommandEncoder({label: '\u{1fb83}\u{1fe48}\uf1c7\u082e\ude70\u{1ff3d}\uf4db'});
+let renderBundle36 = renderBundleEncoder0.finish({label: '\u{1fce2}\u044f\u{1faf6}\ue20f\u{1f734}\u6279'});
+let sampler24 = device0.createSampler({
+  label: '\u{1f7b7}\u058f\uca99\u1b0e',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 91.81,
+});
+let externalTexture17 = device0.importExternalTexture({label: '\u02b0\u3085\u{1ff32}', source: video3, colorSpace: 'display-p3'});
+try {
+computePassEncoder22.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer7, 'uint16');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline51 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint'}, {format: 'r32sint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 22340, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 11092,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 1796, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 6768, shaderLocation: 15},
+          {format: 'float32x4', offset: 6328, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+});
+let shaderModule11 = device0.createShaderModule({
+  label: '\u04cf\u6037\u{1fbc9}\u5e38\udb8a\u{1f818}\u{1f7e8}\u25f0\u08bd\ud6b6\ud39b',
+  code: `@group(2) @binding(4793)
+var<storage, read_write> global6: array<u32>;
+@group(2) @binding(5489)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(1084)
+var<storage, read_write> field6: array<u32>;
+@group(2) @binding(2759)
+var<storage, read_write> global7: array<u32>;
+@group(1) @binding(1084)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3<f32>,
+  @location(5) f1: vec2<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(2) f3: vec4<i32>,
+  @location(4) f4: vec3<i32>,
+  @location(1) f5: vec4<f32>,
+  @location(3) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(6) f0: vec4<u32>,
+  @location(14) f1: vec4<f32>,
+  @location(1) f2: vec3<u32>,
+  @builtin(vertex_index) f3: u32,
+  @location(7) f4: vec4<f32>,
+  @location(11) f5: vec3<f32>,
+  @location(9) f6: f32,
+  @location(2) f7: vec3<f32>,
+  @location(10) f8: vec4<f32>,
+  @location(4) f9: vec3<f32>,
+  @location(12) f10: vec4<f32>,
+  @builtin(instance_index) f11: u32,
+  @location(13) f12: vec4<f16>,
+  @location(0) f13: vec4<u32>,
+  @location(5) f14: vec4<i32>,
+  @location(8) f15: vec2<u32>,
+  @location(15) f16: vec3<u32>,
+  @location(3) f17: vec4<f16>
+}
+
+@vertex
+fn vertex0(a0: S7) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder63 = device0.createCommandEncoder();
+let textureView73 = texture23.createView({label: '\u7066\u0a89\u436d\u03bb\u{1f9c5}\u24a7\u0735\u0f9c'});
+let sampler25 = device0.createSampler({
+  label: '\u099e\u306a\u44a6\u0062\u0863\u6ecb\uf1ac',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.96,
+  lodMaxClamp: 84.14,
+  compare: 'greater',
+});
+try {
+renderBundleEncoder18.drawIndexed(737153240, 736843903, 258333408, -582551418, 340075024);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer5, 24656);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline34);
+} catch {}
+let promise12 = buffer13.mapAsync(GPUMapMode.READ);
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1016 */
+  offset: 976,
+  rowsPerImage: 225,
+  buffer: buffer2,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline52 = device0.createComputePipeline({
+  label: '\u0315\u4df4\u5cb1\u03d4\uc3e8\u3c01\u0927\u{1fd3c}\u02b2\u0c23\u9715',
+  layout: 'auto',
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let pipeline53 = device0.createRenderPipeline({
+  label: '\u1b94\uadf7\u0834',
+  layout: pipelineLayout5,
+  multisample: {mask: 0x1210ae1b},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 3232270114,
+    stencilWriteMask: 1390665553,
+    depthBiasSlopeScale: 145.35876015876744,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 33108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 20144, shaderLocation: 0},
+          {format: 'uint8x2', offset: 5846, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 1212,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 84, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 6280,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 864, shaderLocation: 2}],
+      },
+      {arrayStride: 26972, attributes: [{format: 'snorm16x4', offset: 4604, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let querySet31 = device0.createQuerySet({label: '\u2364\uadc2\ue6bb\u4565\u0150\u8ebc\u0b21\ud1fc\u{1f90b}', type: 'occlusion', count: 1161});
+let commandBuffer15 = commandEncoder49.finish({label: '\u07a9\u0643\ud49d\u6f62\ub810\uf9fb\u5e29'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u9b4f\u941e\u047f\u{1fccb}\ua50d',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder55.copyBufferToBuffer(buffer3, 21160, buffer4, 139516, 13556);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 108, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 168, y: 0, z: 198},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 2398798 */
+{offset: 142, bytesPerRow: 1209, rowsPerImage: 62}, {width: 70, height: 0, depthOrArrayLayers: 33});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 68, y: 123 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline54 = await promise7;
+let querySet32 = device0.createQuerySet({label: '\u9b0f\u0d1d', type: 'occlusion', count: 1246});
+let textureView74 = texture4.createView({label: '\u0777\u00ec\u{1f7df}\u0de0\ub78b\u920f\u{1fd66}', baseMipLevel: 3, mipLevelCount: 4});
+try {
+buffer6.destroy();
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 5040 widthInBlocks: 315 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1472 */
+  offset: 1472,
+  buffer: buffer10,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 315, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+canvas4.getContext('bitmaprenderer');
+} catch {}
+let textureView75 = texture10.createView({label: '\u16a5\u00a8', aspect: 'all'});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup8, new Uint32Array(4873), 4638, 0);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+let texture32 = device0.createTexture({
+  label: '\u3436\u9e00\u{1ffbd}\u057e\u2069\ua804\ufef5\u0794',
+  size: {width: 1152, height: 1, depthOrArrayLayers: 339},
+  mipLevelCount: 11,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let sampler26 = device0.createSampler({
+  label: '\u0578\u0d24\ue770\uf0ec\u07ff\u0165',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.23,
+  lodMaxClamp: 98.06,
+  maxAnisotropy: 9,
+});
+try {
+commandEncoder61.copyBufferToBuffer(buffer8, 48, buffer4, 101544, 1084);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 59, y: 29 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline55 = device0.createRenderPipeline({
+  label: '\ue21f\u04ae\u5be6\ufc8f\u6b64\ua99b\ub9ae\ufdf7\u0a2e',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL}, {format: 'r32sint', writeMask: 0}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 32540, stepMode: 'instance', attributes: []},
+      {arrayStride: 1488, attributes: [{format: 'sint32x3', offset: 4, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+let querySet33 = device0.createQuerySet({label: '\u{1fc55}\u1896\u67ad\uf2b7\u5aee\u2ad7', type: 'occlusion', count: 3793});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet2, 2242, 483, buffer0, 115200);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 49, y: 1011 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas9.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u1a51\u96a3\u07ac\ubafb\uda91',
+  entries: [
+    {
+      binding: 6850,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u{1ff03}\u{1ff9f}\ufb2c\u0bf6\ue7cd\uc4ab\u7d5d\u2c65\u24cc\u0518', bindGroupLayouts: []});
+let commandEncoder64 = device0.createCommandEncoder({label: '\u3bed\u1b58\u{1f87f}\u0964\u89d2\ub01a\uae45\u0bd6\uc6e0\u0c58'});
+let commandBuffer16 = commandEncoder45.finish({});
+let textureView76 = texture16.createView({});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup9, new Uint32Array(7568), 2564, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer9, 'uint32', 85880, 20132);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline28);
+} catch {}
+let arrayBuffer4 = buffer12.getMappedRange();
+try {
+commandEncoder28.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 59, y: 262 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView77 = texture22.createView({label: '\u798c\u3490\u2ba2\u9a9e', baseMipLevel: 1});
+let computePassEncoder23 = commandEncoder7.beginComputePass({label: '\u0413\ue10c\ud1e3\u0cba\u{1fef4}'});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle37 = renderBundleEncoder12.finish();
+let externalTexture19 = device0.importExternalTexture({label: '\u{1fa6f}\u0792\u0365\u022d', source: video1});
+try {
+computePassEncoder21.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({label: '\u9038\u4f9a\u5963\u{1f7fc}\u07b0\u072e\u0ded\ud5cc\u885c\u0a09'});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder17.setBindGroup(4, bindGroup6, new Uint32Array(3451), 2211, 0);
+} catch {}
+try {
+querySet32.destroy();
+} catch {}
+try {
+texture12.destroy();
+} catch {}
+video2.width = 271;
+let commandEncoder66 = device0.createCommandEncoder({label: '\ucf05\u7818\u{1fd60}\u01af\u{1fad7}\u3709'});
+let sampler27 = device0.createSampler({
+  label: '\u0ae2\u030c\u0e90',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.050,
+  lodMaxClamp: 14.99,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder17.dispatchWorkgroupsIndirect(buffer5, 45840);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer9, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2252 widthInBlocks: 563 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3036 */
+  offset: 784,
+  buffer: buffer6,
+}, {width: 563, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 34, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer6, 172092);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 35 */
+{offset: 35}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas3.height = 1991;
+try {
+commandEncoder58.label = '\uebee\u0385\u04e5\u32d7\u{1f6e4}\u{1f9c0}\u1fe2';
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 1629, resource: externalTexture10},
+    {binding: 1640, resource: externalTexture13},
+    {binding: 8842, resource: externalTexture1},
+  ],
+});
+let buffer15 = device0.createBuffer({
+  label: '\u0177\u0317\u6721\u0712',
+  size: 15396,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let querySet34 = device0.createQuerySet({label: '\u9ebb\ud367\u0199', type: 'occlusion', count: 461});
+let textureView78 = texture30.createView({dimension: '3d', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler28 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 86.45,
+  lodMaxClamp: 94.33,
+});
+try {
+renderBundleEncoder28.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let video6 = await videoWithData();
+let commandEncoder67 = device0.createCommandEncoder({label: '\u1aba\u0d35\u3546\u626d\u5a69\u5c54\u{1fab0}'});
+let texture33 = device0.createTexture({
+  label: '\u04c4\ubc69',
+  size: [576, 1, 47],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8snorm', 'rgba8snorm', 'rgba8snorm'],
+});
+let textureView79 = texture22.createView({label: '\u0e3d\u0a59\u00b3\uc941', mipLevelCount: 2});
+let renderBundle38 = renderBundleEncoder8.finish({label: '\u5b10\u04d8\u25dd\u8603\u{1f847}\u8bb1\u{1fab5}\u8747\u0790\ub26f\udb86'});
+try {
+computePassEncoder22.dispatchWorkgroups(2);
+} catch {}
+try {
+commandEncoder62.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet18, 448, 1879, buffer1, 83712);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let videoFrame4 = new VideoFrame(img0, {timestamp: 0});
+let renderBundle39 = renderBundleEncoder23.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 290, y: 0, z: 52},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 18519376 */
+{offset: 455, bytesPerRow: 12041, rowsPerImage: 29}, {width: 744, height: 1, depthOrArrayLayers: 54});
+} catch {}
+try {
+externalTexture5.label = '\ud527\uc67e';
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u{1f763}\u7d7c\u0471\u3906\u{1f693}\u{1fb20}',
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 8842, resource: externalTexture1},
+    {binding: 1629, resource: externalTexture15},
+    {binding: 1640, resource: externalTexture17},
+  ],
+});
+let textureView80 = texture4.createView({dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 5});
+let renderBundle40 = renderBundleEncoder11.finish();
+let sampler29 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.43,
+  lodMaxClamp: 79.91,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline56 = device0.createComputePipeline({
+  label: '\u631b\u{1fbf0}\u{1fc71}\ubbe0\u{1f7d1}\u0c5a\u0920\uaf89\u00b1\uff7b\u01c2',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let textureView81 = texture24.createView({label: '\u09d6\u862a\u0d27\u0e6a', baseArrayLayer: 123, arrayLayerCount: 9});
+let renderBundle41 = renderBundleEncoder7.finish({label: '\u843f\u06e5'});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer7, 37832, 132300);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4520 */
+  offset: 4520,
+  buffer: buffer5,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet19, 225, 977, buffer9, 47616);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video4.width = 149;
+try {
+adapter2.label = '\u{1f8ee}\u9806\u{1f713}';
+} catch {}
+let buffer16 = device0.createBuffer({
+  size: 87207,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture34 = device0.createTexture({
+  label: '\u{1fbe1}\u97f7\u2593\u00c5\ued3d\u60eb\u920b\u076f\u0cb1\u0d46',
+  size: [1152],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let textureView82 = texture29.createView({
+  label: '\u{1f678}\u{1fb3a}\u0d6b\u{1fc97}\u4122\u{1f9bd}\u{1fad2}',
+  dimension: '3d',
+  aspect: 'all',
+  baseMipLevel: 3,
+  baseArrayLayer: 0,
+});
+let computePassEncoder24 = commandEncoder54.beginComputePass({label: '\u205d\u0b35\uf2b3'});
+let renderBundle42 = renderBundleEncoder4.finish({label: '\u{1ff2d}\u62ca\u66aa\ue21e\u{1fd84}\u0496\u24bd\u0851\u866b\ud4f7\u0ad6'});
+let sampler30 = device0.createSampler({
+  label: '\u63d0\u06bb\u027b\u06bc\u{1f75c}\u{1fbd7}\u{1fa23}\u{1f6bb}\u6604',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.13,
+  lodMaxClamp: 62.32,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup8, new Uint32Array(8209), 2538, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 11040 */
+  offset: 10896,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder9.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36528 */
+  offset: 36528,
+  buffer: buffer13,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 487 */
+{offset: 487}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let computePassEncoder25 = commandEncoder65.beginComputePass({label: '\u{1fa53}\u{1f69b}\u{1f86a}\uf1f1\u0995\u{1f935}\uc29f\u0a8d\u{1fbec}'});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\ucab4\uc4a7\u31bb\u{1f9b1}\ud72c\ucf4f\u216a\ued75',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer9, 0);
+} catch {}
+let arrayBuffer5 = buffer15.getMappedRange();
+try {
+commandEncoder2.copyBufferToBuffer(buffer10, 80080, buffer13, 356676, 2352);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder62.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 17920 widthInBlocks: 1120 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 53872 */
+  offset: 53872,
+  buffer: buffer13,
+}, {width: 1120, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 35220, new DataView(new ArrayBuffer(34605)), 8634, 2380);
+} catch {}
+document.body.prepend(video5);
+gc();
+let texture35 = device0.createTexture({
+  label: '\ud191\u0aff\u{1fdd4}\u7fb7\u0702',
+  size: {width: 576},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let textureView83 = texture32.createView({label: '\u{1fcbc}\u{1f6c8}\u15ea', baseMipLevel: 6, baseArrayLayer: 3, arrayLayerCount: 54});
+let renderBundle43 = renderBundleEncoder15.finish({});
+try {
+renderBundleEncoder30.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer5, 46560, buffer6, 42104, 28548);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 6296 */
+  offset: 6296,
+  bytesPerRow: 0,
+  buffer: buffer5,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let video7 = await videoWithData();
+let commandEncoder68 = device0.createCommandEncoder();
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 2017});
+let textureView84 = texture15.createView({label: '\u0e28\u{1fed6}\u0b2e\ue272\u{1f8de}\u01b5', baseMipLevel: 0});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 5, 4);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(10, buffer7, 24088, 102437);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(buffer2, 20268, buffer6, 82552, 7900);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img10 = await imageWithData(288, 96, '#3b746a14', '#684ad9bb');
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({label: '\u086f\u0a28\u0d0c\u0614\uaa44'});
+let querySet36 = device0.createQuerySet({label: '\uea1c\u063c\u077f\u7b4b\u{1ff11}\u025f\u7e4f\ubaca\u{1fc6d}', type: 'occlusion', count: 1026});
+let textureView85 = texture1.createView({format: 'bgra8unorm', baseMipLevel: 4, mipLevelCount: 1});
+let externalTexture21 = device0.importExternalTexture({label: '\u7894\uee1a\u{1fab8}\ua209\u0dd9\u1ad6\u1a79', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(4, bindGroup5, new Uint32Array(5972), 2304, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(4, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 9076, new Int16Array(19047), 1072, 7784);
+} catch {}
+let pipeline57 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 416,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 186, shaderLocation: 2},
+          {format: 'uint32x2', offset: 16, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 10332,
+        attributes: [
+          {format: 'uint8x2', offset: 5912, shaderLocation: 11},
+          {format: 'float16x2', offset: 416, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 25864, stepMode: 'vertex', attributes: []},
+      {arrayStride: 2768, stepMode: 'instance', attributes: []},
+      {arrayStride: 808, attributes: [{format: 'float32x4', offset: 120, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: false},
+});
+let commandEncoder70 = device0.createCommandEncoder({label: '\u59b6\uc1e6\u{1f736}\u406a\u0654\u0c79\ud3c9'});
+let textureView86 = texture25.createView({label: '\u0488\u706c\udbf1\u08df\u21b3\u{1fd06}\u{1fd03}\u28a7', baseMipLevel: 3});
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup6, new Uint32Array(2707), 1534, 0);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+  await buffer13.mapAsync(GPUMapMode.READ, 109960, 276832);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer2, 50060, buffer13, 340136, 10816);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 114, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 173812, new Int16Array(52955), 23289);
+} catch {}
+let pipeline58 = await device0.createRenderPipelineAsync({
+  label: '\u7549\u39ef\u{1fcf1}\u7652\u6404\u0327\u87cf\u{1f863}\ufa98',
+  layout: pipelineLayout2,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb', writeMask: 0}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8sint'}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater-equal', failOp: 'keep', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 3595443071,
+    stencilWriteMask: 1856239476,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 364,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 4, shaderLocation: 1},
+          {format: 'uint8x2', offset: 92, shaderLocation: 15},
+          {format: 'sint32', offset: 52, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 9532, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 512,
+        attributes: [
+          {format: 'uint8x2', offset: 46, shaderLocation: 2},
+          {format: 'sint32x2', offset: 92, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 164, attributes: [{format: 'sint8x2', offset: 22, shaderLocation: 13}]},
+      {
+        arrayStride: 6156,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 2434, shaderLocation: 10}],
+      },
+    ],
+  },
+});
+let commandEncoder71 = device0.createCommandEncoder({label: '\u863e\u{1fe92}\u0353\u0c73\u1431\uef3a'});
+let textureView87 = texture7.createView({label: '\u{1fc98}\u{1fe4c}\u{1f8db}\u0f24\u8b11\u0114\u{1f774}\ud154', baseMipLevel: 0});
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6324 */
+  offset: 6276,
+  buffer: buffer4,
+}, {width: 12, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: {x: 18, y: 0, z: 38},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder66.pushDebugGroup('\u403e');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 32, y: 0, z: 46},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 155280232 */
+{offset: 980, bytesPerRow: 2019, rowsPerImage: 221}, {width: 125, height: 1, depthOrArrayLayers: 349});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(238, 294);
+let bindGroup15 = device0.createBindGroup({
+  label: '\u384f\u{1f63d}\u00f2',
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 1629, resource: externalTexture18},
+    {binding: 1640, resource: externalTexture13},
+    {binding: 8842, resource: externalTexture10},
+  ],
+});
+let commandEncoder72 = device0.createCommandEncoder({label: '\ufac1\ue9d9\uf610\u{1fcea}\u{1faf2}\u884c\u0932\u{1fadb}\ud0a7\u076f\u{1f656}'});
+let texture36 = gpuCanvasContext0.getCurrentTexture();
+let textureView88 = texture19.createView({label: '\u89f0\ub4cc\u0f76\u{1fcd9}\uc526\u374d\u622f', baseMipLevel: 1, mipLevelCount: 2});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet33, 694, 653, buffer1, 275968);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer9, 22792, 48909);
+} catch {}
+let arrayBuffer6 = buffer9.getMappedRange(130520, 12);
+try {
+commandEncoder31.copyBufferToBuffer(buffer11, 73536, buffer4, 179320, 132508);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet18, 2195, 13, buffer9, 4352);
+} catch {}
+let textureView89 = texture23.createView({label: '\u07ed\u{1fc58}\u4bd4\ucd16\ud00c\u5846\u032e\u{1f6b6}\u09d9\u{1fbee}\u0ee1'});
+let renderBundle44 = renderBundleEncoder19.finish({});
+let externalTexture23 = device0.importExternalTexture({label: '\u2c71\u0408\u0d0f\u6cbc\u921c\u610a\u{1f6c3}\u5376\u2025', source: videoFrame2});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline57);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet2, 2308, 371, buffer0, 125696);
+} catch {}
+let pipeline59 = device0.createComputePipeline({
+  label: '\u0223\ua4d2\u08e6',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise8;
+} catch {}
+gc();
+let renderBundle45 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup15, new Uint32Array(420), 187, 0);
+} catch {}
+try {
+computePassEncoder22.dispatchWorkgroups(5, 3);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline46);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 79632, new Int16Array(44679), 40540, 844);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 437, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(991), /* required buffer size: 991 */
+{offset: 991, rowsPerImage: 242}, {width: 189, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 1, y: 72 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = await device0.createComputePipelineAsync({
+  label: '\u0b41\u26f1\uf4e8',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise4;
+} catch {}
+document.body.prepend(img8);
+let querySet37 = device0.createQuerySet({
+  label: '\u094a\u2627\u{1f9f7}\u0004\u{1f6f1}\u3e26\u0189\u5f39\u33f4\u368c\u03cd',
+  type: 'occlusion',
+  count: 2303,
+});
+let sampler31 = device0.createSampler({
+  label: '\u0c8c\u0529\u1d7d\u01dc\u0380\u0f79\u4509\u0c80\u39b8\uc9c0\u05ef',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.42,
+  lodMaxClamp: 61.12,
+  compare: 'never',
+});
+try {
+computePassEncoder14.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer16, 37620, 14465);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let pipeline61 = await device0.createRenderPipelineAsync({
+  label: '\u6647\u0e91\u8920\ub62d\u448c\ub715\u1f5e\u734c\u0ce8\u0c31\u{1fd7f}',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x599f9dc8},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 80,
+        attributes: [
+          {format: 'unorm16x2', offset: 68, shaderLocation: 13},
+          {format: 'sint32x2', offset: 12, shaderLocation: 2},
+          {format: 'uint32x3', offset: 0, shaderLocation: 11},
+          {format: 'uint16x4', offset: 4, shaderLocation: 0},
+          {format: 'float32x3', offset: 16, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let canvas7 = document.createElement('canvas');
+try {
+canvas3.getContext('webgl2');
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({label: '\u{1fb65}\u888e\u09ce'});
+try {
+computePassEncoder13.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4, buffer16);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer11, 25732, buffer13, 12640, 143660);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28132 */
+  offset: 28108,
+  rowsPerImage: 72,
+  buffer: buffer3,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 43700, new BigUint64Array(5578));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 585 */
+{offset: 585, bytesPerRow: 337}, {width: 98, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(246, 497);
+try {
+canvas6.getContext('webgpu');
+} catch {}
+let texture37 = device0.createTexture({
+  label: '\uc669\u0517\u1fae\u05bd\u8e9b\u0ebb\u{1fad1}\u{1fec4}\u0b5c\u{1fdf2}',
+  size: [1152],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture38 = gpuCanvasContext2.getCurrentTexture();
+let sampler32 = device0.createSampler({
+  label: '\u0295\u3981\u0b64\u797c\u{1f7a8}\u378d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.92,
+  lodMaxClamp: 99.79,
+  compare: 'greater',
+  maxAnisotropy: 7,
+});
+try {
+commandEncoder48.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder66.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 11, y: 2 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext7 = canvas5.getContext('webgpu');
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let sampler33 = device0.createSampler({
+  label: '\u4102\u0adc\u035e\u7049\u0db9\u{1fa84}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMinClamp: 99.57,
+  lodMaxClamp: 99.97,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer7, 0, 153525);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 239 */
+{offset: 239, rowsPerImage: 82}, {width: 974, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = device0.createRenderPipeline({
+  label: '\u2446\u{1fe7a}\ue3a6\uc0e3\u0eac\ua1ba\u{1f8e7}\ucc01\ue435',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1772,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 344, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+offscreenCanvas9.height = 542;
+let img11 = await imageWithData(282, 283, '#ac7f6c06', '#bd9c19ac');
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u729d\u019f\u5d65\u57bb\u{1fce6}\u0651'});
+let texture39 = device0.createTexture({
+  label: '\u4c49\u196d',
+  size: [80, 1, 1],
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+try {
+renderBundleEncoder18.setPipeline(pipeline57);
+} catch {}
+let arrayBuffer7 = buffer13.getMappedRange(109960, 1892);
+let promise13 = buffer4.mapAsync(GPUMapMode.READ, 106640);
+let pipeline63 = await device0.createComputePipelineAsync({
+  label: '\u{1fd60}\ud933\u1458',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+video5.width = 126;
+let pipelineLayout11 = device0.createPipelineLayout({label: '\uf508\ue08c\u0e75\u7b4d\u9736', bindGroupLayouts: [bindGroupLayout11, bindGroupLayout4]});
+let texture40 = device0.createTexture({
+  label: '\uf8a6\u9fe3\u0797\ua681',
+  size: {width: 576, height: 1, depthOrArrayLayers: 225},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer9, 'uint32', 15136);
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer({
+  texture: texture40,
+  mipLevel: 3,
+  origin: {x: 72, y: 0, z: 56},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6688 */
+  offset: 6688,
+  bytesPerRow: 0,
+  rowsPerImage: 39,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 84});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+offscreenCanvas5.width = 4405;
+let querySet38 = device0.createQuerySet({
+  label: '\u03ae\u0023\ub56e\u69e0\u0124\udee9\u421d\uc747\u0a39\u1e37\u0d4b',
+  type: 'occlusion',
+  count: 2595,
+});
+let textureView90 = texture27.createView({baseMipLevel: 2});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\u0597\u084e\u{1fb61}\u2eab\u06e9\uc5b5\u0ab8\ue5c5\u5fba\u{1fc84}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder12.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup8, new Uint32Array(9940), 3286, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer7, 0, 86264);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 11 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 58153 */
+  offset: 58153,
+  buffer: buffer2,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 126, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({label: '\u{1fcb3}\u5fd5\u3208\u6349\u4056\u3ec7\u8d50\ua6eb\u0845'});
+let querySet39 = device0.createQuerySet({label: '\u{1fd42}\u0175\u{1fb74}', type: 'occlusion', count: 2370});
+let textureView91 = texture26.createView({
+  label: '\u{1fa67}\u{1f68d}\u{1ff10}\u{1f826}\u{1fc23}\u031b\u0785\u011d',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline16);
+} catch {}
+try {
+buffer15.destroy();
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 774 widthInBlocks: 387 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 47842 */
+  offset: 47842,
+  buffer: buffer2,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 252, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 387, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas8 = document.createElement('canvas');
+let video8 = await videoWithData();
+let imageBitmap4 = await createImageBitmap(canvas6);
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({
+  label: '\u0655\uc62e\u38b9\ua71c\uf3ec\ue2cc\u8cf1\u0751',
+  size: {width: 80, height: 1, depthOrArrayLayers: 39},
+  mipLevelCount: 3,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture42 = gpuCanvasContext2.getCurrentTexture();
+let textureView92 = texture34.createView({label: '\u{1fe67}\u061c\u{1fcfb}\u695b\u0619', dimension: '1d'});
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12144 */
+  offset: 12144,
+  rowsPerImage: 290,
+  buffer: buffer15,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder67.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 19980 */
+  offset: 19980,
+  buffer: buffer6,
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let textureView93 = texture25.createView({baseMipLevel: 4});
+let computePassEncoder26 = commandEncoder64.beginComputePass();
+try {
+computePassEncoder13.dispatchWorkgroups(4, 5, 1);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer8, 'uint16', 1412, 34);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(0, buffer9, 19212, 61419);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline64 = await device0.createComputePipelineAsync({
+  label: '\uc89a\u52e7\uba23\u{1f8d5}\u060d\u{1fb30}\u599b\u0a82\u0b5e',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let canvas9 = document.createElement('canvas');
+let shaderModule12 = device0.createShaderModule({
+  label: '\u2a1a\u{1ff14}\u{1fc1d}\u0aa2\u72fa\uf5ae\u1feb\u0d51\u99fc\u63e3',
+  code: `@group(2) @binding(1133)
+var<storage, read_write> local5: array<u32>;
+@group(0) @binding(1133)
+var<storage, read_write> function9: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> type5: array<u32>;
+@group(3) @binding(1133)
+var<storage, read_write> parameter8: array<u32>;
+@group(4) @binding(1133)
+var<storage, read_write> n8: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(4) f2: vec3<i32>,
+  @location(1) f3: vec4<f32>,
+  @location(5) f4: i32,
+  @location(6) f5: vec2<f32>,
+  @location(2) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(15) f0: vec2<u32>,
+  @location(2) f1: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<i32>, @location(8) a1: vec4<u32>, @location(6) a2: vec4<u32>, @location(3) a3: vec3<f16>, a4: S8, @builtin(vertex_index) a5: u32, @location(4) a6: vec3<f32>, @location(1) a7: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder77 = device0.createCommandEncoder({label: '\ubc41\u{1fa21}\u{1f8e1}'});
+let texture43 = device0.createTexture({
+  size: {width: 576},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let renderBundle46 = renderBundleEncoder6.finish({});
+let gpuCanvasContext8 = offscreenCanvas10.getContext('webgpu');
+let shaderModule13 = device0.createShaderModule({
+  label: '\u0b27\u{1fa45}\u7341\u{1f65b}\u7475\ud932\u1880\u089c\uea82',
+  code: `@group(3) @binding(1133)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> field7: array<u32>;
+@group(2) @binding(1133)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(5687)
+var<storage, read_write> global9: array<u32>;
+@group(4) @binding(1133)
+var<storage, read_write> function10: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(5) f2: vec2<i32>,
+  @location(0) f3: vec4<f32>,
+  @location(2) f4: vec4<i32>,
+  @location(4) f5: vec3<i32>,
+  @location(6) f6: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f32>, @location(10) a1: vec4<i32>, @location(7) a2: vec3<f16>, @location(2) a3: vec2<i32>, @location(5) a4: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder78 = device0.createCommandEncoder({label: '\u0074\u{1fcd2}\uf81f\u0eef'});
+let textureView94 = texture33.createView({label: '\u{1f6ba}\u9c01\u{1ffda}\u5128\ue4e3\u{1f641}\ufecf', baseMipLevel: 5, baseArrayLayer: 0});
+try {
+computePassEncoder22.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16764 */
+  offset: 16764,
+  bytesPerRow: 0,
+  rowsPerImage: 125,
+  buffer: buffer16,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 5});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 191, y: 0, z: 1},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 361683 */
+{offset: 166, bytesPerRow: 1045, rowsPerImage: 23}, {width: 62, height: 1, depthOrArrayLayers: 16});
+} catch {}
+try {
+offscreenCanvas11.getContext('2d');
+} catch {}
+let querySet40 = device0.createQuerySet({
+  label: '\ueee7\ud5f7\ufb61\u{1fb6c}\u60a7\u033c\u0497\u082c\u95c7\u608b\ud044',
+  type: 'occlusion',
+  count: 3203,
+});
+let commandBuffer17 = commandEncoder31.finish();
+let texture44 = device0.createTexture({
+  size: {width: 1152, height: 1, depthOrArrayLayers: 32},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+let textureView95 = texture20.createView({label: '\uafb5\u08af', format: 'rgba32float', baseMipLevel: 2});
+let computePassEncoder27 = commandEncoder67.beginComputePass({label: '\u059b\u01ea\u{1f93b}'});
+let renderBundle47 = renderBundleEncoder1.finish();
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 42, y: 12 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline65 = await device0.createRenderPipelineAsync({
+  label: '\u290e\u641c\ue836\u0f0e\uab15\u0453\u0568',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8404,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 1096, shaderLocation: 5},
+          {format: 'sint8x2', offset: 2358, shaderLocation: 11},
+          {format: 'uint8x4', offset: 544, shaderLocation: 15},
+          {format: 'uint32x4', offset: 2312, shaderLocation: 8},
+          {format: 'sint32', offset: 2084, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 976,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32', offset: 56, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 10},
+          {format: 'float16x2', offset: 392, shaderLocation: 1},
+          {format: 'uint32', offset: 8, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 0},
+          {format: 'sint32x3', offset: 52, shaderLocation: 7},
+          {format: 'uint16x2', offset: 588, shaderLocation: 9},
+          {format: 'float32x3', offset: 16, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 384, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 15224, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10968,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 120, shaderLocation: 2}],
+      },
+      {arrayStride: 28804, attributes: [{format: 'sint8x2', offset: 17106, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw'},
+});
+let texture45 = gpuCanvasContext0.getCurrentTexture();
+let textureView96 = texture21.createView({label: '\u729f\u41d0\u{1f7cc}'});
+let sampler34 = device0.createSampler({
+  label: '\ubd93\u{1fc72}\u{1f696}\u02a4\u04c9\u{1f9f6}\u{1f649}\ude41\u{1f8e3}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 90.30,
+  lodMaxClamp: 90.69,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup9, new Uint32Array(3352), 1941, 0);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet27, 761, 126, buffer3, 8704);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline66 = await device0.createRenderPipelineAsync({
+  label: '\u005f\u6a1b\u0969\ue5cc',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x509562a7},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'replace'},
+    stencilReadMask: 2668310231,
+    depthBiasClamp: 252.99478120697694,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 10876, attributes: []},
+      {arrayStride: 16464, stepMode: 'instance', attributes: []},
+      {arrayStride: 5768, stepMode: 'instance', attributes: []},
+      {arrayStride: 2432, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 8912,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 488, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 2456, shaderLocation: 15},
+          {format: 'float16x2', offset: 5400, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'back'},
+});
+let commandEncoder79 = device0.createCommandEncoder({label: '\u0d2f\u471f\u{1ff59}\u1c8c'});
+let texture46 = device0.createTexture({
+  label: '\u{1ffce}\u0f39\u3563',
+  size: [1152],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let texture47 = gpuCanvasContext2.getCurrentTexture();
+let textureView97 = texture29.createView({label: '\u8798\u0e07\u70e2\u0b98\u{1f69e}\u023d\u0ecb\u9018\u0adc', mipLevelCount: 1});
+let computePassEncoder28 = commandEncoder51.beginComputePass({label: '\u{1f727}\u1ec8\u{1f9c2}'});
+let renderBundle48 = renderBundleEncoder4.finish({label: '\u1460\u{1f607}\u{1f941}\u2c90'});
+try {
+renderBundleEncoder25.setPipeline(pipeline41);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 472 widthInBlocks: 118 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32592 */
+  offset: 32592,
+  buffer: buffer2,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 118, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline67 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r32sint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1688,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 24, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+try {
+  await promise13;
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  code: `@group(0) @binding(3330)
+var<storage, read_write> function11: array<u32>;
+@group(1) @binding(1629)
+var<storage, read_write> field9: array<u32>;
+@group(2) @binding(5687)
+var<storage, read_write> parameter9: array<u32>;
+@group(1) @binding(1640)
+var<storage, read_write> type6: array<u32>;
+@group(1) @binding(8842)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(3) f1: vec4<f32>,
+  @location(6) f2: vec4<f32>,
+  @location(5) f3: i32,
+  @location(0) f4: vec4<f32>,
+  @location(1) f5: vec4<f32>,
+  @location(4) f6: i32,
+  @location(7) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(3) f0: f16,
+  @location(11) f1: vec4<f32>,
+  @location(2) f2: vec2<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(13) f4: vec2<f32>,
+  @location(1) f5: vec3<u32>,
+  @location(0) f6: i32,
+  @location(9) f7: vec3<f16>,
+  @location(10) f8: vec2<i32>,
+  @location(15) f9: vec2<f32>,
+  @location(8) f10: vec2<i32>,
+  @location(12) f11: f16
+}
+
+@vertex
+fn vertex0(a0: S9, @location(14) a1: vec3<i32>, @location(4) a2: vec4<u32>, @builtin(vertex_index) a3: u32, @location(7) a4: vec2<u32>, @location(5) a5: f16, @location(6) a6: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView98 = texture28.createView({label: '\ue52c\u3a42\u9ace'});
+try {
+computePassEncoder14.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline51);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer7, 0, 141522);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer2, 17092, buffer6, 98596, 37684);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 648 */
+  offset: 456,
+  rowsPerImage: 97,
+  buffer: buffer6,
+}, {width: 48, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet17, 481, 827, buffer0, 232448);
+} catch {}
+let gpuCanvasContext9 = canvas7.getContext('webgpu');
+try {
+canvas8.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder();
+let commandBuffer18 = commandEncoder76.finish();
+let renderBundle49 = renderBundleEncoder11.finish({label: '\u04e7\u0893\u0d8e\udfa8\u05ca\u2584'});
+try {
+commandEncoder2.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+renderBundleEncoder28.insertDebugMarker('\u{1fc3e}');
+} catch {}
+let pipeline68 = device0.createComputePipeline({
+  label: '\u{1f606}\u{1f618}\u0cad\uc450\u0493\u{1fb48}\u1af4\u{1ff10}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule6, entryPoint: 'compute0'},
+});
+let texture48 = device0.createTexture({
+  size: [320, 1, 347],
+  mipLevelCount: 8,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u{1f91a}\u543f\u6006\u{1ffcc}\u04ff\u{1f932}\ubf45\u230f\u8281\u7cc1\u36bd',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle50 = renderBundleEncoder29.finish({label: '\u{1fdfc}\u{1f9ef}\u4c61\u0fad\u0dfe'});
+let externalTexture24 = device0.importExternalTexture({
+  label: '\u{1fd46}\u4d3b\u766e\u0105\u48eb\u95e6\u{1ff3b}\u9724',
+  source: videoFrame4,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder35.setPipeline(pipeline41);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet12, 622, 246, buffer0, 103936);
+} catch {}
+let querySet41 = device0.createQuerySet({label: '\u846e\u65ee\u{1fca0}\u0fb6\u{1fb43}\ua439', type: 'occlusion', count: 2546});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u{1f8d6}\u757a\u06ce\ue4cd\u623a\u0b1f\ubeba\u04ed',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer16, 27328, buffer6, 163520, 20424);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 31248 */
+  offset: 31248,
+  buffer: buffer10,
+}, {
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet22, 46, 1975, buffer1, 509952);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 946 */
+{offset: 946, bytesPerRow: 297}, {width: 284, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext10 = canvas9.getContext('webgpu');
+try {
+computePassEncoder15.setBindGroup(3, bindGroup2, new Uint32Array(8621), 4819, 0);
+} catch {}
+try {
+computePassEncoder13.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder14.dispatchWorkgroupsIndirect(buffer5, 89692);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 4072 widthInBlocks: 1018 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10720 */
+  offset: 10720,
+  rowsPerImage: 73,
+  buffer: buffer16,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1018, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 330, y: 0, z: 499},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer7), /* required buffer size: 294 */
+{offset: 294}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let video9 = await videoWithData();
+let querySet42 = device0.createQuerySet({type: 'occlusion', count: 3055});
+try {
+computePassEncoder18.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+commandEncoder55.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 500 widthInBlocks: 125 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1028 */
+  offset: 1028,
+  buffer: buffer6,
+}, {width: 125, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 468 */
+{offset: 460, rowsPerImage: 245}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(img3);
+let commandEncoder81 = device0.createCommandEncoder({label: '\u{1f708}\uadb9\u8f6a\u0419\u059f'});
+let querySet43 = device0.createQuerySet({label: '\ufd09\u{1fdb5}', type: 'occlusion', count: 403});
+let renderBundle51 = renderBundleEncoder14.finish();
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 131 */
+{offset: 131, bytesPerRow: 119, rowsPerImage: 44}, {width: 29, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle52 = renderBundleEncoder1.finish();
+let sampler35 = device0.createSampler({
+  label: '\u7b7c\u0d57\u0e91\u0000\u8ad4',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.01,
+  lodMaxClamp: 82.03,
+});
+try {
+renderBundleEncoder34.setPipeline(pipeline55);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u09d4\ued1a',
+  layout: bindGroupLayout17,
+  entries: [{binding: 6817, resource: externalTexture11}],
+});
+let textureView99 = texture11.createView({});
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer3, 31536, buffer6, 36836, 7396);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet21, 511, 162, buffer7, 145920);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let textureView100 = texture25.createView({label: '\ude81\u0b84', format: 'bgra8unorm', baseMipLevel: 3, baseArrayLayer: 0});
+let computePassEncoder29 = commandEncoder60.beginComputePass({label: '\udc48\u8a36\u{1f739}\u{1ff1c}\ubcf7\u7b49\u4b58\u4ee1\ub86f\u8cca'});
+let renderBundle53 = renderBundleEncoder15.finish({label: '\u015b\u04ac\u33c5\uf0a0\u38b7\u431d\ub444\u8338\u04d7\u040f\uc2f5'});
+let sampler36 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.58,
+  compare: 'never',
+  maxAnisotropy: 19,
+});
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(4, bindGroup0, new Uint32Array(5928), 2884, 0);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline69 = await device0.createRenderPipelineAsync({
+  label: '\u827a\u{1f63b}\u{1fc5d}\u2a8a\uf651\u0cdd\ub80c\u00c8\uafce\u086e\u{1ff93}',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL}, {format: 'r8sint'}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'zero'},
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 656.3634281942961,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 508, shaderLocation: 5},
+          {format: 'sint32x2', offset: 2460, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 1868, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 560, shaderLocation: 11},
+          {format: 'uint32x3', offset: 272, shaderLocation: 9},
+          {format: 'sint16x2', offset: 192, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 96, shaderLocation: 3},
+          {format: 'sint32x4', offset: 324, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 536, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 246, shaderLocation: 0},
+          {format: 'uint8x4', offset: 784, shaderLocation: 12},
+          {format: 'uint32x2', offset: 488, shaderLocation: 1},
+          {format: 'sint8x2', offset: 962, shaderLocation: 14},
+          {format: 'float32', offset: 492, shaderLocation: 10},
+          {format: 'uint8x2', offset: 436, shaderLocation: 2},
+          {format: 'sint32x3', offset: 92, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: false},
+});
+let texture49 = device0.createTexture({
+  size: {width: 80, height: 1, depthOrArrayLayers: 195},
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+try {
+renderBundleEncoder24.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(buffer11, 38408, buffer6, 56200, 19204);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet34, 372, 31, buffer16, 79616);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: canvas0,
+  origin: { x: 56, y: 0 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer17 = device0.createBuffer({size: 93268, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u2e05\u011f\u079e\u{1f6c8}\u{1fe60}\ua14d\u0872\u096b\ubf17',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup5, new Uint32Array(2430), 1448, 0);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(3, buffer7, 0);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer11, 17788, buffer13, 269992, 117972);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 231 widthInBlocks: 231 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 36967 */
+  offset: 36967,
+  buffer: buffer6,
+}, {width: 231, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 11, y: 9 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer19 = commandEncoder39.finish({label: '\u4f69\u{1f674}\u{1f87a}\u{1fe56}\u{1face}\u0c4e\u{1f9f0}\u5c43\u{1fdde}\uccd5\u06d4'});
+let textureView101 = texture32.createView({label: '\u{1f7bf}\uc8d9\u0268\u07db', dimension: '2d', mipLevelCount: 8, baseArrayLayer: 296});
+let renderBundle54 = renderBundleEncoder14.finish({});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup16, new Uint32Array(2976), 2372, 0);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline57);
+} catch {}
+let pipeline70 = await device0.createComputePipelineAsync({
+  label: '\u{1fcc8}\u05d9\u{1f730}\u85ab\u361b\u2332\u801f\ue958\u0346',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame5 = new VideoFrame(video6, {timestamp: 0});
+let shaderModule15 = device0.createShaderModule({
+  label: '\u{1f878}\ud2a7\uea26\u0b27\u60eb\u8315\u96e2\u5515',
+  code: `@group(0) @binding(702)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(2759)
+var<storage, read_write> n9: array<u32>;
+@group(1) @binding(5489)
+var<storage, read_write> n10: array<u32>;
+@group(1) @binding(4793)
+var<storage, read_write> function13: array<u32>;
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @builtin(sample_index) f0: u32,
+  @location(13) f1: vec4<f16>,
+  @location(34) f2: vec2<f32>,
+  @location(54) f3: vec3<f32>,
+  @builtin(position) f4: vec4<f32>,
+  @location(9) f5: f32,
+  @builtin(front_facing) f6: bool,
+  @location(46) f7: vec3<u32>,
+  @location(40) f8: vec2<f32>,
+  @builtin(sample_mask) f9: u32,
+  @location(14) f10: f16,
+  @location(10) f11: vec4<f32>,
+  @location(24) f12: vec2<u32>,
+  @location(33) f13: vec2<f32>,
+  @location(28) f14: vec3<f32>,
+  @location(44) f15: f16,
+  @location(32) f16: vec2<f16>,
+  @location(59) f17: vec4<u32>,
+  @location(56) f18: f32,
+  @location(45) f19: f16,
+  @location(20) f20: vec2<f32>,
+  @location(58) f21: f32,
+  @location(51) f22: vec2<f32>,
+  @location(4) f23: vec2<i32>,
+  @location(57) f24: vec3<u32>,
+  @location(3) f25: vec2<f16>,
+  @location(22) f26: vec2<f32>,
+  @location(2) f27: vec3<f32>,
+  @location(15) f28: u32,
+  @location(37) f29: i32
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(4) f1: vec4<i32>,
+  @location(5) f2: vec2<i32>,
+  @location(1) f3: vec4<f32>,
+  @location(2) f4: vec4<i32>,
+  @location(0) f5: vec4<f32>,
+  @location(6) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(26) a0: vec2<i32>, a1: S10, @location(16) a2: vec2<f16>, @location(47) a3: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(34) f208: vec2<f32>,
+  @location(58) f209: f32,
+  @location(13) f210: vec4<f16>,
+  @location(4) f211: vec2<i32>,
+  @location(20) f212: vec2<f32>,
+  @location(59) f213: vec4<u32>,
+  @location(32) f214: vec2<f16>,
+  @location(54) f215: vec3<f32>,
+  @location(26) f216: vec2<i32>,
+  @location(10) f217: vec4<f32>,
+  @location(47) f218: vec3<i32>,
+  @location(3) f219: vec2<f16>,
+  @location(56) f220: f32,
+  @location(9) f221: f32,
+  @location(40) f222: vec2<f32>,
+  @location(44) f223: f16,
+  @location(15) f224: u32,
+  @location(22) f225: vec2<f32>,
+  @location(45) f226: f16,
+  @location(2) f227: vec3<f32>,
+  @location(51) f228: vec2<f32>,
+  @location(16) f229: vec2<f16>,
+  @location(37) f230: i32,
+  @location(57) f231: vec3<u32>,
+  @builtin(position) f232: vec4<f32>,
+  @location(14) f233: f16,
+  @location(33) f234: vec2<f32>,
+  @location(24) f235: vec2<u32>,
+  @location(46) f236: vec3<u32>,
+  @location(28) f237: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<i32>, @location(8) a1: vec4<f32>, @location(10) a2: vec4<f32>, @location(13) a3: f32, @location(9) a4: vec3<i32>, @location(5) a5: u32, @location(14) a6: vec4<f16>, @location(11) a7: u32, @location(12) a8: vec4<f32>, @location(15) a9: f16, @location(1) a10: vec4<i32>, @builtin(vertex_index) a11: u32, @location(4) a12: vec2<f32>, @location(7) a13: vec4<i32>, @location(2) a14: vec2<f32>, @builtin(instance_index) a15: u32, @location(3) a16: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+let textureView102 = texture3.createView({label: '\ubceb\u9608\u948a\ueb2c\u82f2\u90ac\u0031\u9340\u0ec2', baseMipLevel: 7, mipLevelCount: 3});
+let computePassEncoder30 = commandEncoder81.beginComputePass({label: '\u{1f9a1}\u{1fb20}\uaeec\u44a7\u{1feea}\uc1df\ufb2c\u0c5b\u44a8\u0e28\u59ce'});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 12400 */
+  offset: 12400,
+  bytesPerRow: 0,
+  buffer: buffer2,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 90800 */
+  offset: 90800,
+  buffer: buffer6,
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline71 = await device0.createRenderPipelineAsync({
+  label: '\u9d86\u042c\u61ca\u8baf\ue85e\u2e6a\u0698\u{1f882}\u{1fa60}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'src'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+  },
+}, {format: 'r8sint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'keep', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 2313004201,
+    stencilWriteMask: 4124457545,
+    depthBiasSlopeScale: 135.8466001958158,
+    depthBiasClamp: 992.2591568391404,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1388, shaderLocation: 0},
+          {format: 'uint32x2', offset: 44, shaderLocation: 9},
+          {format: 'float16x4', offset: 2240, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 16404, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 2704, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 56, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 24784,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 13612, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 12106, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 13232,
+        attributes: [
+          {format: 'sint8x2', offset: 3670, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 1362, shaderLocation: 12},
+          {format: 'sint32', offset: 2908, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let querySet44 = device0.createQuerySet({
+  label: '\u83f1\ucf15\u{1f95f}\u{1fc67}\u{1f72a}\u4ba4\ud106\u8b57\u{1fd3e}\u83d3\u932e',
+  type: 'occlusion',
+  count: 818,
+});
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.00,
+  lodMaxClamp: 34.77,
+  maxAnisotropy: 8,
+});
+let externalTexture26 = device0.importExternalTexture({label: '\ub432\u14a9\u3a1f\u8df7\u8aa2\u072d\u{1ff92}', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder18.dispatchWorkgroupsIndirect(buffer5, 44552);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer11, 303872, buffer13, 302280, 8540);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer13);
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({label: '\u0a11\u{1f7df}\uf486\u{1fa76}\u0846\u5c4f\u{1fb87}\u{1f9d9}'});
+let renderBundle55 = renderBundleEncoder4.finish({});
+try {
+commandEncoder56.resolveQuerySet(querySet0, 2100, 515, buffer7, 81664);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u6bd7');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData10 = new ImageData(8, 224);
+let shaderModule16 = device0.createShaderModule({
+  label: '\u46ee\u09bc',
+  code: `@group(1) @binding(5740)
+var<storage, read_write> function14: array<u32>;
+@group(3) @binding(702)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(3330)
+var<storage, read_write> n11: array<u32>;
+
+@compute @workgroup_size(8, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(4) f1: vec4<i32>,
+  @location(5) f2: vec3<i32>,
+  @location(0) f3: vec4<f32>,
+  @location(6) f4: f32,
+  @location(1) f5: vec4<f32>,
+  @location(3) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(13) a1: u32, @builtin(instance_index) a2: u32, @location(9) a3: vec4<f16>, @location(11) a4: i32, @location(0) a5: vec3<u32>, @location(14) a6: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder72.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 40736 */
+  offset: 40736,
+  bytesPerRow: 0,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline72 = await device0.createRenderPipelineAsync({
+  label: '\u{1fd28}\u{1fb78}\ubed4\u0be2\u3298\u01b8\u22cd',
+  layout: pipelineLayout5,
+  multisample: {count: 1, mask: 0xb80fb711},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint16x4', offset: 816, shaderLocation: 2},
+          {format: 'uint32x4', offset: 3664, shaderLocation: 11},
+          {format: 'uint8x2', offset: 10932, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 6788, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3372,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 256, shaderLocation: 13}],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 4836, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 9920,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 404, shaderLocation: 5}],
+      },
+    ],
+  },
+});
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 2445});
+let texture50 = device0.createTexture({
+  label: '\u{1fb7a}\u{1f986}',
+  size: {width: 1152, height: 1, depthOrArrayLayers: 521},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView103 = texture50.createView({dimension: '3d', mipLevelCount: 1});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'], stencilReadOnly: true});
+try {
+renderBundleEncoder32.setPipeline(pipeline51);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer7, 0);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 39, y: 0, z: 13},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 484 widthInBlocks: 121 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 91536 */
+  offset: 59820,
+  bytesPerRow: 512,
+  rowsPerImage: 1,
+  buffer: buffer6,
+}, {width: 121, height: 1, depthOrArrayLayers: 62});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline73 = await device0.createComputePipelineAsync({
+  label: '\u2659\u55c5\u8093\uaff7',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout21 = pipeline67.getBindGroupLayout(1);
+let commandEncoder85 = device0.createCommandEncoder({label: '\u{1f82b}\ua32d\u{1fe79}\ue7bd'});
+try {
+computePassEncoder20.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(4, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline51);
+} catch {}
+let arrayBuffer8 = buffer4.getMappedRange(106640, 24640);
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5744 */
+  offset: 5744,
+  rowsPerImage: 197,
+  buffer: buffer6,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline74 = await device0.createRenderPipelineAsync({
+  label: '\u70c8\uee97\uf66c\u9c96\ubfa9\u0e90\u070b\u447f\u2002\u0afa',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 10440, stepMode: 'instance', attributes: []},
+      {arrayStride: 2384, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8632,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 1552, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 1228, shaderLocation: 5},
+          {format: 'sint16x2', offset: 496, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 4356, attributes: [{format: 'sint8x4', offset: 88, shaderLocation: 10}]},
+      {
+        arrayStride: 15880,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 7504, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let querySet46 = device0.createQuerySet({label: '\u35cc\ubb66\u9e28', type: 'occlusion', count: 3768});
+let textureView104 = texture29.createView({label: '\u{1fa2e}\u8cd1\u8d4e\uca24\u079d\u6f18', format: 'r8sint', mipLevelCount: 1});
+let sampler38 = device0.createSampler({
+  label: '\u974e\u0b15\u{1f928}\u0141\u003e\u0fef\u82c6',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.27,
+  lodMaxClamp: 97.13,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer8, 'uint32');
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4976, undefined, 0);
+} catch {}
+try {
+buffer6.destroy();
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture({
+  /* bytesInLastRow: 18304 widthInBlocks: 1144 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16368 */
+  offset: 16368,
+  bytesPerRow: 18432,
+  buffer: buffer17,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1144, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer8), /* required buffer size: 136152 */
+{offset: 792, bytesPerRow: 96, rowsPerImage: 47}, {width: 19, height: 0, depthOrArrayLayers: 31});
+} catch {}
+let pipeline75 = device0.createComputePipeline({
+  label: '\uee73\u36f4\u944c\u0325\u0a7d\ub29f\u{1f7f4}\u1f84\u{1f9ee}\u04cc\u{1f6bc}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let querySet47 = device0.createQuerySet({label: '\u828d\u18c9', type: 'occlusion', count: 1252});
+let computePassEncoder31 = commandEncoder56.beginComputePass({label: '\u{1fb72}\ucbd0\u0f9d\u6af0\u{1fbd5}\ud1d4\u7cc0\u13e5\u5dec\u{1f8ff}'});
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(3, buffer9, 12332, 53397);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer15, commandBuffer13, commandBuffer19]);
+} catch {}
+let pipeline76 = device0.createComputePipeline({
+  label: '\u1a84\u18dd',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let pipeline77 = await device0.createRenderPipelineAsync({
+  label: '\u{1f872}\u5d3d\u{1fc86}',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 4026293127,
+    stencilWriteMask: 1605787892,
+    depthBias: 606271768,
+    depthBiasSlopeScale: 69.55879549386572,
+    depthBiasClamp: -7.599606502318736,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 15264, attributes: []},
+      {
+        arrayStride: 13088,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 2504, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+let commandEncoder86 = device0.createCommandEncoder({});
+let commandBuffer20 = commandEncoder79.finish({label: '\u015c\u4374\u0b61\ud427\u{1f9d9}\u8fc5\u6289'});
+let sampler39 = device0.createSampler({
+  label: '\u0b7e\uc25c\u5403\u0479\u0ca9\u{1f83f}\u0859\u0bb9\u781f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.33,
+  lodMaxClamp: 46.56,
+  compare: 'greater',
+  maxAnisotropy: 8,
+});
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup14, new Uint32Array(9468), 4384, 0);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(4, buffer9, 95760, 27611);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet24, 1663, 1186, buffer7, 102400);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas9,
+  origin: { x: 5, y: 5 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline78 = await device0.createRenderPipelineAsync({
+  label: '\u648a\u0021\u03e7\u0fa3\u{1fa75}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src'},
+  },
+}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 5560,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 4204, shaderLocation: 13}],
+      },
+      {arrayStride: 9444, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8880,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 1920, shaderLocation: 5},
+          {format: 'sint32x4', offset: 1924, shaderLocation: 2},
+          {format: 'uint8x2', offset: 3722, shaderLocation: 0},
+          {format: 'uint32', offset: 932, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder87 = device0.createCommandEncoder();
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer2, 7348, buffer6, 83432, 38260);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise5;
+} catch {}
+try {
+externalTexture1.label = '\u0a4a\u{1ffa1}\u20d2\ue48c\u70cd\u17e2\ua089';
+} catch {}
+let textureView105 = texture49.createView({
+  label: '\u3a0b\u{1f62c}\u{1f6e5}\ub569\u06ad\u{1f9bf}\u4770\u{1fa88}\u{1f761}\u0d87',
+  baseArrayLayer: 148,
+  arrayLayerCount: 39,
+});
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup0, new Uint32Array(2954), 1998, 0);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 79},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 433, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 31 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline79 = device0.createComputePipeline({
+  label: '\u039b\uf548',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline80 = device0.createRenderPipeline({
+  label: '\u07cc\u037d\u8dd6',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}, {format: 'bgra8unorm-srgb'}, {format: 'rgba8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'keep'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap'},
+    stencilReadMask: 2926129547,
+    stencilWriteMask: 2189051952,
+    depthBiasSlopeScale: 594.995078412655,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1632,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 412, shaderLocation: 9},
+          {format: 'uint16x4', offset: 272, shaderLocation: 8},
+          {format: 'uint32x4', offset: 992, shaderLocation: 12},
+          {format: 'uint32', offset: 640, shaderLocation: 7},
+          {format: 'uint32', offset: 40, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 608, shaderLocation: 10},
+          {format: 'uint8x2', offset: 756, shaderLocation: 3},
+          {format: 'uint8x4', offset: 204, shaderLocation: 5},
+          {format: 'float32x3', offset: 536, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 692, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 7032, shaderLocation: 2},
+          {format: 'sint8x2', offset: 18168, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 3560, shaderLocation: 15},
+          {format: 'sint32', offset: 15748, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 9024,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 1424, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 360, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `@group(4) @binding(4481)
+var<storage, read_write> n12: array<u32>;
+@group(4) @binding(7721)
+var<storage, read_write> function15: array<u32>;
+@group(0) @binding(4481)
+var<storage, read_write> parameter11: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> local6: array<u32>;
+@group(3) @binding(3330)
+var<storage, read_write> local7: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: f16, @location(1) a1: vec4<i32>, @builtin(vertex_index) a2: u32, @location(11) a3: vec4<i32>, @location(5) a4: vec2<u32>, @builtin(instance_index) a5: u32, @location(14) a6: vec4<f32>, @location(10) a7: vec2<u32>, @location(12) a8: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder88 = device0.createCommandEncoder({label: '\ue6bc\ubbdd\u0635\u091c'});
+let querySet48 = device0.createQuerySet({label: '\u0b7c\u06b6\ufbe3\u2217', type: 'occlusion', count: 3108});
+let commandBuffer21 = commandEncoder82.finish();
+let renderBundle56 = renderBundleEncoder15.finish();
+let sampler40 = device0.createSampler({
+  label: '\u02fe\u0ede\ub46d\uc6e5\u05d4\u0bd0\udf49\u{1f842}\u0da9',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.47,
+  lodMaxClamp: 78.35,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline74);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise11;
+} catch {}
+let texture51 = device0.createTexture({
+  label: '\ud2af\u08a4\u03e4\ueb2a\u0dfb\u{1f69a}\u838f',
+  size: [144, 1, 1],
+  mipLevelCount: 3,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView106 = texture35.createView({label: '\u{1f8d7}\u03f5\u1043\u0709\uefea\u0857\uce97\u0ceb'});
+try {
+renderBundleEncoder36.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline7);
+} catch {}
+try {
+  await buffer17.mapAsync(GPUMapMode.WRITE, 28056, 32952);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(buffer10, 60888, buffer13, 111880, 21752);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1831 */
+  offset: 1831,
+  buffer: buffer3,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet34, 302, 99, buffer7, 68352);
+} catch {}
+gc();
+let videoFrame6 = new VideoFrame(img3, {timestamp: 0});
+let querySet49 = device0.createQuerySet({label: '\uec7d\u{1f7d6}\uf266\u081d\uad2e\u0f37', type: 'occlusion', count: 561});
+let textureView107 = texture30.createView({label: '\u37e2\u0504', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder31.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup11, new Uint32Array(9526), 2583, 0);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline74);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer5, 52336, buffer4, 49596, 14780);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline81 = await device0.createComputePipelineAsync({
+  label: '\u018c\u655d\u07a2',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let pipeline82 = device0.createRenderPipeline({
+  label: '\u{1fe1d}\u{1fb30}\u05f6',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0x5d969de4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 1134469598,
+    depthBias: -1133034791,
+    depthBiasClamp: 386.13997438732696,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 12620, attributes: [{format: 'unorm8x2', offset: 6556, shaderLocation: 2}]},
+    ],
+  },
+});
+let commandEncoder89 = device0.createCommandEncoder({label: '\uc5b4\u{1f780}\u{1f86b}\u902d\u{1f8dd}\u003d\u{1f6a0}\u66d1\u{1f7c5}'});
+let computePassEncoder32 = commandEncoder69.beginComputePass({label: '\u{1ffff}\u387a'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u0b20\u015e',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let sampler41 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 93.69});
+let externalTexture27 = device0.importExternalTexture({label: '\u0892\u2158\u9472\uc02c\u{1ffa6}\ud7a4', source: video8, colorSpace: 'srgb'});
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(4, bindGroup1, new Uint32Array(6157), 5637, 0);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet15, 443, 1369, buffer7, 81664);
+} catch {}
+let texture52 = device0.createTexture({
+  label: '\u{1fb61}\ua280\u42c0\u07de\u083a\u04e3',
+  size: {width: 576},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView108 = texture45.createView({});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let externalTexture28 = device0.importExternalTexture({label: '\ueb0f\u1666\u{1fb14}\ud4b3\u06dd', source: video0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(4, buffer7, 0, 15137);
+} catch {}
+try {
+commandEncoder75.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 7},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 45588886 */
+{offset: 822, bytesPerRow: 1336, rowsPerImage: 282}, {width: 67, height: 1, depthOrArrayLayers: 122});
+} catch {}
+let canvas10 = document.createElement('canvas');
+let img12 = await imageWithData(18, 191, '#f073e28d', '#8f71f30b');
+let commandEncoder90 = device0.createCommandEncoder({label: '\u0e15\u{1fd51}\ud613'});
+let textureView109 = texture20.createView({label: '\u72f3\u983d', format: 'rgba32float', baseMipLevel: 3, mipLevelCount: 1});
+let computePassEncoder33 = commandEncoder61.beginComputePass({label: '\u978f\u4d8d\udbda\u0cf6\u3d96'});
+let renderBundle57 = renderBundleEncoder20.finish({});
+let sampler42 = device0.createSampler({
+  label: '\u0ae5\u5c16',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.52,
+  lodMaxClamp: 76.73,
+});
+let externalTexture29 = device0.importExternalTexture({label: '\u0fc8\u{1f683}\u{1f949}\u99e9\u924c', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder14.dispatchWorkgroups(2, 3, 2);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet33, 2629, 1034, buffer3, 15616);
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(542, 720);
+let commandEncoder91 = device0.createCommandEncoder({label: '\u076a\u{1f70c}\u{1ffa1}\u0548\ua49f\u3476\u12e6\u42b4\u2d9b\ue42c'});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle58 = renderBundleEncoder21.finish({label: '\u{1fece}\ua0db\u{1fe79}\u4114\u7056\u9df2'});
+let externalTexture30 = device0.importExternalTexture({source: video7});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup11, new Uint32Array(7693), 2523, 0);
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17496 */
+  offset: 17496,
+  buffer: buffer6,
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise14 = device0.createComputePipelineAsync({
+  label: '\u0b2a\u{1fbbc}\u1304\u020f\u0e6e\ucb97\u0df7\uc7f7',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let texture53 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder29.setBindGroup(2, bindGroup9, new Uint32Array(3910), 3005, 0);
+} catch {}
+let pipeline83 = await device0.createComputePipelineAsync({
+  label: '\ue7f5\u3080\u0012\u3148\u{1f728}\u0b4c\u{1fda6}\u{1fc9d}\u07a2\u{1f7b5}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let imageData11 = new ImageData(20, 16);
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u09d2\u0d46\u{1fc76}\uf4b6\u{1fa0b}\u{1fb95}\u0f0c\u02af\u{1fe36}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle59 = renderBundleEncoder42.finish({label: '\u{1faf5}\u{1f7a4}\ud25b\u0852'});
+try {
+commandEncoder86.copyBufferToBuffer(buffer11, 109332, buffer6, 38864, 19536);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 187 widthInBlocks: 187 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3932 */
+  offset: 3932,
+  rowsPerImage: 101,
+  buffer: buffer6,
+}, {width: 187, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 274 */
+{offset: 274, rowsPerImage: 90}, {width: 150, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer18 = device0.createBuffer({
+  label: '\u{1faef}\u5568\u951e\uacba\u246c\u0850\u0ac0\u228f\u0e9a',
+  size: 432727,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let computePassEncoder34 = commandEncoder47.beginComputePass({});
+let renderBundle60 = renderBundleEncoder36.finish({label: '\uff1b\u45e6\u0690'});
+let sampler43 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.41,
+  lodMaxClamp: 86.94,
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline55);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(3, buffer7, 0, 48603);
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 201090 */
+  offset: 37698,
+  bytesPerRow: 256,
+  rowsPerImage: 11,
+  buffer: buffer18,
+}, {width: 64, height: 1, depthOrArrayLayers: 59});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 7,
+  origin: {x: 0, y: 1, z: 190},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 29001 */
+{offset: 81, bytesPerRow: 241, rowsPerImage: 10}, {width: 2, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let imageBitmap5 = await createImageBitmap(video1);
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u05b7\ua39c\uc1a1\u{1f80b}\u{1ffd1}\u{1fe9f}\u5a77\u{1fe3c}\u167d',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout2, bindGroupLayout15, bindGroupLayout14],
+});
+let commandEncoder92 = device0.createCommandEncoder({label: '\u78a4\u793e\u{1fcf9}\u{1fbdb}\u1c80\u0a9e'});
+let texture54 = device0.createTexture({
+  label: '\u0a43\u0be2\u{1f8fc}\u0b0f\ud611\u956e\u{1fbe9}\u{1f9fc}',
+  size: [80],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView110 = texture11.createView({label: '\ufe65\u5911\ub458\uf80f\u3bb9\u58b9\u4a27\u4597\uaf9b\ubf1c', mipLevelCount: 1});
+let sampler44 = device0.createSampler({
+  label: '\u0d7c\u0f7b',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.79,
+  lodMaxClamp: 69.35,
+  maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder33.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(3, buffer16, 0, 27986);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  label: '\u{1fd01}\u4e71\u0790\u33b4\ua10a\u0d4d\u0f11',
+  code: `@group(1) @binding(4638)
+var<storage, read_write> n13: array<u32>;
+@group(2) @binding(942)
+var<storage, read_write> function16: array<u32>;
+@group(0) @binding(3330)
+var<storage, read_write> field10: array<u32>;
+@group(2) @binding(3127)
+var<storage, read_write> type8: array<u32>;
+@group(1) @binding(5740)
+var<storage, read_write> field11: array<u32>;
+@group(3) @binding(702)
+var<storage, read_write> global10: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+  @location(29) f0: f32,
+  @location(20) f1: vec4<i32>,
+  @location(40) f2: vec2<f32>,
+  @builtin(position) f3: vec4<f32>,
+  @location(42) f4: f16,
+  @location(39) f5: vec3<u32>,
+  @builtin(front_facing) f6: bool,
+  @location(21) f7: vec4<i32>,
+  @location(48) f8: f16
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<i32>,
+  @location(0) f1: vec3<i32>,
+  @location(1) f2: vec4<i32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S12, @location(58) a2: f32, @location(8) a3: f32, @location(45) a4: i32, @builtin(sample_mask) a5: u32, @location(32) a6: vec2<i32>, @location(56) a7: i32, @location(24) a8: i32, @location(55) a9: vec4<f16>, @location(52) a10: vec3<u32>, @location(27) a11: vec3<f16>, @location(54) a12: vec2<f32>, @location(7) a13: vec2<u32>, @location(15) a14: u32, @location(49) a15: f16, @location(36) a16: vec3<f16>, @location(34) a17: vec3<i32>, @location(26) a18: vec2<i32>, @location(33) a19: vec3<i32>, @location(46) a20: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(5) f0: i32,
+  @location(2) f1: f32,
+  @location(3) f2: vec4<f16>,
+  @location(6) f3: vec2<f32>,
+  @location(12) f4: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(32) f238: vec2<i32>,
+  @location(49) f239: f16,
+  @location(42) f240: f16,
+  @location(8) f241: f32,
+  @location(52) f242: vec3<u32>,
+  @location(24) f243: i32,
+  @location(33) f244: vec3<i32>,
+  @location(15) f245: u32,
+  @location(27) f246: vec3<f16>,
+  @location(55) f247: vec4<f16>,
+  @location(56) f248: i32,
+  @location(58) f249: f32,
+  @location(40) f250: vec2<f32>,
+  @builtin(position) f251: vec4<f32>,
+  @location(29) f252: f32,
+  @location(54) f253: vec2<f32>,
+  @location(21) f254: vec4<i32>,
+  @location(36) f255: vec3<f16>,
+  @location(34) f256: vec3<i32>,
+  @location(20) f257: vec4<i32>,
+  @location(46) f258: vec3<f16>,
+  @location(26) f259: vec2<i32>,
+  @location(45) f260: i32,
+  @location(7) f261: vec2<u32>,
+  @location(39) f262: vec3<u32>,
+  @location(48) f263: f16
+}
+
+@vertex
+fn vertex0(a0: S11, @location(8) a1: vec3<f16>, @location(10) a2: f16, @location(7) a3: vec2<i32>, @location(15) a4: vec4<i32>, @location(4) a5: vec2<f16>, @location(13) a6: f16, @location(9) a7: vec2<f16>, @location(11) a8: u32, @location(14) a9: vec2<u32>, @location(1) a10: vec4<i32>, @location(0) a11: vec3<u32>, @builtin(instance_index) a12: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandBuffer22 = commandEncoder28.finish({label: '\u073f\u15f1\u48bc\uc439\udc80\u{1f9a8}\uf1e6\uadcf\u{1ff22}\u{1fc7e}\u{1f608}'});
+let textureView111 = texture30.createView({mipLevelCount: 1});
+let renderBundle61 = renderBundleEncoder2.finish({label: '\ufa5f\u6715\u{1f91d}\u{1f818}\u{1fe65}\u{1ffaa}\u3568\u356b'});
+try {
+renderBundleEncoder25.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 435, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let videoFrame7 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let buffer19 = device0.createBuffer({
+  label: '\ufc31\uc9b9\u01d4\u1e4c\ua0a5\udd2f\u022a\u624c\u6061',
+  size: 538027,
+  usage: GPUBufferUsage.INDIRECT,
+});
+let commandEncoder93 = device0.createCommandEncoder({label: '\u0e22\u7933\uf71f'});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined], depthReadOnly: false});
+let renderBundle62 = renderBundleEncoder23.finish({label: '\u058c\u05fa\u{1f608}'});
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup7, new Uint32Array(3534), 917, 0);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline74);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer8, 844, buffer18, 422568, 404);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 18928 */
+  offset: 18928,
+  bytesPerRow: 0,
+  buffer: buffer16,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 180 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22592 */
+  offset: 22592,
+  rowsPerImage: 144,
+  buffer: buffer18,
+}, {width: 45, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer2), /* required buffer size: 11939925 */
+{offset: 525, bytesPerRow: 300, rowsPerImage: 198}, {width: 0, height: 1, depthOrArrayLayers: 202});
+} catch {}
+let pipeline84 = device0.createComputePipeline({
+  label: '\ub23b\u900c\uf4f4\u1549\u5e1a',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+let pipeline85 = device0.createRenderPipeline({
+  label: '\ub75b\uc9b0\u{1fb49}\u{1fdf0}\u04f2\uded0\u{1f864}\u580c\u0ceb\u0be5',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6420,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 150, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let video10 = await videoWithData();
+let buffer20 = device0.createBuffer({label: '\u024f\ub761', size: 73893, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 71648 */
+  offset: 71648,
+  rowsPerImage: 106,
+  buffer: buffer5,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet2, 2132, 953, buffer1, 29184);
+} catch {}
+let img13 = await imageWithData(223, 114, '#3abbb34b', '#668079e5');
+let videoFrame8 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let bindGroupLayout22 = device0.createBindGroupLayout({entries: []});
+let commandEncoder94 = device0.createCommandEncoder();
+try {
+computePassEncoder23.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(0, buffer7, 0, 172916);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer2, 12164, buffer4, 326028, 39556);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 182, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 53, y: 49 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle63 = renderBundleEncoder4.finish({label: '\u{1f900}\uaa28\u{1ff01}\ue01c\u398d\uf769\ue40a\u0d40\u28b9\uc26d'});
+try {
+renderBundleEncoder37.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(1, buffer7, 52200, 27446);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer18, 41248, 115068);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 144136, new Float32Array(32662), 6581, 8412);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({label: '\u6eac\u0fb8\u{1ffa0}\uaca3\u{1fc5c}'});
+let textureView112 = texture36.createView({label: '\u{1ffef}\u0fed\u0964\u4c85', dimension: '2d-array'});
+try {
+computePassEncoder14.dispatchWorkgroups(1, 1, 5);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11100 */
+  offset: 11100,
+  buffer: buffer18,
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 80, y: 71 },
+  flipY: true,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({});
+let texture55 = device0.createTexture({
+  label: '\uf9df\u{1fb22}\u02a7\u0042\u{1f6cd}\u03b8',
+  size: [40],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+let textureView113 = texture8.createView({label: '\u098b\u7fb4\u0b73\ub10c\u4429\u{1f827}'});
+let renderBundle64 = renderBundleEncoder12.finish({label: '\uc1d6\u9e1d\u7e21\u00eb\ud606'});
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 1588 widthInBlocks: 794 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 61666 */
+  offset: 60078,
+  buffer: buffer10,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 794, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 38},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 152345 */
+{offset: 524, bytesPerRow: 301, rowsPerImage: 24}, {width: 117, height: 1, depthOrArrayLayers: 22});
+} catch {}
+let imageData12 = new ImageData(56, 88);
+let bindGroup17 = device0.createBindGroup({
+  label: '\u{1fa79}\u5cf2\u0bdd\ub42f\uaa64\uf666\ufbb5\u294c\uec2f',
+  layout: bindGroupLayout17,
+  entries: [{binding: 6817, resource: externalTexture1}],
+});
+let commandEncoder97 = device0.createCommandEncoder({label: '\u{1fb0c}\ue07e\u0397'});
+let textureView114 = texture44.createView({label: '\u7ee7\u0749', dimension: '3d'});
+try {
+computePassEncoder3.setBindGroup(4, bindGroup6, new Uint32Array(7667), 5252, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup8, new Uint32Array(6288), 4900, 0);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet38, 57, 1303, buffer3, 3840);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 3980, new BigUint64Array(8478), 2130, 3288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 81, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(949), /* required buffer size: 949 */
+{offset: 949}, {width: 77, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 90, y: 34 },
+  flipY: true,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline86 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  multisample: {mask: 0x805326c},
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float'}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'r8sint'}, {format: 'r32sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'keep', passOp: 'zero'},
+    stencilReadMask: 3675751582,
+    stencilWriteMask: 3776719242,
+    depthBias: 2070663482,
+    depthBiasSlopeScale: 530.7659568253443,
+    depthBiasClamp: 545.7897178512254,
+  },
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5276,
+        attributes: [
+          {format: 'sint16x2', offset: 1528, shaderLocation: 3},
+          {format: 'float16x2', offset: 1884, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 1816, shaderLocation: 12},
+          {format: 'float32x4', offset: 328, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 84, shaderLocation: 15},
+          {format: 'uint16x2', offset: 816, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 3052, shaderLocation: 4},
+          {format: 'sint32x2', offset: 1728, shaderLocation: 9},
+          {format: 'sint8x4', offset: 76, shaderLocation: 6},
+          {format: 'uint32x3', offset: 1916, shaderLocation: 5},
+          {format: 'float16x2', offset: 396, shaderLocation: 8},
+          {format: 'float16x2', offset: 1688, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 4776,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 112, shaderLocation: 1},
+          {format: 'float32x2', offset: 60, shaderLocation: 14},
+          {format: 'sint32x4', offset: 1436, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(img9);
+try {
+offscreenCanvas12.getContext('2d');
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  label: '\ua1d2\ub161\u0208\u0705\u0fb9\ue863',
+  code: `@group(2) @binding(3127)
+var<storage, read_write> function17: array<u32>;
+@group(2) @binding(942)
+var<storage, read_write> function18: array<u32>;
+@group(1) @binding(4638)
+var<storage, read_write> parameter12: array<u32>;
+@group(1) @binding(5740)
+var<storage, read_write> global11: array<u32>;
+@group(1) @binding(876)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec2<f32>,
+  @location(0) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>,
+  @location(4) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(7) f0: vec4<u32>,
+  @builtin(vertex_index) f1: u32
+}
+
+@vertex
+fn vertex0(a0: S13, @location(1) a1: f16, @location(10) a2: vec2<i32>, @location(11) a3: f16, @location(2) a4: vec3<f32>, @location(9) a5: vec4<u32>, @builtin(instance_index) a6: u32, @location(15) a7: vec4<u32>, @location(8) a8: vec3<f16>, @location(13) a9: vec3<f32>, @location(4) a10: vec3<u32>, @location(14) a11: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let texture56 = device0.createTexture({
+  label: '\u0218\ubee8\u0ad4\u844f\u011c\u0d52\u3f12\ud120\u73c1',
+  size: [40, 1, 671],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView115 = texture2.createView({aspect: 'all', arrayLayerCount: 1});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({
+  label: '\ueae9\u00ef\u7c69\u0c85',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  depthReadOnly: true,
+});
+let renderBundle65 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder34.setPipeline(pipeline70);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer15, 3200, buffer4, 281160, 11932);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder29.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 33312 */
+  offset: 33312,
+  buffer: buffer18,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+let promise15 = device0.createComputePipelineAsync({
+  label: '\u{1f982}\u0cb7\uc297',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+video2.height = 108;
+let texture57 = device0.createTexture({
+  size: {width: 1152, height: 1, depthOrArrayLayers: 706},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView116 = texture10.createView({label: '\u03cc\u02f8\u{1f860}\u9b0f\u0dd9\uedab\u0982\u{1fa3d}\u0114\u59e9', baseArrayLayer: 0});
+try {
+computePassEncoder23.dispatchWorkgroups(5);
+} catch {}
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+commandEncoder40.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 27776 */
+  offset: 27776,
+  bytesPerRow: 256,
+  buffer: buffer18,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([commandBuffer20]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 35844, new BigUint64Array(3830), 1808, 216);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 297 */
+{offset: 297}, {width: 52, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline87 = device0.createComputePipeline({
+  label: '\u0265\u{1fd80}\u0395\u0c41',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+video8.height = 179;
+let img14 = await imageWithData(243, 276, '#6bd60529', '#68d3a9d9');
+let imageBitmap6 = await createImageBitmap(offscreenCanvas9);
+let textureView117 = texture34.createView({label: '\u{1f8b3}\u0357\ucc6b\u{1fb01}\ub7f8\u2f96\u{1f886}\u{1fc9c}\u8735\u6313\u{1f749}'});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\u0d15\u{1fa00}\u0b6d\u04f3\u8307\uc159\u0f82\u7103\u{1fc6f}',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+});
+try {
+computePassEncoder26.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(3, buffer16, 0, 21438);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet19, 1992, 6, buffer1, 530176);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer8), /* required buffer size: 144 */
+{offset: 144}, {width: 39, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView118 = texture44.createView({label: '\u0f1f\ua8a8\u02cb\u2d59\u4b40\ue605'});
+let computePassEncoder35 = commandEncoder36.beginComputePass({label: '\u012c\u{1fc97}\u83ff'});
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\ucb25\ua4d3\u63e7\u{1fa74}\u03d8\u{1fda5}\u3582\u{1f7e7}\u3873\ufbb4\u3fcc',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 495 widthInBlocks: 495 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10800 */
+  offset: 10800,
+  rowsPerImage: 20,
+  buffer: buffer6,
+}, {width: 495, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder89.insertDebugMarker('\u412a');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+gc();
+let commandEncoder98 = device0.createCommandEncoder();
+let sampler45 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 97.64,
+  lodMaxClamp: 97.86,
+});
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline88 = device0.createComputePipeline({
+  label: '\uf711\u65e9\u052a\u{1fb27}\u0444\u3150\u2df6\u9755\u9a92\u{1f70c}',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder99 = device0.createCommandEncoder({label: '\u0c98\u08d7\u0ac0\ud76d'});
+let commandBuffer23 = commandEncoder47.finish({});
+let computePassEncoder36 = commandEncoder77.beginComputePass({});
+let renderBundle66 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup13, new Uint32Array(4409), 4355, 0);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer5), /* required buffer size: 349 */
+{offset: 349}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 73, y: 5 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = canvas10.getContext('webgpu');
+let buffer21 = device0.createBuffer({
+  label: '\u5770\u36d8\u{1fbc7}\u0ac6\udf5d\u4a3b\u00b7\u{1fefe}\u0451',
+  size: 337379,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let querySet50 = device0.createQuerySet({type: 'occlusion', count: 309});
+try {
+buffer9.unmap();
+} catch {}
+try {
+  await buffer20.mapAsync(GPUMapMode.WRITE, 29544, 6908);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer17, 33064, buffer18, 79996, 5056);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 38540, new Int16Array(16196), 4173, 1004);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 128, y: 8 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView119 = texture34.createView({label: '\u0887\u16e5\u{1f85c}\u{1fd68}\u0b22\u253e\u86d4\u8a28', format: 'r8sint'});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({
+  label: '\u6ab6\u4d61\u0587\u6875\ua8bd\u5e24\u0b02\u9c8f\uad38',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder21.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer9, 'uint32', 89524, 8018);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer20, 28004, buffer13, 69568, 21716);
+dissociateBuffer(device0, buffer20);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 207 widthInBlocks: 207 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 90531 */
+  offset: 90531,
+  buffer: buffer5,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 92, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 207, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline89 = await device0.createComputePipelineAsync({
+  label: '\uf178\u324a\ua7a4\u01bc\u964c',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\u0595\ua37e\u3954\u0a0a\uc604\u02c2',
+  entries: [
+    {
+      binding: 1097,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1041,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 7893,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout13 = device0.createPipelineLayout({label: '\uf59a\u4c46', bindGroupLayouts: [bindGroupLayout16, bindGroupLayout15, bindGroupLayout4]});
+let buffer22 = device0.createBuffer({
+  label: '\u0ef4\u07f8\ud73c\u9a5d',
+  size: 73745,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder100 = device0.createCommandEncoder({label: '\ud683\ub321\u3663\u6e45\u{1f952}'});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u0cd4\ubed0\ud778\u0885\u{1fad1}\u55e1\u727e\u{1fc33}\u{1ff87}',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let externalTexture31 = device0.importExternalTexture({
+  label: '\u{1f618}\u{1fe08}\u{1fbf4}\u0a54\ue1fa\u0645\uf5ab',
+  source: video9,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder12.setBindGroup(4, bindGroup17, new Uint32Array(7989), 5109, 0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline85);
+} catch {}
+let arrayBuffer9 = buffer13.getMappedRange(111856, 153108);
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 204 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 53932 */
+  offset: 53932,
+  buffer: buffer18,
+}, {width: 51, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline90 = device0.createRenderPipeline({
+  label: '\u{1fb60}\u{1fe5c}',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'not-equal', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 1823805136,
+    stencilWriteMask: 1961957825,
+    depthBiasSlopeScale: 600.7151387192414,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x4', offset: 48, shaderLocation: 11},
+          {format: 'uint8x4', offset: 2304, shaderLocation: 7},
+          {format: 'float32x3', offset: 37384, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 6048, shaderLocation: 9},
+          {format: 'uint8x4', offset: 6360, shaderLocation: 1},
+          {format: 'sint32x2', offset: 7592, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 2252, shaderLocation: 3},
+          {format: 'uint32x2', offset: 12048, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 14488,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 2400, shaderLocation: 8},
+          {format: 'sint32', offset: 20, shaderLocation: 2},
+          {format: 'sint16x4', offset: 296, shaderLocation: 6},
+          {format: 'sint16x4', offset: 1276, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 11760, shaderLocation: 15},
+          {format: 'float16x4', offset: 856, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 2240, shaderLocation: 13},
+          {format: 'sint8x4', offset: 3280, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let bindGroupLayout24 = pipeline70.getBindGroupLayout(1);
+let querySet51 = device0.createQuerySet({label: '\u0b7f\uf156\u048c\ub852\ub912\uaba2\u1edf\u{1f976}\u{1fd0e}', type: 'occlusion', count: 3088});
+let textureView120 = texture5.createView({
+  label: '\u{1ff2a}\u8bd0\u80d0\u4bd6\ub9b2\uf75e\ufdb5\u{1ff31}\ub5de\ue745\u{1fecc}',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined], stencilReadOnly: true});
+let sampler46 = device0.createSampler({
+  label: '\u0af7\u0258\ufb0a\u0ea6\u{1fc12}\ue47d\u8e1b\u022e\u9ae7',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 31.17,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder45.setIndexBuffer(buffer7, 'uint16', 80924, 89119);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(4, buffer9, 11456, 115988);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 316 widthInBlocks: 79 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1980 */
+  offset: 1664,
+  buffer: buffer6,
+}, {width: 79, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet8, 1181, 398, buffer3, 28672);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 304, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 4901729 */
+{offset: 261, bytesPerRow: 902, rowsPerImage: 286}, {width: 201, height: 0, depthOrArrayLayers: 20});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(641, 999);
+let commandBuffer24 = commandEncoder66.finish();
+let texture58 = device0.createTexture({
+  label: '\u{1f95e}\u80e5\u2c28\uf53d',
+  size: {width: 40},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+});
+let externalTexture32 = device0.importExternalTexture({
+  label: '\u{1f911}\uc95d\ua1b7\u0d47\u{1fb10}\u{1faaa}\u0bfd\u3a6d',
+  source: video8,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup17, new Uint32Array(9259), 6722, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer8, 'uint16', 604, 504);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5, buffer16, 63164, 16390);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet15, 1038, 635, buffer22, 52992);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame9 = videoFrame8.clone();
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3747,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 6991,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet52 = device0.createQuerySet({label: '\u09bc\ufdb8', type: 'occlusion', count: 1395});
+let computePassEncoder37 = commandEncoder2.beginComputePass({label: '\u7189\u0cbc\u6775\u0c4a\uf86b\u0b0b\uc4ad\u0984'});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+try {
+commandEncoder89.copyBufferToBuffer(buffer5, 35960, buffer4, 172144, 1240);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+renderBundleEncoder18.insertDebugMarker('\u0ac0');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 18, y: 28 },
+  flipY: false,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video11 = await videoWithData();
+let commandEncoder101 = device0.createCommandEncoder({label: '\u{1fdd2}\u70cd\u{1fc63}\ud677\u{1f760}\u7406\u{1f73c}\u5a0c\u9f01\ua021\u13f0'});
+let texture59 = device0.createTexture({
+  label: '\u358e\u{1ff3a}\u014a',
+  size: {width: 320, height: 1, depthOrArrayLayers: 101},
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+try {
+computePassEncoder25.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline91 = device0.createComputePipeline({
+  label: '\ub3e4\u11cb\u{1f981}\udb5e\u{1ff54}\u48ea',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline92 = await device0.createRenderPipelineAsync({
+  label: '\u{1fbf7}\u7cab\ucdf4',
+  layout: pipelineLayout7,
+  multisample: {mask: 0x8e24e0d8},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb'}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2136, attributes: [{format: 'float32x4', offset: 244, shaderLocation: 15}]},
+      {
+        arrayStride: 4184,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 276, shaderLocation: 5},
+          {format: 'uint32x2', offset: 720, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw'},
+});
+let imageData13 = new ImageData(240, 204);
+let shaderModule20 = device0.createShaderModule({
+  code: `@group(1) @binding(1133)
+var<storage, read_write> function19: array<u32>;
+@group(2) @binding(56)
+var<storage, read_write> n14: array<u32>;
+@group(3) @binding(1084)
+var<storage, read_write> function20: array<u32>;
+@group(2) @binding(2129)
+var<storage, read_write> parameter13: array<u32>;
+@group(2) @binding(3674)
+var<storage, read_write> n15: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3<f32>,
+  @location(2) f1: vec4<i32>,
+  @location(4) f2: vec4<i32>,
+  @location(0) f3: vec4<f32>,
+  @location(1) f4: vec4<f32>,
+  @location(3) f5: vec4<f32>,
+  @location(5) f6: i32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer23 = device0.createBuffer({size: 153813, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let querySet53 = device0.createQuerySet({label: '\ub0be\uc6b7\u2909\u48ee\u{1f7ec}\u6ae7\u7cdf', type: 'occlusion', count: 2736});
+let sampler47 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 11.35,
+  lodMaxClamp: 98.13,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder18.dispatchWorkgroups(5, 1, 5);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer9, 0, 121575);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 303184, new Int16Array(20759), 2615, 8656);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas13.getContext('webgl2');
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder();
+let textureView121 = texture8.createView({label: '\u9d78\u8d56\u4426\u041e\u05b0\u01d4\ua1e3\u62e4\u2c08\u9bd3\u4d1b'});
+let renderBundle67 = renderBundleEncoder45.finish({});
+try {
+renderBundleEncoder35.setVertexBuffer(3, buffer21, 180000, 34953);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 288 widthInBlocks: 72 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27508 */
+  offset: 27508,
+  buffer: buffer18,
+}, {width: 72, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\uc37b');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  label: '\u0546\u067e\u{1fcea}\u597c\u{1fa63}\u6c41\u6ae4\u1eb6\ud9f1\u336b',
+  layout: bindGroupLayout10,
+  entries: [],
+});
+let textureView122 = texture56.createView({});
+try {
+renderBundleEncoder46.setBindGroup(1, bindGroup15, new Uint32Array(9099), 8527, 0);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13732 */
+  offset: 13732,
+  buffer: buffer18,
+}, {width: 18, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 151, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 123 */
+{offset: 123}, {width: 141, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(436, 1023);
+let commandEncoder103 = device0.createCommandEncoder({});
+let querySet54 = device0.createQuerySet({label: '\u{1f7d3}\u619a\u0662\uee9f\ud81f', type: 'occlusion', count: 1333});
+let texture60 = device0.createTexture({
+  label: '\u0794\ue69c\u0d51\u0658\u{1fe0e}\u06d0\u{1fbc3}\uab56\u6267\u094d',
+  size: [320, 1, 1],
+  sampleCount: 4,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView123 = texture47.createView({
+  label: '\uf71f\u769f\u{1ff72}\u{1f71f}',
+  dimension: '2d-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({
+  label: '\uc572\ud623\u{1ff0b}\u{1ff7f}\uaddc\u0589\u86c4\u0ba7\u0659',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  depthReadOnly: true,
+});
+try {
+commandEncoder42.copyBufferToBuffer(buffer5, 91112, buffer4, 143796, 4208);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline93 = await device0.createRenderPipelineAsync({
+  label: '\u{1f92d}\ua683',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rgba8sint'}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 228,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 8, shaderLocation: 1},
+          {format: 'sint8x4', offset: 32, shaderLocation: 6},
+          {format: 'sint8x4', offset: 20, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 5172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 1232, shaderLocation: 8},
+          {format: 'float16x4', offset: 252, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32x3', offset: 5736, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 14788, shaderLocation: 13},
+          {format: 'uint8x2', offset: 744, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 8148, shaderLocation: 2},
+          {format: 'sint8x4', offset: 26748, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1968,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 336, shaderLocation: 9},
+          {format: 'float32x2', offset: 180, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 24448,
+        attributes: [
+          {format: 'float16x2', offset: 6536, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 4564, shaderLocation: 12},
+          {format: 'float32', offset: 7964, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let imageBitmap7 = await createImageBitmap(offscreenCanvas1);
+let bindGroup19 = device0.createBindGroup({
+  label: '\u0185\u5f56\u0dfe\u4ae4\u{1f78f}\u{1fb50}\ub1d6\u7fbc\ufdef\u7aba\u37f8',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let texture61 = device0.createTexture({
+  label: '\u{1f6de}\u{1f95e}',
+  size: [80],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderBundleEncoder35.setVertexBuffer(10, buffer22, 35028, 7685);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 399, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 214148, new BigUint64Array(22860), 853, 6112);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder({label: '\u{1f9da}\ud2f8'});
+let texture62 = device0.createTexture({
+  label: '\u023d\u{1f8c4}\u7f37\u726a\u0821\u{1f635}\ua034\u0819\u0012',
+  size: [160],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8unorm'],
+});
+let computePassEncoder38 = commandEncoder94.beginComputePass({label: '\uc466\u8e1b\u0585\u{1f84e}\u39bd\u6243\u0bfc'});
+try {
+computePassEncoder29.setPipeline(pipeline17);
+} catch {}
+let arrayBuffer10 = buffer13.getMappedRange(264968, 101120);
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 27, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer8), /* required buffer size: 426 */
+{offset: 426}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline94 = await device0.createRenderPipelineAsync({
+  label: '\ue4d8\u095d\uefd8\u{1f782}\u0dce\u0e07\u5ef6\u26cb\u1378\u090f\u0be8',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 21500, stepMode: 'instance', attributes: []},
+      {arrayStride: 7928, stepMode: 'instance', attributes: []},
+      {arrayStride: 6520, attributes: []},
+      {arrayStride: 4836, attributes: [{format: 'sint8x4', offset: 236, shaderLocation: 0}]},
+    ],
+  },
+});
+try {
+  await promise3;
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({
+  label: '\uc8cc\u702f\ue369\u85e6\u417c\u{1ffe8}\u7eeb\u0f26',
+  bindGroupLayouts: [bindGroupLayout23, bindGroupLayout17, bindGroupLayout3],
+});
+let commandEncoder105 = device0.createCommandEncoder();
+let renderBundle68 = renderBundleEncoder33.finish({label: '\uac10\u09e8\uc03e\u3ef6\u0bb8\u26f5\u2dd7\u2a0f\u3c82\u{1f931}'});
+try {
+renderBundleEncoder44.setBindGroup(2, bindGroup17, new Uint32Array(8697), 2755, 0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer21, 0, 258860);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3308 widthInBlocks: 827 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1700 */
+  offset: 1700,
+  buffer: buffer18,
+}, {width: 827, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer6, 145756);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer22]);
+} catch {}
+let canvas11 = document.createElement('canvas');
+let commandEncoder106 = device0.createCommandEncoder({});
+let computePassEncoder39 = commandEncoder75.beginComputePass();
+let renderBundle69 = renderBundleEncoder8.finish({label: '\u0fe6\u0e79\u{1fd19}\u07e8\u{1fd82}\u0932\u{1f7c9}\u0467\u{1f6fd}\ude2d'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup10, new Uint32Array(3351), 2107, 0);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(1, bindGroup13, new Uint32Array(5045), 2940, 0);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer23, 89408, buffer6, 10652, 47836);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet25, 3101, 40, buffer23, 128256);
+} catch {}
+let pipeline95 = device0.createRenderPipeline({
+  label: '\ue359\u{1f77a}\uf88f\u{1ff61}\u{1fed6}\u0440',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0x2d19c9f0},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rgba8unorm-srgb', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 2935713916,
+    stencilWriteMask: 2171404488,
+    depthBias: -1617356040,
+    depthBiasClamp: 569.3308790886833,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 24152,
+        attributes: [
+          {format: 'float32x4', offset: 11328, shaderLocation: 14},
+          {format: 'float32x2', offset: 1280, shaderLocation: 13},
+          {format: 'uint32x3', offset: 2940, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 4032, shaderLocation: 1},
+          {format: 'uint32x4', offset: 12548, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 4416, shaderLocation: 8},
+          {format: 'uint16x2', offset: 2124, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 1252, shaderLocation: 11},
+          {format: 'float16x4', offset: 8912, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 8108, attributes: []},
+      {
+        arrayStride: 21632,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 2016, shaderLocation: 10}],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 12820, attributes: [{format: 'uint32x2', offset: 5144, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let canvas12 = document.createElement('canvas');
+let commandEncoder107 = device0.createCommandEncoder();
+let computePassEncoder40 = commandEncoder83.beginComputePass({label: '\u3bf1\u3a18\u0ac6\u0cb0\ua7f8\uf379\u1a68\u{1faa4}\u2bbd\u{1fb98}'});
+try {
+computePassEncoder18.dispatchWorkgroups(2, 1, 2);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet37, 1293, 206, buffer1, 157952);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer4), /* required buffer size: 367 */
+{offset: 367}, {width: 32, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline96 = device0.createComputePipeline({layout: pipelineLayout14, compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}}});
+canvas4.height = 1194;
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\u2476\u{1fa85}\u{1f74e}\u489a\u6664',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+let externalTexture33 = device0.importExternalTexture({source: video7, colorSpace: 'srgb'});
+try {
+renderBundleEncoder39.setVertexBuffer(9, buffer21);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 50, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline97 = await device0.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}}});
+gc();
+let img15 = await imageWithData(188, 37, '#2ae47b23', '#4c18e30f');
+let buffer24 = device0.createBuffer({
+  label: '\u02d5\u2407\u0a1c\u044c\u{1f7cd}\u{1f943}\u85ec\ub47f\u0a72\uc886',
+  size: 57138,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 82, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 149, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 167, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: img13,
+  origin: { x: 7, y: 15 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas10);
+let canvas13 = document.createElement('canvas');
+let videoFrame10 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let buffer25 = device0.createBuffer({
+  label: '\u6e3c\u0c53\u0aa8\u98ac\u8c37\u0cb9',
+  size: 111076,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView124 = texture39.createView({
+  label: '\u7f7e\u{1fe99}\u4d67\u{1fc3f}\u8f42\u807c\u071e\u{1fbec}\u{1f68b}\u26de',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+});
+let computePassEncoder41 = commandEncoder35.beginComputePass({label: '\u{1fa89}\uf16f\u{1fa0d}\u042c\u153f\ue414\u03fb'});
+let externalTexture34 = device0.importExternalTexture({source: video7, colorSpace: 'srgb'});
+try {
+renderBundleEncoder39.setVertexBuffer(2160, undefined, 0, 3100045542);
+} catch {}
+try {
+  await buffer25.mapAsync(GPUMapMode.READ, 0, 40352);
+} catch {}
+let imageBitmap8 = await createImageBitmap(imageData6);
+try {
+externalTexture4.label = '\u350d\u{1fb1e}\u8fce';
+} catch {}
+let shaderModule21 = device0.createShaderModule({
+  label: '\u{1ffd9}\u9934\ubd4e',
+  code: `@group(3) @binding(1133)
+var<storage, read_write> n16: array<u32>;
+@group(2) @binding(1133)
+var<storage, read_write> global12: array<u32>;
+@group(4) @binding(1133)
+var<storage, read_write> local9: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: vec4<f32>,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f32>, @location(6) a1: vec4<i32>, @builtin(instance_index) a2: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let textureView125 = texture0.createView({
+  label: '\u62b5\u7f76\u{1f96f}\u{1f968}\u0354\u0b5c\ubaf7\u{1f605}\u289b\u002e',
+  baseMipLevel: 2,
+  baseArrayLayer: 119,
+  arrayLayerCount: 35,
+});
+let externalTexture35 = device0.importExternalTexture({label: '\u446d\u7e66\u0626', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder53.setVertexBuffer(3, buffer16, 0, 50667);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer2, 28100, buffer13, 416436, 2976);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 198240, new BigUint64Array(56875), 32494, 3796);
+} catch {}
+let pipeline98 = device0.createComputePipeline({
+  label: '\uc993\uc2b8\u{1ffe2}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let canvas14 = document.createElement('canvas');
+let commandEncoder108 = device0.createCommandEncoder({label: '\u180a\u0e55\u{1f9d3}\ub640\u07e6\u25ac\ubace\u0d78\u{1fa25}\uefd5'});
+let texture63 = device0.createTexture({
+  label: '\u2723\u3eec\uc473\u0749\u6824',
+  size: {width: 1152},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({
+  label: '\uf6c1\u{1feb6}\u0b12\ubfe4',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let sampler48 = device0.createSampler({
+  label: '\ud6c7\u0350\u0039\ub463',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.16,
+  maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder41.setIndexBuffer(buffer8, 'uint16', 1272);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline93);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(1, buffer21);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+try {
+computePassEncoder20.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 4188 widthInBlocks: 1047 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 82176 */
+  offset: 82176,
+  buffer: buffer16,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1047, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+canvas13.getContext('bitmaprenderer');
+} catch {}
+let textureView126 = texture12.createView({
+  label: '\u09f0\u{1fba5}\u00c9\u0d19\u609d\u0a8e\u{1ff59}',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder42 = commandEncoder16.beginComputePass({label: '\u0db0\u981a\u{1fce2}'});
+let externalTexture36 = device0.importExternalTexture({
+  label: '\u3acc\u{1fd68}\u3095\uc045\u{1fed2}\u8932\u7153\u096d',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 180 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 136352 */
+  offset: 27628,
+  bytesPerRow: 256,
+  rowsPerImage: 212,
+  buffer: buffer23,
+}, {
+  texture: texture33,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 45, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(querySet12, 456, 169, buffer1, 395008);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 24996, new DataView(new ArrayBuffer(22595)), 18572, 92);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas7,
+  origin: { x: 8, y: 14 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline99 = device0.createComputePipeline({
+  label: '\u85fa\u{1fa1b}\u0a64\u{1f9c3}\u91b6',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+try {
+window.someLabel = renderBundle5.label;
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup10);
+} catch {}
+let arrayBuffer11 = buffer11.getMappedRange(0, 2408);
+try {
+device0.queue.writeBuffer(buffer18, 99696, new Int16Array(22738), 5511, 3328);
+} catch {}
+let pipeline100 = await promise14;
+let gpuCanvasContext12 = canvas14.getContext('webgpu');
+let textureView127 = texture33.createView({baseMipLevel: 1, mipLevelCount: 3, arrayLayerCount: 1});
+let sampler49 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 96.32,
+  lodMaxClamp: 97.36,
+});
+try {
+computePassEncoder30.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 388 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1348 */
+  offset: 1348,
+  buffer: buffer5,
+}, {
+  texture: texture33,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 97, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder90.resolveQuerySet(querySet34, 96, 227, buffer0, 150784);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({label: '\u19c4\uf5af\u0994\u040b\u0d46\u0559'});
+try {
+renderBundleEncoder51.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 39 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 65918 */
+  offset: 65918,
+  buffer: buffer2,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder108.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 14824, new Int16Array(2865), 1265, 60);
+} catch {}
+let pipeline101 = await device0.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}}});
+let pipeline102 = await device0.createRenderPipelineAsync({
+  label: '\u0387\u{1f822}\u0b56\u9018\u{1fd42}\ucd43\uef18\u2164\u27e8',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha'},
+  },
+}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'zero'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilWriteMask: 2426980816,
+    depthBias: 345598186,
+    depthBiasSlopeScale: 722.577314625424,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9160,
+        attributes: [
+          {format: 'uint8x2', offset: 6152, shaderLocation: 9},
+          {format: 'float32', offset: 1500, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 4584, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4060,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 72, shaderLocation: 13},
+          {format: 'float32x3', offset: 844, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 6516,
+        attributes: [
+          {format: 'uint32x2', offset: 988, shaderLocation: 15},
+          {format: 'sint8x2', offset: 854, shaderLocation: 11},
+          {format: 'uint32x4', offset: 2520, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 4220, shaderLocation: 2},
+          {format: 'sint32x3', offset: 760, shaderLocation: 5},
+          {format: 'uint8x2', offset: 198, shaderLocation: 8},
+          {format: 'sint8x4', offset: 1280, shaderLocation: 14},
+          {format: 'sint32', offset: 560, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 2916, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 416, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 37632,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 29560, shaderLocation: 6}],
+      },
+      {arrayStride: 5000, attributes: [{format: 'sint32', offset: 128, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+let offscreenCanvas15 = new OffscreenCanvas(617, 549);
+try {
+canvas12.getContext('webgl');
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  label: '\u{1f912}\ucfc1\udca9\uf6c1',
+  layout: bindGroupLayout17,
+  entries: [{binding: 6817, resource: externalTexture33}],
+});
+let commandEncoder111 = device0.createCommandEncoder({label: '\u4819\u00c6\u0fbe\u3391\ue540\uab61\u1edf\u1dce\u5cc7\u086f\u08e0'});
+let commandBuffer25 = commandEncoder93.finish({label: '\u88ea\u821f\u0c23\u03e8\u1bff\uca5f\u4651\u05b8\uf007'});
+let texture64 = device0.createTexture({
+  label: '\u32fb\ue18d',
+  size: [288, 1, 127],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder101.copyBufferToBuffer(buffer8, 52, buffer6, 87708, 96);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 628 widthInBlocks: 157 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28264 */
+  offset: 27636,
+  bytesPerRow: 768,
+  buffer: buffer18,
+}, {width: 157, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer25, commandBuffer23, commandBuffer16]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(72)), /* required buffer size: 458 */
+{offset: 458}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let querySet55 = device0.createQuerySet({type: 'occlusion', count: 2747});
+let texture65 = device0.createTexture({
+  label: '\u37d2\u{1f9ac}\u0004\u0718\u0170\u074b\ud1af\u3d02\u525c\ub744',
+  size: {width: 144, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  label: '\u0984\ua06c\u6aee\ud349',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup5, new Uint32Array(391), 143, 0);
+} catch {}
+try {
+buffer8.destroy();
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer2, 13744, buffer25, 105068, 948);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+commandEncoder106.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let pipeline103 = await promise15;
+let commandEncoder112 = device0.createCommandEncoder({label: '\ue852\u296a\u0c18\u98dc'});
+let textureView128 = texture23.createView({label: '\u08e6\u4b68'});
+let computePassEncoder43 = commandEncoder104.beginComputePass({label: '\u018e\ua5cb\u0ea6\uee49\u00cd\uf7bb\u{1fe3f}\u099d\u615c\u{1fe5f}'});
+try {
+commandEncoder59.resolveQuerySet(querySet37, 1351, 264, buffer3, 15616);
+} catch {}
+try {
+device0.queue.submit([commandBuffer24]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 432724, new BigUint64Array(37209), 7291, 0);
+} catch {}
+let texture66 = device0.createTexture({
+  label: '\u37b9\u{1f8fc}\u4d33\uc850',
+  size: [1152],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder44 = commandEncoder107.beginComputePass({label: '\u0d41\ud729\u{1f62b}\u07b5\u021f\u4294\u152e\u{1ff60}\u2507'});
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 38},
+  aspect: 'all',
+}, new ArrayBuffer(61702576), /* required buffer size: 61702576 */
+{offset: 823, bytesPerRow: 3651, rowsPerImage: 43}, {width: 219, height: 1, depthOrArrayLayers: 394});
+} catch {}
+let bindGroupLayout26 = pipeline2.getBindGroupLayout(0);
+let textureView129 = texture38.createView({label: '\u{1f64a}\u{1fa05}\u723a\u0991\u0dbc\u4214\u{1f962}\u{1f8eb}', baseMipLevel: 0});
+try {
+computePassEncoder37.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer9, 0, 114124);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder62.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 150, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 13 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 73978 */
+  offset: 73978,
+  bytesPerRow: 256,
+  buffer: buffer18,
+}, {width: 13, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer4, 367008);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder109.resolveQuerySet(querySet4, 1340, 770, buffer0, 138240);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 29, y: 0, z: 3},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(32)), /* required buffer size: 733850 */
+{offset: 284, bytesPerRow: 1303, rowsPerImage: 281}, {width: 80, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let pipeline104 = await device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext13 = offscreenCanvas15.getContext('webgpu');
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+canvas11.getContext('webgl2');
+} catch {}
+let buffer26 = device0.createBuffer({
+  label: '\ueb95\u{1fcbe}\u7c86\u9d29\u0778\u7985\u3206\u03f3\u{1f781}\u7c97',
+  size: 105558,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView130 = texture6.createView({
+  label: '\u{1f739}\u084c\u0ec1\uf171\u0811\u{1f85f}\u2e8f\u{1f73a}\u8194\u{1f77b}\u0bef',
+  dimension: '1d',
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\u5b7e\u0bf6\ud028\ua337\u{1f9da}\u53c0\u{1ff74}\ud6e0\u{1fe47}\u0f99',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+});
+let renderBundle70 = renderBundleEncoder11.finish({label: '\u0301\u04e8\u1e10\u205e\u043a\uaf7b\uf141\u{1f774}\u5a36'});
+let externalTexture37 = device0.importExternalTexture({
+  label: '\u{1feb2}\ucab2\u27db\u091f\u2277\u61bf\u{1ff49}\u0e71',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder18.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline89);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(2, buffer9, 42948, 70077);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 392 widthInBlocks: 98 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 100392 */
+  offset: 100000,
+  buffer: buffer18,
+}, {width: 98, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 532 */
+{offset: 532}, {width: 133, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  label: '\u0c1c\u0d11',
+  entries: [
+    {binding: 1650, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 1864,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 2910, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder113 = device0.createCommandEncoder();
+let computePassEncoder45 = commandEncoder102.beginComputePass();
+let renderBundle71 = renderBundleEncoder22.finish({label: '\u07b7\u4505\u0543\u{1f959}\u79eb\ud8fd\u{1f702}\ud55e\u1c92\u{1f605}'});
+try {
+renderBundleEncoder49.setVertexBuffer(0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 8, y: 50 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas14.getContext('webgpu');
+canvas13.width = 101;
+let imageBitmap9 = await createImageBitmap(canvas13);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder();
+let computePassEncoder46 = commandEncoder108.beginComputePass({});
+let externalTexture38 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderBundleEncoder53.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(322573246, 705983561, 713229566, -913315130, 77483570);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline85);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet54, 488, 462, buffer22, 49152);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 6532, new BigUint64Array(7303), 3850, 376);
+} catch {}
+let pipeline105 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb'}, {format: 'rgba8sint'}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8sint'}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11336,
+        attributes: [
+          {format: 'uint8x2', offset: 956, shaderLocation: 13},
+          {format: 'sint32x3', offset: 1996, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 154, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 2414, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 3432, shaderLocation: 6},
+          {format: 'sint16x2', offset: 1812, shaderLocation: 4},
+          {format: 'sint32x2', offset: 592, shaderLocation: 14},
+          {format: 'uint32x3', offset: 236, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 3388,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 520, shaderLocation: 3},
+          {format: 'float16x2', offset: 1288, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 3996,
+        attributes: [
+          {format: 'uint32x2', offset: 1136, shaderLocation: 15},
+          {format: 'uint32', offset: 316, shaderLocation: 8},
+          {format: 'sint8x2', offset: 468, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 2012, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 6452, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5544,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1224, shaderLocation: 10},
+          {format: 'sint16x4', offset: 1000, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let commandEncoder115 = device0.createCommandEncoder();
+let renderBundleEncoder57 = device0.createRenderBundleEncoder({
+  label: '\u178a\u028f\ub0d0\u5712\u8d06\u6c81\u02c7\u{1fb6f}\u0491',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer19, 48924);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer8, 764, buffer25, 35900, 296);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer25);
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({
+  label: '\uecc3\u5600\u5c27\u0199\u009a\u0ce4\u798e',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout8, bindGroupLayout26, bindGroupLayout25],
+});
+let commandEncoder116 = device0.createCommandEncoder();
+let textureView131 = texture45.createView({label: '\u8a64\udb29\uc747\u0e44\u8069\u0727', arrayLayerCount: 1});
+let computePassEncoder47 = commandEncoder9.beginComputePass({label: '\u1d96\u7543\ub57d\u{1f9ce}\u73a5'});
+try {
+computePassEncoder32.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer19, 5956);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer21, 25412);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer8, 'uint32', 136, 1235);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer22, 31944, 29096);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: img5,
+  origin: { x: 3, y: 92 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas5.width = 904;
+let textureView132 = texture42.createView({label: '\ua2ab\ufbfa', dimension: '2d-array'});
+let renderBundle72 = renderBundleEncoder6.finish();
+try {
+computePassEncoder3.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder49.draw(428713203);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(1015576835, 639770212, 1164303794, -528531578, 402036929);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer21, 143212);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer8, 'uint16', 406);
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(buffer10, 87136, buffer4, 318772, 588);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet40, 1801, 500, buffer0, 17920);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 55604, new Int16Array(41347), 26878, 2912);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 895 */
+{offset: 895}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 2, y: 37 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline106 = device0.createRenderPipeline({
+  label: '\ue9df\u87e8\u1bc4\u4f29\ua228\u4356\ub384',
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0x28f6c50e},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'keep'},
+    stencilBack: {depthFailOp: 'keep', passOp: 'increment-clamp'},
+    stencilWriteMask: 2682325678,
+    depthBias: 0,
+    depthBiasSlopeScale: 287.5170699549022,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 2108, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10808,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 1208, shaderLocation: 10}],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 10156, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder117 = device0.createCommandEncoder({label: '\u{1ff8a}\ud650\u{1fb75}\u0e96\u0078\u8f5d\u3919\u1260'});
+let textureView133 = texture8.createView({label: '\u0c42\u0c1d\u0e0d\u{1f9b5}\u{1fdca}\u{1feee}\ubc52', aspect: 'all'});
+let externalTexture39 = device0.importExternalTexture({label: '\uc538\u{1f7ea}\udb34\u3cd5\u089f\u0852\u7a69', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let img16 = await imageWithData(95, 270, '#1f3242b7', '#4df40c7f');
+let texture67 = device0.createTexture({
+  label: '\u{1fd7f}\uf669\ud82d\uc45f\u0ecf\u3505',
+  size: {width: 288, height: 1, depthOrArrayLayers: 1259},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let renderBundle73 = renderBundleEncoder22.finish();
+try {
+computePassEncoder5.setBindGroup(4, bindGroup8, new Uint32Array(1303), 750, 0);
+} catch {}
+try {
+computePassEncoder14.dispatchWorkgroups(5, 1);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline44);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup14, new Uint32Array(3997), 330, 0);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 84216 */
+  offset: 84216,
+  rowsPerImage: 61,
+  buffer: buffer16,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 49380, new BigUint64Array(35627), 33894, 564);
+} catch {}
+let pipeline107 = await device0.createRenderPipelineAsync({
+  label: '\u887b\u{1ffd3}',
+  layout: pipelineLayout0,
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 218071961,
+    stencilWriteMask: 3066963,
+    depthBiasClamp: 886.71551363551,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6372,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1292, shaderLocation: 0},
+          {format: 'uint8x4', offset: 200, shaderLocation: 13},
+          {format: 'float32x2', offset: 2164, shaderLocation: 9},
+          {format: 'sint32x4', offset: 928, shaderLocation: 11},
+          {format: 'sint8x4', offset: 592, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+offscreenCanvas13.width = 541;
+let imageData14 = new ImageData(40, 12);
+let bindGroup21 = device0.createBindGroup({
+  label: '\u07d7\ue0ee',
+  layout: bindGroupLayout1,
+  entries: [{binding: 5340, resource: externalTexture0}],
+});
+let buffer27 = device0.createBuffer({
+  label: '\u{1f6ef}\uee62\u{1f7f7}\ubd08',
+  size: 54120,
+  usage: GPUBufferUsage.INDEX,
+  mappedAtCreation: true,
+});
+let commandEncoder118 = device0.createCommandEncoder({label: '\u59d3\u{1fadc}\ubc81\u0547\u094f\u0e0a'});
+let computePassEncoder48 = commandEncoder48.beginComputePass({label: '\u0720\u0278\u0f3f\ub43f\u0d48\u2a91\u8f1a\u6f93\u2499'});
+try {
+renderBundleEncoder51.setBindGroup(4, bindGroup14, new Uint32Array(6241), 4774, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(556527319, 69485858);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer8, 'uint16', 706, 556);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(3, buffer9);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32152 */
+  offset: 32152,
+  buffer: buffer6,
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap10 = await createImageBitmap(video0);
+try {
+adapter1.label = '\udaaf\u09a5\u0793\u{1f64a}\u7735\u6806\ub8a5';
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({label: '\u0563\u391f\udc69\u{1ff2b}\u0ccd'});
+let textureView134 = texture0.createView({
+  label: '\u0f07\ubb74\ucd59\u{1f7df}\u5096\u6865\u{1fce1}\u0493\u91cb\uc72e',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 131,
+  arrayLayerCount: 17,
+});
+let computePassEncoder49 = commandEncoder100.beginComputePass({});
+let sampler50 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 20.87,
+  lodMaxClamp: 90.93,
+  compare: 'never',
+});
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer5, 4976);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer5, 30484);
+} catch {}
+let promise17 = device0.popErrorScope();
+try {
+commandEncoder101.copyBufferToBuffer(buffer8, 220, buffer25, 1400, 1180);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet2, 145, 1147, buffer23, 66304);
+} catch {}
+try {
+renderBundleEncoder39.insertDebugMarker('\u01f9');
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({label: '\u76f8\u786a\u4f7a\u9586\u0314\ua906'});
+let textureView135 = texture9.createView({dimension: '2d-array', baseMipLevel: 4});
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder49.draw(807990296, 482567120);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer7);
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet23, 782, 662, buffer22, 35584);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 99404, new Int16Array(12537), 10407, 268);
+} catch {}
+try {
+  await promise17;
+} catch {}
+try {
+window.someLabel = externalTexture36.label;
+} catch {}
+let shaderModule22 = device0.createShaderModule({
+  label: '\u218e\ubfa3',
+  code: `@group(3) @binding(1084)
+var<storage, read_write> type9: array<u32>;
+@group(2) @binding(56)
+var<storage, read_write> type10: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: vec2<f32>,
+  @location(3) f3: vec4<f32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(12) f0: vec2<i32>,
+  @location(2) f1: vec3<f32>,
+  @location(5) f2: vec3<u32>,
+  @builtin(vertex_index) f3: u32,
+  @location(11) f4: vec2<f16>,
+  @location(1) f5: vec2<i32>,
+  @location(10) f6: u32,
+  @location(3) f7: vec4<i32>,
+  @location(4) f8: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: f32, @location(8) a1: vec3<u32>, @location(9) a2: f32, a3: S14, @location(6) a4: vec4<f16>, @location(13) a5: vec4<u32>, @location(14) a6: vec3<f32>, @location(15) a7: vec3<f32>, @location(7) a8: vec3<f16>, @builtin(instance_index) a9: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let buffer28 = device0.createBuffer({
+  label: '\u{1f876}\u055c\u09dd\u5fdc\u957f\u{1f8b0}\u006c\u0fdc\u0012\u7421\u0073',
+  size: 33673,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let textureView136 = texture21.createView({label: '\u092d\u09e7\u{1f81e}\u143b\u76de', baseArrayLayer: 0});
+let sampler51 = device0.createSampler({
+  label: '\u{1fe66}\u0736\u{1fc82}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 53.62,
+  lodMaxClamp: 84.36,
+});
+try {
+computePassEncoder14.dispatchWorkgroupsIndirect(buffer19, 532624);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(3, bindGroup13, new Uint32Array(3037), 1385, 0);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 19792 */
+  offset: 19792,
+  rowsPerImage: 126,
+  buffer: buffer2,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder118.clearBuffer(buffer6, 93244);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder99.resolveQuerySet(querySet23, 575, 154, buffer23, 51968);
+} catch {}
+canvas14.width = 609;
+let buffer29 = device0.createBuffer({
+  label: '\u{1fd24}\u06fd\u4676\u{1f6a0}',
+  size: 241739,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder121 = device0.createCommandEncoder({label: '\u022f\u{1fcb8}\u{1f631}\u0c86\u4c09\u0e0f\ubd39\u10ea\u08df\u{1f8a6}'});
+let externalTexture40 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'display-p3'});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup11, new Uint32Array(9016), 7695, 0);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline34);
+} catch {}
+let buffer30 = device0.createBuffer({size: 29824, usage: GPUBufferUsage.UNIFORM});
+let textureView137 = texture12.createView({
+  label: '\u2354\u0a9c\uc0a7\u0ece\u09dd\u005a',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let computePassEncoder50 = commandEncoder117.beginComputePass({label: '\ue533\u03bb\u{1fb7b}'});
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup14, new Uint32Array(9832), 2300, 0);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer19, 188816);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 37784 */
+  offset: 37784,
+  buffer: buffer23,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 261, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3472 widthInBlocks: 217 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 7232 */
+  offset: 3760,
+  buffer: buffer18,
+}, {width: 217, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet12, 840, 381, buffer3, 11520);
+} catch {}
+let pipeline108 = device0.createRenderPipeline({
+  label: '\ub229\u0564\u0c99',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb'}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'src'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'invert'},
+    stencilWriteMask: 390614491,
+    depthBias: 0,
+    depthBiasSlopeScale: 485.56059500297806,
+    depthBiasClamp: 892.1879437726142,
+  },
+  vertex: {module: shaderModule20, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let img17 = await imageWithData(237, 98, '#681f81ff', '#ba1bbbe0');
+let video12 = await videoWithData();
+let commandBuffer26 = commandEncoder84.finish({label: '\u{1ffc0}\u{1f92d}\u0073'});
+let texture68 = device0.createTexture({
+  size: [160, 1, 248],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView138 = texture1.createView({label: '\u01cb\ucb40\u68c2', dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\ud4ee\u52cd\u14e6\u0dbe',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer19, 23120);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 16, y: 1 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame11 = new VideoFrame(canvas0, {timestamp: 0});
+try {
+adapter2.label = '\u171a\uebd8\u038c\u0f6e\u55bc\u{1f66f}\u0f49\u0284\u71d5\u0c6a\u6770';
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\ud415\u{1fa7f}\u096a\ued59\udc49',
+  entries: [{binding: 5286, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }}],
+});
+let buffer31 = device0.createBuffer({label: '\u0b99\u833c\u072a\u9180', size: 51172, usage: GPUBufferUsage.MAP_WRITE});
+let externalTexture41 = device0.importExternalTexture({
+  label: '\u{1f711}\u0c0e\u578d\ub923\u0d88\u0099\u{1f8b5}\u{1fe01}\u0698\u721e\u7632',
+  source: videoFrame5,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline34);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 59040, new BigUint64Array(55105), 29528, 1608);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 47},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer2), /* required buffer size: 3657706 */
+{offset: 110, bytesPerRow: 266, rowsPerImage: 125}, {width: 24, height: 1, depthOrArrayLayers: 111});
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(849, 898);
+let imageBitmap11 = await createImageBitmap(canvas4);
+try {
+offscreenCanvas16.getContext('webgl2');
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder();
+let textureView139 = texture17.createView({format: 'rgba32float', baseArrayLayer: 0, arrayLayerCount: 1});
+let sampler52 = device0.createSampler({
+  label: '\u16d4\udf20',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 3.003,
+  lodMaxClamp: 26.06,
+});
+try {
+renderBundleEncoder53.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(883292752, 242113126, 178076819, 567914036);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline62);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(10, buffer22, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 8, y: 408 },
+  flipY: true,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline109 = await device0.createComputePipelineAsync({
+  label: '\u3ad1\u1a9b',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+let commandEncoder123 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({
+  label: '\u6bb5\u84e8',
+  size: {width: 144, height: 1, depthOrArrayLayers: 57},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let texture70 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder51 = commandEncoder53.beginComputePass({});
+try {
+computePassEncoder25.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(1100946538, 489183091);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(8, buffer9, 15112);
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10827 */
+  offset: 10827,
+  bytesPerRow: 256,
+  rowsPerImage: 14,
+  buffer: buffer3,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer28, 9824, 19336);
+dissociateBuffer(device0, buffer28);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 48076, new DataView(new ArrayBuffer(34538)), 21406, 580);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline110 = await device0.createComputePipelineAsync({
+  label: '\u05cb\udc99\ua418\uf4f2\u0b31\u{1fbee}\uaec6',
+  layout: 'auto',
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap12 = await createImageBitmap(imageData2);
+let commandEncoder124 = device0.createCommandEncoder();
+let querySet56 = device0.createQuerySet({
+  label: '\u68ef\u09c9\uaf22\ubac2\u{1f914}\uc329\uceb7\u8909\uf2c0\u{1f7ed}',
+  type: 'occlusion',
+  count: 1856,
+});
+let textureView140 = texture46.createView({label: '\ud019\u{1f920}\uf0fe\u{1fc62}\u{1fc7f}\u44a0\u5530\u0e5e', dimension: '1d'});
+try {
+renderBundleEncoder10.drawIndexed(832311631);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer21, 337376);
+} catch {}
+try {
+commandEncoder91.resolveQuerySet(querySet19, 1767, 147, buffer16, 50688);
+} catch {}
+let buffer32 = device0.createBuffer({
+  label: '\u6a98\u0a98\u0d93\ue998\ubcf0\u{1fd4e}\u14f3\u{1fb18}\uf8fe\u93e8\u8ef0',
+  size: 200354,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture71 = device0.createTexture({
+  size: [144, 1, 315],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let textureView141 = texture56.createView({label: '\ud570\u{1fe98}\u{1fee0}\ue8d9\u{1fca2}', baseArrayLayer: 0});
+let externalTexture42 = device0.importExternalTexture({label: '\u89df\u03e0\uc41d\u0bbc\u{1f9f2}', source: video8, colorSpace: 'srgb'});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline98);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer19, 99592);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer21, 207668);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(3, buffer22, 66048, 1434);
+} catch {}
+let promise18 = buffer29.mapAsync(GPUMapMode.WRITE, 37816, 170244);
+try {
+commandEncoder109.copyBufferToBuffer(buffer16, 22216, buffer4, 33816, 63984);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14080 */
+  offset: 14080,
+  rowsPerImage: 173,
+  buffer: buffer18,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet49, 137, 27, buffer7, 134912);
+} catch {}
+let pipeline111 = await device0.createComputePipelineAsync({
+  label: '\u3263\u9d40\u3c08\u0db7\u96d2\u{1fe0b}\u0257\u032c\u4061\u0fb5',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline112 = await device0.createRenderPipelineAsync({
+  label: '\u09d3\ub642\u0be2\u{1f784}\ud015\u5822\u052d\uc2c2\u08fc',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'src-alpha'},
+  },
+}, {format: 'r8sint', writeMask: 0}, {format: 'r32sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'zero'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 3593307476,
+    stencilWriteMask: 2231764234,
+    depthBias: 1371057185,
+    depthBiasSlopeScale: 383.34506686442256,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2976,
+        attributes: [
+          {format: 'sint16x2', offset: 656, shaderLocation: 8},
+          {format: 'uint8x4', offset: 116, shaderLocation: 2},
+          {format: 'uint32x2', offset: 72, shaderLocation: 15},
+          {format: 'uint32x2', offset: 516, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1456,
+        attributes: [
+          {format: 'sint16x4', offset: 56, shaderLocation: 6},
+          {format: 'sint16x4', offset: 744, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 6864,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 1860, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+canvas8.height = 1632;
+let commandEncoder125 = device0.createCommandEncoder({label: '\u0370\u{1f87b}\u{1f9bb}\u02f3'});
+let texture72 = gpuCanvasContext7.getCurrentTexture();
+let computePassEncoder52 = commandEncoder92.beginComputePass();
+let renderBundleEncoder59 = device0.createRenderBundleEncoder({
+  label: '\u{1f698}\u80d6\u8eae',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  stencilReadOnly: true,
+});
+let externalTexture43 = device0.importExternalTexture({label: '\uf115\u53b9\ua49d', source: video6, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder10.drawIndirect(buffer5, 24744);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder72.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32956 */
+  offset: 32956,
+  buffer: buffer18,
+}, {width: 36, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: imageData14,
+  origin: { x: 3, y: 3 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+  await promise18;
+} catch {}
+offscreenCanvas7.width = 414;
+let img18 = await imageWithData(300, 144, '#4cc96949', '#ef7ceb6f');
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let buffer33 = device0.createBuffer({size: 170449, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture73 = device0.createTexture({
+  label: '\u8103\u515f\u0706\u0416\u3865\u0db7\u32a2\u1a35\u8336',
+  size: {width: 80, height: 1, depthOrArrayLayers: 130},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView142 = texture71.createView({
+  label: '\u{1f869}\uad59\u0f95\u3a33\u{1fec9}\uc9c3\u{1fc9d}\u0c40\u1e0a',
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  mipLevelCount: 1,
+  baseArrayLayer: 190,
+});
+let sampler53 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 54.72,
+  lodMaxClamp: 81.60,
+});
+try {
+computePassEncoder38.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(661322652);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(1891, undefined, 2071779903, 775261620);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas5.width = 1105;
+let commandEncoder126 = device0.createCommandEncoder();
+let textureView143 = texture12.createView({dimension: '2d-array', mipLevelCount: 3});
+let renderBundleEncoder60 = device0.createRenderBundleEncoder({
+  label: '\u06de\u{1fe6e}\u04db\u{1fd02}\u0427\u0f45\uebfe\u161b\uc48c',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle74 = renderBundleEncoder9.finish({label: '\ubd74\u06df\u30a8\u{1fe51}\u061f'});
+let sampler54 = device0.createSampler({
+  label: '\u32c0\u08df\ue08f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 53.03,
+  lodMaxClamp: 61.93,
+});
+try {
+renderBundleEncoder49.drawIndexed(943696150, 469792557, 220476051);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(buffer27, 'uint32', 53844, 203);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 219}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 0, y: 14 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 25},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({label: '\u{1f805}\u0711\u761e\udf50\u{1fa09}\u3bf8'});
+let computePassEncoder53 = commandEncoder115.beginComputePass({label: '\u3845\u4992\u6e81\u0e8c\uc10d\u0ccb'});
+let sampler55 = device0.createSampler({
+  label: '\uc660\u311e\u0701\u0065\u{1f908}\u25dd\u0413',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.37,
+  lodMaxClamp: 90.80,
+  maxAnisotropy: 8,
+});
+try {
+renderBundleEncoder58.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(551151418);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer5, 17464);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 2040 widthInBlocks: 1020 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 77186 */
+  offset: 77186,
+  rowsPerImage: 114,
+  buffer: buffer33,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1020, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer33);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 47, y: 320 },
+  flipY: false,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let texture74 = device0.createTexture({
+  label: '\u0cef\ue3e9\u0a1b\ufcb6\ue894\u{1fc2d}\u0e78\uca2a\u0180',
+  size: {width: 80, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView144 = texture74.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder54 = commandEncoder63.beginComputePass();
+let sampler56 = device0.createSampler({
+  label: '\u{1fe9c}\u8ebe\u30de\u716d\u29eb\ud7da\u{1fbcc}\ud855\ud736\u0d69\u6d5a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.191,
+  lodMaxClamp: 17.95,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder39.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(1053915355, 1138844353, 555839778, 1003719047, 138086464);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer21, 96580);
+} catch {}
+try {
+renderBundleEncoder34.setPipeline(pipeline93);
+} catch {}
+let promise19 = buffer31.mapAsync(GPUMapMode.WRITE, 38432, 6748);
+try {
+computePassEncoder31.insertDebugMarker('\u1a48');
+} catch {}
+try {
+device0.queue.submit([commandBuffer26]);
+} catch {}
+let shaderModule23 = device0.createShaderModule({
+  label: '\uf296\u39d7\u0e49\u97ed\u{1f71d}\u0953\ud3ac\ubad8\u0e34',
+  code: `@group(0) @binding(4481)
+var<storage, read_write> type11: array<u32>;
+@group(4) @binding(7721)
+var<storage, read_write> field12: array<u32>;
+@group(1) @binding(1133)
+var<storage, read_write> local10: array<u32>;
+@group(0) @binding(7721)
+var<storage, read_write> n17: array<u32>;
+@group(3) @binding(3330)
+var<storage, read_write> type12: array<u32>;
+@group(4) @binding(4481)
+var<storage, read_write> local11: array<u32>;
+
+@compute @workgroup_size(6, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(2) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(52) a0: vec4<f16>, @location(45) a1: vec3<f16>, @location(1) a2: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f264: vec2<i32>,
+  @builtin(position) f265: vec4<f32>,
+  @location(45) f266: vec3<f16>,
+  @location(31) f267: vec3<u32>,
+  @location(32) f268: vec4<i32>,
+  @location(19) f269: vec2<i32>,
+  @location(36) f270: vec2<i32>,
+  @location(1) f271: vec2<f16>,
+  @location(56) f272: vec2<u32>,
+  @location(41) f273: vec2<i32>,
+  @location(23) f274: vec2<f32>,
+  @location(58) f275: f32,
+  @location(52) f276: vec4<f16>,
+  @location(6) f277: vec3<i32>,
+  @location(53) f278: vec2<f16>,
+  @location(48) f279: vec4<f16>,
+  @location(2) f280: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<u32>, @location(9) a1: u32, @builtin(vertex_index) a2: u32, @location(13) a3: f32, @location(2) a4: vec2<f16>, @location(7) a5: vec2<u32>, @location(5) a6: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup22 = device0.createBindGroup({
+  label: '\u0dd2\u9950\u1da6\u7ad3\u{1fd9e}\u2a35\u0f3b\u0e02',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 1650, resource: sampler53},
+    {binding: 2910, resource: sampler19},
+    {binding: 1864, resource: {buffer: buffer30, offset: 27392, size: 968}},
+  ],
+});
+let querySet57 = device0.createQuerySet({
+  label: '\u8699\uf7fd\u3f26\u{1f926}\u9d2d\u9a69\uc4c4\u{1fa35}\u0ea7\u2303',
+  type: 'occlusion',
+  count: 3711,
+});
+let textureView145 = texture18.createView({label: '\u{1fc41}\u0ee5\u06f9\uae23\uae0a\u4206\u22b9\u3448\u6b73'});
+let sampler57 = device0.createSampler({
+  label: '\u04c1\u0fa8\u06dc\uc0d4\u{1f9d2}\u21ac\u39e0',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.74,
+  lodMaxClamp: 98.78,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder30.setBindGroup(4, bindGroup7, new Uint32Array(1808), 681, 0);
+} catch {}
+try {
+renderBundleEncoder10.draw(606950755, 1177882076);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(10, buffer22, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 4200, new DataView(new ArrayBuffer(22363)), 127, 10524);
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder({label: '\u0ab6\u05be\udb2d\u3c30\u{1fefe}\u0e10\u068a\u{1f61f}\u7461\u07c8'});
+let querySet58 = device0.createQuerySet({label: '\u03de\u1aba\uf96d\u{1feb9}\u1a99\u0aea\u39f7\u60b7', type: 'occlusion', count: 532});
+let textureView146 = texture64.createView({label: '\uca94\u383a\u1a76\u{1fb8f}\ud688\u001b\u8f1f', dimension: '3d'});
+let renderBundleEncoder61 = device0.createRenderBundleEncoder({
+  label: '\u{1f621}\u2f4c\u90e3',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let renderBundle75 = renderBundleEncoder50.finish({});
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer19, 158292);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder120.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2488 */
+  offset: 2488,
+  buffer: buffer32,
+}, {
+  texture: texture73,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer32);
+} catch {}
+try {
+commandEncoder109.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 58248 */
+  offset: 58248,
+  bytesPerRow: 256,
+  buffer: buffer18,
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 128, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 149, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 212},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 4519244 */
+{offset: 588, bytesPerRow: 252, rowsPerImage: 139}, {width: 11, height: 1, depthOrArrayLayers: 130});
+} catch {}
+let pipeline113 = await device0.createComputePipelineAsync({
+  label: '\u{1fd0f}\u049a\ueb00\u{1f7d6}\u9e40\u0c29\u5aa5\u0681',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule21, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup23 = device0.createBindGroup({
+  label: '\ubec4\u0bd3\ubdd3\u0459\u{1faa9}\uda8d\u611d\u0326\u3a65',
+  layout: bindGroupLayout28,
+  entries: [{binding: 5286, resource: sampler13}],
+});
+let commandEncoder130 = device0.createCommandEncoder({label: '\udad1\u{1f60d}\u{1fbe3}\u01b0'});
+let texture75 = device0.createTexture({
+  label: '\u096b\u{1f8df}\u{1ff2a}\udfe5\u0f4e\uc90f\u2386\ub03c',
+  size: {width: 40, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32sint'],
+});
+let sampler58 = device0.createSampler({
+  label: '\u042a\ud2c4\u{1fa27}\u{1ff26}\u0ab9\udd86\u1225\ue8e6\u06ca\u7ae8',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 68.49,
+  maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder49.draw(1072796177);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer19, 14476);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline93);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer15, 15160, buffer13, 254680, 196);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 28});
+} catch {}
+canvas5.width = 130;
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\ub9a1\u{1fc4e}',
+  entries: [
+    {
+      binding: 7646,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 5322,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer34 = device0.createBuffer({
+  label: '\u7589\u{1f7e8}\u06bb',
+  size: 108098,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet59 = device0.createQuerySet({label: '\u0a38\u5d77\u71d5\u9fe1\ubeb6\u92ec', type: 'occlusion', count: 621});
+let textureView147 = texture23.createView({label: '\u{1fff3}\u0cfd\u3633\u3045', mipLevelCount: 1});
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer21, 160852);
+} catch {}
+try {
+renderBundleEncoder35.setIndexBuffer(buffer8, 'uint16', 238, 1011);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 172 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16016 */
+  offset: 16016,
+  rowsPerImage: 172,
+  buffer: buffer34,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer34);
+} catch {}
+let pipeline114 = await device0.createComputePipelineAsync({
+  label: '\u16c9\u{1ff76}\u{1f6e9}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise19;
+} catch {}
+let video13 = await videoWithData();
+let bindGroup24 = device0.createBindGroup({
+  label: '\u0347\uec74\u33fe\u4b12\u073b\u{1ffdf}\uc144\u2fce',
+  layout: bindGroupLayout19,
+  entries: [{binding: 6464, resource: {buffer: buffer14, offset: 1792, size: 3428}}],
+});
+let textureView148 = texture19.createView({label: '\u0642\u4c87\u4c7b\u050b\u8057\u0dae\ub3c8\u00ac\u{1f768}', baseMipLevel: 2});
+try {
+renderBundleEncoder57.setVertexBuffer(5, buffer16);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer26, 31036, buffer25, 95380, 924);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer7), /* required buffer size: 801 */
+{offset: 780, bytesPerRow: 175}, {width: 21, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(335, 14);
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  label: '\u5090\u00b3\u4a46\u9874',
+  entries: [
+    {
+      binding: 2120,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 3330, resource: {buffer: buffer30, offset: 4736, size: 22956}}],
+});
+let commandEncoder131 = device0.createCommandEncoder({label: '\u159c\u0a64\u{1fc33}\ud50c\u0128\u5888\uaa22\ue512\ue52c\ud919\ua44e'});
+let textureView149 = texture52.createView({label: '\u{1ff4a}\uedb6\uea8c\u{1fca0}\u33f0', dimension: '1d', format: 'rgba8unorm-srgb'});
+let externalTexture44 = device0.importExternalTexture({label: '\u725f\u7f8c\uc5e2\u{1f778}\u2299\u3942\u9c2e\ubc22', source: video13, colorSpace: 'srgb'});
+try {
+renderBundleEncoder49.drawIndirect(buffer19, 65544);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(10, buffer9, 13708);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let textureView150 = texture39.createView({label: '\u{1fe24}\u020f\u3724'});
+let renderBundle76 = renderBundleEncoder2.finish({label: '\u1843\u{1f918}\u0eef\u3c72'});
+let sampler59 = device0.createSampler({
+  label: '\u58cc\u6b6f\u753b\u{1f84d}\ue68b\u09d0\u{1fc2d}\u07d9\uc791',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.52,
+  compare: 'less',
+});
+try {
+computePassEncoder37.dispatchWorkgroups(4, 4, 5);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(1, buffer21, 297640);
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 292 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3840 */
+  offset: 3840,
+  bytesPerRow: 768,
+  buffer: buffer10,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 73, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 1134, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder43.insertDebugMarker('\u{1fb84}');
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let pipeline115 = device0.createComputePipeline({
+  label: '\u07ff\u987c\u{1f67e}\ude90\ue1d9\ub87a\u53bf\u{1f694}\ub280\uc306\u8503',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let querySet60 = device0.createQuerySet({type: 'occlusion', count: 3515});
+let textureView151 = texture62.createView({label: '\u{1f810}\u{1f6ca}\u4ab7'});
+let externalTexture45 = device0.importExternalTexture({
+  label: '\u06d3\u5080\u0fe3\u6e66\uf291\u{1fcbe}\udbe9\u030e\u{1fec5}',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer21, 6676);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer19, 5460);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(8, buffer7, 64888);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 23 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2242 */
+  offset: 2242,
+  rowsPerImage: 88,
+  buffer: buffer10,
+}, {
+  texture: texture74,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+let externalTexture46 = device0.importExternalTexture({label: '\u4872\u0e27', source: video9, colorSpace: 'display-p3'});
+try {
+computePassEncoder51.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder49.draw(108388256, 538266536, 795107255);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(1141271966, 1071381998, 30556047, 439986783, 204934510);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer5, 43432);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer21);
+} catch {}
+let promise21 = buffer34.mapAsync(GPUMapMode.WRITE, 0, 94700);
+try {
+commandEncoder13.copyBufferToBuffer(buffer10, 39628, buffer13, 323228, 34648);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5728 */
+  offset: 5728,
+  buffer: buffer26,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet52, 44, 438, buffer23, 76288);
+} catch {}
+let pipeline116 = await device0.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}}});
+video10.width = 99;
+let shaderModule24 = device0.createShaderModule({
+  label: '\u900a\ua118\uf152',
+  code: `@group(1) @binding(6817)
+var<storage, read_write> local12: array<u32>;
+@group(0) @binding(7893)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(1097)
+var<storage, read_write> function21: array<u32>;
+@group(0) @binding(1041)
+var<storage, read_write> n18: array<u32>;
+
+@compute @workgroup_size(2, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(33) f0: vec4<f16>,
+  @location(21) f1: vec4<i32>,
+  @location(30) f2: vec4<f16>,
+  @location(16) f3: vec4<i32>,
+  @location(42) f4: vec4<f32>,
+  @location(25) f5: vec4<f32>,
+  @builtin(front_facing) f6: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(5) f1: i32,
+  @location(6) f2: vec2<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(2) f4: vec4<i32>,
+  @location(3) f5: vec4<f32>,
+  @location(4) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(26) a0: vec3<f16>, @location(46) a1: vec2<i32>, a2: S15, @location(38) a3: vec2<f16>, @location(39) a4: vec4<u32>, @location(31) a5: vec4<u32>, @location(47) a6: f16, @location(14) a7: vec2<u32>, @location(12) a8: f32, @location(37) a9: vec2<i32>, @location(34) a10: vec4<f16>, @location(52) a11: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(26) f281: vec3<f16>,
+  @location(4) f282: vec4<f16>,
+  @location(54) f283: f32,
+  @builtin(position) f284: vec4<f32>,
+  @location(25) f285: vec4<f32>,
+  @location(30) f286: vec4<f16>,
+  @location(10) f287: vec2<i32>,
+  @location(51) f288: vec4<f32>,
+  @location(33) f289: vec4<f16>,
+  @location(37) f290: vec2<i32>,
+  @location(27) f291: vec2<f32>,
+  @location(52) f292: vec4<i32>,
+  @location(34) f293: vec4<f16>,
+  @location(38) f294: vec2<f16>,
+  @location(44) f295: vec2<u32>,
+  @location(11) f296: vec2<u32>,
+  @location(39) f297: vec4<u32>,
+  @location(6) f298: vec2<u32>,
+  @location(43) f299: vec2<f16>,
+  @location(46) f300: vec2<i32>,
+  @location(42) f301: vec4<f32>,
+  @location(47) f302: f16,
+  @location(16) f303: vec4<i32>,
+  @location(45) f304: vec4<f16>,
+  @location(21) f305: vec4<i32>,
+  @location(2) f306: vec4<f32>,
+  @location(14) f307: vec2<u32>,
+  @location(3) f308: vec4<i32>,
+  @location(31) f309: vec4<u32>,
+  @location(49) f310: vec4<f16>,
+  @location(12) f311: f32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder132 = device0.createCommandEncoder();
+let textureView152 = texture37.createView({label: '\u8a5f\ua2cd\u0393\u076a\u5d00\u028b\u072d\u0065\u0f97\u041d', mipLevelCount: 1});
+let computePassEncoder55 = commandEncoder103.beginComputePass({label: '\ue505\u41b4\ufd1e\u3bdd\ucecb\u7008\u18ca\u16ec'});
+let sampler60 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.880,
+  lodMaxClamp: 88.31,
+  compare: 'not-equal',
+  maxAnisotropy: 9,
+});
+let externalTexture47 = device0.importExternalTexture({source: video8, colorSpace: 'display-p3'});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer21, 151940);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer23, 'uint16', 80894, 11183);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(9, buffer21, 0, 67033);
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 118},
+  aspect: 'all',
+},
+{
+  texture: texture71,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 25, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer13, 83068, 290828);
+dissociateBuffer(device0, buffer13);
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas17.getContext('webgpu');
+let promise22 = adapter2.requestAdapterInfo();
+let commandEncoder133 = device0.createCommandEncoder({label: '\u0b25\u9540\u0322\u7eb3\u{1fa94}\u023b\u1ab6\u0de3\u77e9'});
+let renderBundle77 = renderBundleEncoder61.finish({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder39.dispatchWorkgroupsIndirect(buffer5, 71928);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(948911216, 631597216, 731288709);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer19, 60668);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(2, buffer22, 63020);
+} catch {}
+try {
+commandEncoder68.clearBuffer(buffer4);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 243364, new Float32Array(18030), 2520, 444);
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({label: '\u{1fdba}\ud125\u0ca5\u0d8f\u2720\u{1f885}', bindGroupLayouts: [bindGroupLayout23]});
+let renderBundle78 = renderBundleEncoder17.finish({});
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup24, new Uint32Array(5338), 1374, 1);
+} catch {}
+try {
+renderBundleEncoder10.draw(651019763);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer21, 12732);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3868,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 6872, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let textureView153 = texture51.createView({label: '\uda94\u18a7\u03ac\u{1f674}\uedd9\u061a\u7fdd', baseMipLevel: 2});
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({
+  label: '\u027c\u0f83\u{1fc63}\u0ce7',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  stencilReadOnly: true,
+});
+let externalTexture48 = device0.importExternalTexture({label: '\u091e\u0600\u9a06\u0276', source: video12, colorSpace: 'srgb'});
+try {
+renderBundleEncoder28.setBindGroup(4, bindGroup14, new Uint32Array(1319), 730, 0);
+} catch {}
+try {
+renderBundleEncoder10.draw(56053666, 775157972);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer33, 154976, buffer6, 50512, 2624);
+dissociateBuffer(device0, buffer33);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet56, 826, 112, buffer23, 49920);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandBuffer27 = commandEncoder29.finish();
+try {
+renderBundleEncoder49.draw(908173031, 181600743, 538601533, 615781802);
+} catch {}
+try {
+commandEncoder109.copyBufferToBuffer(buffer29, 129056, buffer6, 63024, 30784);
+dissociateBuffer(device0, buffer29);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 1736 widthInBlocks: 434 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8424 */
+  offset: 8424,
+  buffer: buffer5,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 434, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer13);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 30, y: 2 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline117 = await device0.createRenderPipelineAsync({
+  label: '\ud178\u0e5e\udb33',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3636,
+        attributes: [
+          {format: 'sint32', offset: 920, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 180, shaderLocation: 0},
+          {format: 'uint32x3', offset: 332, shaderLocation: 8},
+          {format: 'uint8x4', offset: 852, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 1276, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 80, shaderLocation: 6},
+          {format: 'sint32x3', offset: 2572, shaderLocation: 14},
+          {format: 'float32x3', offset: 560, shaderLocation: 1},
+          {format: 'sint16x4', offset: 112, shaderLocation: 5},
+          {format: 'sint16x2', offset: 1124, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 362, shaderLocation: 2},
+          {format: 'uint32x4', offset: 2168, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 6160,
+        attributes: [
+          {format: 'uint16x2', offset: 1636, shaderLocation: 13},
+          {format: 'sint32x4', offset: 1800, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint8x4', offset: 1108, shaderLocation: 3}]},
+      {arrayStride: 7960, stepMode: 'vertex', attributes: []},
+      {arrayStride: 21376, attributes: []},
+      {arrayStride: 7800, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2348,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 392, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back'},
+});
+let buffer35 = device0.createBuffer({size: 163853, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let textureView154 = texture32.createView({label: '\u0a89\u038e', dimension: '2d', baseMipLevel: 9, baseArrayLayer: 159});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\u{1f734}\u{1fc32}\u2f08\u0b46\u0285\u08f4\u01d7',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'rgba8sint', 'rgba8unorm-srgb', 'r8sint', 'r32sint', 'r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture49 = device0.importExternalTexture({source: video10, colorSpace: 'srgb'});
+try {
+computePassEncoder44.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7909, undefined, 0, 1480389246);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 27, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder42.resolveQuerySet(querySet30, 833, 278, buffer7, 110848);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(721), /* required buffer size: 721 */
+{offset: 721, bytesPerRow: 874}, {width: 146, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 66, y: 3 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let buffer36 = device0.createBuffer({
+  label: '\u8188\u05ab\ub905\u034b\u408f\u{1f655}\u0423',
+  size: 166114,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let renderBundleEncoder64 = device0.createRenderBundleEncoder({
+  label: '\u8f2a\ub604\u4123\u{1fbbc}\u{1fffc}\u80f3\ua074\u09da\u{1fcb5}\u0d27',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder49.draw(1027385441, 922233143, 569856106, 424507751);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(1108768447, 248241236);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer9, 'uint16', 11896, 13028);
+} catch {}
+let promise23 = device0.popErrorScope();
+let promise24 = device0.createRenderPipelineAsync({
+  label: '\u6f86\ud8c6\u1efd\ua96e\u0bdc\u{1ffb3}\u0568\ub844\ua3fd\u69fd',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0xeaf2b8f0},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint'}, {format: 'rgba32sint', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1552,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 32, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 42, shaderLocation: 2},
+          {format: 'uint16x2', offset: 40, shaderLocation: 1},
+          {format: 'sint8x2', offset: 378, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 7472,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 266, shaderLocation: 13},
+          {format: 'uint32x4', offset: 764, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: false},
+});
+let commandEncoder134 = device0.createCommandEncoder({label: '\u0217\ue161\ufceb\u7f2e'});
+let textureView155 = texture69.createView({
+  label: '\u9382\u8c55\u{1f654}\u14a1\u{1fde9}\u{1fe20}\u0dde\u6cf2\ufb8b',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup3, new Uint32Array(1897), 1700, 0);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(1, bindGroup6, new Uint32Array(6458), 2547, 0);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer21, 50092);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer21, 105204);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas5,
+  origin: { x: 15, y: 6 },
+  flipY: true,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView156 = texture7.createView({label: '\u06a1\u2741\u990e\uc248'});
+let externalTexture50 = device0.importExternalTexture({source: video6, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder10.drawIndexed(1032385571, 1108665659, 1137680388, 1062144272, 972781772);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 777, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 110, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet3, 785, 1797, buffer23, 80896);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u06b4');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video7,
+  origin: { x: 4, y: 5 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline118 = device0.createComputePipeline({
+  label: '\u{1fd23}\u0f88\u0ea1\uf546\uffea\u3bfe',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let commandEncoder135 = device0.createCommandEncoder({});
+let commandBuffer28 = commandEncoder44.finish({label: '\ufb49\u6fcd\u027e\u{1f6a7}\u21c9\u{1fef3}\u0111'});
+let textureView157 = texture52.createView({label: '\u00ef\u4201\u682e', dimension: '1d'});
+try {
+renderBundleEncoder49.drawIndexed(307221463, 246727545);
+} catch {}
+let arrayBuffer12 = buffer29.getMappedRange(171624, 2412);
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 64477 */
+  offset: 64477,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture74,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 506},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 320, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 137, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 14146 */
+{offset: 642, bytesPerRow: 13657}, {width: 844, height: 1, depthOrArrayLayers: 1});
+} catch {}
+canvas7.width = 1052;
+let buffer37 = device0.createBuffer({
+  label: '\u3f02\u7979\u019c\u1ed2\u0aa5\u026d\u971d',
+  size: 192989,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer29 = commandEncoder133.finish({label: '\u5f82\u0022\u00fc\u920b\u02ba\u017b\ue2d7\u088b\u08d3\u5a49\u{1f8eb}'});
+let texture76 = device0.createTexture({
+  size: {width: 80},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let renderBundle79 = renderBundleEncoder19.finish({label: '\u{1f806}\ube4f\u0790'});
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.456,
+  lodMaxClamp: 76.15,
+});
+let externalTexture51 = device0.importExternalTexture({label: '\ue8f4\uf88e', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+renderBundleEncoder49.draw(974922571, 798614069, 555993766, 534526470);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer21, 50796);
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 164 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23320 */
+  offset: 23156,
+  bytesPerRow: 256,
+  rowsPerImage: 36,
+  buffer: buffer36,
+}, {width: 41, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise25 = device0.createComputePipelineAsync({
+  label: '\u0e17\u{1fc4c}\u832d\u{1ff1b}\u0bd0\uba94\u20f6',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+let imageBitmap13 = await createImageBitmap(imageData13);
+let texture77 = device0.createTexture({
+  size: {width: 160, height: 1, depthOrArrayLayers: 512},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let computePassEncoder56 = commandEncoder131.beginComputePass({label: '\u{1f97f}\u08fb\u8a88'});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline99);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer21, 46060);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline92);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 215, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1712 widthInBlocks: 107 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 14192 */
+  offset: 12480,
+  buffer: buffer35,
+}, {width: 107, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer35);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let canvas15 = document.createElement('canvas');
+let bindGroup26 = device0.createBindGroup({
+  label: '\ubd33\ud298\u073c\u041f',
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 1640, resource: externalTexture50},
+    {binding: 1629, resource: externalTexture28},
+    {binding: 8842, resource: externalTexture47},
+  ],
+});
+let textureView158 = texture37.createView({label: '\u2534\u2544\uc8d3\u09c9\u594a\u1441\u847f\u27af\u35e4'});
+let renderBundleEncoder65 = device0.createRenderBundleEncoder({
+  label: '\u0c41\u03e1\u0d21\u{1fca5}\u{1f901}\uc914\u14bc',
+  colorFormats: ['rgba16sint', 'r8unorm', 'rgb10a2unorm', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let renderBundle80 = renderBundleEncoder44.finish({label: '\u9d42\u0b1d\u8c25\u274a\u2f01\u4fc4\u0daf'});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(8, buffer21);
+} catch {}
+let arrayBuffer13 = buffer31.getMappedRange(41536, 2008);
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 3496 widthInBlocks: 874 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1612 */
+  offset: 1612,
+  buffer: buffer33,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 874, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer33);
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer28, 424, 1512);
+dissociateBuffer(device0, buffer28);
+} catch {}
+let video14 = await videoWithData();
+let textureView159 = texture0.createView({dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 4, baseArrayLayer: 79, arrayLayerCount: 90});
+let sampler62 = device0.createSampler({
+  label: '\uac81\u10fe\ub03c\ubd94\u098c\u{1fdfd}\u0855',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 98.23,
+  lodMaxClamp: 98.59,
+});
+try {
+renderBundleEncoder10.draw(102470531, 212586957, 571754457, 1232236932);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(9, buffer7);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder125.copyBufferToBuffer(buffer34, 3132, buffer25, 88632, 6252);
+dissociateBuffer(device0, buffer34);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+commandEncoder132.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27]);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let video15 = await videoWithData();
+let imageData15 = new ImageData(68, 44);
+try {
+canvas15.getContext('2d');
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  label: '\u056b\u{1f948}\u5a99\ub483\u0669\u0987\u8302\u9357\u28ef',
+  entries: [
+    {
+      binding: 7635,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 2498,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 8606,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup27 = device0.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 2120, resource: {buffer: buffer30, offset: 20224}}]});
+let pipelineLayout17 = device0.createPipelineLayout({
+  label: '\u0ff4\u8e6e\u3d55\u0424\u1578\u0ce4',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout3, bindGroupLayout29, bindGroupLayout11],
+});
+let commandEncoder136 = device0.createCommandEncoder({label: '\u0e6e\u0d82\u0fd7'});
+let externalTexture52 = device0.importExternalTexture({label: '\uce26\u0b8c\u6889\u{1f667}\u4488\uad5f', source: videoFrame11, colorSpace: 'srgb'});
+try {
+renderBundleEncoder10.drawIndexed(126052457, 29442957);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer5, 1256);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer37, 39744);
+} catch {}
+try {
+renderBundleEncoder63.setIndexBuffer(buffer23, 'uint16', 146190, 866);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(0, buffer7, 136832, 39667);
+} catch {}
+let promise27 = buffer33.mapAsync(GPUMapMode.WRITE, 125304, 40884);
+try {
+device0.queue.writeBuffer(buffer35, 97260, new DataView(new ArrayBuffer(9254)), 690, 2676);
+} catch {}
+let texture78 = device0.createTexture({
+  label: '\u062c\u{1fb75}\u19a0\u{1f9e4}',
+  size: [1152],
+  dimension: '1d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8snorm', 'rg8snorm'],
+});
+let textureView160 = texture70.createView({label: '\u01c3\uadbe\ue7ed\u18ce\u{1f9ef}\u0762\u29f9', dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup7, new Uint32Array(6227), 5714, 0);
+} catch {}
+try {
+renderBundleEncoder10.draw(1007781396);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(115957352, 856417098, 232053508, 565614717, 19881013);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder126.copyBufferToBuffer(buffer20, 28284, buffer25, 106828, 2044);
+dissociateBuffer(device0, buffer20);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet4, 1682, 203, buffer7, 165632);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 102, y: 369 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+  await promise21;
+} catch {}
+gc();
+let video16 = await videoWithData();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(106, 727);
+try {
+textureView120.label = '\u{1fe03}\u28bd\u7578\u27ac\uecfb\u{1face}\u0928\u0d2f\u{1fd2f}\u74fd\uf6a0';
+} catch {}
+try {
+  await promise22;
+} catch {}
+let img19 = await imageWithData(161, 7, '#18eb07f4', '#7285a640');
+let imageData16 = new ImageData(88, 184);
+gc();
+let imageBitmap14 = await createImageBitmap(offscreenCanvas17);
+offscreenCanvas17.width = 510;
+let videoFrame12 = videoFrame10.clone();
+try {
+offscreenCanvas18.getContext('bitmaprenderer');
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageBitmap13);
+try {
+  await promise27;
+} catch {}
+let video17 = await videoWithData();
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(5, 668);
+try {
+videoFrame12.close();
+} catch {}
+let gpuCanvasContext16 = offscreenCanvas19.getContext('webgpu');
+document.body.prepend(img12);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let canvas16 = document.createElement('canvas');
+let imageBitmap16 = await createImageBitmap(canvas1);
+let gpuCanvasContext17 = canvas16.getContext('webgpu');
+try {
+  await promise26;
+} catch {}
+let imageBitmap17 = await createImageBitmap(offscreenCanvas0);
+let adapter3 = await navigator.gpu.requestAdapter({});
+let device1 = await adapter2.requestDevice({
+  label: '\u06b2\u{1fc3f}\u{1f86a}\u0b3a',
+  defaultQueue: {label: '\u{1fbbc}\ud5bb\u63fb\u{1fc0e}\u0749\u{1fcba}\u{1f819}\u0eb5\u{1fa7c}\u1663'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 5,
+    maxColorAttachmentBytesPerSample: 53,
+    maxVertexAttributes: 26,
+    maxVertexBufferArrayStride: 8994,
+    maxStorageTexturesPerShaderStage: 35,
+    maxStorageBuffersPerShaderStage: 14,
+    maxDynamicStorageBuffersPerPipelineLayout: 64442,
+    maxDynamicUniformBuffersPerPipelineLayout: 37032,
+    maxBindingsPerBindGroup: 9386,
+    maxTextureArrayLayers: 1720,
+    maxTextureDimension1D: 14673,
+    maxTextureDimension2D: 12143,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 71074087,
+    maxUniformBuffersPerShaderStage: 22,
+    maxSampledTexturesPerShaderStage: 32,
+    maxInterStageShaderVariables: 111,
+    maxInterStageShaderComponents: 118,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let texture79 = device0.createTexture({
+  label: '\u6038\u0cc1\u0028\u{1fdb7}\u0f57\ud4b8\u1f3a\u15df',
+  size: {width: 144, height: 1, depthOrArrayLayers: 523},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder28.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup6, new Uint32Array(4637), 821, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer37, 140060);
+} catch {}
+try {
+renderBundleEncoder62.setIndexBuffer(buffer36, 'uint32', 72940, 74524);
+} catch {}
+let promise28 = buffer32.mapAsync(GPUMapMode.WRITE, 86640, 44816);
+try {
+commandEncoder70.copyBufferToBuffer(buffer29, 98120, buffer28, 18844, 13360);
+dissociateBuffer(device0, buffer29);
+dissociateBuffer(device0, buffer28);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 140 widthInBlocks: 140 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 6660 */
+  offset: 6520,
+  buffer: buffer36,
+}, {width: 140, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer36);
+} catch {}
+let pipeline119 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8unorm-srgb'}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'dst'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 1333915213,
+    stencilWriteMask: 2234903245,
+    depthBias: -460093315,
+    depthBiasSlopeScale: 703.6817359783805,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: [{format: 'sint32x3', offset: 6212, shaderLocation: 10}]},
+      {arrayStride: 9528, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10916,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 1672, shaderLocation: 9}],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 13272,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 624, shaderLocation: 5}],
+      },
+      {arrayStride: 6804, attributes: [{format: 'sint16x4', offset: 3648, shaderLocation: 2}]},
+      {arrayStride: 6228, attributes: [{format: 'float32', offset: 2404, shaderLocation: 7}]},
+    ],
+  },
+});
+try {
+  await promise20;
+} catch {}
+let video18 = await videoWithData();
+let commandEncoder137 = device1.createCommandEncoder({label: '\u{1fad3}\u7ab1\u07fd\u2ec0'});
+let querySet61 = device1.createQuerySet({label: '\u7578\u2363\u4270\u5621\u3bda\u6fb8\u0f42\u2945\u02d1', type: 'occlusion', count: 1089});
+try {
+device1.queue.submit([]);
+} catch {}
+let commandEncoder138 = device1.createCommandEncoder({label: '\u{1f6eb}\u40c9\u8c82\u0d98\ue13f\u{1fcf2}'});
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({
+  label: '\u66d7\u0927\u25eb\u02f3\u0442\u9c26\u0ea3\u0932\u{1fd4e}\ub5d9\ue2cb',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+});
+let imageBitmap18 = await createImageBitmap(canvas3);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(canvas15);
+let renderBundle81 = renderBundleEncoder66.finish({label: '\u0ccd\ue375\uc4e1\u{1fcf0}\u{1f760}'});
+let externalTexture53 = device1.importExternalTexture({label: '\u{1fd4f}\u7a92\u0bfa\u07ca\u6757', source: video4, colorSpace: 'srgb'});
+try {
+commandEncoder137.pushDebugGroup('\ud236');
+} catch {}
+let querySet62 = device1.createQuerySet({type: 'occlusion', count: 28});
+let texture80 = device1.createTexture({
+  label: '\u04e7\u0ba6\u020f\u34cd\u0726\u{1fda7}\ue409\u6991\u3c7e\ubae4\u0b00',
+  size: {width: 600, height: 2, depthOrArrayLayers: 858},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+window.someLabel = renderBundle81.label;
+} catch {}
+let querySet63 = device1.createQuerySet({
+  label: '\u0875\u7afa\u8b88\u018a\u01ef\u85ad\ub713\u4d45\u0fb4\u{1ffb6}\u2c61',
+  type: 'occlusion',
+  count: 2428,
+});
+let commandEncoder139 = device1.createCommandEncoder();
+let textureView161 = texture80.createView({
+  label: '\u{1fe84}\uf68e\uc4d5\u93ca\u84f6\u{1ff77}\u{1f7e9}\u0ec7',
+  dimension: '3d',
+  format: 'r16uint',
+  baseArrayLayer: 0,
+});
+let computePassEncoder57 = commandEncoder138.beginComputePass({label: '\u972e\u9932\u790e'});
+let canvas17 = document.createElement('canvas');
+let video19 = await videoWithData();
+let commandEncoder140 = device1.createCommandEncoder({label: '\u097a\u{1fd07}\u521e\u0a83\u{1f6d1}'});
+let computePassEncoder58 = commandEncoder137.beginComputePass({});
+let externalTexture54 = device1.importExternalTexture({source: video3, colorSpace: 'srgb'});
+let gpuCanvasContext18 = canvas17.getContext('webgpu');
+let commandEncoder141 = device1.createCommandEncoder();
+let commandBuffer30 = commandEncoder141.finish({label: '\u7bc9\u01e6\u915c\u068c\u07df\uf9a6\u{1f9f2}\u{1fd2f}\u{1fe58}\u{1ffb1}'});
+let textureView162 = texture80.createView({aspect: 'all'});
+let sampler63 = device1.createSampler({
+  label: '\ub573\ufc2b\u74a6\u0c11\ud57a\uc60a\u1050\u{1f88b}\udd4c\u9118\u1037',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 29.89,
+  compare: 'equal',
+});
+try {
+  await promise28;
+} catch {}
+let querySet64 = device1.createQuerySet({label: '\u6138\u0a71\ue28f', type: 'occlusion', count: 3218});
+let texture81 = device1.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 1624},
+  mipLevelCount: 5,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let computePassEncoder59 = commandEncoder140.beginComputePass({label: '\ue337\u00f4\u3fb3\u3500\u{1fe05}\u81a1\ud316'});
+let renderBundle82 = renderBundleEncoder66.finish();
+offscreenCanvas11.height = 2779;
+let textureView163 = texture81.createView({
+  label: '\u{1fa2c}\uf853\uf9a1\u05fd\u0878\u1d60\u40d4\u{1ffda}\ubaba',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 565,
+  arrayLayerCount: 355,
+});
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'], sampleCount: 4, stencilReadOnly: true});
+let sampler64 = device1.createSampler({
+  label: '\u{1fd40}\u0ba2\u07cd\u82a7\ue6ca',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.95,
+  lodMaxClamp: 90.40,
+  maxAnisotropy: 10,
+});
+let externalTexture55 = device1.importExternalTexture({label: '\u610d\u{1f658}\u59ff\u1dd9\ud88e\uc3d9', source: videoFrame5, colorSpace: 'srgb'});
+let promise29 = device1.queue.onSubmittedWorkDone();
+let video20 = await videoWithData();
+let bindGroupLayout33 = device1.createBindGroupLayout({
+  label: '\ua7e8\u{1fe3f}\u0252\u{1f8d6}\u{1fdb2}\ue6ad\u07e2',
+  entries: [
+    {
+      binding: 3627,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 799645, hasDynamicOffset: false },
+    },
+    {
+      binding: 5439,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder142 = device1.createCommandEncoder({label: '\u47b1\u397e\u05c6\uac44\ub04b\u089b\uef87\u{1facb}\uce76'});
+let texture82 = device1.createTexture({
+  label: '\ua24c\u9b01\u{1fd2f}\u3584\ufe47\u076c\uad9d',
+  size: {width: 2040, height: 1, depthOrArrayLayers: 134},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let textureView164 = texture80.createView({baseMipLevel: 0});
+let sampler65 = device1.createSampler({
+  label: '\ue185\u54dc\ud7ad\u{1fb93}\u{1f9b3}\u73a2',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 54.83,
+});
+try {
+window.someLabel = renderBundle4.label;
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let querySet65 = device1.createQuerySet({label: '\u06f7\u0dfd', type: 'occlusion', count: 471});
+let commandBuffer31 = commandEncoder142.finish({label: '\u{1fabc}\u0a20\u04a7\u{1f9cc}\u{1fe17}\u{1fe98}'});
+let texture83 = device1.createTexture({
+  size: [75],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let renderBundleEncoder68 = device1.createRenderBundleEncoder({
+  label: '\u0341\u6cf5\ud806\u842e\u06a1\u147b\u7697',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+});
+let externalTexture56 = device1.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer13), /* required buffer size: 508 */
+{offset: 508, bytesPerRow: 323}, {width: 65, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture84 = device1.createTexture({
+  size: [2040, 1, 991],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture57 = device1.importExternalTexture({
+  label: '\u372b\u{1f869}\u{1ff9e}\ud533\u5667\u07c1\u0c4d\u{1fcea}\u3e44\u81cd\u612a',
+  source: videoFrame11,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder139.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 429},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 504, height: 1, depthOrArrayLayers: 84});
+} catch {}
+let imageData17 = new ImageData(120, 212);
+let adapter4 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let imageBitmap19 = await createImageBitmap(videoFrame3);
+canvas12.height = 2419;
+let img20 = await imageWithData(126, 228, '#8815c038', '#01070ffd');
+try {
+window.someLabel = computePassEncoder21.label;
+} catch {}
+document.body.prepend(video11);
+let img21 = await imageWithData(147, 91, '#521b088f', '#ac0eade9');
+let video21 = await videoWithData();
+let videoFrame13 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let canvas18 = document.createElement('canvas');
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let textureView165 = texture83.createView({label: '\uc3ed\u2a10\uc21e\u{1fa00}\u0ac4\u02a2\u97d3\uf9a7', format: 'r16uint'});
+let renderBundle83 = renderBundleEncoder66.finish({label: '\u0192\ubf75\u{1f8e1}\u8040\ue21b\uc069\u0ad1\u85c1\ud4ef\u1304'});
+gc();
+let commandEncoder143 = device1.createCommandEncoder({label: '\u46ae\u3c07'});
+let textureView166 = texture83.createView({label: '\uda3f\u1eeb\u{1f9e2}\u9036\ue6ee\u19ee\uda1e\u5dbe'});
+let computePassEncoder60 = commandEncoder139.beginComputePass();
+let externalTexture58 = device1.importExternalTexture({label: '\u{1fd22}\u{1fac6}\u6a36\u1130\u076d\u2b92\u0565\u3124', source: video19, colorSpace: 'srgb'});
+try {
+renderBundleEncoder68.setVertexBuffer(4266, undefined, 3742788225, 14432499);
+} catch {}
+let querySet66 = device1.createQuerySet({label: '\uf196\u425f', type: 'occlusion', count: 1421});
+let renderBundleEncoder69 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 18, y: 0, z: 1065},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 876 */
+{offset: 876, rowsPerImage: 99}, {width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img22 = await imageWithData(75, 12, '#9b2acc18', '#b435b4de');
+let textureView167 = texture81.createView({
+  label: '\ue339\u{1fab6}\u{1fc52}\u4bb2\u5f59\u6d4f\ue87f\u051a\u{1fcaf}\u0542\u{1ffb9}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 438,
+});
+let renderBundleEncoder70 = device1.createRenderBundleEncoder({
+  label: '\u483e\u0746\u{1fa34}\u0d1e\u1de7\u0ce4\u0b33\u{1fa6d}\u{1f99d}\uc266',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let img23 = await imageWithData(45, 155, '#fb4bfbd0', '#a7e74489');
+let imageData18 = new ImageData(12, 232);
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 37},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 883, height: 0, depthOrArrayLayers: 63});
+} catch {}
+try {
+commandEncoder143.insertDebugMarker('\u3af8');
+} catch {}
+canvas5.height = 1187;
+let canvas19 = document.createElement('canvas');
+try {
+  await promise29;
+} catch {}
+try {
+canvas19.getContext('2d');
+} catch {}
+let commandEncoder144 = device1.createCommandEncoder();
+let textureView168 = texture81.createView({
+  label: '\u4e9c\ub5e0\u17ca\u2d75\u82c5\ue6c2\ue011\u{1fc17}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 1319,
+});
+let renderBundle84 = renderBundleEncoder66.finish({label: '\u5ebf\u09da\uc764\u00df\u63eb'});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+commandEncoder137.popDebugGroup();
+} catch {}
+let img24 = await imageWithData(209, 135, '#f135e417', '#68a0d7e2');
+document.body.prepend(video16);
+try {
+window.someLabel = renderBundleEncoder67.label;
+} catch {}
+let pipelineLayout18 = device1.createPipelineLayout({
+  label: '\u6b1f\ue95e\u8127\ufc7f\ua85f\u{1f82f}',
+  bindGroupLayouts: [bindGroupLayout33, bindGroupLayout33, bindGroupLayout33, bindGroupLayout33, bindGroupLayout33],
+});
+let querySet67 = device1.createQuerySet({label: '\u{1f78c}\ue226', type: 'occlusion', count: 947});
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 78},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 171, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 64, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas20 = document.createElement('canvas');
+let shaderModule25 = device1.createShaderModule({
+  label: '\u{1fe56}\u{1f93d}\u{1f706}\u2e4c\u{1fad9}',
+  code: `@group(4) @binding(5439)
+var<storage, read_write> global13: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> parameter14: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> type13: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> global14: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> n19: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> local13: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> field14: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> local14: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> n20: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @location(51) f0: f16,
+  @location(107) f1: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<u32>,
+  @location(6) f1: vec3<i32>,
+  @location(2) f2: vec4<i32>,
+  @location(0) f3: f32,
+  @location(3) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(43) a0: vec4<f16>, @location(93) a1: vec3<f16>, @location(32) a2: vec4<i32>, @location(49) a3: vec4<f16>, @location(57) a4: vec4<f16>, @location(21) a5: vec2<f32>, @location(29) a6: vec4<u32>, @builtin(position) a7: vec4<f32>, @builtin(sample_index) a8: u32, @location(18) a9: vec2<f16>, @location(5) a10: vec4<u32>, @location(106) a11: vec3<f16>, @location(75) a12: vec4<f32>, @builtin(sample_mask) a13: u32, @location(96) a14: u32, @location(81) a15: i32, a16: S17) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(25) f0: vec4<u32>,
+  @location(3) f1: vec2<u32>,
+  @location(11) f2: vec4<i32>,
+  @location(5) f3: vec3<f16>,
+  @location(24) f4: f16,
+  @location(9) f5: f16,
+  @location(1) f6: vec4<u32>,
+  @location(6) f7: vec3<f16>,
+  @location(19) f8: f32,
+  @location(7) f9: f32,
+  @builtin(instance_index) f10: u32,
+  @location(2) f11: vec2<f16>,
+  @location(12) f12: vec2<i32>,
+  @builtin(vertex_index) f13: u32,
+  @location(21) f14: vec3<i32>,
+  @location(18) f15: vec4<i32>,
+  @location(16) f16: vec4<u32>,
+  @location(13) f17: vec2<i32>,
+  @location(0) f18: vec3<f16>,
+  @location(20) f19: f32,
+  @location(14) f20: vec3<i32>,
+  @location(15) f21: u32
+}
+struct VertexOutput0 {
+  @location(14) f312: u32,
+  @location(43) f313: vec4<f16>,
+  @location(51) f314: f16,
+  @location(29) f315: vec4<u32>,
+  @location(31) f316: vec3<u32>,
+  @location(107) f317: vec3<i32>,
+  @location(104) f318: vec4<f16>,
+  @location(56) f319: vec2<f32>,
+  @location(81) f320: i32,
+  @location(23) f321: vec3<f32>,
+  @location(18) f322: vec2<f16>,
+  @builtin(position) f323: vec4<f32>,
+  @location(93) f324: vec3<f16>,
+  @location(21) f325: vec2<f32>,
+  @location(25) f326: vec2<f16>,
+  @location(106) f327: vec3<f16>,
+  @location(49) f328: vec4<f16>,
+  @location(98) f329: vec4<f16>,
+  @location(57) f330: vec4<f16>,
+  @location(75) f331: vec4<f32>,
+  @location(26) f332: f32,
+  @location(32) f333: vec4<i32>,
+  @location(52) f334: vec2<f16>,
+  @location(5) f335: vec4<u32>,
+  @location(96) f336: u32
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec2<u32>, a1: S16, @location(10) a2: i32, @location(22) a3: vec3<f32>, @location(23) a4: vec3<i32>, @location(17) a5: f32, @location(8) a6: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView169 = texture80.createView({label: '\u{1fddf}\u0c6f\u0580'});
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 128},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(48)), /* required buffer size: 8343202 */
+{offset: 10, bytesPerRow: 363, rowsPerImage: 52}, {width: 10, height: 0, depthOrArrayLayers: 443});
+} catch {}
+let pipeline120 = device1.createComputePipeline({
+  label: '\u8d57\u01fc\u7f7b\u306a\u{1fbfc}\u{1fbbe}\u0d49\u5aaa\u8c8d',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule25, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let gpuCanvasContext19 = canvas20.getContext('webgpu');
+let buffer38 = device1.createBuffer({
+  label: '\u84d7\u0fa7\u{1f988}\u1aef\u{1fdfd}\u577f\u025d\u1eda\u3014\u9381',
+  size: 399973,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder145 = device1.createCommandEncoder();
+let textureView170 = texture82.createView({label: '\uf010\u0251'});
+try {
+commandEncoder144.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 35},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 65, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 256, height: 0, depthOrArrayLayers: 326});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 184},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 8401491 */
+{offset: 771, bytesPerRow: 1136, rowsPerImage: 255}, {width: 548, height: 0, depthOrArrayLayers: 30});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+video20.height = 114;
+let shaderModule26 = device1.createShaderModule({
+  code: `@group(1) @binding(3627)
+var<storage, read_write> local15: array<u32>;
+@group(4) @binding(5439)
+var<storage, read_write> function22: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> type14: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> function23: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> type15: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> local16: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> field15: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> type16: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: f32,
+  @location(2) f1: vec3<i32>,
+  @location(1) f2: vec2<u32>,
+  @location(3) f3: vec2<i32>,
+  @location(7) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let buffer39 = device1.createBuffer({label: '\u03c7\ufa88\u027c', size: 9098, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+renderBundleEncoder68.setVertexBuffer(9, buffer39);
+} catch {}
+let commandBuffer32 = commandEncoder140.finish({label: '\u2d35\u028c\uec4a\u0efa\u5ab9\uffe7\u{1f9a5}\u3730\u3480\u9c12'});
+let textureView171 = texture84.createView({label: '\u{1f882}\u4ade\u7ad5\u{1ffe4}\u097b\u2285', baseMipLevel: 1});
+let sampler66 = device1.createSampler({
+  label: '\u0427\u1874\u078a\u{1ffe0}\u2204\ua35c\u0ff1\ua06b\u0362\u0122\u{1ff54}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.53,
+  compare: 'greater-equal',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline120);
+} catch {}
+let promise30 = device1.queue.onSubmittedWorkDone();
+try {
+canvas18.getContext('webgpu');
+} catch {}
+let commandEncoder146 = device1.createCommandEncoder({label: '\u09a5\u535d\u{1f84f}\u8979\u{1fa41}\u31e6\u7ac1\u{1f91b}\u{1fc6b}\ufacd\u07b1'});
+let querySet68 = device1.createQuerySet({type: 'occlusion', count: 3306});
+let commandBuffer33 = commandEncoder145.finish({label: '\u0106\ue1e1\u03c4'});
+let textureView172 = texture81.createView({
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 1089,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder71 = device1.createRenderBundleEncoder({
+  label: '\u0645\u15ac\ua004\uea75\u0569\u0423\u01cd',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+});
+try {
+commandEncoder144.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 179},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 40},
+  aspect: 'all',
+},
+{width: 574, height: 0, depthOrArrayLayers: 131});
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\u{1fc68}');
+} catch {}
+try {
+device1.queue.submit([commandBuffer30]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 211},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer4), /* required buffer size: 24357967 */
+{offset: 95, bytesPerRow: 1163, rowsPerImage: 187}, {width: 490, height: 0, depthOrArrayLayers: 113});
+} catch {}
+let pipeline121 = device1.createComputePipeline({
+  label: '\u96a8\ueb60\uef50\u{1f661}\u{1f78d}\u4737\u{1f8ae}\u{1fcb8}\udd44\u3590\u0534',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let pipeline122 = device1.createRenderPipeline({
+  label: '\u5808\u{1fd83}\ue334\u0c29\u0860\ub8fe\ub9a4\u524b\u{1fcaa}\u10c1',
+  layout: pipelineLayout18,
+  multisample: {count: 4, mask: 0x9ebb044c},
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule26, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+document.body.prepend(canvas8);
+let imageBitmap20 = await createImageBitmap(video3);
+let buffer40 = device1.createBuffer({size: 440232, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+let texture85 = device1.createTexture({
+  label: '\u88d5\u9112\u{1fa0d}\u{1fb43}\ud5e9\u09ca\ub783\ud87c\u52bf\u0224',
+  size: {width: 640, height: 8, depthOrArrayLayers: 216},
+  mipLevelCount: 6,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView173 = texture80.createView({label: '\ufeeb\u094c\uae2e\u9cc3\u091c\uc83b\u2545\u{1fe86}'});
+let renderBundleEncoder72 = device1.createRenderBundleEncoder({
+  label: '\u0492\uf457\u{1ff20}\ue4ed\u4d5b\u1b9e\u{1f746}\u054c',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle85 = renderBundleEncoder68.finish({label: '\u9a7a\u{1ff39}\u{1fc98}\u06b1'});
+let externalTexture59 = device1.importExternalTexture({label: '\udf57\u63d0\u59fb\u{1ff74}\u{1f67f}', source: videoFrame10, colorSpace: 'display-p3'});
+let pipeline123 = device1.createComputePipeline({
+  label: '\u0f0a\u{1fbbf}\u{1ffef}\u{1fb4b}\u0eb1\u91da\ue75f\ufc8f\u08b9\u0623\u{1fe7d}',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let texture86 = device1.createTexture({
+  label: '\u{1f96d}\u9cd4\ub431\uc3c4\uecdf\u06c2\u99bd',
+  size: {width: 4080},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView174 = texture83.createView({label: '\u062b\u4c61\u06c2\udf74', format: 'r16uint'});
+let externalTexture60 = device1.importExternalTexture({source: videoFrame9});
+let pipeline124 = device1.createRenderPipeline({
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg32sint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 609061667,
+    depthBiasSlopeScale: 597.5115977418624,
+    depthBiasClamp: 826.8194288709888,
+  },
+  vertex: {module: shaderModule26, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let imageBitmap21 = await createImageBitmap(imageData7);
+let commandEncoder147 = device1.createCommandEncoder({label: '\u{1ffa9}\u04d4\u{1ff7e}\uf0b1\uadb1'});
+let renderBundle86 = renderBundleEncoder66.finish({label: '\u{1fd55}\u60ec\u{1fc3a}\uf6cd\u{1fe76}'});
+try {
+renderBundleEncoder69.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(0, buffer39, 3128, 773);
+} catch {}
+try {
+commandEncoder143.resolveQuerySet(querySet65, 325, 2, buffer40, 210176);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 443, y: 0, z: 65},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer12), /* required buffer size: 23816074 */
+{offset: 74, bytesPerRow: 916, rowsPerImage: 260}, {width: 376, height: 0, depthOrArrayLayers: 101});
+} catch {}
+let promise31 = device1.queue.onSubmittedWorkDone();
+let buffer41 = device1.createBuffer({
+  label: '\u{1f967}\ub840\u1c01\u022b\u8682\u8185\ud457\ua602\u69fc\u6123',
+  size: 508450,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder148 = device1.createCommandEncoder({});
+let textureView175 = texture82.createView({label: '\u0d8e\u64b4\ud30d\u{1f861}\uf3ad', baseArrayLayer: 0});
+let renderBundle87 = renderBundleEncoder67.finish({});
+try {
+renderBundleEncoder69.drawIndexed(1009657564);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(1, buffer39, 0, 1897);
+} catch {}
+try {
+commandEncoder143.resolveQuerySet(querySet68, 1793, 623, buffer40, 306432);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 84, y: 0, z: 32},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer5), /* required buffer size: 742160 */
+{offset: 680, bytesPerRow: 794, rowsPerImage: 29}, {width: 339, height: 6, depthOrArrayLayers: 33});
+} catch {}
+try {
+  await promise31;
+} catch {}
+let renderBundle88 = renderBundleEncoder66.finish({label: '\u4cb1\u0ddc\ua2c0\u93a4\u0465\u09f9\u{1fb32}\u01b9\u{1f92a}\u1d75'});
+try {
+renderBundleEncoder69.setVertexBuffer(7, buffer39, 3648, 2781);
+} catch {}
+try {
+commandEncoder148.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1450, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 854 widthInBlocks: 427 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3366 */
+  offset: 2512,
+  bytesPerRow: 1280,
+  buffer: buffer41,
+}, {width: 427, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+renderBundleEncoder70.pushDebugGroup('\u{1fd4b}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 938 */
+{offset: 938}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let querySet69 = device1.createQuerySet({label: '\u06c1\u15e0\u092a\uf50e\ub97b\u0c8f', type: 'occlusion', count: 3321});
+let renderBundle89 = renderBundleEncoder68.finish({label: '\u8167\ub601\uf4f7\u0d62'});
+try {
+computePassEncoder57.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder69.draw(1104870597, 682740369, 584895454, 910054830);
+} catch {}
+try {
+commandEncoder143.copyBufferToBuffer(buffer38, 386632, buffer41, 31196, 12260);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline125 = await device1.createComputePipelineAsync({
+  label: '\ud966\u0654\u01ea\u66af\u{1f8ce}\u{1fb12}\u0e79\uf8dd\ua09f\u4aad\u3f26',
+  layout: 'auto',
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let shaderModule27 = device1.createShaderModule({
+  label: '\ubf14\u0bb3\u{1fa10}\u13fe\u6a3a',
+  code: `@group(1) @binding(3627)
+var<storage, read_write> field16: array<u32>;
+@group(4) @binding(5439)
+var<storage, read_write> function24: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> type17: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> parameter15: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> local17: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> local18: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> field17: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> type18: array<u32>;
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<i32>,
+  @location(2) f2: vec4<i32>,
+  @location(1) f3: vec2<u32>,
+  @location(5) f4: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: vec4<u32>, @location(9) a1: f32, @location(20) a2: vec3<i32>, @location(1) a3: vec3<i32>, @location(7) a4: vec4<u32>, @location(19) a5: vec2<i32>, @builtin(vertex_index) a6: u32, @location(2) a7: vec3<f32>, @location(0) a8: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder149 = device1.createCommandEncoder({label: '\u010e\u7644\u4f20\u{1f83f}'});
+let commandBuffer34 = commandEncoder149.finish({label: '\ub296\u{1fd65}\u{1f9e9}\u{1fd0b}\ufeb8\u{1fa5c}\u06bf\u0605\u{1fdf1}\u061f\u45d3'});
+let texture87 = device1.createTexture({
+  label: '\ub183\u{1fd28}\ufe8d\u{1fcb7}\uc67b\u0ca8\u0cf4\u{1f68e}\u0620\u46c5\u0685',
+  size: [160],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView176 = texture85.createView({
+  label: '\uae7c\uc634\u05a7\ufb44\u1b28\u2365\u0bbb\u4098\u01d1\uc451',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 129,
+  arrayLayerCount: 80,
+});
+try {
+renderBundleEncoder69.drawIndexed(945715191);
+} catch {}
+try {
+commandEncoder146.resolveQuerySet(querySet64, 17, 1097, buffer40, 347904);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 3200908 */
+{offset: 212, bytesPerRow: 7004, rowsPerImage: 114}, {width: 859, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await promise30;
+} catch {}
+let commandBuffer35 = commandEncoder144.finish({label: '\u{1f6be}\u{1fb32}\u14ae\u0f49\u{1fa05}\u02be\udd52\u0976\ucd53\u0bb8'});
+let textureView177 = texture80.createView({label: '\u{1ff48}\u0712\u6b59\u04ba\ub4b1\u075e', baseMipLevel: 0});
+let renderBundleEncoder73 = device1.createRenderBundleEncoder({
+  label: '\u{1fa7b}\u0b3f\u0e0f\ua43c\u0244',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder69.draw(216156888, 439181589, 171668792, 109019249);
+} catch {}
+try {
+renderBundleEncoder72.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(2, buffer39, 8704, 176);
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 58 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9378 */
+  offset: 9320,
+  rowsPerImage: 159,
+  buffer: buffer38,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 29, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer41, 68992, new Float32Array(59692), 48310, 7704);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let querySet70 = device1.createQuerySet({label: '\u0f61\u19fd\u0173\ub08f\ub4b2\u91ec\u93d9\u07b8', type: 'occlusion', count: 3626});
+let textureView178 = texture80.createView({dimension: '3d'});
+try {
+renderBundleEncoder72.draw(666528742);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer41, 138396, new BigUint64Array(13112), 2047, 60);
+} catch {}
+let commandBuffer36 = commandEncoder139.finish();
+let texture88 = device1.createTexture({
+  size: [4080],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+let renderBundleEncoder74 = device1.createRenderBundleEncoder({
+  label: '\u4c35\u123f\u0807\u0dbe\u0695\u8089\u125e\u7052\uc52f\u06a8\u{1fe00}',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: false,
+});
+try {
+renderBundleEncoder74.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(1, buffer39);
+} catch {}
+try {
+commandEncoder146.copyBufferToBuffer(buffer38, 191084, buffer41, 419920, 36312);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder137.resolveQuerySet(querySet61, 746, 36, buffer40, 9472);
+} catch {}
+let computePassEncoder61 = commandEncoder148.beginComputePass();
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer38, 327600, buffer41, 2172, 69260);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder143.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 2195, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3358 widthInBlocks: 1679 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 29916 */
+  offset: 26558,
+  rowsPerImage: 190,
+  buffer: buffer41,
+}, {width: 1679, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+renderBundleEncoder70.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer41, 34480, new BigUint64Array(40782), 14652, 176);
+} catch {}
+let pipeline126 = device1.createComputePipeline({
+  label: '\u795f\u1296',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let pipeline127 = device1.createRenderPipeline({
+  label: '\u0751\u053e\u{1ffcd}\u0a7c\u0d6e\ubd13\u4863\u67e9\u03eb\uad10\u15d4',
+  layout: pipelineLayout18,
+  multisample: {mask: 0xffffffff},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2644,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 912, shaderLocation: 2},
+          {format: 'uint16x2', offset: 96, shaderLocation: 4},
+          {format: 'sint16x4', offset: 1024, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 232, shaderLocation: 9},
+          {format: 'uint8x2', offset: 198, shaderLocation: 7},
+          {format: 'sint8x4', offset: 336, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 828,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 44, shaderLocation: 0}],
+      },
+      {arrayStride: 204, attributes: [{format: 'sint8x2', offset: 10, shaderLocation: 1}]},
+    ],
+  },
+});
+let querySet71 = device1.createQuerySet({label: '\u8d45\uf787', type: 'occlusion', count: 2417});
+let textureView179 = texture83.createView({label: '\u0579\u0144\u031f\ucf6e\u0440\uf16f\u973e\u02ff\ufa00', baseMipLevel: 0, arrayLayerCount: 1});
+let sampler67 = device1.createSampler({
+  label: '\uc4af\u{1f9f8}\u5638\u0108\u{1fc2c}\u{1f676}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.59,
+  lodMaxClamp: 73.38,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder71.setPipeline(pipeline122);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 51, y: 0, z: 4},
+  aspect: 'all',
+}, new DataView(arrayBuffer1), /* required buffer size: 29366419 */
+{offset: 109, bytesPerRow: 1622, rowsPerImage: 255}, {width: 784, height: 0, depthOrArrayLayers: 72});
+} catch {}
+let pipeline128 = device1.createComputePipeline({
+  label: '\ub255\u{1fbbb}\u{1f83c}\u062e\u{1ffba}\uf58d',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}},
+});
+let buffer42 = device1.createBuffer({
+  label: '\u2dba\u1ffe\ud25c\u19da\u{1f7f8}\ua610',
+  size: 222571,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let texture89 = device1.createTexture({
+  label: '\u4665\u761c\ua0dd\ue113\u{1f798}\u0255\u0bb8\u8f97',
+  size: [2220, 20, 1703],
+  mipLevelCount: 10,
+  format: 'astc-4x4-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView180 = texture83.createView({label: '\u0920\u0ddc\u04cb'});
+try {
+renderBundleEncoder71.draw(284984384, 1031348468, 107971808, 237962208);
+} catch {}
+try {
+commandEncoder147.copyBufferToTexture({
+  /* bytesInLastRow: 26 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 16068 */
+  offset: 16068,
+  buffer: buffer38,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder137.clearBuffer(buffer41, 471120, 25936);
+dissociateBuffer(device1, buffer41);
+} catch {}
+let promise32 = device1.createComputePipelineAsync({
+  label: '\u84d7\u2963\u9fd0\u98aa\u832c\u07d3\u3012',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame14 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let querySet72 = device1.createQuerySet({label: '\u4fcd\u53af\u5d47\u{1ff61}\ud292\u05a5\u{1fe08}', type: 'occlusion', count: 3686});
+let texture90 = device1.createTexture({size: [640], sampleCount: 1, dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView181 = texture82.createView({label: '\u040b\udc0c\u003b\u0dfd\u{1fc6d}', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle90 = renderBundleEncoder68.finish({});
+let externalTexture61 = device1.importExternalTexture({
+  label: '\u0995\u{1fd16}\uacab\ua7ca\u{1f977}\u0023\u{1f776}\u00b5\ud2f7\ue57d',
+  source: video19,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder72.drawIndexed(387725854, 1062904307, 474362170, 1146979127, 1036409840);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(5, buffer39);
+} catch {}
+try {
+commandEncoder143.copyBufferToBuffer(buffer38, 287500, buffer42, 15328, 72976);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+commandEncoder137.resolveQuerySet(querySet69, 1255, 1786, buffer40, 39168);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer42, 16000, new Float32Array(43373), 10396, 11420);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline129 = device1.createRenderPipeline({
+  label: '\ua098\u{1fdee}\ub060\ud724\u951a\u0016\u0176',
+  layout: pipelineLayout18,
+  multisample: {mask: 0x60b3e595},
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'zero'},
+    stencilWriteMask: 1912827780,
+    depthBiasSlopeScale: 678.4060556983152,
+  },
+  vertex: {module: shaderModule26, entryPoint: 'vertex0', buffers: []},
+});
+let sampler68 = device1.createSampler({
+  label: '\udb8c\u214e\u115b\uf42f\uca24\u{1fa3d}\u{1f846}\u{1fe46}\u9089\u{1f7ce}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 53.48,
+  lodMaxClamp: 88.00,
+});
+try {
+renderBundleEncoder73.setPipeline(pipeline122);
+} catch {}
+canvas2.width = 592;
+let offscreenCanvas20 = new OffscreenCanvas(521, 320);
+let imageBitmap22 = await createImageBitmap(imageData13);
+let shaderModule28 = device1.createShaderModule({
+  code: `@group(4) @binding(5439)
+var<storage, read_write> type19: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> global15: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> parameter16: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> local19: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> n21: array<u32>;
+@group(1) @binding(3627)
+var<storage, read_write> global16: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> field18: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(2) f1: vec2<i32>,
+  @location(1) f2: vec2<u32>,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec4<f16>, @location(4) a1: vec2<f16>, @location(27) a2: vec4<u32>, @location(19) a3: i32, @location(91) a4: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(14) f0: vec2<i32>,
+  @location(25) f1: f16,
+  @location(15) f2: vec3<u32>,
+  @location(18) f3: vec2<u32>,
+  @location(1) f4: vec2<i32>,
+  @location(3) f5: vec4<u32>,
+  @location(23) f6: vec2<u32>,
+  @location(5) f7: vec2<u32>,
+  @location(6) f8: vec4<i32>,
+  @location(20) f9: vec2<i32>,
+  @location(13) f10: f32,
+  @location(8) f11: vec4<f16>,
+  @location(2) f12: f16,
+  @location(24) f13: vec4<i32>,
+  @location(17) f14: vec3<i32>,
+  @location(16) f15: vec4<i32>,
+  @location(0) f16: f16,
+  @location(21) f17: vec4<f16>,
+  @location(10) f18: vec2<i32>,
+  @location(9) f19: vec2<f32>,
+  @location(7) f20: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(23) f337: vec4<f16>,
+  @location(16) f338: vec3<f16>,
+  @location(96) f339: vec4<u32>,
+  @location(34) f340: u32,
+  @builtin(position) f341: vec4<f32>,
+  @location(88) f342: vec4<f16>,
+  @location(43) f343: vec3<f32>,
+  @location(4) f344: vec2<f16>,
+  @location(51) f345: u32,
+  @location(106) f346: vec4<u32>,
+  @location(54) f347: u32,
+  @location(24) f348: vec2<f16>,
+  @location(45) f349: f16,
+  @location(7) f350: vec3<i32>,
+  @location(77) f351: f16,
+  @location(89) f352: vec2<u32>,
+  @location(75) f353: vec3<i32>,
+  @location(72) f354: vec4<f32>,
+  @location(84) f355: vec3<f32>,
+  @location(0) f356: vec4<f16>,
+  @location(25) f357: vec4<f32>,
+  @location(27) f358: vec4<u32>,
+  @location(76) f359: vec3<f32>,
+  @location(17) f360: f32,
+  @location(53) f361: vec4<u32>,
+  @location(90) f362: vec2<u32>,
+  @location(95) f363: vec2<f16>,
+  @location(98) f364: vec3<f16>,
+  @location(19) f365: i32,
+  @location(58) f366: vec2<f32>,
+  @location(44) f367: vec3<i32>,
+  @location(21) f368: f32,
+  @location(91) f369: vec3<i32>,
+  @location(37) f370: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: u32, @builtin(vertex_index) a1: u32, @location(11) a2: vec2<u32>, @builtin(instance_index) a3: u32, @location(19) a4: vec2<f32>, a5: S18, @location(22) a6: u32, @location(12) a7: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder150 = device1.createCommandEncoder({label: '\u{1fcdb}\uc130\u0cb3\u{1f82f}\u6d0b\u4d46\u0dad\u{1f9ae}\u1d9e\udb0b\u43f4'});
+let querySet73 = device1.createQuerySet({label: '\uc61b\u0b0c\u07ca\ueb57\u1b4d', type: 'occlusion', count: 2306});
+let textureView182 = texture89.createView({baseMipLevel: 3, mipLevelCount: 3, baseArrayLayer: 70, arrayLayerCount: 1265});
+let renderBundle91 = renderBundleEncoder70.finish({label: '\u025c\u0f13\ud55f\u2813\u41be'});
+try {
+renderBundleEncoder73.setVertexBuffer(1, buffer39, 0, 1193);
+} catch {}
+try {
+commandEncoder143.copyBufferToBuffer(buffer38, 335532, buffer41, 31624, 25228);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder143.resolveQuerySet(querySet73, 1618, 673, buffer40, 76288);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 171},
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 1190198 */
+{offset: 302, bytesPerRow: 986, rowsPerImage: 201}, {width: 390, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let pipeline130 = device1.createComputePipeline({
+  label: '\u{1f62b}\u{1fdfd}\u0f64\u0717\u9a48\u4c9f',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}},
+});
+let texture91 = device1.createTexture({
+  label: '\uec09\u02a3',
+  size: {width: 555, height: 5, depthOrArrayLayers: 100},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView183 = texture84.createView({mipLevelCount: 2});
+let computePassEncoder62 = commandEncoder143.beginComputePass({});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  label: '\ufb67\u68af\u{1fba2}',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture62 = device1.importExternalTexture({label: '\u0988\u0407\u178e', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline131 = await promise32;
+let shaderModule29 = device1.createShaderModule({
+  label: '\u5822\u{1f973}\ub47a\u0384\ue989\u003b\u9df1\u9904',
+  code: `@group(3) @binding(3627)
+var<storage, read_write> type20: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> global17: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> field19: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> function25: array<u32>;
+@group(1) @binding(3627)
+var<storage, read_write> parameter17: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> function26: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> field20: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> field21: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> local20: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: f32,
+  @location(2) f1: vec3<i32>,
+  @location(3) f2: vec4<i32>,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(4) f0: vec2<f16>,
+  @location(2) f1: vec2<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(16) f3: vec4<i32>,
+  @location(13) f4: vec2<f32>,
+  @location(17) f5: f16,
+  @builtin(vertex_index) f6: u32,
+  @location(19) f7: vec3<u32>,
+  @location(9) f8: vec4<f16>,
+  @location(21) f9: vec4<f16>,
+  @location(6) f10: u32,
+  @location(5) f11: i32,
+  @location(12) f12: f16,
+  @location(23) f13: f16,
+  @location(14) f14: vec4<u32>,
+  @location(22) f15: vec4<f32>,
+  @location(20) f16: vec3<f16>,
+  @location(10) f17: vec4<u32>,
+  @location(8) f18: i32,
+  @location(15) f19: vec3<f32>,
+  @location(7) f20: vec2<f32>,
+  @location(18) f21: vec3<u32>,
+  @location(0) f22: vec3<u32>,
+  @location(11) f23: vec3<f32>
+}
+struct VertexOutput0 {
+  @builtin(position) f371: vec4<f32>,
+  @location(79) f372: vec2<i32>,
+  @location(24) f373: f16,
+  @location(13) f374: vec3<f32>,
+  @location(109) f375: vec2<u32>,
+  @location(74) f376: vec4<f16>,
+  @location(59) f377: f16,
+  @location(57) f378: vec4<f16>,
+  @location(81) f379: vec2<i32>,
+  @location(62) f380: vec4<u32>,
+  @location(0) f381: vec3<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, a1: S19, @location(1) a2: vec3<i32>, @location(24) a3: u32, @location(25) a4: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView184 = texture91.createView({label: '\u{1feb8}\u0241', baseMipLevel: 1});
+let renderBundleEncoder76 = device1.createRenderBundleEncoder({
+  label: '\u0f14\uf36c\u0dd3\u03e2\u9b9c\ue7c9\u07f8\u0ec2\u03c4',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder61.setPipeline(pipeline130);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(5, buffer39);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2588, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder71.insertDebugMarker('\u{1fef9}');
+} catch {}
+let pipeline132 = device1.createRenderPipeline({
+  label: '\ud41b\u{1f728}\uf1ca',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint'}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {module: shaderModule26, entryPoint: 'vertex0', buffers: []},
+});
+let gpuCanvasContext20 = offscreenCanvas20.getContext('webgpu');
+let commandEncoder151 = device1.createCommandEncoder({label: '\u0920\u05be\u0384\u424e\u{1ffd0}\u07d5\u1002'});
+let textureView185 = texture88.createView({label: '\u{1f81a}\uc540\ue168\u{1f708}', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder63 = commandEncoder150.beginComputePass({});
+let sampler69 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 94.60,
+  lodMaxClamp: 97.95,
+});
+try {
+  await buffer42.mapAsync(GPUMapMode.READ, 0, 131280);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer38, 5132, buffer42, 152920, 22840);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 218, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 129, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline133 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout18,
+  multisample: {count: 4, mask: 0x926a8844},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1404,
+        attributes: [
+          {format: 'float32x4', offset: 80, shaderLocation: 0},
+          {format: 'float16x4', offset: 508, shaderLocation: 2},
+          {format: 'sint32x2', offset: 188, shaderLocation: 19},
+          {format: 'sint32', offset: 300, shaderLocation: 20},
+          {format: 'float16x4', offset: 124, shaderLocation: 9},
+          {format: 'sint32x3', offset: 100, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 2288,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 608, shaderLocation: 7}],
+      },
+      {arrayStride: 1472, attributes: [{format: 'uint16x4', offset: 264, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let adapter5 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas21 = new OffscreenCanvas(192, 221);
+let imageBitmap23 = await createImageBitmap(video21);
+let commandEncoder152 = device1.createCommandEncoder({label: '\u{1f8fd}\u{1fd58}\u0533\u0498\ud337\u5db4\u{1ff40}\u{1fba5}\u0402\u223f\u7f1d'});
+let texture92 = device1.createTexture({
+  label: '\u1bfa\uc5eb',
+  size: {width: 277, height: 2, depthOrArrayLayers: 859},
+  mipLevelCount: 8,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+let textureView186 = texture84.createView({label: '\uf3f6\ud974\u52f6\u{1fb5b}\u{1fd12}\u{1f7ef}', baseMipLevel: 1, baseArrayLayer: 0});
+try {
+computePassEncoder63.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder69.drawIndexed(687593278, 1147706554, 193880114, 103793779, 705808628);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline133);
+} catch {}
+gc();
+let querySet74 = device1.createQuerySet({label: '\u6b51\u2aa1\u0024\u0272\u5984\ue73d\udabd', type: 'occlusion', count: 3597});
+let sampler70 = device1.createSampler({
+  label: '\u6ee9\u39d9\u0cfa\u0964\u8dd2',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.53,
+  lodMaxClamp: 97.38,
+});
+let externalTexture63 = device1.importExternalTexture({
+  label: '\u6768\u0c2a\ub7d3\u0532\u{1fab9}\u{1f985}\u0d6a\u0b00',
+  source: videoFrame14,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder152.resolveQuerySet(querySet69, 3142, 11, buffer40, 163840);
+} catch {}
+try {
+device1.queue.submit([commandBuffer34]);
+} catch {}
+let commandBuffer37 = commandEncoder138.finish({label: '\u0125\u0e7c\ueaa5\u462f\u6c7a\u079e\u{1fc5e}\u8a7f\ub550\u2159'});
+let textureView187 = texture92.createView({label: '\ua79b\ubf64\u5256\uf212\u5b27\u4564\ud926', baseMipLevel: 6, mipLevelCount: 1});
+let computePassEncoder64 = commandEncoder151.beginComputePass({label: '\u087c\u0e99\u0f51'});
+let renderBundleEncoder77 = device1.createRenderBundleEncoder({
+  label: '\uec5a\ud297\u91d6\u7707\u2943\u{1fece}\uadd8',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+let renderBundle92 = renderBundleEncoder74.finish({label: '\u11c1\u00f5\u08f1\u7abe\u62b7\u0b98\u0bc4\u2086'});
+try {
+renderBundleEncoder73.drawIndexed(49732683, 547673628, 672932794, -1145568236);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(8, buffer39, 0, 1776);
+} catch {}
+try {
+commandEncoder146.clearBuffer(buffer42, 161148, 48940);
+dissociateBuffer(device1, buffer42);
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise33;
+} catch {}
+try {
+adapter4.label = '\u621b\u{1fca8}\u0ede\u1ee8\u06cd\u{1f869}\u{1fa28}\ueba2';
+} catch {}
+try {
+offscreenCanvas21.getContext('webgl2');
+} catch {}
+canvas13.height = 469;
+let imageData19 = new ImageData(140, 104);
+let commandBuffer38 = commandEncoder147.finish({label: '\u{1f8f4}\u97e8\u{1f694}\u356c\u{1ff59}\u578f\ue22d\u08c8\u0d45'});
+let textureView188 = texture83.createView({label: '\u0dfb\u0cb0\u02d9\u{1f7d5}\u{1f962}\u2647\u03b8\u{1fa95}\ud6e4\u798e', dimension: '1d'});
+try {
+renderBundleEncoder73.draw(291847043, 148247431, 348701607, 543836662);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexed(929869059, 38257209, 1144095529);
+} catch {}
+try {
+renderBundleEncoder75.setPipeline(pipeline133);
+} catch {}
+let promise34 = buffer38.mapAsync(GPUMapMode.WRITE, 380216, 8932);
+try {
+commandEncoder152.copyBufferToBuffer(buffer38, 144556, buffer41, 361308, 36320);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 595, y: 0, z: 47},
+  aspect: 'all',
+}, new ArrayBuffer(14580194), /* required buffer size: 14580194 */
+{offset: 418, bytesPerRow: 2018, rowsPerImage: 84}, {width: 218, height: 1, depthOrArrayLayers: 87});
+} catch {}
+video10.height = 268;
+let shaderModule30 = device1.createShaderModule({
+  code: `@group(0) @binding(3627)
+var<storage, read_write> field22: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> global18: array<u32>;
+@group(4) @binding(5439)
+var<storage, read_write> global19: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> n22: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> local21: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> type21: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> parameter18: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> n23: array<u32>;
+@group(1) @binding(3627)
+var<storage, read_write> n24: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @location(2) f1: vec4<i32>,
+  @location(3) f2: vec3<i32>,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(2) f0: vec4<f16>,
+  @location(24) f1: vec3<f32>,
+  @location(1) f2: vec3<f16>,
+  @location(4) f3: vec2<i32>,
+  @location(18) f4: vec2<f32>,
+  @location(16) f5: vec4<f16>,
+  @location(22) f6: vec2<i32>,
+  @location(5) f7: vec2<i32>,
+  @location(6) f8: vec3<f16>,
+  @location(14) f9: vec4<i32>,
+  @location(23) f10: vec4<i32>,
+  @location(3) f11: f32,
+  @location(11) f12: vec2<f32>,
+  @location(10) f13: vec3<f32>,
+  @location(15) f14: vec3<u32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, @location(9) a2: vec4<i32>, @location(8) a3: vec2<f16>, @location(0) a4: vec4<i32>, @location(25) a5: f16, @location(19) a6: vec2<f16>, a7: S20, @location(21) a8: vec2<f32>, @location(13) a9: vec4<i32>, @location(12) a10: vec3<f32>, @location(7) a11: f16, @location(20) a12: u32, @location(17) a13: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout19 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout33, bindGroupLayout33, bindGroupLayout33, bindGroupLayout33]});
+let commandEncoder153 = device1.createCommandEncoder({label: '\ue089\u12b5\u841e'});
+let querySet75 = device1.createQuerySet({label: '\u{1ffe8}\u0cc3\u27e8\u2fe5', type: 'occlusion', count: 3067});
+let computePassEncoder65 = commandEncoder153.beginComputePass({label: '\u001f\ua30f\u9d3c\u755e\u{1fbf7}\u05de\u0aa5\u037b\u0593'});
+let renderBundleEncoder78 = device1.createRenderBundleEncoder({
+  label: '\u{1fd17}\u0091\u{1f9fd}',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder72.draw(838333195, 486586321, 315554540, 241839423);
+} catch {}
+let pipeline134 = device1.createRenderPipeline({
+  label: '\u{1f616}\ue15c\u686d\u48af\u{1ff04}\u{1fd12}\u62fe\uc5b8\ub112\u03ec\u073c',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint'}],
+},
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 200, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 648,
+        attributes: [
+          {format: 'uint16x4', offset: 512, shaderLocation: 15},
+          {format: 'sint32x3', offset: 16, shaderLocation: 23},
+          {format: 'float16x2', offset: 148, shaderLocation: 0},
+          {format: 'sint8x2', offset: 558, shaderLocation: 12},
+          {format: 'uint16x4', offset: 280, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 104, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 208, shaderLocation: 24},
+          {format: 'snorm8x2', offset: 22, shaderLocation: 20},
+          {format: 'uint16x2', offset: 16, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 9},
+          {format: 'sint8x2', offset: 188, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 2812,
+        attributes: [
+          {format: 'sint32x4', offset: 1148, shaderLocation: 8},
+          {format: 'sint16x4', offset: 48, shaderLocation: 14},
+          {format: 'sint16x4', offset: 160, shaderLocation: 18},
+          {format: 'sint16x2', offset: 180, shaderLocation: 10},
+          {format: 'uint8x4', offset: 156, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 652, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 1690, shaderLocation: 7},
+          {format: 'float32x3', offset: 204, shaderLocation: 6},
+          {format: 'float32', offset: 428, shaderLocation: 17},
+          {format: 'uint32x4', offset: 4, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 932,
+        attributes: [
+          {format: 'unorm8x2', offset: 82, shaderLocation: 2},
+          {format: 'uint32x3', offset: 24, shaderLocation: 25},
+          {format: 'sint8x2', offset: 478, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 3288,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 260, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+adapter2.label = '\u4a29\u016c\u{1fd9c}\u7b34\u6e8e\u0c5a\ue68b\u{1fd93}';
+} catch {}
+let shaderModule31 = device0.createShaderModule({
+  label: '\u{1fcb5}\ue58c',
+  code: `@group(1) @binding(4481)
+var<storage, read_write> global20: array<u32>;
+@group(1) @binding(7721)
+var<storage, read_write> field23: array<u32>;
+@group(0) @binding(56)
+var<storage, read_write> type22: array<u32>;
+@group(2) @binding(1133)
+var<storage, read_write> type23: array<u32>;
+@group(0) @binding(3674)
+var<storage, read_write> local22: array<u32>;
+@group(0) @binding(2129)
+var<storage, read_write> field24: array<u32>;
+@group(3) @binding(6991)
+var<storage, read_write> global21: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3<f32>,
+  @location(5) f1: i32,
+  @location(1) f2: vec4<f32>,
+  @location(4) f3: vec2<i32>,
+  @location(0) f4: vec4<f32>,
+  @location(3) f5: vec4<f32>,
+  @location(2) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(44) a0: vec4<i32>, @location(7) a1: f32, @location(18) a2: vec4<f32>, @location(26) a3: vec3<f32>, @location(37) a4: vec2<f16>, @location(31) a5: vec4<u32>, @location(10) a6: vec4<u32>, @location(33) a7: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(8) f382: f16,
+  @location(45) f383: vec2<f16>,
+  @location(23) f384: vec3<f16>,
+  @location(34) f385: vec2<f16>,
+  @location(46) f386: vec4<f16>,
+  @location(33) f387: vec2<f16>,
+  @location(18) f388: vec4<f32>,
+  @location(26) f389: vec3<f32>,
+  @location(39) f390: vec4<f32>,
+  @location(19) f391: vec2<u32>,
+  @location(58) f392: vec2<f16>,
+  @location(31) f393: vec4<u32>,
+  @location(35) f394: vec3<f32>,
+  @location(51) f395: vec2<i32>,
+  @location(37) f396: vec2<f16>,
+  @location(6) f397: vec4<f16>,
+  @location(7) f398: f32,
+  @location(44) f399: vec4<i32>,
+  @location(47) f400: vec2<f32>,
+  @location(57) f401: f16,
+  @location(42) f402: vec2<i32>,
+  @builtin(position) f403: vec4<f32>,
+  @location(15) f404: vec4<f32>,
+  @location(11) f405: vec4<u32>,
+  @location(0) f406: vec3<f16>,
+  @location(10) f407: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<u32>, @location(12) a1: vec3<i32>, @location(13) a2: i32, @location(7) a3: f32, @builtin(instance_index) a4: u32, @location(4) a5: u32, @builtin(vertex_index) a6: u32, @location(15) a7: vec4<u32>, @location(9) a8: f16, @location(8) a9: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder154 = device0.createCommandEncoder({label: '\ub4b6\ubc0f\u573e\u050a'});
+let texture93 = device0.createTexture({
+  label: '\u0181\u2ed4\u041b\u71d5\u01cb\u0952',
+  size: {width: 576, height: 1, depthOrArrayLayers: 321},
+  mipLevelCount: 8,
+  sampleCount: 1,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+try {
+computePassEncoder21.setPipeline(pipeline116);
+} catch {}
+try {
+renderBundleEncoder10.draw(274657509, 155126833, 949402686);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(941213643);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer37, 42680);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer5, 59592, buffer36, 65756, 39568);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 4520, new Int16Array(3929), 2831, 12);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(117, 648);
+let gpuCanvasContext21 = offscreenCanvas22.getContext('webgpu');
+let imageBitmap24 = await createImageBitmap(imageData15);
+try {
+  await promise34;
+} catch {}
+document.body.prepend(img15);
+let shaderModule32 = device1.createShaderModule({
+  label: '\u0d78\u01e3\u1776',
+  code: `@group(2) @binding(3627)
+var<storage, read_write> field25: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> n25: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> field26: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> local23: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> function27: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> local24: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> parameter19: array<u32>;
+@group(4) @binding(5439)
+var<storage, read_write> global22: array<u32>;
+@group(1) @binding(3627)
+var<storage, read_write> local25: array<u32>;
+
+@compute @workgroup_size(3, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(6) f1: u32,
+  @location(0) f2: f32,
+  @location(5) f3: i32,
+  @location(2) f4: vec2<i32>,
+  @location(3) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(11) f0: vec4<i32>,
+  @location(6) f1: vec2<f16>,
+  @location(5) f2: vec4<i32>,
+  @location(10) f3: vec3<u32>,
+  @location(0) f4: vec3<f32>,
+  @location(23) f5: u32,
+  @location(9) f6: vec2<i32>,
+  @location(20) f7: vec4<f32>,
+  @location(16) f8: vec2<f32>,
+  @location(8) f9: vec3<i32>,
+  @location(7) f10: vec4<f32>,
+  @location(4) f11: vec2<f32>,
+  @location(1) f12: vec3<f32>,
+  @builtin(vertex_index) f13: u32
+}
+
+@vertex
+fn vertex0(@location(22) a0: u32, @location(12) a1: vec3<u32>, @location(18) a2: vec2<i32>, @location(17) a3: vec4<u32>, @location(3) a4: vec3<f32>, @location(21) a5: vec2<i32>, @location(25) a6: vec4<i32>, @location(15) a7: vec3<f32>, @location(24) a8: vec4<i32>, @location(2) a9: vec4<u32>, @location(19) a10: vec3<u32>, @location(13) a11: f32, @location(14) a12: i32, a13: S21, @builtin(instance_index) a14: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder155 = device1.createCommandEncoder();
+let texture94 = gpuCanvasContext5.getCurrentTexture();
+let textureView189 = texture92.createView({
+  label: '\ub46c\u{1fd17}\u{1f633}\u02be\ub559\u{1f776}\u8a81\u6650\uf71a\u35af\u7e1f',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder63.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder72.draw(204309511, 722072049, 576402525);
+} catch {}
+try {
+renderBundleEncoder73.drawIndexed(583927104, 550940572);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline122);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder146.clearBuffer(buffer42, 164924, 10568);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer41, 247468, new Int16Array(47226), 1911, 2712);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img19,
+  origin: { x: 15, y: 0 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video11);
+let renderBundleEncoder79 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture64 = device1.importExternalTexture({label: '\ue4a2\u0416\u01f2\u076b\u085a\u0063\u77c7\u{1f8e5}\u2868\u0f6f\ub532', source: video10});
+try {
+computePassEncoder63.end();
+} catch {}
+try {
+commandEncoder146.copyBufferToBuffer(buffer38, 341964, buffer41, 349744, 49320);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder152.resolveQuerySet(querySet75, 3060, 7, buffer40, 210432);
+} catch {}
+try {
+renderBundleEncoder73.insertDebugMarker('\u{1f9c0}');
+} catch {}
+canvas10.width = 276;
+let videoFrame15 = new VideoFrame(imageBitmap12, {timestamp: 0});
+let textureView190 = texture86.createView({label: '\u0cf6\u0956\u{1fc91}\u{1fe25}\u0fd1\u{1fbe0}\uc2cf\u0115\u02b5', mipLevelCount: 1});
+let computePassEncoder66 = commandEncoder155.beginComputePass({label: '\u{1f900}\ube74\u{1f7d2}\u{1fec2}\u92c5\u{1f757}\u4d87'});
+let renderBundleEncoder80 = device1.createRenderBundleEncoder({
+  label: '\u20fb\u{1f819}\ub3e3\u9932\u86f2\u{1feef}\ua114',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+renderBundleEncoder78.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(4, buffer39, 0, 2988);
+} catch {}
+try {
+buffer38.destroy();
+} catch {}
+try {
+commandEncoder153.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3026 */
+  offset: 3026,
+  rowsPerImage: 203,
+  buffer: buffer38,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+device1.queue.submit([commandBuffer36, commandBuffer37]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img21,
+  origin: { x: 18, y: 1 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule33 = device1.createShaderModule({
+  label: '\ue510\u{1fc42}\u06f1\u0a90\u0e90\u98ce\u5649\u174b',
+  code: `@group(0) @binding(3627)
+var<storage, read_write> global23: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> function28: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> n26: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> field27: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> function29: array<u32>;
+
+@compute @workgroup_size(2, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @location(14) f0: vec4<i32>,
+  @location(50) f1: vec3<f32>,
+  @location(77) f2: vec4<f16>,
+  @location(25) f3: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec2<i32>,
+  @location(2) f1: vec2<i32>,
+  @location(0) f2: f32,
+  @location(1) f3: u32
+}
+
+@fragment
+fn fragment0(@location(105) a0: vec2<f16>, a1: S22, @location(91) a2: vec2<i32>, @location(2) a3: f32, @location(22) a4: f16, @location(49) a5: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(42) f408: vec3<u32>,
+  @location(19) f409: i32,
+  @location(68) f410: vec3<f16>,
+  @location(47) f411: vec2<f16>,
+  @location(73) f412: vec4<u32>,
+  @location(26) f413: vec4<i32>,
+  @location(71) f414: vec2<f32>,
+  @location(43) f415: vec3<u32>,
+  @location(91) f416: vec2<i32>,
+  @location(90) f417: vec4<f16>,
+  @location(44) f418: vec4<f32>,
+  @location(34) f419: vec4<u32>,
+  @location(14) f420: vec4<i32>,
+  @location(65) f421: vec2<u32>,
+  @location(50) f422: vec3<f32>,
+  @location(28) f423: vec4<f16>,
+  @location(107) f424: vec2<f16>,
+  @location(21) f425: f16,
+  @location(22) f426: f16,
+  @location(105) f427: vec2<f16>,
+  @location(25) f428: vec4<f16>,
+  @builtin(position) f429: vec4<f32>,
+  @location(77) f430: vec4<f16>,
+  @location(60) f431: vec3<f32>,
+  @location(48) f432: i32,
+  @location(59) f433: u32,
+  @location(96) f434: vec4<f32>,
+  @location(2) f435: f32,
+  @location(49) f436: vec2<f32>,
+  @location(89) f437: vec3<u32>,
+  @location(46) f438: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+document.body.prepend(img0);
+let commandEncoder156 = device0.createCommandEncoder({label: '\u1706\ua03b\u05c8\u309b\u6ce8\u349c\u{1f6b5}\u{1fb96}\u194a\u2f2c\u3319'});
+let querySet76 = device0.createQuerySet({label: '\u2bd5\u05fd\u9d9b\u2a34\u56fc\u3e9d\u{1fbce}\ub9ba', type: 'occlusion', count: 1034});
+let commandBuffer39 = commandEncoder58.finish();
+try {
+computePassEncoder30.setBindGroup(1, bindGroup8, new Uint32Array(258), 102, 0);
+} catch {}
+let arrayBuffer14 = buffer17.getMappedRange(54920, 3664);
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer36, 7952, 41504);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline135 = device0.createRenderPipeline({
+  label: '\u8374\u0a9c\u0480\u07a6\u8c1a\u0056\u6b68\ud84d\ufcf9',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0xec32162c},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8sint'}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8sint'}, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1164,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 56, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 0},
+          {format: 'float32', offset: 0, shaderLocation: 3},
+          {format: 'uint16x2', offset: 616, shaderLocation: 12},
+          {format: 'sint32x2', offset: 232, shaderLocation: 8},
+          {format: 'float32x4', offset: 860, shaderLocation: 11},
+          {format: 'uint8x4', offset: 52, shaderLocation: 9},
+          {format: 'float32x3', offset: 84, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 556, shaderLocation: 13},
+          {format: 'sint32x2', offset: 20, shaderLocation: 4},
+          {format: 'sint32x2', offset: 116, shaderLocation: 7},
+          {format: 'uint8x4', offset: 20, shaderLocation: 1},
+          {format: 'sint32x4', offset: 1148, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 3024, stepMode: 'instance', attributes: []},
+      {arrayStride: 7292, stepMode: 'instance', attributes: []},
+      {arrayStride: 2328, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 21140,
+        attributes: [
+          {format: 'sint16x4', offset: 7584, shaderLocation: 14},
+          {format: 'float16x4', offset: 2524, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 19684, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let imageData20 = new ImageData(148, 36);
+let commandEncoder157 = device1.createCommandEncoder({label: '\u1962\u0f78\u08bd\u{1ff98}\u{1fbb6}\u30a8'});
+let texture95 = device1.createTexture({
+  label: '\u660d\ubd14\u{1fc37}\u{1fec9}\u{1f608}\u30e3\u7118\uf46e\u0516\u00cd',
+  size: [1110, 10, 79],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView191 = texture87.createView({label: '\u00cd\u4e69\u{1f998}'});
+let promise35 = buffer41.mapAsync(GPUMapMode.READ, 0, 3620);
+try {
+commandEncoder153.copyBufferToTexture({
+  /* bytesInLastRow: 140 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25984 */
+  offset: 25984,
+  buffer: buffer38,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder146.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 4078, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 94, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder157.resolveQuerySet(querySet61, 815, 215, buffer40, 272384);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 2,
+  origin: {x: 29, y: 0, z: 228},
+  aspect: 'all',
+}, new DataView(arrayBuffer13), /* required buffer size: 27349870 */
+{offset: 814, bytesPerRow: 476, rowsPerImage: 108}, {width: 34, height: 0, depthOrArrayLayers: 533});
+} catch {}
+let canvas21 = document.createElement('canvas');
+let img25 = await imageWithData(243, 70, '#c58361f7', '#615a5d7e');
+try {
+canvas21.getContext('webgpu');
+} catch {}
+let textureView192 = texture87.createView({baseArrayLayer: 0});
+let computePassEncoder67 = commandEncoder153.beginComputePass({});
+let externalTexture65 = device1.importExternalTexture({
+  label: '\u0b52\u0e0c\uf9e8\uc461\u4d34\ud574\u{1fa48}\u0028\u{1fc6a}\u8ae2',
+  source: videoFrame8,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder67.setPipeline(pipeline126);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(1, buffer39, 0, 5912);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 31},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 113068206 */
+{offset: 742, bytesPerRow: 296, rowsPerImage: 276}, {width: 25, height: 1, depthOrArrayLayers: 1385});
+} catch {}
+let canvas22 = document.createElement('canvas');
+let videoFrame16 = new VideoFrame(imageBitmap16, {timestamp: 0});
+let shaderModule34 = device1.createShaderModule({
+  label: '\u0ec5\u{1fc26}\u05b3\u4d61\u9d28\u17f4\u{1fe76}\u5b73',
+  code: `@group(2) @binding(5439)
+var<storage, read_write> parameter20: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> global24: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> local26: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> field28: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> global25: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<i32>,
+  @location(0) f1: vec2<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(1) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+try {
+renderBundleEncoder77.setPipeline(pipeline122);
+} catch {}
+try {
+commandEncoder146.clearBuffer(buffer41, 171228, 294188);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+renderBundleEncoder75.insertDebugMarker('\u{1fae2}');
+} catch {}
+let commandBuffer40 = commandEncoder146.finish({label: '\u{1f602}\ua051\u{1fed3}\ua929\ud499\u3b23\ua61b'});
+try {
+computePassEncoder61.setPipeline(pipeline130);
+} catch {}
+try {
+renderBundleEncoder77.drawIndexed(376863450, 451025671, 1187755455, 682695265);
+} catch {}
+try {
+renderBundleEncoder75.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(7513, undefined, 0, 2618737034);
+} catch {}
+try {
+commandEncoder137.copyBufferToBuffer(buffer38, 301460, buffer42, 67200, 6852);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer42);
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  label: '\u00df\u41ec\u5a32\u57c9\uf4bf\u{1fd92}\u0581\ud177',
+  entries: [
+    {
+      binding: 2060,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let textureView193 = texture84.createView({label: '\uc7dc\u0270\uc897\u2beb', format: 'r16uint', baseMipLevel: 1});
+try {
+renderBundleEncoder78.draw(585902209, 583262334, 958860944, 800423525);
+} catch {}
+try {
+commandEncoder152.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 33},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder80.pushDebugGroup('\u{1f856}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 4,
+  origin: {x: 8, y: 0, z: 133},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 18410044 */
+{offset: 661, bytesPerRow: 141, rowsPerImage: 267}, {width: 12, height: 0, depthOrArrayLayers: 490});
+} catch {}
+let gpuCanvasContext22 = canvas22.getContext('webgpu');
+let shaderModule35 = device1.createShaderModule({
+  label: '\uf35c\u03ee\u3cda\u0ff9\u8608\uf08e',
+  code: `@group(2) @binding(3627)
+var<storage, read_write> global26: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> field29: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> type24: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> type25: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> global27: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> global28: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+  @location(89) f0: vec3<f32>,
+  @location(47) f1: vec2<f32>,
+  @location(108) f2: vec4<f32>,
+  @location(39) f3: vec3<f16>,
+  @location(0) f4: vec2<i32>,
+  @builtin(sample_index) f5: u32,
+  @location(102) f6: vec3<u32>,
+  @location(35) f7: f32,
+  @location(25) f8: vec3<i32>,
+  @location(17) f9: vec3<i32>,
+  @location(75) f10: vec4<f16>,
+  @location(34) f11: i32
+}
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(2) f1: vec3<i32>,
+  @location(0) f2: vec3<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(3) f4: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec2<f16>, @location(99) a1: vec3<i32>, @location(40) a2: u32, @location(26) a3: vec4<u32>, @location(31) a4: vec4<u32>, @location(38) a5: vec2<f32>, @location(24) a6: vec3<i32>, @location(65) a7: vec4<f32>, @location(2) a8: vec2<i32>, @location(37) a9: f16, @location(49) a10: vec3<u32>, @location(59) a11: vec4<f16>, @location(32) a12: vec2<f32>, @location(33) a13: i32, @location(77) a14: vec3<i32>, @location(104) a15: vec2<u32>, @location(4) a16: f16, @location(92) a17: vec2<u32>, @builtin(front_facing) a18: bool, @location(7) a19: f16, @builtin(sample_mask) a20: u32, @location(5) a21: u32, a22: S23, @location(51) a23: u32, @location(3) a24: vec4<f32>, @location(93) a25: vec4<f32>, @location(44) a26: vec3<u32>, @location(103) a27: vec3<i32>, @location(13) a28: vec2<f16>, @location(21) a29: vec3<u32>, @location(70) a30: vec4<f16>, @location(78) a31: vec3<f16>, @location(15) a32: vec4<u32>, @location(28) a33: vec2<f16>, @location(98) a34: vec2<f32>, @location(45) a35: vec2<u32>, @location(20) a36: vec2<f16>, @builtin(position) a37: vec4<f32>, @location(54) a38: u32, @location(105) a39: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(32) f439: vec2<f32>,
+  @location(89) f440: vec3<f32>,
+  @builtin(position) f441: vec4<f32>,
+  @location(59) f442: vec4<f16>,
+  @location(78) f443: vec3<f16>,
+  @location(98) f444: vec2<f32>,
+  @location(54) f445: u32,
+  @location(51) f446: u32,
+  @location(93) f447: vec4<f32>,
+  @location(24) f448: vec3<i32>,
+  @location(28) f449: vec2<f16>,
+  @location(39) f450: vec3<f16>,
+  @location(34) f451: i32,
+  @location(5) f452: u32,
+  @location(75) f453: vec4<f16>,
+  @location(3) f454: vec4<f32>,
+  @location(35) f455: f32,
+  @location(40) f456: u32,
+  @location(108) f457: vec4<f32>,
+  @location(25) f458: vec3<i32>,
+  @location(92) f459: vec2<u32>,
+  @location(103) f460: vec3<i32>,
+  @location(26) f461: vec4<u32>,
+  @location(102) f462: vec3<u32>,
+  @location(15) f463: vec4<u32>,
+  @location(17) f464: vec3<i32>,
+  @location(13) f465: vec2<f16>,
+  @location(44) f466: vec3<u32>,
+  @location(0) f467: vec2<i32>,
+  @location(7) f468: f16,
+  @location(99) f469: vec3<i32>,
+  @location(4) f470: f16,
+  @location(37) f471: f16,
+  @location(1) f472: vec2<f16>,
+  @location(33) f473: i32,
+  @location(2) f474: vec2<i32>,
+  @location(38) f475: vec2<f32>,
+  @location(45) f476: vec2<u32>,
+  @location(49) f477: vec3<u32>,
+  @location(47) f478: vec2<f32>,
+  @location(105) f479: vec3<f32>,
+  @location(77) f480: vec3<i32>,
+  @location(20) f481: vec2<f16>,
+  @location(70) f482: vec4<f16>,
+  @location(31) f483: vec4<u32>,
+  @location(21) f484: vec3<u32>,
+  @location(104) f485: vec2<u32>,
+  @location(65) f486: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec2<f16>, @location(12) a1: vec4<u32>, @builtin(vertex_index) a2: u32, @location(8) a3: vec2<f32>, @location(6) a4: vec3<u32>, @location(23) a5: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView194 = texture91.createView({label: '\ufb5a\u{1fc26}\u588f', mipLevelCount: 1});
+let sampler71 = device1.createSampler({
+  label: '\u{1fa9d}\u0e54',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.39,
+  lodMaxClamp: 91.68,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder75.draw(1163485241);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(8, buffer39);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+canvas15.width = 1141;
+let commandEncoder158 = device1.createCommandEncoder();
+let commandBuffer41 = commandEncoder137.finish();
+let externalTexture66 = device1.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+renderBundleEncoder77.setVertexBuffer(5, buffer39, 5780, 1411);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let img26 = await imageWithData(14, 177, '#d1894479', '#44a03454');
+let imageBitmap25 = await createImageBitmap(imageBitmap22);
+let commandEncoder159 = device1.createCommandEncoder();
+let texture96 = device1.createTexture({
+  label: '\ud6bd\ua031\u{1f6e9}\u0df6\u1ace\u01b4\u3176\u94e1',
+  size: [555, 5, 168],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder66.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(5, buffer39, 8612, 292);
+} catch {}
+try {
+commandEncoder152.copyBufferToBuffer(buffer38, 70576, buffer42, 6008, 4696);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+renderBundleEncoder80.popDebugGroup();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas10,
+  origin: { x: 73, y: 3 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline136 = await device1.createComputePipelineAsync({
+  label: '\u02ae\u6899\ubdf0\uc682\u0528\ub82c\u{1ff39}',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}},
+});
+let pipeline137 = device1.createRenderPipeline({
+  label: '\u013e\u96c8\u4cf6\u4e28\u{1fe7f}\u017c\u0ce3',
+  layout: pipelineLayout18,
+  multisample: {mask: 0xe6ae1824},
+  fragment: {
+  module: shaderModule32,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'zero'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 510313908,
+    stencilWriteMask: 3592260163,
+    depthBiasSlopeScale: 676.3623053486363,
+  },
+  vertex: {
+    module: shaderModule32,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 948,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 572, shaderLocation: 19},
+          {format: 'uint32', offset: 112, shaderLocation: 17},
+          {format: 'sint32x4', offset: 60, shaderLocation: 21},
+          {format: 'sint8x4', offset: 68, shaderLocation: 11},
+          {format: 'uint8x4', offset: 640, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 232, shaderLocation: 3},
+          {format: 'sint32x2', offset: 368, shaderLocation: 14},
+          {format: 'sint8x4', offset: 28, shaderLocation: 25},
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 60, shaderLocation: 4},
+          {format: 'sint8x2', offset: 24, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 6},
+          {format: 'uint8x2', offset: 226, shaderLocation: 10},
+          {format: 'uint32x4', offset: 68, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 680, shaderLocation: 20},
+          {format: 'float32x4', offset: 76, shaderLocation: 15},
+          {format: 'sint8x4', offset: 64, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 516, shaderLocation: 13},
+          {format: 'sint16x2', offset: 352, shaderLocation: 8},
+          {format: 'float32x3', offset: 120, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 352,
+        attributes: [{format: 'sint8x4', offset: 24, shaderLocation: 9}, {format: 'uint8x4', offset: 8, shaderLocation: 23}],
+      },
+      {
+        arrayStride: 3392,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 2124, shaderLocation: 12}],
+      },
+      {arrayStride: 6644, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2468,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 828, shaderLocation: 24}],
+      },
+    ],
+  },
+});
+let textureView195 = texture82.createView({label: '\u39b6\ue150\u180b\u0981', mipLevelCount: 1});
+let computePassEncoder68 = commandEncoder150.beginComputePass({label: '\u{1fe5c}\uefe0\u0737\u{1ffd7}'});
+let renderBundleEncoder81 = device1.createRenderBundleEncoder({
+  label: '\u{1fcc2}\u3743',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle93 = renderBundleEncoder76.finish({label: '\ue4dc\u021f\u825e\u80e0\u3687\u{1fdea}\u0979\u0b01\u049e\u5f2b'});
+try {
+computePassEncoder68.setPipeline(pipeline126);
+} catch {}
+try {
+renderBundleEncoder71.draw(886538654);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1403, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 27, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 748, y: 0, z: 306},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 8259203 */
+{offset: 23, bytesPerRow: 173, rowsPerImage: 217}, {width: 40, height: 4, depthOrArrayLayers: 221});
+} catch {}
+let pipeline138 = device1.createRenderPipeline({
+  label: '\u53c6\u0f67\u65b0\u9420\ubd89\u0301\u9f08\u080b',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule35,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'zero'},
+    stencilBack: {compare: 'less', depthFailOp: 'zero', passOp: 'replace'},
+    stencilWriteMask: 4255741555,
+    depthBias: 0,
+    depthBiasSlopeScale: 653.1019643871734,
+    depthBiasClamp: 192.33705291495346,
+  },
+  vertex: {
+    module: shaderModule35,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 8988, shaderLocation: 22}],
+      },
+      {
+        arrayStride: 3652,
+        attributes: [
+          {format: 'uint32x3', offset: 1732, shaderLocation: 6},
+          {format: 'uint8x2', offset: 70, shaderLocation: 12},
+          {format: 'float16x4', offset: 1384, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 1392, attributes: []},
+      {arrayStride: 7116, stepMode: 'instance', attributes: []},
+      {arrayStride: 2700, attributes: [{format: 'unorm16x4', offset: 44, shaderLocation: 8}]},
+    ],
+  },
+});
+let texture97 = device1.createTexture({
+  label: '\u{1f8cb}\u23b2\uc310\uae59\u0849\u0f62',
+  size: [1020, 1, 1080],
+  mipLevelCount: 10,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView196 = texture89.createView({
+  label: '\u0972\u{1f7f1}\u{1ff0d}\u1c9d\u08b6',
+  dimension: '2d',
+  baseMipLevel: 6,
+  baseArrayLayer: 701,
+  arrayLayerCount: 1,
+});
+let computePassEncoder69 = commandEncoder157.beginComputePass({label: '\u76ee\u0ded\u7e39\u5a29\ua71b'});
+let sampler72 = device1.createSampler({
+  label: '\ubbb5\u{1fc4c}\u{1f686}\u3ee1\udaf1\u25b3',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.29,
+});
+let externalTexture67 = device1.importExternalTexture({label: '\u0df1\u{1f64c}\ua762\ud3ac\u55a6', source: video7, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder73.drawIndexed(747053153, 1089281664, 137663280, -468688799, 138100748);
+} catch {}
+let texture98 = device1.createTexture({
+  label: '\u{1fe4b}\u08d7\u{1f75d}\ue68d',
+  size: {width: 640, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'etc2-rgb8a1unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm', 'etc2-rgb8a1unorm-srgb'],
+});
+let textureView197 = texture96.createView({label: '\uc85b\uc606\u3973\udb2e\u{1fb56}\u0843\u{1f645}\uffee\u06f3\ucd28\u53ee', mipLevelCount: 1});
+let computePassEncoder70 = commandEncoder158.beginComputePass({label: '\u5a44\u0e7b\u3788\u0796\u0961\u0352'});
+try {
+computePassEncoder68.setPipeline(pipeline130);
+} catch {}
+try {
+renderBundleEncoder71.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder79.setVertexBuffer(7, buffer39, 3852, 1093);
+} catch {}
+let canvas23 = document.createElement('canvas');
+let querySet77 = device1.createQuerySet({
+  label: '\u{1f989}\u0827\uf9a0\u0c38\u{1f604}\ue79c\u2f24\u1fd0\u31c0\u{1f863}\uf899',
+  type: 'occlusion',
+  count: 3325,
+});
+let texture99 = device1.createTexture({
+  label: '\u0ac8\u{1f620}\u5060\u4f22\ub2cd\u6ec4\u18a7\u{1f91a}',
+  size: [80],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView198 = texture91.createView({label: '\u2eb0\u{1f872}\u0f96\u2011\u2535\u4e15\u{1f9fb}\u6e0b\u017c', baseMipLevel: 0});
+let computePassEncoder71 = commandEncoder159.beginComputePass({label: '\u{1fa58}\u6061\u776f\u09b5\u22b4\u54dd\u425b\u9a5b'});
+let renderBundleEncoder82 = device1.createRenderBundleEncoder({
+  label: '\u06e7\u{1fb63}\u51d1\u{1fd17}',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder72.draw(1011524363, 824346249, 449236379, 381266809);
+} catch {}
+try {
+renderBundleEncoder71.drawIndexed(1126341483, 569139609, 714195614, 1052615042, 438305622);
+} catch {}
+try {
+commandEncoder152.copyBufferToBuffer(buffer38, 175584, buffer41, 358080, 105432);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder152.copyBufferToTexture({
+  /* bytesInLastRow: 50 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 22906 */
+  offset: 22906,
+  bytesPerRow: 512,
+  buffer: buffer38,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer38);
+} catch {}
+video0.height = 89;
+let buffer43 = device1.createBuffer({
+  label: '\u05e0\u6823\u0a6e\ua7e4\u0dd4\u0422\u{1fd4e}\u{1ff77}\u5e81',
+  size: 25928,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let textureView199 = texture85.createView({
+  label: '\u196a\u0f04\u01d6\uee10\u{1ffaa}\u0804\u85d5\u{1f954}',
+  format: 'r16uint',
+  baseMipLevel: 5,
+  baseArrayLayer: 15,
+  arrayLayerCount: 190,
+});
+try {
+renderBundleEncoder69.draw(1007186619, 919394640, 514843640);
+} catch {}
+let arrayBuffer15 = buffer43.getMappedRange(7736);
+try {
+commandEncoder152.copyBufferToBuffer(buffer38, 51660, buffer41, 317408, 50372);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder152.clearBuffer(buffer43);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+device1.queue.submit([commandBuffer40, commandBuffer41, commandBuffer32, commandBuffer31]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 277, height: 2, depthOrArrayLayers: 84}
+*/
+{
+  source: canvas13,
+  origin: { x: 4, y: 11 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 1,
+  origin: {x: 64, y: 0, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext23 = canvas23.getContext('webgpu');
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let img27 = await imageWithData(297, 56, '#f0219ad2', '#75fa78b5');
+let promise36 = adapter0.requestAdapterInfo();
+try {
+  await promise36;
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter();
+let video22 = await videoWithData();
+let buffer44 = device1.createBuffer({
+  label: '\u6d86\u0d9e\u{1f943}\u0c13\u2a68\u8102\ue6c8',
+  size: 206410,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet78 = device1.createQuerySet({label: '\u{1f834}\ud198\u9e16\u{1fd79}\u0a5f\u{1f6c6}', type: 'occlusion', count: 2907});
+let texture100 = device1.createTexture({
+  label: '\u0ac0\u76ec\u06fa\u{1f611}\uefa2\ufd12\u3fd5',
+  size: {width: 277},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView200 = texture88.createView({label: '\u0353\ucf3f\u09c0\u0423\u69e9\u0789\u05f1\u{1ffac}\ubf61', format: 'rg8sint'});
+let renderBundleEncoder83 = device1.createRenderBundleEncoder({
+  label: '\u349f\u1cc5\u7cc3',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder66.end();
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer38]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video20,
+  origin: { x: 4, y: 8 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let offscreenCanvas23 = new OffscreenCanvas(127, 391);
+let canvas24 = document.createElement('canvas');
+let imageData21 = new ImageData(172, 24);
+let commandEncoder160 = device1.createCommandEncoder({label: '\ud896\u3939'});
+let texture101 = device1.createTexture({
+  label: '\u9d73\u0efd\u0b03\u57b1\u6dd5',
+  size: {width: 300, height: 1, depthOrArrayLayers: 429},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView201 = texture86.createView({label: '\ua484\u0b70'});
+let renderBundle94 = renderBundleEncoder79.finish({label: '\u06b1\u05e6'});
+try {
+renderBundleEncoder71.drawIndexed(165579046, 204451425, 1045473187);
+} catch {}
+try {
+renderBundleEncoder75.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(2, buffer39, 0, 6117);
+} catch {}
+let commandEncoder161 = device1.createCommandEncoder({label: '\u{1fa80}\u0720\uef60\ub688\u0738\ub160\u2db3\u0289\u985f'});
+let textureView202 = texture90.createView({label: '\u{1f68a}\u1437\uec1d\u0be6\u03ad\u0881\u{1f894}', aspect: 'all'});
+let sampler73 = device1.createSampler({
+  label: '\ucdc3\u5f37\u0dc6\u8141\u{1fa31}\u5026',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.85,
+  lodMaxClamp: 96.08,
+});
+let externalTexture68 = device1.importExternalTexture({label: '\u18a8\u15f2\u{1f87d}\u37b7', source: video10});
+try {
+commandEncoder155.clearBuffer(buffer43);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 477},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 17335443 */
+{offset: 959, bytesPerRow: 2782, rowsPerImage: 70}, {width: 328, height: 1, depthOrArrayLayers: 90});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 138, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 59, y: 679 },
+  flipY: true,
+}, {
+  texture: texture96,
+  mipLevel: 2,
+  origin: {x: 22, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise35;
+} catch {}
+let commandEncoder162 = device1.createCommandEncoder();
+let textureView203 = texture86.createView({label: '\uafd4\u3c9e\u8e05\u0788\u0538\u4111\u0f88\u089a', arrayLayerCount: 1});
+let sampler74 = device1.createSampler({
+  label: '\uf44f\u0806\ue074\u1b11',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 43.10,
+  lodMaxClamp: 95.17,
+});
+let externalTexture69 = device1.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder75.draw(838701783, 462169609, 761220775, 737795630);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline122);
+} catch {}
+try {
+commandEncoder162.copyBufferToTexture({
+  /* bytesInLastRow: 204 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 40268 */
+  offset: 40268,
+  buffer: buffer38,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 102, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder152.resolveQuerySet(querySet63, 573, 589, buffer43, 8448);
+} catch {}
+let pipeline139 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rg32sint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'keep', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 1762730536,
+    stencilWriteMask: 3727762204,
+    depthBiasSlopeScale: 167.8437951938709,
+  },
+  vertex: {module: shaderModule26, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  label: '\u9bae\ueed7\u0785\u987d\u{1fcfb}\u74cb',
+  entries: [
+    {binding: 927, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 7040,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder163 = device1.createCommandEncoder({label: '\u80e3\u6472\u{1fe32}\u010b\u{1f7ed}'});
+let renderBundleEncoder84 = device1.createRenderBundleEncoder({
+  label: '\u0eb1\u{1f7cf}\u{1f9d6}\u{1ff92}\uaee0\u66f9\u7dfd\u0eb9\u70da\u{1fbfb}\u19ce',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle95 = renderBundleEncoder68.finish({});
+let sampler75 = device1.createSampler({
+  label: '\u02c2\u00aa\u{1fe29}\uc41f\u9e90\u0923\u{1fdac}\ucfd4\ue663',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 28.96,
+});
+try {
+commandEncoder152.clearBuffer(buffer43);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+device1.queue.submit([commandBuffer33]);
+} catch {}
+gc();
+let img28 = await imageWithData(126, 69, '#02bd9af8', '#5199385b');
+let buffer45 = device1.createBuffer({label: '\ub083\ube5f\u{1f765}', size: 248065, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder164 = device1.createCommandEncoder({label: '\u88d9\u5271\u3ad7'});
+let commandBuffer42 = commandEncoder163.finish({label: '\u0f35\ue3f5\u045c'});
+let texture102 = device1.createTexture({
+  size: [75],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder72 = commandEncoder152.beginComputePass({});
+try {
+computePassEncoder70.end();
+} catch {}
+try {
+commandEncoder162.copyBufferToBuffer(buffer44, 141008, buffer43, 25504, 384);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder155.copyBufferToTexture({
+  /* bytesInLastRow: 5744 widthInBlocks: 359 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 59136 */
+  offset: 47504,
+  bytesPerRow: 5888,
+  buffer: buffer44,
+}, {
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 220, y: 0, z: 171},
+  aspect: 'all',
+}, {width: 1436, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer44);
+} catch {}
+try {
+commandEncoder164.insertDebugMarker('\ub5f1');
+} catch {}
+let pipeline140 = device1.createRenderPipeline({
+  label: '\u0f45\uc3df\u045d\u22d8\u7745\ubeef\uf28b',
+  layout: pipelineLayout18,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule28,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint'}],
+},
+  vertex: {
+    module: shaderModule28,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8164,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 5956, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 376, shaderLocation: 25},
+          {format: 'uint32x2', offset: 4620, shaderLocation: 3},
+          {format: 'sint32x2', offset: 704, shaderLocation: 14},
+          {format: 'uint16x4', offset: 392, shaderLocation: 23},
+          {format: 'sint16x2', offset: 240, shaderLocation: 6},
+          {format: 'uint16x2', offset: 6612, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 3412, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 3712,
+        attributes: [
+          {format: 'snorm16x4', offset: 424, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 84, shaderLocation: 19},
+          {format: 'float32x4', offset: 192, shaderLocation: 21},
+          {format: 'uint32x4', offset: 544, shaderLocation: 5},
+          {format: 'float32', offset: 652, shaderLocation: 7},
+          {format: 'sint8x2', offset: 800, shaderLocation: 17},
+          {format: 'uint32', offset: 1648, shaderLocation: 18},
+          {format: 'sint32x2', offset: 556, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 180, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 9},
+          {format: 'uint8x2', offset: 784, shaderLocation: 11},
+          {format: 'uint32', offset: 488, shaderLocation: 12},
+          {format: 'uint8x4', offset: 1012, shaderLocation: 22},
+          {format: 'sint8x4', offset: 456, shaderLocation: 16},
+          {format: 'sint16x4', offset: 924, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 48, attributes: [{format: 'sint32x2', offset: 8, shaderLocation: 24}]},
+      {
+        arrayStride: 604,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x2', offset: 72, shaderLocation: 2},
+          {format: 'uint16x2', offset: 272, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: false},
+});
+let video23 = await videoWithData();
+let imageBitmap26 = await createImageBitmap(img12);
+let videoFrame17 = new VideoFrame(canvas16, {timestamp: 0});
+let img29 = await imageWithData(215, 43, '#0809c129', '#e9133aef');
+let shaderModule36 = device1.createShaderModule({
+  label: '\u{1f718}\u{1fb47}\u{1ffe9}\u0dca\ud16d\u0d7c\u{1f887}\u{1fab7}',
+  code: `@group(3) @binding(5439)
+var<storage, read_write> field30: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> parameter22: array<u32>;
+@group(1) @binding(3627)
+var<storage, read_write> parameter23: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> type26: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> local27: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> function30: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> type27: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(1) f1: vec2<u32>,
+  @location(2) f2: vec3<i32>,
+  @location(0) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(23) a1: vec4<f32>, @location(21) a2: f16, @location(20) a3: i32, @location(13) a4: vec4<i32>, @builtin(instance_index) a5: u32, @location(11) a6: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView204 = texture95.createView({label: '\u88a3\ub60f\u{1f899}\uf4c4\u4600\u08df\ub456', baseMipLevel: 8});
+try {
+commandEncoder164.copyBufferToBuffer(buffer38, 5616, buffer43, 5608, 17576);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture97,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 86},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 48, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+computePassEncoder62.insertDebugMarker('\u5a31');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 69, height: 1, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 7, y: 14 },
+  flipY: true,
+}, {
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 21, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet79 = device1.createQuerySet({label: '\u00fd\uea0f\u0042\u0f96\u21a4', type: 'occlusion', count: 3255});
+let computePassEncoder73 = commandEncoder162.beginComputePass();
+try {
+commandEncoder155.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 69, height: 1, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 56, y: 18 },
+  flipY: true,
+}, {
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline141 = device1.createRenderPipeline({
+  label: '\u938b\u{1f98d}\u0124\u{1f753}\u{1fa8f}\u05bd',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rg32sint', writeMask: 0}, {format: 'rg8sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 73912925,
+    depthBias: -499341277,
+  },
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7568,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 6332, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 640, shaderLocation: 11},
+          {format: 'uint16x2', offset: 972, shaderLocation: 14},
+          {format: 'float16x2', offset: 3148, shaderLocation: 20},
+          {format: 'uint8x4', offset: 932, shaderLocation: 19},
+          {format: 'uint32x2', offset: 340, shaderLocation: 25},
+          {format: 'sint32', offset: 188, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 2644,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 260, shaderLocation: 24},
+          {format: 'sint8x4', offset: 240, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 232, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 12},
+          {format: 'float32x2', offset: 48, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 1952, shaderLocation: 7},
+          {format: 'float32', offset: 60, shaderLocation: 23},
+          {format: 'snorm8x4', offset: 1000, shaderLocation: 17},
+          {format: 'uint32x2', offset: 760, shaderLocation: 3},
+          {format: 'uint16x4', offset: 1016, shaderLocation: 18},
+          {format: 'float32', offset: 304, shaderLocation: 9},
+          {format: 'float16x4', offset: 60, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 1180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 344, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 132, shaderLocation: 21},
+          {format: 'uint16x2', offset: 852, shaderLocation: 0},
+          {format: 'uint32x4', offset: 44, shaderLocation: 10},
+          {format: 'uint8x4', offset: 64, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 764, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 3712,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 504, shaderLocation: 6},
+          {format: 'sint32x2', offset: 408, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let texture103 = device1.createTexture({
+  label: '\u00e0\udf7a\u4457\u9e7d\u089f\u49d1\u9546\u3c2f\ud45d',
+  size: {width: 600},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView205 = texture91.createView({mipLevelCount: 1});
+let externalTexture70 = device1.importExternalTexture({
+  label: '\ufb46\u97f6\uf9b4\ueaec\ua0ec\uc237\ud2bf\u{1fc8a}\u07d0\u1624\uf20a',
+  source: videoFrame13,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder73.drawIndexed(64118323, 895067536, 722650316, -201172828, 1146900076);
+} catch {}
+try {
+renderBundleEncoder82.setPipeline(pipeline133);
+} catch {}
+try {
+device1.queue.submit([commandBuffer35]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 66, y: 0, z: 21},
+  aspect: 'all',
+}, new ArrayBuffer(7394325), /* required buffer size: 7394325 */
+{offset: 33, bytesPerRow: 1086, rowsPerImage: 46}, {width: 402, height: 1, depthOrArrayLayers: 149});
+} catch {}
+let imageData22 = new ImageData(176, 192);
+try {
+adapter5.label = '\u4ec4\u3081\u{1f798}\u97b8\u033c\ud665';
+} catch {}
+let renderBundle96 = renderBundleEncoder67.finish({label: '\uc54e\u28c4\u{1f6f0}\ufe7b\uae6c\u{1fa94}'});
+try {
+renderBundleEncoder71.draw(222287738, 876801368, 740746574, 493141802);
+} catch {}
+try {
+renderBundleEncoder73.drawIndexed(270600603, 432659910, 215215699);
+} catch {}
+try {
+renderBundleEncoder82.setPipeline(pipeline140);
+} catch {}
+try {
+commandEncoder161.copyBufferToBuffer(buffer38, 76892, buffer41, 345224, 73992);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder155.copyBufferToTexture({
+  /* bytesInLastRow: 62 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 67568 */
+  offset: 67506,
+  rowsPerImage: 64,
+  buffer: buffer38,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder158.clearBuffer(buffer41, 94772, 280212);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video13,
+  origin: { x: 6, y: 2 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas25 = document.createElement('canvas');
+try {
+canvas25.getContext('webgl2');
+} catch {}
+let texture104 = device1.createTexture({
+  label: '\u{1fbd4}\u{1fa9d}\ub5d9',
+  size: [320, 4, 1],
+  mipLevelCount: 8,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView206 = texture83.createView({label: '\u0e55\u013d'});
+let computePassEncoder74 = commandEncoder155.beginComputePass({});
+let renderBundle97 = renderBundleEncoder82.finish({label: '\u82aa\u9400\u{1f89f}\u5717\u27f8\uacad\u8212\u8f3b\u454d\u0217\uf7f4'});
+try {
+renderBundleEncoder72.setVertexBuffer(7683, undefined, 0, 3483950243);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer44, 131500, buffer41, 80948, 35024);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder160.resolveQuerySet(querySet62, 13, 15, buffer40, 165376);
+} catch {}
+try {
+renderBundleEncoder72.insertDebugMarker('\ua77b');
+} catch {}
+let pipeline142 = device1.createComputePipeline({
+  label: '\ueb92\u6eae\u6e36\u0b8a',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule28, entryPoint: 'compute0', constants: {}},
+});
+let texture105 = device1.createTexture({
+  label: '\ua2c0\u{1fc0d}\u56d7\u{1fb64}\u051f\u{1ff49}\u8ba6\u{1faa5}\u08e9\u0262\u27a2',
+  size: [1020, 1, 1483],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+let textureView207 = texture87.createView({label: '\u{1fb51}\u09f2\u7277\u9ef4\u7522\u52dd\u0b80\ua5e5\u4308\u0472'});
+let sampler76 = device1.createSampler({
+  label: '\u3729\u{1f681}\u023f\ue473\udd61\u7600\u8456',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 46.34,
+  lodMaxClamp: 64.48,
+  compare: 'not-equal',
+});
+try {
+renderBundleEncoder72.draw(6219194, 938429107, 491047374, 585378993);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexed(1226884583, 663869272, 1034722299, -480146057, 1142414352);
+} catch {}
+try {
+commandEncoder161.copyBufferToBuffer(buffer44, 183020, buffer42, 141116, 15484);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 76278 */
+  offset: 76278,
+  buffer: buffer38,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture98,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 92, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder164.resolveQuerySet(querySet63, 1275, 23, buffer43, 1792);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 138, height: 1, depthOrArrayLayers: 42}
+*/
+{
+  source: canvas14,
+  origin: { x: 195, y: 1 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 82, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline143 = device1.createComputePipeline({
+  label: '\u0555\u05f5\u{1fac4}',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule30, entryPoint: 'compute0', constants: {}},
+});
+let pipeline144 = await device1.createRenderPipelineAsync({
+  label: '\u{1ffc0}\u00df\u0740\uada9\uc936',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule28,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: 0}, {format: 'rg8sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule28,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1556,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 304, shaderLocation: 13},
+          {format: 'sint8x4', offset: 60, shaderLocation: 6},
+          {format: 'sint8x2', offset: 548, shaderLocation: 17},
+          {format: 'uint16x2', offset: 64, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 128, shaderLocation: 7},
+          {format: 'float32', offset: 52, shaderLocation: 0},
+          {format: 'uint32x3', offset: 388, shaderLocation: 3},
+          {format: 'float16x2', offset: 32, shaderLocation: 21},
+          {format: 'uint16x4', offset: 84, shaderLocation: 15},
+          {format: 'sint8x2', offset: 392, shaderLocation: 20},
+          {format: 'uint16x4', offset: 848, shaderLocation: 11},
+          {format: 'sint8x2', offset: 576, shaderLocation: 24},
+          {format: 'float32x2', offset: 144, shaderLocation: 8},
+          {format: 'uint8x4', offset: 20, shaderLocation: 22},
+          {format: 'sint32', offset: 1116, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 872,
+        attributes: [
+          {format: 'uint16x2', offset: 24, shaderLocation: 18},
+          {format: 'uint32x4', offset: 312, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 19},
+          {format: 'float32x3', offset: 44, shaderLocation: 9},
+          {format: 'float32x3', offset: 520, shaderLocation: 25},
+          {format: 'sint8x2', offset: 870, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32x4', offset: 2816, shaderLocation: 5},
+          {format: 'sint32x3', offset: 1116, shaderLocation: 10},
+          {format: 'uint32', offset: 2500, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 1172,
+        attributes: [
+          {format: 'snorm16x4', offset: 72, shaderLocation: 2},
+          {format: 'sint8x2', offset: 40, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let offscreenCanvas24 = new OffscreenCanvas(16, 967);
+let img30 = await imageWithData(247, 218, '#b460f833', '#66205287');
+try {
+canvas24.getContext('webgpu');
+} catch {}
+let bindGroupLayout36 = device1.createBindGroupLayout({label: '\u8371\u{1f8e0}\u9cb2\u906e\u{1fdf5}\u4998\u9a80\u088d\ubaa1\u22c2\u0f49', entries: []});
+let commandEncoder165 = device1.createCommandEncoder({});
+let querySet80 = device1.createQuerySet({label: '\u0c47\u{1f81d}', type: 'occlusion', count: 13});
+let texture106 = device1.createTexture({
+  label: '\u9e5b\uc290\u8e9f\u{1f9ec}\u3224',
+  size: {width: 160, height: 2, depthOrArrayLayers: 77},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let externalTexture71 = device1.importExternalTexture({label: '\ud51b\u89a7\u0cc9\u071a\u0c6f\ua98a\u6af3', source: video22});
+try {
+renderBundleEncoder77.draw(1033494627);
+} catch {}
+try {
+renderBundleEncoder71.drawIndexed(1055512288, 1028816361);
+} catch {}
+try {
+renderBundleEncoder72.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(8, buffer39, 948, 4973);
+} catch {}
+try {
+  await buffer44.mapAsync(GPUMapMode.WRITE, 178808, 23632);
+} catch {}
+let pipeline145 = device1.createComputePipeline({
+  label: '\u1b71\u05e9\u0fb5',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext24 = offscreenCanvas24.getContext('webgpu');
+let offscreenCanvas25 = new OffscreenCanvas(856, 349);
+canvas7.height = 1901;
+let bindGroup28 = device1.createBindGroup({
+  label: '\ue2c1\u01ca\u0e27\u0924\u{1ff9d}\u0cc9\u09e4\u0b30\u6528\u743c\u0781',
+  layout: bindGroupLayout36,
+  entries: [],
+});
+let commandEncoder166 = device1.createCommandEncoder();
+try {
+renderBundleEncoder69.setBindGroup(3, bindGroup28, new Uint32Array(4138), 3686, 0);
+} catch {}
+try {
+renderBundleEncoder73.draw(555567947, 177062272, 377196826);
+} catch {}
+try {
+renderBundleEncoder78.setVertexBuffer(9, buffer39, 4124);
+} catch {}
+try {
+commandEncoder158.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 207040 */
+  offset: 4212,
+  bytesPerRow: 256,
+  rowsPerImage: 264,
+  buffer: buffer38,
+}, {
+  texture: texture106,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 19, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder160.clearBuffer(buffer42, 93676, 66188);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder167 = device1.createCommandEncoder({label: '\u0056\u{1faa9}\u618b'});
+let renderBundleEncoder85 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderBundleEncoder85.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder73.drawIndexed(790338684, 475817914, 940473484);
+} catch {}
+try {
+renderBundleEncoder84.setPipeline(pipeline140);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(4, buffer39, 7864, 480);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise37 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 69, height: 1, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 162, y: 162 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas21.width = 1278;
+let commandEncoder168 = device1.createCommandEncoder({label: '\ub6c4\u04a7\u{1fdeb}'});
+let texture107 = device1.createTexture({
+  label: '\u{1fbc5}\u04d2\u{1fc76}\u3f8c\u{1f620}\u9457\ue686\u{1fd75}',
+  size: [300],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView208 = texture85.createView({baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 141, arrayLayerCount: 40});
+try {
+renderBundleEncoder84.setPipeline(pipeline122);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 108 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9010 */
+  offset: 9010,
+  buffer: buffer38,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 54, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 566 */
+{offset: 558, rowsPerImage: 160}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+canvas16.width = 1314;
+let canvas26 = document.createElement('canvas');
+let textureView209 = texture82.createView({label: '\u{1f80e}\u0e10\uf0a1\uc679\uf42c\u{1f729}\u0417\u{1ff0d}\udd4e', aspect: 'all'});
+let renderBundleEncoder86 = device1.createRenderBundleEncoder({
+  label: '\u0c20\u0271\ufa47\u0e99\u9612\u94fc\uf399',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler77 = device1.createSampler({
+  label: '\u{1f7a0}\uca43\u0d3d\u{1ff80}\ud4d6\u{1f720}\u3b3e\u3df2\u{1febb}\u{1f90d}\u0f49',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.13,
+  lodMaxClamp: 42.04,
+  compare: 'less-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder72.setPipeline(pipeline126);
+} catch {}
+try {
+renderBundleEncoder71.draw(1061738226, 545025926);
+} catch {}
+try {
+renderBundleEncoder81.setPipeline(pipeline140);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer41, 320008, 147468);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet79, 141, 2562, buffer40, 104704);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 555, height: 5, depthOrArrayLayers: 168}
+*/
+{
+  source: imageData4,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 231, y: 0, z: 49},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule37 = device1.createShaderModule({
+  label: '\ucd4e\u6767\u0f9c\u29e7\uf7eb\uf4d0\u09e1\u030b\u3753',
+  code: `@group(2) @binding(5439)
+var<storage, read_write> type28: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> function31: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> field31: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> parameter25: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> global29: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> field32: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: i32,
+  @location(1) f1: f32,
+  @location(2) f2: vec4<f32>,
+  @location(0) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup29 = device1.createBindGroup({label: '\u10c7\u0d5a', layout: bindGroupLayout36, entries: []});
+let buffer46 = device1.createBuffer({
+  label: '\ud448\ud611\u0ac6\u{1fa7c}\u0538\ub9ad\u77a7\u817b\ufcba\u033d',
+  size: 174504,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true,
+});
+let commandBuffer43 = commandEncoder161.finish({label: '\u193b\u3628\ub3d7\u0dbf\uc86d'});
+try {
+renderBundleEncoder75.setPipeline(pipeline122);
+} catch {}
+try {
+commandEncoder166.copyBufferToBuffer(buffer38, 344372, buffer43, 12384, 2424);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder164.clearBuffer(buffer43);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 14},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 22176497 */
+{offset: 497, bytesPerRow: 600, rowsPerImage: 140}, {width: 196, height: 0, depthOrArrayLayers: 265});
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder({label: '\udb03\uf9d8\u0477\ud07f'});
+try {
+renderBundleEncoder10.drawIndexed(891688521, 4821807);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer47 = device1.createBuffer({
+  label: '\u0051\u0320\u844d\u009f\u116b\u{1f8e1}\u04f1\u6d20\u056c\u4cb3\u5b91',
+  size: 342688,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX,
+});
+let commandEncoder170 = device1.createCommandEncoder({});
+let textureView210 = texture80.createView({});
+let externalTexture72 = device1.importExternalTexture({
+  label: '\ucd9d\u{1fda2}\u5389\u1d9f\u2ab2\u{1f9c2}\u07ff\u0e75\u0b76\u{1fbd6}\u04f1',
+  source: video6,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup28, new Uint32Array(7709), 2991, 0);
+} catch {}
+try {
+renderBundleEncoder71.drawIndexed(46758346, 691270502);
+} catch {}
+try {
+commandEncoder168.copyBufferToBuffer(buffer44, 142824, buffer42, 163868, 58332);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 597 */
+{offset: 597}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline146 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  multisample: {mask: 0x852211e6},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha'},
+  },
+}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2784,
+        attributes: [
+          {format: 'snorm8x2', offset: 168, shaderLocation: 23},
+          {format: 'float32', offset: 1560, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 1032, shaderLocation: 11},
+          {format: 'sint8x4', offset: 1608, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 628, attributes: []},
+      {arrayStride: 1792, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 3836, shaderLocation: 20}],
+      },
+    ],
+  },
+});
+let gpuCanvasContext25 = offscreenCanvas25.getContext('webgpu');
+try {
+externalTexture6.label = '\ub387\u0f1e\u055d\ucc93';
+} catch {}
+let bindGroup30 = device1.createBindGroup({label: '\uab10\u5137\u0aaf\u04e3\u0575\u5085\u0b20\uf3c3', layout: bindGroupLayout36, entries: []});
+let buffer48 = device1.createBuffer({
+  label: '\u451e\u{1fbe9}\u03eb\u6f35\u{1f637}\u3238\ub7bf\ua4c2',
+  size: 177198,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView211 = texture95.createView({
+  label: '\u{1feb7}\u{1f8c0}\u3f18\ud19c\ued90\u3e16\u0966\u{1f9de}\u04d9\u{1fe97}',
+  baseMipLevel: 8,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder87 = device1.createRenderBundleEncoder({
+  label: '\u0a66\u33af\ud77b\u8655',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder73.drawIndexed(614422677);
+} catch {}
+try {
+commandEncoder168.copyBufferToBuffer(buffer46, 102652, buffer42, 45900, 43940);
+dissociateBuffer(device1, buffer46);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 24364, new Int16Array(12793), 7739, 92);
+} catch {}
+let img31 = await imageWithData(238, 122, '#1086d839', '#8c4a8a41');
+let commandEncoder171 = device1.createCommandEncoder({});
+let querySet81 = device1.createQuerySet({type: 'occlusion', count: 406});
+let computePassEncoder75 = commandEncoder166.beginComputePass({label: '\u00ce\u7eb9\u08a8\u{1f919}\u{1fea4}\ud559'});
+let sampler78 = device1.createSampler({
+  label: '\u{1fbfc}\ufe47\u{1fc10}\ufd66\ude99\u0d3c\u6426\u4aa0\u94b8',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.98,
+  maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder77.drawIndexed(1142001793, 1154231933, 567307305, 487851643, 876949570);
+} catch {}
+try {
+renderBundleEncoder73.setPipeline(pipeline133);
+} catch {}
+try {
+commandEncoder165.resolveQuerySet(querySet73, 1950, 173, buffer43, 20480);
+} catch {}
+let pipeline147 = await device1.createComputePipelineAsync({
+  label: '\u6e88\u{1fa15}\ueaab\u34a9\u2250',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule35, entryPoint: 'compute0'},
+});
+let pipeline148 = device1.createRenderPipeline({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule32,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 2103520810,
+    stencilWriteMask: 4294967295,
+    depthBiasSlopeScale: 361.2686904638259,
+    depthBiasClamp: 286.7696806314711,
+  },
+  vertex: {
+    module: shaderModule32,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3968,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 1436, shaderLocation: 5},
+          {format: 'uint32', offset: 276, shaderLocation: 2},
+          {format: 'sint8x4', offset: 672, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 1368, shaderLocation: 15},
+          {format: 'uint32x3', offset: 208, shaderLocation: 23},
+          {format: 'sint32x4', offset: 304, shaderLocation: 8},
+          {format: 'float32x2', offset: 436, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 856, shaderLocation: 20},
+          {format: 'uint32x4', offset: 352, shaderLocation: 19},
+          {format: 'uint8x4', offset: 148, shaderLocation: 17},
+          {format: 'sint32x2', offset: 208, shaderLocation: 24},
+          {format: 'float32x2', offset: 520, shaderLocation: 0},
+          {format: 'uint32', offset: 1472, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 720, shaderLocation: 7},
+          {format: 'sint8x4', offset: 528, shaderLocation: 11},
+          {format: 'sint8x2', offset: 14, shaderLocation: 14},
+          {format: 'sint16x4', offset: 28, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 3960, shaderLocation: 13},
+          {format: 'sint8x2', offset: 454, shaderLocation: 18},
+          {format: 'sint32', offset: 512, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 6},
+          {format: 'uint32x3', offset: 868, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 1184,
+        attributes: [
+          {format: 'float16x4', offset: 80, shaderLocation: 1},
+          {format: 'uint16x4', offset: 280, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 312, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 448,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x4', offset: 32, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+canvas15.height = 313;
+let imageBitmap27 = await createImageBitmap(imageBitmap0);
+let imageData23 = new ImageData(240, 220);
+let shaderModule38 = device1.createShaderModule({
+  label: '\u3500\ud584\u242c\u2e70\u{1fb10}\u0219',
+  code: `@group(1) @binding(5439)
+var<storage, read_write> parameter26: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> parameter27: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> local28: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> parameter28: array<u32>;
+@group(4) @binding(5439)
+var<storage, read_write> local29: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> local30: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> local31: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+  @location(68) f0: vec2<i32>,
+  @location(0) f1: vec2<u32>,
+  @location(108) f2: vec4<u32>,
+  @location(31) f3: vec2<u32>,
+  @location(28) f4: vec4<i32>,
+  @location(41) f5: vec2<f32>,
+  @location(67) f6: vec4<i32>,
+  @location(88) f7: vec3<f16>,
+  @location(87) f8: vec4<f32>,
+  @location(15) f9: vec3<f16>,
+  @location(65) f10: vec4<f16>,
+  @location(40) f11: f32,
+  @location(66) f12: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(1) f1: vec2<u32>,
+  @location(2) f2: vec2<i32>,
+  @location(0) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(95) a0: vec3<f32>, @location(29) a1: vec4<i32>, @location(97) a2: vec4<f32>, @location(104) a3: vec4<u32>, @location(82) a4: vec3<u32>, @location(12) a5: vec4<f32>, @location(107) a6: f16, @location(83) a7: vec3<u32>, @location(102) a8: vec2<u32>, @location(24) a9: i32, a10: S25, @location(89) a11: vec4<u32>, @location(52) a12: vec4<u32>, @location(26) a13: vec4<u32>, @builtin(sample_index) a14: u32, @location(11) a15: f16, @builtin(position) a16: vec4<f32>, @builtin(front_facing) a17: bool, @builtin(sample_mask) a18: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @builtin(vertex_index) f0: u32,
+  @location(20) f1: vec4<f16>,
+  @location(9) f2: vec2<i32>,
+  @location(2) f3: vec4<i32>,
+  @location(10) f4: vec3<f32>,
+  @location(16) f5: f32,
+  @location(12) f6: vec2<i32>,
+  @location(11) f7: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(52) f487: vec4<u32>,
+  @location(41) f488: vec2<f32>,
+  @location(97) f489: vec4<f32>,
+  @location(31) f490: vec2<u32>,
+  @location(28) f491: vec4<i32>,
+  @builtin(position) f492: vec4<f32>,
+  @location(104) f493: vec4<u32>,
+  @location(95) f494: vec3<f32>,
+  @location(66) f495: vec4<f32>,
+  @location(88) f496: vec3<f16>,
+  @location(65) f497: vec4<f16>,
+  @location(11) f498: f16,
+  @location(67) f499: vec4<i32>,
+  @location(26) f500: vec4<u32>,
+  @location(83) f501: vec3<u32>,
+  @location(102) f502: vec2<u32>,
+  @location(87) f503: vec4<f32>,
+  @location(108) f504: vec4<u32>,
+  @location(89) f505: vec4<u32>,
+  @location(107) f506: f16,
+  @location(68) f507: vec2<i32>,
+  @location(24) f508: i32,
+  @location(82) f509: vec3<u32>,
+  @location(0) f510: vec2<u32>,
+  @location(29) f511: vec4<i32>,
+  @location(40) f512: f32,
+  @location(12) f513: vec4<f32>,
+  @location(15) f514: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(25) a0: vec2<u32>, @location(3) a1: vec2<f16>, @location(5) a2: vec2<i32>, @location(13) a3: vec3<i32>, @location(15) a4: vec3<i32>, @location(8) a5: vec2<i32>, @location(4) a6: vec2<u32>, @location(0) a7: vec4<f32>, @location(21) a8: vec2<f32>, @location(23) a9: vec2<f16>, @builtin(instance_index) a10: u32, @location(7) a11: vec2<f32>, @location(19) a12: i32, @location(1) a13: f32, @location(17) a14: vec3<u32>, a15: S24, @location(22) a16: vec4<u32>, @location(24) a17: vec4<u32>, @location(6) a18: vec2<u32>, @location(14) a19: u32, @location(18) a20: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup31 = device1.createBindGroup({
+  label: '\u{1fa87}\u017b\u{1feb3}\u{1f937}\uf3e4\u{1f6cf}\u{1fe8d}\u0f5d\ufcc3\udcf0\u5c89',
+  layout: bindGroupLayout36,
+  entries: [],
+});
+let texture108 = device1.createTexture({
+  label: '\u92c2\ud81d\u0012',
+  size: {width: 320, height: 4, depthOrArrayLayers: 154},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let textureView212 = texture88.createView({label: '\u9f73\u{1fece}\u0972\u00d9\u0b1e\u1bca\u06ca\u4faa\u1117\u80e1'});
+let renderBundleEncoder88 = device1.createRenderBundleEncoder({
+  label: '\u{1fbed}\u0022\u{1fb08}\uc238\u2016\u0b5e\ubca9\u047f\ude21\u0713',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle98 = renderBundleEncoder74.finish();
+try {
+renderBundleEncoder69.setPipeline(pipeline133);
+} catch {}
+try {
+commandEncoder167.copyTextureToBuffer({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 146 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3852 */
+  offset: 3852,
+  buffer: buffer47,
+}, {width: 73, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer41, 90656, 138048);
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let buffer49 = device1.createBuffer({size: 590328, usage: GPUBufferUsage.INDIRECT, mappedAtCreation: true});
+let textureView213 = texture83.createView({mipLevelCount: 1});
+let renderBundleEncoder89 = device1.createRenderBundleEncoder({
+  label: '\u2ac0\u94a1\u5193\ub629\u{1ffff}\u{1ff3c}\u1f8e\u0583\u5813',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData23,
+  origin: { x: 3, y: 47 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet82 = device1.createQuerySet({label: '\u0b2a\u6fe5\ue290\u{1ffe4}\u{1f72a}\uf36b\u673b', type: 'occlusion', count: 1626});
+let textureView214 = texture107.createView({label: '\u047e\u00e2\u027b\u94e4\uf295\uc2eb\u65b6\u9663'});
+try {
+computePassEncoder75.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder80.drawIndirect(buffer49, 18736);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline122);
+} catch {}
+let img32 = await imageWithData(186, 99, '#9a46d2bc', '#d19c7043');
+let gpuCanvasContext26 = canvas26.getContext('webgpu');
+try {
+  await promise37;
+} catch {}
+let videoFrame18 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let querySet83 = device1.createQuerySet({label: '\u01a2\u{1f835}\u5e17\u{1f7c9}', type: 'occlusion', count: 3943});
+let textureView215 = texture108.createView({
+  label: '\u0fc3\u9632\u{1fe72}\u{1f950}\uda66\u31f2\u0021\u7777\u3603\u64ca',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder90 = device1.createRenderBundleEncoder({
+  label: '\u0733\ucb13\uad11\uf0d6\u3759\u0da8\u3c7c\u{1f925}',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture73 = device1.importExternalTexture({label: '\u28c0\u{1fd3a}\u05f9\ucb5a\ue785\uaba1', source: video2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder85.setBindGroup(2, bindGroup28, new Uint32Array(6833), 2871, 0);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexed(1049973847, 1178514320, 840389565, 321771717);
+} catch {}
+try {
+renderBundleEncoder75.drawIndexedIndirect(buffer49, 590328);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(3, buffer39, 3944, 1276);
+} catch {}
+try {
+commandEncoder168.copyBufferToTexture({
+  /* bytesInLastRow: 5738 widthInBlocks: 2869 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9188 */
+  offset: 9188,
+  buffer: buffer38,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 668, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2869, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 37952, new Int16Array(57340), 16210, 6116);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 555, height: 5, depthOrArrayLayers: 168}
+*/
+{
+  source: img27,
+  origin: { x: 101, y: 4 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 65},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 92, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline149 = await device1.createComputePipelineAsync({layout: pipelineLayout18, compute: {module: shaderModule36, entryPoint: 'compute0', constants: {}}});
+gc();
+let img33 = await imageWithData(281, 49, '#cb542d5c', '#02ba7c6c');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let bindGroupLayout37 = device1.createBindGroupLayout({
+  label: '\u00a0\ue662\u{1f7be}\u919e\u3e1b\u0428\u1540\u0a63',
+  entries: [
+    {binding: 4644, visibility: 0, externalTexture: {}},
+    {
+      binding: 7072,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 5858, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let computePassEncoder76 = commandEncoder164.beginComputePass({label: '\u78b6\u7ca2\u{1fb1f}\u05fe\u0035\u0f02\u20a9'});
+let renderBundle99 = renderBundleEncoder88.finish({label: '\ua048\u{1f6db}\ued52\u{1f7f3}\u0392\u{1f7e1}\uc8a7\u023c\ub69a\u60c3'});
+let sampler79 = device1.createSampler({
+  label: '\ua93d\uf3c5\u{1fd1e}\u34b6',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.039,
+  maxAnisotropy: 4,
+});
+try {
+commandEncoder160.clearBuffer(buffer42, 35896, 159272);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img17,
+  origin: { x: 6, y: 19 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline150 = device1.createComputePipeline({
+  label: '\u{1fee2}\u0859\u5bcc\u05a4\ufe8f\u0cc2\u{1ff99}',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule28, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video8);
+gc();
+let imageData24 = new ImageData(240, 140);
+document.body.prepend(img15);
+let computePassEncoder77 = commandEncoder160.beginComputePass();
+let renderBundle100 = renderBundleEncoder82.finish({label: '\ubda8\u0f2d\u0492\u0b35\u8aff\ufd4f\ue348'});
+try {
+renderBundleEncoder80.draw(550789779, 437008583, 665212018, 188042494);
+} catch {}
+let arrayBuffer16 = buffer43.getMappedRange(7208, 20);
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet67, 201, 66, buffer48, 129792);
+} catch {}
+let shaderModule39 = device1.createShaderModule({
+  code: `@group(2) @binding(5439)
+var<storage, read_write> function32: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> field33: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> local32: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> parameter29: array<u32>;
+@group(3) @binding(3627)
+var<storage, read_write> local33: array<u32>;
+@group(3) @binding(5439)
+var<storage, read_write> function33: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @location(41) f0: f32,
+  @location(29) f1: f16,
+  @builtin(front_facing) f2: bool,
+  @builtin(sample_mask) f3: u32,
+  @location(53) f4: vec4<i32>,
+  @location(16) f5: vec4<u32>,
+  @builtin(sample_index) f6: u32,
+  @location(69) f7: vec4<f32>,
+  @location(91) f8: vec4<f32>,
+  @location(44) f9: vec3<f16>,
+  @location(70) f10: i32,
+  @location(67) f11: vec2<f32>,
+  @location(8) f12: vec2<f32>,
+  @location(58) f13: vec3<u32>,
+  @location(9) f14: vec3<u32>,
+  @location(77) f15: vec4<u32>,
+  @location(74) f16: vec3<u32>,
+  @location(82) f17: vec3<i32>,
+  @location(33) f18: vec3<f32>,
+  @location(102) f19: vec2<i32>,
+  @location(12) f20: u32,
+  @location(50) f21: vec3<f16>,
+  @location(42) f22: f32,
+  @location(4) f23: f32,
+  @location(5) f24: vec3<i32>,
+  @location(17) f25: vec2<u32>,
+  @location(34) f26: vec3<u32>,
+  @location(61) f27: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<u32>,
+  @location(2) f1: vec4<i32>,
+  @location(0) f2: vec3<f32>,
+  @location(3) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(100) a0: vec3<f32>, a1: S26, @location(52) a2: vec2<f16>, @location(101) a3: vec2<f32>, @builtin(position) a4: vec4<f32>, @location(51) a5: vec4<f16>, @location(62) a6: vec4<u32>, @location(6) a7: vec3<f32>, @location(65) a8: vec4<u32>, @location(25) a9: f32, @location(63) a10: vec2<u32>, @location(90) a11: i32, @location(104) a12: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(101) f515: vec2<f32>,
+  @location(70) f516: i32,
+  @location(5) f517: vec3<i32>,
+  @location(91) f518: vec4<f32>,
+  @location(4) f519: f32,
+  @location(104) f520: vec4<f16>,
+  @location(74) f521: vec3<u32>,
+  @location(15) f522: vec2<i32>,
+  @location(12) f523: u32,
+  @location(17) f524: vec2<u32>,
+  @builtin(position) f525: vec4<f32>,
+  @location(65) f526: vec4<u32>,
+  @location(44) f527: vec3<f16>,
+  @location(85) f528: vec2<f16>,
+  @location(34) f529: vec3<u32>,
+  @location(53) f530: vec4<i32>,
+  @location(28) f531: vec3<f32>,
+  @location(6) f532: vec3<f32>,
+  @location(92) f533: vec3<f16>,
+  @location(67) f534: vec2<f32>,
+  @location(25) f535: f32,
+  @location(58) f536: vec3<u32>,
+  @location(52) f537: vec2<f16>,
+  @location(41) f538: f32,
+  @location(16) f539: vec4<u32>,
+  @location(82) f540: vec3<i32>,
+  @location(50) f541: vec3<f16>,
+  @location(63) f542: vec2<u32>,
+  @location(90) f543: i32,
+  @location(100) f544: vec3<f32>,
+  @location(102) f545: vec2<i32>,
+  @location(77) f546: vec4<u32>,
+  @location(66) f547: vec3<i32>,
+  @location(87) f548: vec2<f32>,
+  @location(93) f549: vec3<i32>,
+  @location(62) f550: vec4<u32>,
+  @location(56) f551: vec2<u32>,
+  @location(69) f552: vec4<f32>,
+  @location(59) f553: u32,
+  @location(103) f554: vec4<i32>,
+  @location(8) f555: vec2<f32>,
+  @location(42) f556: f32,
+  @location(33) f557: vec3<f32>,
+  @location(9) f558: vec3<u32>,
+  @location(61) f559: vec2<f16>,
+  @location(51) f560: vec4<f16>,
+  @location(29) f561: f16
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec3<u32>, @location(0) a1: vec4<i32>, @location(14) a2: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let renderBundle101 = renderBundleEncoder70.finish({});
+let sampler80 = device1.createSampler({
+  label: '\u{1fbd0}\u0c24\ue462\u0db7\u0591\u{1ff98}\u{1f82c}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 75.90,
+  lodMaxClamp: 96.03,
+  compare: 'greater-equal',
+});
+let externalTexture74 = device1.importExternalTexture({
+  label: '\u{1fe1b}\u9037\u0f18\u5f81\ue624\u0a8f\ud6bc\u5873\u6d9a\u0457',
+  source: video17,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder87.drawIndirect(buffer49, 56532);
+} catch {}
+try {
+commandEncoder143.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 1,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 45064 */
+  offset: 45064,
+  rowsPerImage: 293,
+  buffer: buffer48,
+}, {width: 20, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer48, 150904, 12060);
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer47, 87160, new Float32Array(26518));
+} catch {}
+video22.width = 22;
+let renderBundle102 = renderBundleEncoder84.finish();
+let externalTexture75 = device1.importExternalTexture({source: video14, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder80.setBindGroup(4, bindGroup29, new Uint32Array(7425), 7073, 0);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline133);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(7, buffer39);
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 12});
+} catch {}
+let commandEncoder172 = device1.createCommandEncoder({});
+let textureView216 = texture89.createView({
+  label: '\u{1fed3}\u3723\u{1fc64}\uc629\u0117',
+  dimension: '2d',
+  baseMipLevel: 7,
+  mipLevelCount: 2,
+  baseArrayLayer: 1095,
+});
+let sampler81 = device1.createSampler({
+  label: '\u05bd\u0428\uf21c\u{1f72f}\u156d\u0f57\u0467\ue023\u3ffb\u33a4',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 56.60,
+  compare: 'less-equal',
+  maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder72.draw(473342941, 214059350, 912177352, 364500927);
+} catch {}
+try {
+renderBundleEncoder75.drawIndexedIndirect(buffer49, 61668);
+} catch {}
+try {
+renderBundleEncoder83.setPipeline(pipeline140);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 218, y: 0, z: 97},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 31231510 */
+{offset: 310, bytesPerRow: 780, rowsPerImage: 154}, {width: 256, height: 0, depthOrArrayLayers: 261});
+} catch {}
+let pipeline151 = device1.createRenderPipeline({
+  label: '\u2145\u0b29',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 97496059,
+    depthBias: -376587566,
+    depthBiasSlopeScale: 278.4627219316037,
+  },
+  vertex: {
+    module: shaderModule39,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 6680, attributes: [{format: 'sint32x2', offset: 1624, shaderLocation: 14}]},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 564, shaderLocation: 0},
+          {format: 'uint32x4', offset: 36, shaderLocation: 21},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let imageData25 = new ImageData(80, 128);
+let commandEncoder173 = device1.createCommandEncoder({label: '\uc060\u003a\u365e\u0d15\u{1fa8b}\u{1fea0}\u9f1e\u{1f973}\u078b\u012d'});
+let querySet84 = device1.createQuerySet({label: '\u50f1\uffd3', type: 'occlusion', count: 3206});
+let textureView217 = texture91.createView({});
+try {
+commandEncoder167.copyBufferToBuffer(buffer44, 49200, buffer47, 300812, 36928);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder168.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21804 */
+  offset: 21748,
+  buffer: buffer38,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap28 = await createImageBitmap(video0);
+document.body.prepend(canvas17);
+canvas13.width = 122;
+gc();
+let video24 = await videoWithData();
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let commandEncoder174 = device1.createCommandEncoder({label: '\u74c9\u02c6\u299e\u{1fa7d}\u4a73\u0d59\u{1fd9c}\uecb8\u{1f759}\u8e06\u156a'});
+let textureView218 = texture84.createView({
+  label: '\u767f\ue6de\u8b9e\u{1fb8d}\ue093\uefd9\u07d6\ude9b\uedb0',
+  format: 'r16uint',
+  baseMipLevel: 1,
+});
+let sampler82 = device1.createSampler({
+  label: '\u0b16\u2807',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.23,
+  lodMaxClamp: 91.40,
+});
+try {
+renderBundleEncoder90.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder90.setBindGroup(3, bindGroup29, new Uint32Array(7690), 5298, 0);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(3, buffer39, 0, 3198);
+} catch {}
+try {
+commandEncoder172.copyTextureToBuffer({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2144 widthInBlocks: 268 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 12752 */
+  offset: 12752,
+  buffer: buffer48,
+}, {width: 268, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder173.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 549},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 75, y: 0, z: 18},
+  aspect: 'all',
+},
+{width: 210, height: 0, depthOrArrayLayers: 35});
+} catch {}
+try {
+gpuCanvasContext23.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline152 = await device1.createComputePipelineAsync({
+  label: '\uf397\u6a81\u1c25\u59ff\u0626\u80bd\u1471\u9649\u{1f724}\u114b\u0422',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas26);
+let imageBitmap29 = await createImageBitmap(imageData9);
+let textureView219 = texture96.createView({label: '\u58bb\u2665\u0854\u{1f772}\u7dda', dimension: '3d', baseMipLevel: 3, baseArrayLayer: 0});
+let externalTexture76 = device1.importExternalTexture({label: '\u04a1\udc13\u296d', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder71.drawIndirect(buffer49, 7228);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+commandEncoder167.copyBufferToBuffer(buffer38, 134488, buffer47, 304460, 1864);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+canvas11.height = 447;
+let bindGroupLayout38 = device1.createBindGroupLayout({
+  label: '\ucb48\ua673\u5d45\u4d34\u4988\u0483',
+  entries: [
+    {
+      binding: 9059,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView220 = texture102.createView({label: '\u0b35\u0068\u0841\u906f\u7ffa\uc7c2\ueb02', baseArrayLayer: 0});
+let externalTexture77 = device1.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup31, new Uint32Array(9434), 303, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder78.draw(76062810);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexedIndirect(buffer49, 35032);
+} catch {}
+try {
+renderBundleEncoder77.drawIndirect(buffer49, 198768);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(0, buffer47, 113248, 161139);
+} catch {}
+try {
+commandEncoder167.copyBufferToBuffer(buffer44, 78044, buffer46, 142232, 13028);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer46);
+} catch {}
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 246, y: 0, z: 89},
+  aspect: 'all',
+},
+{width: 36, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder168.resolveQuerySet(querySet70, 2045, 517, buffer48, 71168);
+} catch {}
+try {
+commandEncoder143.insertDebugMarker('\u07e6');
+} catch {}
+let pipeline153 = await device1.createComputePipelineAsync({layout: pipelineLayout19, compute: {module: shaderModule39, entryPoint: 'compute0', constants: {}}});
+video8.width = 288;
+document.body.prepend(img18);
+let commandEncoder175 = device1.createCommandEncoder();
+try {
+computePassEncoder75.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(0, bindGroup29, new Uint32Array(2804), 942, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline126);
+} catch {}
+try {
+renderBundleEncoder78.setPipeline(pipeline133);
+} catch {}
+try {
+commandEncoder170.copyBufferToBuffer(buffer38, 261168, buffer41, 53292, 66444);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer41);
+} catch {}
+let pipeline154 = await device1.createComputePipelineAsync({
+  label: '\u{1f610}\u0513\u0c17\u{1f945}\u96e2\u9692',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule28, entryPoint: 'compute0', constants: {}},
+});
+let canvas27 = document.createElement('canvas');
+try {
+canvas27.getContext('webgl2');
+} catch {}
+let imageBitmap30 = await createImageBitmap(video9);
+let videoFrame19 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let textureView221 = texture92.createView({
+  label: '\ub854\u0ba7\ucc40\u{1fd17}',
+  format: 'rg8sint',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderBundleEncoder71.draw(1213376347, 488484105);
+} catch {}
+try {
+commandEncoder158.copyTextureToBuffer({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2176 widthInBlocks: 272 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14896 */
+  offset: 12720,
+  buffer: buffer41,
+}, {width: 272, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+commandEncoder175.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 274, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer41, 56220, new BigUint64Array(13588), 10788, 1320);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline155 = device1.createRenderPipeline({
+  label: '\uf700\u0d60\u{1ffe8}\u{1fd86}\u3d47\u32ed\u62da\u2f12\u05c5',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+  },
+}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 3412, attributes: [{format: 'sint32x2', offset: 472, shaderLocation: 4}]}],
+  },
+});
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let img34 = await imageWithData(71, 258, '#581a8715', '#21625913');
+video0.width = 81;
+let pipelineLayout20 = device1.createPipelineLayout({
+  label: '\u13c8\ub212\uf386\u68a6\u1b24\u09eb',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout37, bindGroupLayout37, bindGroupLayout34],
+});
+let commandEncoder176 = device1.createCommandEncoder();
+let texture109 = device1.createTexture({
+  label: '\ub7ca\u0153\u7c24\u1693\u034f\u0d13\u4150',
+  size: {width: 1110, height: 10, depthOrArrayLayers: 1375},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView222 = texture84.createView({label: '\u0bb3\u{1fc70}\u0010\ub67c\u0b05\u554b', mipLevelCount: 1});
+let renderBundle103 = renderBundleEncoder67.finish({label: '\u423d\u6658\u{1f973}'});
+try {
+renderBundleEncoder75.drawIndexed(811966902, 896995196);
+} catch {}
+try {
+renderBundleEncoder75.drawIndexedIndirect(buffer49, 17452);
+} catch {}
+try {
+renderBundleEncoder86.setVertexBuffer(8, buffer39, 0, 5178);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer41, 300576, new Float32Array(20143), 16094, 176);
+} catch {}
+gc();
+let canvas28 = document.createElement('canvas');
+canvas28.height = 1473;
+try {
+canvas28.getContext('webgl2');
+} catch {}
+try {
+externalTexture75.label = '\u171d\ub9eb\ufd90\u0282\u{1f6f7}\u0423';
+} catch {}
+let bindGroupLayout39 = device1.createBindGroupLayout({
+  label: '\u08ae\u0925\u2c83',
+  entries: [
+    {
+      binding: 2827,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 3706,
+      visibility: 0,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture110 = device1.createTexture({
+  label: '\u0ec1\u013f',
+  size: [4080],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let sampler83 = device1.createSampler({
+  label: '\u{1f76f}\u0d58\u2901\u0859\u9e7b\u0af5\u0e86\uc91a\u6d8d\u0d41',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.35,
+  lodMaxClamp: 63.60,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder77.drawIndexedIndirect(buffer49, 454228);
+} catch {}
+try {
+renderBundleEncoder72.drawIndirect(buffer49, 325684);
+} catch {}
+try {
+commandEncoder175.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 27, y: 0, z: 372},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise38 = device1.createComputePipelineAsync({layout: pipelineLayout18, compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}}});
+let pipeline156 = device1.createRenderPipeline({
+  label: '\u6757\u55ee\u{1fadd}\u6b2b\u4cf9\u91df\u0519\uedc4\u{1f69a}',
+  layout: pipelineLayout20,
+  multisample: {mask: 0x180f170},
+  fragment: {
+  module: shaderModule37,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.ALL}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 52852809,
+    stencilWriteMask: 2668674924,
+    depthBias: 0,
+  },
+  vertex: {module: shaderModule37, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas20);
+offscreenCanvas23.width = 755;
+let img35 = await imageWithData(165, 55, '#893a1a86', '#cd836a55');
+let renderBundleEncoder91 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'], sampleCount: 4, depthReadOnly: true});
+let sampler84 = device1.createSampler({
+  label: '\u{1f751}\u{1f6a0}\uf1a8\u3fec\u{1f933}\uc6e4',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.48,
+  lodMaxClamp: 71.53,
+  compare: 'equal',
+});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(2, bindGroup28, new Uint32Array(2459), 129, 0);
+} catch {}
+try {
+renderBundleEncoder77.draw(82480414, 808153773, 656855366, 1128948681);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(531268219, 452473864);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexedIndirect(buffer49, 6388);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline122);
+} catch {}
+try {
+commandEncoder175.copyBufferToTexture({
+  /* bytesInLastRow: 6652 widthInBlocks: 3326 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 27214 */
+  offset: 27214,
+  buffer: buffer38,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 228, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3326, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder175.copyTextureToTexture({
+  texture: texture106,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder165.resolveQuerySet(querySet67, 614, 145, buffer43, 20736);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 889, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 289 */
+{offset: 289}, {width: 165, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 555, height: 5, depthOrArrayLayers: 687}
+*/
+{
+  source: video21,
+  origin: { x: 11, y: 4 },
+  flipY: false,
+}, {
+  texture: texture109,
+  mipLevel: 1,
+  origin: {x: 55, y: 2, z: 615},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img36 = await imageWithData(67, 184, '#e80e28e9', '#8f5337f1');
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+try {
+window.someLabel = externalTexture76.label;
+} catch {}
+let buffer50 = device1.createBuffer({label: '\u8906\uc5a1', size: 74674, usage: GPUBufferUsage.UNIFORM});
+let texture111 = device1.createTexture({
+  label: '\u7274\u0d38',
+  size: {width: 160, height: 2, depthOrArrayLayers: 1325},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder78 = commandEncoder172.beginComputePass({});
+let renderBundleEncoder92 = device1.createRenderBundleEncoder({
+  label: '\ufca6\u{1ff10}\u0db0\u0755\u2b12\u78a1\u88e0\uacfd\u76d2\u{1f690}\u8769',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler85 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.50,
+  lodMaxClamp: 83.10,
+  compare: 'greater-equal',
+});
+try {
+renderBundleEncoder87.drawIndexedIndirect(buffer49, 58640);
+} catch {}
+try {
+renderBundleEncoder87.setVertexBuffer(2, buffer47);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video24.height = 219;
+let video25 = await videoWithData();
+canvas12.width = 5;
+let shaderModule40 = device1.createShaderModule({
+  label: '\u2d2e\uf320\u0d8c\ua51d\u0fa0\u{1fadb}',
+  code: `@group(1) @binding(3627)
+var<storage, read_write> function34: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> field34: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> type29: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> n27: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> parameter30: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @builtin(vertex_index) f0: u32,
+  @location(14) f1: vec2<i32>,
+  @location(15) f2: vec4<i32>,
+  @location(21) f3: vec2<u32>,
+  @location(13) f4: vec3<f32>,
+  @location(17) f5: vec3<i32>,
+  @location(20) f6: vec4<f32>,
+  @location(4) f7: vec3<i32>,
+  @location(23) f8: f16,
+  @location(5) f9: vec3<f32>,
+  @location(9) f10: vec4<f32>,
+  @location(10) f11: vec3<i32>,
+  @location(25) f12: i32,
+  @location(11) f13: vec3<i32>,
+  @location(8) f14: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: f16, @location(7) a1: vec4<f16>, @location(1) a2: vec2<f16>, @location(16) a3: vec2<u32>, @location(19) a4: vec4<u32>, @location(0) a5: vec3<i32>, @location(2) a6: vec2<u32>, @location(12) a7: f16, @location(24) a8: vec3<u32>, @location(3) a9: vec4<u32>, @location(22) a10: vec2<u32>, a11: S27, @builtin(instance_index) a12: u32, @location(6) a13: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout40 = device1.createBindGroupLayout({
+  label: '\u05ad\udc57\u{1fa29}\u4cf8\u0b39\u0149\u03c3\u60d8\ud1cc',
+  entries: [
+    {
+      binding: 4626,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 2934,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 682, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder177 = device1.createCommandEncoder({label: '\ub350\u0091\u0b46\u0f4e\u{1f852}\uffd1'});
+let querySet85 = device1.createQuerySet({label: '\u0bea\u0c09', type: 'occlusion', count: 160});
+try {
+renderBundleEncoder89.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+querySet64.destroy();
+} catch {}
+try {
+buffer44.destroy();
+} catch {}
+try {
+commandEncoder177.copyTextureToBuffer({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1040 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1264 */
+  offset: 224,
+  rowsPerImage: 261,
+  buffer: buffer48,
+}, {width: 130, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder167.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 2,
+  origin: {x: 82, y: 1, z: 63},
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise39 = device1.createRenderPipelineAsync({
+  label: '\u86f7\u{1fb2c}\ub3ea\u29af\u01f1',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one'},
+  },
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 3735117678,
+    stencilWriteMask: 2574418875,
+    depthBiasSlopeScale: 142.78209098875973,
+  },
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 5920, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2224,
+        attributes: [
+          {format: 'uint8x4', offset: 2220, shaderLocation: 15},
+          {format: 'sint32x3', offset: 200, shaderLocation: 14},
+          {format: 'float32x2', offset: 2216, shaderLocation: 18},
+          {format: 'float32x3', offset: 524, shaderLocation: 2},
+          {format: 'sint32', offset: 224, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 8488,
+        attributes: [
+          {format: 'uint8x2', offset: 1766, shaderLocation: 20},
+          {format: 'float32', offset: 2128, shaderLocation: 7},
+          {format: 'sint32x4', offset: 708, shaderLocation: 23},
+          {format: 'snorm16x2', offset: 436, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 3208, shaderLocation: 12},
+          {format: 'float16x4', offset: 1144, shaderLocation: 10},
+          {format: 'sint32', offset: 6440, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 676, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 1112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 24},
+          {format: 'snorm16x2', offset: 132, shaderLocation: 16},
+          {format: 'sint32x3', offset: 44, shaderLocation: 13},
+          {format: 'sint32x4', offset: 140, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 442, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 32, shaderLocation: 11},
+          {format: 'sint32x4', offset: 436, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 120, shaderLocation: 8},
+          {format: 'sint32', offset: 332, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 92, shaderLocation: 3},
+          {format: 'sint8x4', offset: 44, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 72, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+let offscreenCanvas26 = new OffscreenCanvas(535, 80);
+let querySet86 = device1.createQuerySet({type: 'occlusion', count: 1461});
+let commandBuffer44 = commandEncoder173.finish();
+try {
+renderBundleEncoder77.drawIndexed(739396540, 750006674, 444056296, 584658555, 842022742);
+} catch {}
+try {
+renderBundleEncoder80.drawIndirect(buffer49, 38900);
+} catch {}
+try {
+renderBundleEncoder83.setVertexBuffer(1, buffer47, 12536);
+} catch {}
+try {
+commandEncoder170.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 243, y: 0, z: 300},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 2,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 138, height: 1, depthOrArrayLayers: 171}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 31, y: 7 },
+  flipY: false,
+}, {
+  texture: texture109,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 41},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame20 = new VideoFrame(videoFrame14, {timestamp: 0});
+offscreenCanvas24.height = 382;
+try {
+offscreenCanvas26.getContext('webgpu');
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  label: '\u{1fd91}\u3a05\u8d38\u01cd\ucbe1\u{1fb91}\uaa30\u4479\u0e01\u57a3',
+  layout: bindGroupLayout1,
+  entries: [{binding: 5340, resource: externalTexture22}],
+});
+let textureView223 = texture93.createView({
+  label: '\u{1fc8f}\u{1fae3}\u0cd2\ueb9c\u018a\u{1ff34}\u0e9c',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 271,
+});
+let renderBundleEncoder93 = device0.createRenderBundleEncoder({
+  label: '\u{1f940}\u{1f937}\u2027',
+  colorFormats: ['rg8sint', 'rgba32sint', 'r8sint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup6, new Uint32Array(141), 90, 0);
+} catch {}
+try {
+computePassEncoder30.dispatchWorkgroups(2, 4, 1);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer37, 129148);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer23, 'uint16', 54742, 11575);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder30.insertDebugMarker('\u{1f937}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer6), /* required buffer size: 618 */
+{offset: 618, bytesPerRow: 57}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img11,
+  origin: { x: 26, y: 11 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline157 = await device0.createComputePipelineAsync({
+  label: '\u{1f8ed}\ud6ef\u8739\ua508\u002a\ucc05\u88a5\u{1fba2}\ua947\u07a8\u0657',
+  layout: 'auto',
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let canvas29 = document.createElement('canvas');
+let imageBitmap31 = await createImageBitmap(offscreenCanvas13);
+let canvas30 = document.createElement('canvas');
+try {
+canvas29.getContext('webgpu');
+} catch {}
+let bindGroup33 = device1.createBindGroup({
+  label: '\u54ec\u{1f953}\u7019\uadb1\ua397\u{1ff5c}\u8bb3\uc7af\u{1fd47}',
+  layout: bindGroupLayout36,
+  entries: [],
+});
+let buffer51 = device1.createBuffer({size: 89400, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder178 = device1.createCommandEncoder();
+let commandBuffer45 = commandEncoder170.finish({label: '\u{1f612}\ucc1c\u{1fb57}\u{1fa55}\u589a\u00db\ubbb8\u0fb0\u1430\u{1f9ed}'});
+let textureView224 = texture105.createView({
+  label: '\u{1fc44}\u8120\u1ba8\u35fd',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+  baseArrayLayer: 714,
+  arrayLayerCount: 199,
+});
+let renderBundleEncoder94 = device1.createRenderBundleEncoder({
+  label: '\u0a07\u1155\u8a5a\u{1ff7d}\u0209\u{1f6f3}\u{1f6ac}\u{1f85b}\u0d3a\u6dcf',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder77.setBindGroup(4, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder75.drawIndexedIndirect(buffer49, 188204);
+} catch {}
+try {
+renderBundleEncoder71.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder91.setVertexBuffer(9, buffer47, 298628, 25662);
+} catch {}
+try {
+commandEncoder174.copyTextureToTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 180, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet66, 801, 104, buffer40, 200192);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 138, height: 1, depthOrArrayLayers: 171}
+*/
+{
+  source: img7,
+  origin: { x: 28, y: 34 },
+  flipY: false,
+}, {
+  texture: texture109,
+  mipLevel: 3,
+  origin: {x: 62, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline158 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  multisample: {count: 4},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 3811279318,
+    stencilWriteMask: 416306664,
+    depthBias: -927349702,
+    depthBiasClamp: 507.97433353837505,
+  },
+  vertex: {
+    module: shaderModule32,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1812, shaderLocation: 15},
+          {format: 'uint32x4', offset: 1312, shaderLocation: 17},
+          {format: 'uint16x4', offset: 2216, shaderLocation: 19},
+          {format: 'unorm16x2', offset: 1668, shaderLocation: 13},
+          {format: 'float16x4', offset: 304, shaderLocation: 7},
+          {format: 'uint8x4', offset: 420, shaderLocation: 23},
+          {format: 'uint32', offset: 2108, shaderLocation: 2},
+          {format: 'sint16x4', offset: 1752, shaderLocation: 21},
+          {format: 'sint8x2', offset: 1604, shaderLocation: 25},
+          {format: 'sint8x2', offset: 3818, shaderLocation: 24},
+          {format: 'snorm8x4', offset: 1776, shaderLocation: 0},
+          {format: 'sint8x2', offset: 206, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 2512, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 7956, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 1092,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 350, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 74, shaderLocation: 1},
+          {format: 'sint32x4', offset: 212, shaderLocation: 8},
+          {format: 'sint32x3', offset: 88, shaderLocation: 11},
+          {format: 'sint32x2', offset: 64, shaderLocation: 5},
+          {format: 'uint32x4', offset: 456, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 4844,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 280, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 1568, shaderLocation: 3},
+          {format: 'uint16x4', offset: 388, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 2204,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 936, shaderLocation: 6},
+          {format: 'sint32', offset: 308, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let externalTexture78 = device1.importExternalTexture({label: '\u1651\u6fbf\u024b\u4e85\u2e9a\u0ed0\u01b3', source: video22, colorSpace: 'srgb'});
+try {
+computePassEncoder77.end();
+} catch {}
+try {
+renderBundleEncoder87.drawIndexedIndirect(buffer49, 28096);
+} catch {}
+try {
+renderBundleEncoder77.drawIndirect(buffer49, 60048);
+} catch {}
+try {
+commandEncoder178.clearBuffer(buffer46, 60668);
+dissociateBuffer(device1, buffer46);
+} catch {}
+try {
+commandEncoder168.insertDebugMarker('\u9224');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 2,
+  origin: {x: 24, y: 0, z: 7},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 14472364 */
+{offset: 934, bytesPerRow: 336, rowsPerImage: 291}, {width: 123, height: 2, depthOrArrayLayers: 149});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 138, height: 1, depthOrArrayLayers: 171}
+*/
+{
+  source: imageBitmap29,
+  origin: { x: 85, y: 0 },
+  flipY: true,
+}, {
+  texture: texture109,
+  mipLevel: 3,
+  origin: {x: 22, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline159 = device1.createComputePipeline({
+  label: '\u0e30\u27de\ua71b\u16f8\u9686\uba58\u{1f663}\u{1fec4}',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule37, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas9.height = 444;
+let shaderModule41 = device1.createShaderModule({
+  label: '\u{1fcea}\u0890',
+  code: `@group(3) @binding(3627)
+var<storage, read_write> type30: array<u32>;
+@group(1) @binding(3627)
+var<storage, read_write> type31: array<u32>;
+@group(2) @binding(5439)
+var<storage, read_write> function35: array<u32>;
+@group(4) @binding(3627)
+var<storage, read_write> parameter31: array<u32>;
+@group(0) @binding(5439)
+var<storage, read_write> function36: array<u32>;
+@group(2) @binding(3627)
+var<storage, read_write> global30: array<u32>;
+@group(4) @binding(5439)
+var<storage, read_write> global31: array<u32>;
+@group(1) @binding(5439)
+var<storage, read_write> field35: array<u32>;
+@group(0) @binding(3627)
+var<storage, read_write> n28: array<u32>;
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S29 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec2<i32>,
+  @location(1) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(a0: S29, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S28 {
+  @location(12) f0: vec3<f16>,
+  @location(24) f1: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, a1: S28, @builtin(vertex_index) a2: u32, @builtin(instance_index) a3: u32, @location(2) a4: vec4<f16>, @location(23) a5: vec4<f16>, @location(16) a6: vec3<f32>, @location(18) a7: vec3<f32>, @location(14) a8: vec3<i32>, @location(5) a9: vec2<f16>, @location(4) a10: vec3<f32>, @location(11) a11: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let texture112 = device1.createTexture({
+  size: [80, 1, 480],
+  mipLevelCount: 4,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder95 = device1.createRenderBundleEncoder({label: '\u0c61\udea2', colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'], sampleCount: 4});
+try {
+renderBundleEncoder86.setVertexBuffer(8, buffer39, 0, 2349);
+} catch {}
+try {
+commandEncoder175.copyBufferToBuffer(buffer44, 161700, buffer51, 86588, 2232);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer51);
+} catch {}
+document.body.prepend(video12);
+canvas28.width = 63;
+document.body.prepend(video10);
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let device2 = await adapter6.requestDevice({
+  label: '\u3e6f\u716c\ub40a\ucf33\u0ab9\u261d\u0a90\ufbf9\uf1ae\uad9f',
+  defaultQueue: {label: '\u{1fcf3}\u0c93\u06ac\u7cc5\uca05\ucba5\u018a\u97f9\u06ec'},
+  requiredFeatures: ['texture-compression-etc2', 'texture-compression-astc', 'shader-f16', 'bgra8unorm-storage'],
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxColorAttachmentBytesPerSample: 57,
+    maxVertexAttributes: 17,
+    maxVertexBufferArrayStride: 55304,
+    maxStorageTexturesPerShaderStage: 41,
+    maxStorageBuffersPerShaderStage: 15,
+    maxDynamicStorageBuffersPerPipelineLayout: 44695,
+    maxDynamicUniformBuffersPerPipelineLayout: 40781,
+    maxBindingsPerBindGroup: 6322,
+    maxTextureArrayLayers: 1233,
+    maxTextureDimension1D: 13469,
+    maxTextureDimension2D: 10499,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 92715567,
+    maxUniformBuffersPerShaderStage: 33,
+    maxSampledTexturesPerShaderStage: 29,
+    maxInterStageShaderVariables: 72,
+    maxInterStageShaderComponents: 100,
+  },
+});
+let commandEncoder179 = device2.createCommandEncoder({label: '\u0cd1\u0f6f\uf8d8\u09d6\uf8ad\u03eb'});
+let computePassEncoder79 = commandEncoder179.beginComputePass({label: '\u0df6\u1e29\u06d8'});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+let commandEncoder180 = device2.createCommandEncoder({label: '\u{1fc5d}\ue618\u{1ffae}\u700b\u1942\u02df\u{1f817}'});
+let texture113 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder80 = commandEncoder176.beginComputePass({label: '\u{1fd0e}\u0410\uaae7\u4e17'});
+let renderBundle104 = renderBundleEncoder92.finish({label: '\u33d8\u012d\u794c\u1664\ud2a3'});
+try {
+renderBundleEncoder81.setBindGroup(3, bindGroup30);
+} catch {}
+let arrayBuffer17 = buffer43.getMappedRange(6872, 116);
+try {
+device1.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 900 */
+{offset: 900}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline160 = await device1.createRenderPipelineAsync({
+  label: '\u7087\u738b\u168c\u{1fafe}\u054c\udb33\ubdd6\u0517\u{1f7e0}',
+  layout: pipelineLayout19,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 2998845627,
+    stencilWriteMask: 3211348088,
+    depthBias: -125621189,
+    depthBiasSlopeScale: 455.94147943951407,
+  },
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 912,
+        attributes: [
+          {format: 'unorm8x2', offset: 122, shaderLocation: 6},
+          {format: 'float32x3', offset: 288, shaderLocation: 11},
+          {format: 'float32x4', offset: 272, shaderLocation: 1},
+          {format: 'float32', offset: 80, shaderLocation: 3},
+          {format: 'float32x3', offset: 368, shaderLocation: 12},
+          {format: 'sint16x2', offset: 56, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 276,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 32, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 19},
+          {format: 'uint32x3', offset: 32, shaderLocation: 15},
+          {format: 'sint8x4', offset: 8, shaderLocation: 23},
+          {format: 'sint32', offset: 164, shaderLocation: 0},
+          {format: 'sint8x4', offset: 168, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 3776, attributes: [{format: 'uint16x4', offset: 196, shaderLocation: 20}]},
+      {
+        arrayStride: 5680,
+        attributes: [
+          {format: 'float32x4', offset: 1964, shaderLocation: 16},
+          {format: 'sint32x4', offset: 1860, shaderLocation: 14},
+          {format: 'sint32x4', offset: 1992, shaderLocation: 22},
+          {format: 'sint16x4', offset: 512, shaderLocation: 9},
+          {format: 'sint32', offset: 2100, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 1540, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 460, shaderLocation: 2},
+          {format: 'sint16x2', offset: 176, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 4572, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 364, shaderLocation: 25},
+          {format: 'float32x2', offset: 4128, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 680,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 284, shaderLocation: 24}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas30.getContext('webgl');
+} catch {}
+document.body.prepend(canvas19);
+let canvas31 = document.createElement('canvas');
+let buffer52 = device2.createBuffer({
+  label: '\u091a\u3475\u{1f757}\u0856\u664b\ue91f\u{1f9b6}',
+  size: 53297,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder181 = device2.createCommandEncoder({label: '\u0e73\u00b5\u524d\u{1fd43}\uf19c\ubfa0\u{1ffab}\u{1fbdf}\u095e'});
+let renderBundleEncoder96 = device2.createRenderBundleEncoder({label: '\u0330\u0e50\uab38', colorFormats: ['bgra8unorm'], depthReadOnly: true});
+let img37 = await imageWithData(231, 267, '#72dda899', '#b1fbe5c5');
+let bindGroupLayout41 = device2.createBindGroupLayout({
+  label: '\u{1f67e}\u{1f762}\u7f82\u3ba0',
+  entries: [
+    {
+      binding: 365,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder182 = device2.createCommandEncoder({label: '\u{1f8f6}\u0ed9\u2f72\ud601\u0405\u8204\u{1fc51}\u005d\u4c2b\u0801'});
+let computePassEncoder81 = commandEncoder180.beginComputePass({});
+try {
+renderBundleEncoder96.setVertexBuffer(3224, undefined, 0, 1196095057);
+} catch {}
+canvas16.height = 204;
+let querySet87 = device2.createQuerySet({
+  label: '\u{1fc4a}\u{1fc58}\u0501\ue3cb\u0067\ue45b\u{1fad1}\uf2c5\u{1f8b0}',
+  type: 'occlusion',
+  count: 1524,
+});
+try {
+renderBundleEncoder96.setVertexBuffer(3820, undefined, 0, 2635091159);
+} catch {}
+let device3 = await adapter3.requestDevice({
+  label: '\u03e8\ud15c\u484b\u04f7\u57d2\ub422\uec72',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxVertexAttributes: 26,
+    maxVertexBufferArrayStride: 37506,
+    maxStorageTexturesPerShaderStage: 28,
+    maxStorageBuffersPerShaderStage: 10,
+    maxDynamicStorageBuffersPerPipelineLayout: 15773,
+    maxDynamicUniformBuffersPerPipelineLayout: 26251,
+    maxBindingsPerBindGroup: 6513,
+    maxTextureArrayLayers: 344,
+    maxTextureDimension1D: 11566,
+    maxTextureDimension2D: 11200,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 219117781,
+    maxUniformBuffersPerShaderStage: 25,
+    maxSampledTexturesPerShaderStage: 19,
+    maxInterStageShaderVariables: 122,
+    maxInterStageShaderComponents: 100,
+  },
+});
+let img38 = await imageWithData(285, 67, '#6a5741fe', '#183aeb86');
+let pipelineLayout21 = device2.createPipelineLayout({label: '\u{1fae9}\u1049\u0c2a\u8786\u0129\u{1fec8}\u55d5', bindGroupLayouts: [bindGroupLayout41]});
+let commandEncoder183 = device2.createCommandEncoder({label: '\u7a4d\u0991\uf2fe\u06ef\ud4b2\u04de\u0495\u{1f9d6}\u5651\ud142'});
+let querySet88 = device2.createQuerySet({
+  label: '\u{1fe1f}\u23c8\u639a\u040c\u032a\u{1f915}\u0f59\u25db\u0444\u0869\u{1fd13}',
+  type: 'occlusion',
+  count: 2119,
+});
+let computePassEncoder82 = commandEncoder183.beginComputePass({label: '\u7196\u817e\u{1f892}\ud6a7\u4754'});
+let commandEncoder184 = device2.createCommandEncoder({});
+let texture114 = device2.createTexture({
+  label: '\u{1fddd}\u{1f808}\ub62b\ude35',
+  size: [895, 1, 128],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView225 = texture114.createView({
+  label: '\u{1fd5a}\ud6fe\u000e\u0a15\u7a39\u{1f7ce}\uc5bd\uc81a\u0813\u{1fee7}',
+  baseMipLevel: 3,
+  arrayLayerCount: 1,
+});
+try {
+commandEncoder181.copyBufferToTexture({
+  /* bytesInLastRow: 100 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6004 */
+  offset: 6004,
+  rowsPerImage: 285,
+  buffer: buffer52,
+}, {
+  texture: texture114,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 25, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer52);
+} catch {}
+try {
+commandEncoder184.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 13, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+computePassEncoder81.insertDebugMarker('\u0afa');
+} catch {}
+let sampler86 = device1.createSampler({
+  label: '\u0e6f\u07eb\u8465\u003a\u0f8a\u18dc\u{1ffc1}\u1740\u0c3f\u{1fe76}\ufdbe',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.94,
+  lodMaxClamp: 91.04,
+});
+try {
+renderBundleEncoder71.draw(1191199991, 546853283, 32274191, 343386618);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(481982017);
+} catch {}
+try {
+renderBundleEncoder73.setPipeline(pipeline133);
+} catch {}
+try {
+canvas31.getContext('webgl');
+} catch {}
+let bindGroup34 = device1.createBindGroup({
+  label: '\u80eb\u0bf1\u8726',
+  layout: bindGroupLayout35,
+  entries: [{binding: 7040, resource: sampler85}, {binding: 927, resource: externalTexture71}],
+});
+let querySet89 = device1.createQuerySet({label: '\u0d03\u2483\u{1fbc1}', type: 'occlusion', count: 2533});
+let texture115 = device1.createTexture({
+  label: '\u0964\u{1fa2c}\u97c7\u061f\u09bf\u89a1\ue412\u83be\u0b36\u{1f87b}',
+  size: [277],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder87.draw(1148725346, 548189069, 733527570, 515801209);
+} catch {}
+try {
+renderBundleEncoder80.drawIndexed(743705049, 273486825, 1071204093, -169635207, 603412954);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(6, buffer47, 144440);
+} catch {}
+try {
+commandEncoder167.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8344 */
+  offset: 8344,
+  buffer: buffer38,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture106,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder185 = device3.createCommandEncoder({});
+let renderBundleEncoder97 = device3.createRenderBundleEncoder({
+  label: '\u35fd\u87bd\u{1ffef}',
+  colorFormats: ['rgba8unorm', 'rg32sint', 'rg32uint', 'rgba16float'],
+  depthReadOnly: true,
+});
+let canvas32 = document.createElement('canvas');
+let video26 = await videoWithData();
+let imageBitmap32 = await createImageBitmap(video17);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(912, 551);
+let texture116 = device1.createTexture({
+  label: '\u5433\u{1f776}\u{1f913}\u0552\u{1f848}',
+  size: [150],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView226 = texture102.createView({label: '\ue239\u{1fb69}\u{1fc0e}\u8e8c\u{1fc9e}'});
+let renderBundleEncoder98 = device1.createRenderBundleEncoder({
+  label: '\u{1f94d}\u0347\u{1fff9}\u{1f9d9}\ubc89',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder77.draw(5327006, 71649536, 370252901, 109724412);
+} catch {}
+try {
+renderBundleEncoder69.drawIndexedIndirect(buffer49, 61368);
+} catch {}
+let promise40 = buffer51.mapAsync(GPUMapMode.READ, 29912);
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer45]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer47, 136848, new Float32Array(1382), 1083, 20);
+} catch {}
+let pipeline161 = await device1.createRenderPipelineAsync({
+  label: '\u02c8\u0cca',
+  layout: pipelineLayout20,
+  multisample: {count: 4, mask: 0xcf34c1d},
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'zero'},
+    stencilReadMask: 161858825,
+    stencilWriteMask: 2002580449,
+    depthBiasSlopeScale: 586.5028102200085,
+  },
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3408, attributes: [{format: 'uint32x4', offset: 2188, shaderLocation: 1}]},
+      {
+        arrayStride: 252,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 32, shaderLocation: 10},
+          {format: 'uint8x4', offset: 0, shaderLocation: 4},
+          {format: 'float16x2', offset: 16, shaderLocation: 9},
+          {format: 'uint8x2', offset: 30, shaderLocation: 25},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 2196,
+        attributes: [
+          {format: 'sint8x2', offset: 1164, shaderLocation: 13},
+          {format: 'float32x4', offset: 384, shaderLocation: 17},
+          {format: 'sint32x2', offset: 1624, shaderLocation: 18},
+          {format: 'float32', offset: 1116, shaderLocation: 19},
+          {format: 'sint32x4', offset: 1260, shaderLocation: 21},
+          {format: 'uint32x3', offset: 0, shaderLocation: 15},
+          {format: 'uint16x2', offset: 956, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 756, shaderLocation: 2},
+          {format: 'sint16x2', offset: 176, shaderLocation: 23},
+          {format: 'sint32x4', offset: 88, shaderLocation: 11},
+          {format: 'sint32x4', offset: 468, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 546, shaderLocation: 6},
+          {format: 'sint32', offset: 900, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 580, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 492, shaderLocation: 0},
+          {format: 'sint32x3', offset: 128, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 1080, shaderLocation: 5},
+          {format: 'uint8x2', offset: 128, shaderLocation: 16},
+          {format: 'float32x2', offset: 24, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 740, attributes: []},
+      {
+        arrayStride: 440,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm10-10-10-2', offset: 144, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroupLayout42 = device1.createBindGroupLayout({label: '\ueeb0\u6304\ub98a\u0477\u8898\ubc43', entries: []});
+let querySet90 = device1.createQuerySet({label: '\ud123\uf974\u0961\u0225\u{1fea9}\u0b4c\u30f2', type: 'occlusion', count: 3211});
+let textureView227 = texture99.createView({label: '\u0966\u11cf\uea17\uf613\ue484\u0b79', baseArrayLayer: 0});
+let renderBundle105 = renderBundleEncoder70.finish();
+try {
+renderBundleEncoder77.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder69.drawIndexed(1066396804, 642862663, 984741178);
+} catch {}
+try {
+renderBundleEncoder77.drawIndexedIndirect(buffer49, 202092);
+} catch {}
+try {
+renderBundleEncoder77.drawIndirect(buffer49, 157604);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 1229, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 1900 */
+{offset: 246}, {width: 827, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder186 = device3.createCommandEncoder({label: '\u963f\u745a'});
+let texture117 = device3.createTexture({
+  label: '\u0a94\ub75d\u8dd8\u{1f99d}\u{1ff66}\u6de4\uafc0',
+  size: {width: 240, height: 480, depthOrArrayLayers: 118},
+  mipLevelCount: 6,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView228 = texture117.createView({
+  label: '\u0468\u{1f6d6}\u375c\u5881\u{1f8e9}\u3ca3\u{1f6e8}\u{1fe8e}\u297f\u5cf3',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 17,
+  arrayLayerCount: 75,
+});
+let renderBundleEncoder99 = device3.createRenderBundleEncoder({label: '\u{1fb0b}\u{1fe93}', colorFormats: ['rgba8unorm', 'rg32sint', 'rg32uint', 'rgba16float']});
+let externalTexture79 = device3.importExternalTexture({label: '\u64da\ud62c', source: videoFrame5, colorSpace: 'srgb'});
+let gpuCanvasContext27 = canvas32.getContext('webgpu');
+let canvas33 = document.createElement('canvas');
+let commandEncoder187 = device1.createCommandEncoder({label: '\u4ade\u062a\u06f1\u5f06\ue6bf\u1132\u7300\ua435\u5584\u517f\u8210'});
+let textureView229 = texture97.createView({
+  label: '\u8484\u4180\ueb7e\u055b\u4a01\u8331\u58fd\u4a04\ub53b\u{1f71c}\u0452',
+  mipLevelCount: 8,
+  baseArrayLayer: 43,
+  arrayLayerCount: 539,
+});
+let renderBundleEncoder100 = device1.createRenderBundleEncoder({colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle106 = renderBundleEncoder68.finish({label: '\uec2d\u0684\u37df\u750c\u{1fa05}\u8479\u{1f787}\u0ce7\u{1f640}\u{1f6c8}\u05cd'});
+try {
+renderBundleEncoder80.drawIndexedIndirect(buffer49, 16880);
+} catch {}
+try {
+renderBundleEncoder72.drawIndirect(buffer49, 382944);
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer38, 291032, buffer47, 101600, 103516);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder177.clearBuffer(buffer47);
+dissociateBuffer(device1, buffer47);
+} catch {}
+let textureView230 = texture83.createView({label: '\u9d16\u0464', arrayLayerCount: 1});
+try {
+computePassEncoder74.setPipeline(pipeline128);
+} catch {}
+try {
+renderBundleEncoder75.drawIndexed(561164895, 1063541386, 1179124374);
+} catch {}
+try {
+renderBundleEncoder72.drawIndirect(buffer49, 96436);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 300},
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 28723093 */
+{offset: 826, bytesPerRow: 597, rowsPerImage: 79}, {width: 155, height: 0, depthOrArrayLayers: 610});
+} catch {}
+let pipeline162 = await device1.createRenderPipelineAsync({
+  label: '\u5842\u0560\u{1fe9c}\u0948\ub367\u0cba',
+  layout: pipelineLayout18,
+  multisample: {count: 4, mask: 0xf98a6838},
+  fragment: {
+  module: shaderModule37,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+  },
+}],
+},
+  vertex: {module: shaderModule37, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list'},
+});
+let commandBuffer46 = commandEncoder167.finish({label: '\ubee1\u04b8\ue3c9\udc1c\u6ff3\u7b9c\u{1f63b}'});
+let textureView231 = texture81.createView({
+  label: '\u{1ffec}\u7b64\ufb38\u8e6d\u5d53\ub9e1\u008c\ub069',
+  baseMipLevel: 2,
+  baseArrayLayer: 394,
+  arrayLayerCount: 768,
+});
+let sampler87 = device1.createSampler({
+  label: '\u8494\u7306\u8945\u9f93\u827e',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.31,
+  lodMaxClamp: 74.58,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder72.drawIndexedIndirect(buffer49, 80632);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline162);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(0, buffer39, 0, 1200);
+} catch {}
+try {
+commandEncoder160.copyBufferToBuffer(buffer44, 180476, buffer48, 166316, 2116);
+dissociateBuffer(device1, buffer44);
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder171.copyTextureToBuffer({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 496 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 32208 */
+  offset: 31712,
+  buffer: buffer47,
+}, {width: 62, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder175.resolveQuerySet(querySet63, 459, 855, buffer48, 3840);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer47, 146152, new Float32Array(23394));
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 14730 */
+{offset: 540, bytesPerRow: 55, rowsPerImage: 43}, {width: 0, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let gpuCanvasContext28 = offscreenCanvas27.getContext('webgpu');
+let commandEncoder188 = device1.createCommandEncoder({label: '\u0842\u0ec2\u1ae2\u{1fa9f}\u94f0\u067c\u{1fd5c}\u7fad'});
+let commandBuffer47 = commandEncoder165.finish({label: '\u078e\u4082\u6c26\u0995\u9c69'});
+let textureView232 = texture113.createView({label: '\ue5ab\u7bf7\uf89b\u1b94\uecd1', dimension: '2d-array', format: 'bgra8unorm-srgb'});
+let computePassEncoder83 = commandEncoder143.beginComputePass({label: '\u0001\u07be\u0f11\u3123\u05a4\u9940\u4c45'});
+let externalTexture80 = device1.importExternalTexture({
+  label: '\u4bf8\u0a34\u63ac\uf922\uf36f\u3e26\u4bc2\u{1f93e}\u0a17\u{1f7da}\ufdb2',
+  source: videoFrame11,
+});
+try {
+renderBundleEncoder86.draw(758292655, 376075178, 288580971, 773347735);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline133);
+} catch {}
+try {
+commandEncoder158.resolveQuerySet(querySet74, 3178, 170, buffer48, 59904);
+} catch {}
+let canvas34 = document.createElement('canvas');
+let externalTexture81 = device2.importExternalTexture({
+  label: '\u{1fdee}\u{1fb3d}\u{1ffd9}\u{1fafa}\uff57\u{1fedd}\u0aeb\u52c2',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 60},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 910830 */
+{offset: 278, bytesPerRow: 1993, rowsPerImage: 114}, {width: 436, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let buffer53 = device1.createBuffer({label: '\u0bc6\u{1f921}\u71ab\u0c03\u1fca', size: 86743, usage: GPUBufferUsage.STORAGE});
+let commandEncoder189 = device1.createCommandEncoder({});
+let textureView233 = texture96.createView({label: '\u9801\uf6d3\ud759\uc865\uae7b\ua06b\u0181\u7d1c\uc93b', baseMipLevel: 3});
+let renderBundle107 = renderBundleEncoder68.finish({label: '\u06df\u4956'});
+let externalTexture82 = device1.importExternalTexture({source: video16, colorSpace: 'display-p3'});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+commandEncoder189.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 79},
+  aspect: 'all',
+},
+{
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder178.resolveQuerySet(querySet74, 3280, 121, buffer40, 167168);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise41 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 69, height: 1, depthOrArrayLayers: 85}
+*/
+{
+  source: imageData24,
+  origin: { x: 58, y: 40 },
+  flipY: false,
+}, {
+  texture: texture109,
+  mipLevel: 4,
+  origin: {x: 6, y: 0, z: 63},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video12);
+let querySet91 = device3.createQuerySet({label: '\u1424\u6f09\u0d68\u4ecf\u554a\u{1fe81}\u644d\u80dc\u7611', type: 'occlusion', count: 735});
+let commandBuffer48 = commandEncoder185.finish();
+let renderBundleEncoder101 = device3.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm', 'rg32sint', 'rg32uint', 'rgba16float'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let sampler88 = device3.createSampler({
+  label: '\u2d71\u{1fcea}\u99bd\u0c02\uf650\u{1fc13}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.71,
+  lodMaxClamp: 52.51,
+  maxAnisotropy: 13,
+});
+let promise42 = device3.queue.onSubmittedWorkDone();
+try {
+  await promise40;
+} catch {}
+video9.width = 65;
+let computePassEncoder84 = commandEncoder186.beginComputePass({label: '\ubb3d\u3f35\uf9b0\u04cb\u5e43'});
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+canvas34.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder190 = device3.createCommandEncoder({label: '\u58f4\u1693\u522c\u053e\u0136\u4b83'});
+let renderBundleEncoder102 = device3.createRenderBundleEncoder({
+  label: '\u521e\u0295\u{1fb65}\u{1ffe3}\u{1fd81}\u0c8a\u57cf\u0136\u0dc8',
+  colorFormats: ['rgba8unorm', 'rg32sint', 'rg32uint', 'rgba16float'],
+  stencilReadOnly: true,
+});
+let renderBundle108 = renderBundleEncoder101.finish({label: '\u0310\u0aec\u15b5\u74ab\uef7a\u6619\u03cf\u6443\uf5de'});
+let sampler89 = device3.createSampler({
+  label: '\u{1feb7}\ua5dd\u{1f827}\ufaa2\u{1fe39}\u9be6\ueba7\ub6ff\u0502',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.62,
+  lodMaxClamp: 84.61,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder99.setVertexBuffer(4630, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let gpuCanvasContext29 = canvas33.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let videoFrame21 = videoFrame0.clone();
+let buffer54 = device2.createBuffer({size: 350193, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder191 = device2.createCommandEncoder({});
+let querySet92 = device2.createQuerySet({
+  label: '\u0623\u{1f744}\u03a1\u0dd7\u{1ffd1}\u0c43\u{1fa7d}\u6afc\ube9d\u267e',
+  type: 'occlusion',
+  count: 1234,
+});
+let renderBundle109 = renderBundleEncoder96.finish({label: '\ue6e9\u0e3f\u0b79\u43ad\ue672\u{1fc55}\u{1f78d}\u079a\u0eff'});
+try {
+querySet88.destroy();
+} catch {}
+let img39 = await imageWithData(184, 219, '#d2c34973', '#f5b744d5');
+let textureView234 = texture117.createView({baseMipLevel: 5, mipLevelCount: 1, baseArrayLayer: 18, arrayLayerCount: 51});
+let sampler90 = device3.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.50,
+  lodMaxClamp: 74.39,
+});
+let externalTexture83 = device3.importExternalTexture({
+  label: '\u9e0d\uab78\u47dd\u8e34\u7ea8\u7df6\uaf31\u{1f974}\uf405\u77ce',
+  source: video17,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder97.setVertexBuffer(3258, undefined, 1360360483, 862000560);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let texture118 = device1.createTexture({
+  label: '\u0742\u003b\u02bd\u73e0\u07fd\u3dbd',
+  size: {width: 160},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let textureView235 = texture91.createView({
+  label: '\u4a13\u3fcc\u39ba\ubf02\u0470\u{1fe65}\u08e5\u78cf\u5ca9\u{1fdc9}\u0c36',
+  format: 'r16uint',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder71.draw(36831014, 1154594366, 876063729, 705129942);
+} catch {}
+try {
+renderBundleEncoder71.drawIndexed(621172447, 979957840, 904810202, 375767829);
+} catch {}
+try {
+commandEncoder178.copyTextureToTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder177.resolveQuerySet(querySet70, 3129, 199, buffer43, 23552);
+} catch {}
+try {
+computePassEncoder75.pushDebugGroup('\u9cfc');
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let shaderModule42 = device2.createShaderModule({
+  label: '\u7823\u0469\uc4fb\u{1f7fa}\u{1f933}',
+  code: `@group(0) @binding(365)
+var<storage, read_write> local34: array<u32>;
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @location(34) f0: vec3<i32>,
+  @location(22) f1: vec3<f16>,
+  @location(40) f2: vec3<u32>,
+  @builtin(front_facing) f3: bool,
+  @location(6) f4: vec2<i32>,
+  @builtin(sample_mask) f5: u32,
+  @location(23) f6: f32,
+  @location(38) f7: vec2<f32>,
+  @location(35) f8: vec2<i32>,
+  @location(70) f9: u32,
+  @location(32) f10: vec3<u32>,
+  @location(5) f11: vec3<f32>,
+  @location(28) f12: vec2<f16>,
+  @location(19) f13: f32,
+  @location(55) f14: vec3<u32>,
+  @location(17) f15: vec4<f16>,
+  @location(39) f16: vec2<f32>,
+  @location(49) f17: vec3<u32>,
+  @location(46) f18: vec3<u32>,
+  @location(16) f19: vec4<f16>,
+  @location(59) f20: vec4<i32>,
+  @location(9) f21: vec4<i32>,
+  @location(14) f22: vec4<i32>,
+  @location(26) f23: f32,
+  @location(63) f24: vec2<f16>,
+  @location(54) f25: vec4<f32>,
+  @location(11) f26: f16,
+  @location(43) f27: vec2<f16>,
+  @location(18) f28: i32,
+  @location(20) f29: vec3<f16>,
+  @location(21) f30: f16,
+  @location(48) f31: vec3<f16>,
+  @location(8) f32: vec4<f32>,
+  @location(10) f33: vec4<i32>,
+  @location(65) f34: u32,
+  @location(61) f35: vec4<u32>,
+  @location(56) f36: vec4<f16>,
+  @location(45) f37: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<i32>,
+  @location(2) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(a0: S31, @location(44) a1: vec4<f32>, @builtin(position) a2: vec4<f32>, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @location(8) f0: vec4<i32>,
+  @location(4) f1: vec4<u32>,
+  @location(9) f2: u32,
+  @location(3) f3: i32,
+  @location(1) f4: vec2<i32>,
+  @location(16) f5: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(22) f562: vec3<f16>,
+  @location(14) f563: vec4<i32>,
+  @location(35) f564: vec2<i32>,
+  @location(44) f565: vec4<f32>,
+  @location(23) f566: f32,
+  @location(43) f567: vec2<f16>,
+  @location(45) f568: vec4<f32>,
+  @builtin(position) f569: vec4<f32>,
+  @location(34) f570: vec3<i32>,
+  @location(70) f571: u32,
+  @location(28) f572: vec2<f16>,
+  @location(5) f573: vec3<f32>,
+  @location(65) f574: u32,
+  @location(6) f575: vec2<i32>,
+  @location(54) f576: vec4<f32>,
+  @location(32) f577: vec3<u32>,
+  @location(11) f578: f16,
+  @location(9) f579: vec4<i32>,
+  @location(40) f580: vec3<u32>,
+  @location(20) f581: vec3<f16>,
+  @location(10) f582: vec4<i32>,
+  @location(21) f583: f16,
+  @location(63) f584: vec2<f16>,
+  @location(16) f585: vec4<f16>,
+  @location(56) f586: vec4<f16>,
+  @location(48) f587: vec3<f16>,
+  @location(61) f588: vec4<u32>,
+  @location(38) f589: vec2<f32>,
+  @location(55) f590: vec3<u32>,
+  @location(49) f591: vec3<u32>,
+  @location(18) f592: i32,
+  @location(46) f593: vec3<u32>,
+  @location(39) f594: vec2<f32>,
+  @location(19) f595: f32,
+  @location(17) f596: vec4<f16>,
+  @location(26) f597: f32,
+  @location(8) f598: vec4<f32>,
+  @location(59) f599: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<i32>, @location(10) a1: vec2<f32>, @location(13) a2: vec3<f32>, @location(12) a3: vec3<u32>, @location(2) a4: vec3<f16>, @location(14) a5: vec2<f32>, @location(7) a6: vec3<f32>, a7: S30, @location(0) a8: vec2<f32>, @location(6) a9: vec4<f32>, @location(11) a10: vec4<i32>, @location(15) a11: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView236 = texture114.createView({label: '\u99d2\u{1ffe9}\u0334\ued69\u0f92\u6aa9\uf71c\u0e6c\u01da\u295e\uf6db', mipLevelCount: 1});
+let promise43 = buffer54.mapAsync(GPUMapMode.READ, 0, 170324);
+try {
+commandEncoder191.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 2,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+commandEncoder181.clearBuffer(buffer54, 349932, 140);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let shaderModule43 = device2.createShaderModule({
+  label: '\u0e1c\u631f\u{1f6ba}\u43bc\u0b8e\u{1fb01}\u01b5\u16e4',
+  code: `
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S32 {
+  @location(53) f0: vec2<u32>,
+  @builtin(position) f1: vec4<f32>,
+  @location(19) f2: f16,
+  @location(34) f3: f32,
+  @builtin(sample_index) f4: u32,
+  @location(3) f5: vec4<f16>,
+  @location(49) f6: vec2<f32>,
+  @location(31) f7: vec4<f16>,
+  @location(64) f8: vec2<u32>,
+  @builtin(sample_mask) f9: u32,
+  @builtin(front_facing) f10: bool,
+  @location(61) f11: vec4<f32>,
+  @location(15) f12: vec4<u32>,
+  @location(18) f13: vec2<f16>,
+  @location(67) f14: vec2<f16>,
+  @location(46) f15: f16,
+  @location(69) f16: u32,
+  @location(23) f17: u32,
+  @location(44) f18: vec2<f32>,
+  @location(2) f19: i32,
+  @location(54) f20: vec3<u32>,
+  @location(59) f21: f16,
+  @location(71) f22: vec3<u32>,
+  @location(51) f23: vec2<f32>,
+  @location(30) f24: vec4<u32>,
+  @location(57) f25: vec3<u32>,
+  @location(26) f26: u32,
+  @location(63) f27: vec2<u32>,
+  @location(45) f28: i32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec3<i32>,
+  @location(3) f1: vec3<i32>,
+  @location(0) f2: vec4<i32>,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(70) a0: i32, @location(8) a1: vec4<u32>, @location(32) a2: f32, @location(14) a3: vec2<u32>, a4: S32, @location(16) a5: vec2<u32>, @location(43) a6: vec3<i32>, @location(56) a7: vec2<u32>, @location(41) a8: vec4<i32>, @location(11) a9: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(23) f600: u32,
+  @location(53) f601: vec2<u32>,
+  @location(71) f602: vec3<u32>,
+  @location(32) f603: f32,
+  @location(18) f604: vec2<f16>,
+  @location(54) f605: vec3<u32>,
+  @location(70) f606: i32,
+  @location(45) f607: i32,
+  @location(46) f608: f16,
+  @location(2) f609: i32,
+  @location(14) f610: vec2<u32>,
+  @location(8) f611: vec4<u32>,
+  @location(19) f612: f16,
+  @location(64) f613: vec2<u32>,
+  @location(61) f614: vec4<f32>,
+  @location(69) f615: u32,
+  @location(11) f616: vec2<i32>,
+  @location(16) f617: vec2<u32>,
+  @location(44) f618: vec2<f32>,
+  @location(3) f619: vec4<f16>,
+  @location(59) f620: f16,
+  @location(31) f621: vec4<f16>,
+  @location(49) f622: vec2<f32>,
+  @location(51) f623: vec2<f32>,
+  @location(57) f624: vec3<u32>,
+  @builtin(position) f625: vec4<f32>,
+  @location(63) f626: vec2<u32>,
+  @location(15) f627: vec4<u32>,
+  @location(30) f628: vec4<u32>,
+  @location(26) f629: u32,
+  @location(34) f630: f32,
+  @location(43) f631: vec3<i32>,
+  @location(67) f632: vec2<f16>,
+  @location(56) f633: vec2<u32>,
+  @location(41) f634: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<i32>, @location(11) a1: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout43 = device2.createBindGroupLayout({
+  label: '\u9596\u07bd\u0321\u{1fef9}\u0106\udc92',
+  entries: [
+    {
+      binding: 1543,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let querySet93 = device2.createQuerySet({
+  label: '\uff27\u{1fd93}\u0357\u03da\ubf13\u{1f6a0}\u{1ffd2}\u4497\u{1f609}\u82ed\u{1ff5d}',
+  type: 'occlusion',
+  count: 3722,
+});
+let texture119 = device2.createTexture({
+  size: [1790, 1, 166],
+  mipLevelCount: 11,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+try {
+commandEncoder191.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 5,
+  origin: {x: 11, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+let pipeline163 = await device2.createComputePipelineAsync({
+  label: '\uf7c4\u848d\u78f9\ub9c8\u984b\uef20\ua43f\u{1f9b2}\u00cc\u47b5\ub227',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule43, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise41;
+} catch {}
+document.body.prepend(canvas0);
+let textureView237 = texture117.createView({dimension: '2d', baseMipLevel: 5, baseArrayLayer: 45});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55) };
+} catch {}
+offscreenCanvas19.width = 1396;
+try {
+window.someLabel = pipeline45.label;
+} catch {}
+let commandEncoder192 = device3.createCommandEncoder({label: '\u019e\u6af2\uf243\u{1f653}'});
+let textureView238 = texture117.createView({
+  label: '\u89a5\uddf8\u8581\u6d41\udded\u048c\uda15\ud7d2',
+  mipLevelCount: 1,
+  baseArrayLayer: 88,
+  arrayLayerCount: 6,
+});
+let sampler91 = device3.createSampler({
+  label: '\u{1fd30}\u0b75\u0f60\u4442\u0d70\u{1f6d3}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.98,
+  lodMaxClamp: 24.81,
+  maxAnisotropy: 14,
+});
+video17.width = 190;
+gc();
+pseudoSubmit(device1, commandEncoder164);
+let sampler92 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 42.50,
+  compare: 'always',
+});
+try {
+renderBundleEncoder80.draw(491549647, 346591647, 459593351, 438210403);
+} catch {}
+try {
+renderBundleEncoder86.drawIndexedIndirect(buffer49, 431960);
+} catch {}
+try {
+renderBundleEncoder80.drawIndirect(buffer49, 30408);
+} catch {}
+try {
+renderBundleEncoder78.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder89.setVertexBuffer(9, buffer39, 1320, 3194);
+} catch {}
+try {
+  await buffer41.mapAsync(GPUMapMode.READ, 0, 502900);
+} catch {}
+try {
+commandEncoder168.resolveQuerySet(querySet81, 246, 147, buffer43, 20480);
+} catch {}
+try {
+device1.queue.submit([commandBuffer46]);
+} catch {}
+let pipeline164 = device1.createRenderPipeline({
+  label: '\u{1fb48}\u32bc\u54b2\u9d33\u0d3b\u9019\u352a\u018d\u{1f80a}\u0724\u{1f7e5}',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule40,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule40,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 176,
+        attributes: [
+          {format: 'snorm8x2', offset: 82, shaderLocation: 12},
+          {format: 'sint8x2', offset: 64, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 7},
+          {format: 'sint32x2', offset: 24, shaderLocation: 8},
+          {format: 'float32x3', offset: 4, shaderLocation: 1},
+          {format: 'uint32x4', offset: 28, shaderLocation: 24},
+          {format: 'sint8x2', offset: 28, shaderLocation: 25},
+          {format: 'float16x2', offset: 0, shaderLocation: 20},
+          {format: 'uint16x2', offset: 4, shaderLocation: 22},
+          {format: 'uint16x4', offset: 80, shaderLocation: 2},
+          {format: 'sint32', offset: 16, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 3888,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 468, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 128, shaderLocation: 13},
+          {format: 'float32x2', offset: 452, shaderLocation: 5},
+          {format: 'uint32x4', offset: 308, shaderLocation: 19},
+          {format: 'uint16x4', offset: 1512, shaderLocation: 21},
+          {format: 'float16x2', offset: 28, shaderLocation: 23},
+          {format: 'float32x3', offset: 268, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 2652,
+        attributes: [
+          {format: 'sint8x2', offset: 1432, shaderLocation: 14},
+          {format: 'sint32x3', offset: 128, shaderLocation: 11},
+          {format: 'sint32', offset: 1456, shaderLocation: 17},
+          {format: 'sint32x2', offset: 4, shaderLocation: 0},
+          {format: 'uint8x2', offset: 444, shaderLocation: 3},
+          {format: 'uint32x3', offset: 1684, shaderLocation: 16},
+          {format: 'sint32x3', offset: 508, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 696, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+gc();
+let promise44 = adapter4.requestDevice({
+  label: '\u{1fae3}\u{1f65f}\u06ae',
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 64,
+    maxVertexAttributes: 22,
+    maxVertexBufferArrayStride: 11677,
+    maxStorageTexturesPerShaderStage: 32,
+    maxStorageBuffersPerShaderStage: 9,
+    maxDynamicStorageBuffersPerPipelineLayout: 781,
+    maxDynamicUniformBuffersPerPipelineLayout: 51961,
+    maxBindingsPerBindGroup: 5363,
+    maxTextureArrayLayers: 1787,
+    maxTextureDimension1D: 8535,
+    maxTextureDimension2D: 13552,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 237120802,
+    maxUniformBuffersPerShaderStage: 43,
+    maxSampledTexturesPerShaderStage: 38,
+    maxInterStageShaderVariables: 80,
+    maxInterStageShaderComponents: 108,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+try {
+externalTexture81.label = '\u{1f89b}\u{1fa81}';
+} catch {}
+let texture120 = device2.createTexture({
+  size: {width: 1790, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let textureView239 = texture120.createView({label: '\u0296\u53fe', mipLevelCount: 3});
+let externalTexture84 = device2.importExternalTexture({
+  label: '\u{1f8ef}\u0d02\u0db8\u0e43\u05d8\u0114\u{1f87c}\uc132\uf294',
+  source: videoFrame10,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder181.copyBufferToBuffer(buffer52, 43352, buffer54, 92812, 2964);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+commandEncoder191.clearBuffer(buffer54, 101168, 145432);
+dissociateBuffer(device2, buffer54);
+} catch {}
+let commandEncoder193 = device1.createCommandEncoder();
+let querySet94 = device1.createQuerySet({label: '\u026b\u{1f609}\u313a\u{1fda5}\u02b6\u{1f955}', type: 'occlusion', count: 259});
+try {
+renderBundleEncoder71.drawIndexed(458715879, 1074830649, 422299347, -870970005, 38836621);
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(2, buffer47, 184716);
+} catch {}
+try {
+commandEncoder171.copyTextureToBuffer({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 30704 */
+  offset: 30704,
+  rowsPerImage: 138,
+  buffer: buffer48,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder174.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 20},
+  aspect: 'all',
+},
+{width: 74, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap33 = await createImageBitmap(imageBitmap11);
+let buffer55 = device2.createBuffer({
+  label: '\u0419\u16ed\u8ac3\uef32\ud02c\u{1fc15}\u{1ff22}',
+  size: 28674,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView240 = texture119.createView({dimension: '3d', mipLevelCount: 1});
+let renderBundleEncoder103 = device2.createRenderBundleEncoder({
+  label: '\u1302\ua558\u2965',
+  colorFormats: ['rgba16sint', 'rgb10a2uint', 'rg32sint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus',
+  depthReadOnly: false,
+});
+let externalTexture85 = device2.importExternalTexture({label: '\u{1f884}\uc97a\u74eb\u0b8b\u29d0\u00d1\u0ea5', source: videoFrame9});
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline165 = device2.createRenderPipeline({
+  label: '\u{1fe95}\u7efc\u{1fdd3}',
+  layout: pipelineLayout21,
+  multisample: {},
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32sint'}, {format: 'rg16sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1988,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x4', offset: 0, shaderLocation: 11},
+          {format: 'sint32x3', offset: 132, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(218, 306);
+let textureView241 = texture106.createView({label: '\uaaf5\ued2f\u02eb\u032b\u8d9a\u01c9\ua83a\u0631', baseMipLevel: 5, mipLevelCount: 1});
+let computePassEncoder85 = commandEncoder174.beginComputePass({label: '\u1eee\u71ea\u5be4\u{1fa5d}\u8b3d\u{1fd3c}\u0416\u041a\u0476'});
+let renderBundle110 = renderBundleEncoder95.finish({label: '\u8fd9\u0aa8\u{1f608}'});
+let sampler93 = device1.createSampler({
+  label: '\u0420\u0e84\u59dd\u0e34\u0556\uc67d',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 55.48,
+  lodMaxClamp: 85.90,
+});
+try {
+renderBundleEncoder81.setBindGroup(4, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder86.drawIndexed(926299013, 860494341, 487971827, -37903534, 1144848964);
+} catch {}
+try {
+renderBundleEncoder78.drawIndexedIndirect(buffer49, 40968);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder100.setVertexBuffer(1, buffer47, 0, 333110);
+} catch {}
+try {
+commandEncoder178.copyBufferToBuffer(buffer38, 355004, buffer42, 186816, 6492);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+commandEncoder178.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 1,
+  origin: {x: 81, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 48, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let gpuCanvasContext30 = offscreenCanvas28.getContext('webgpu');
+let videoFrame22 = new VideoFrame(imageBitmap20, {timestamp: 0});
+let bindGroupLayout44 = device1.createBindGroupLayout({
+  label: '\u80bc\u05da\udf57\ufe32\u027f\u0170\u4f68\u{1fe43}',
+  entries: [
+    {
+      binding: 6655,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 58415, hasDynamicOffset: true },
+    },
+    {
+      binding: 7262,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView242 = texture112.createView({label: '\u9b3d\u0648', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 48});
+let sampler94 = device1.createSampler({
+  label: '\u0030\u{1fb9e}\u9fea\u0f44\u2074',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.27,
+  lodMaxClamp: 57.94,
+  maxAnisotropy: 19,
+});
+let externalTexture86 = device1.importExternalTexture({label: '\u2cfe\uc9b3\u0c9b\u2391\u0749\u7dd0\u0750', source: video25, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder77.drawIndexed(554796450, 362933410, 349907634, -1142490774);
+} catch {}
+try {
+renderBundleEncoder91.setVertexBuffer(4, buffer39, 0, 7194);
+} catch {}
+try {
+commandEncoder178.resolveQuerySet(querySet81, 81, 324, buffer40, 387072);
+} catch {}
+let canvas35 = document.createElement('canvas');
+let imageBitmap34 = await createImageBitmap(offscreenCanvas11);
+let bindGroupLayout45 = device1.createBindGroupLayout({entries: []});
+let buffer56 = device1.createBuffer({
+  label: '\u0406\u0ef5\ud668\u{1fd9d}\u00b2\u39d8\u01a3\u{1fcb4}\u089d\u{1fa7b}',
+  size: 236945,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder86 = commandEncoder189.beginComputePass({});
+try {
+renderBundleEncoder91.setBindGroup(0, bindGroup31, []);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexed(1184557559, 946353633, 773124881);
+} catch {}
+try {
+renderBundleEncoder80.drawIndirect(buffer49, 90716);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline162);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+commandEncoder188.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 1215, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.submit([commandBuffer43, commandBuffer42]);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let textureView243 = texture97.createView({baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 416, arrayLayerCount: 467});
+let computePassEncoder87 = commandEncoder193.beginComputePass({label: '\u66e1\uba3e\uefa8\u8fd3\u{1fb46}'});
+try {
+renderBundleEncoder87.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder98.setBindGroup(3, bindGroup29, new Uint32Array(9922), 751, 0);
+} catch {}
+try {
+renderBundleEncoder72.drawIndirect(buffer49, 193216);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline162);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(7, buffer56, 210556);
+} catch {}
+try {
+commandEncoder158.clearBuffer(buffer43);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder158.resolveQuerySet(querySet80, 10, 2, buffer43, 9472);
+} catch {}
+try {
+computePassEncoder75.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 36552, new Int16Array(17941), 384, 4988);
+} catch {}
+let canvas36 = document.createElement('canvas');
+let texture121 = device1.createTexture({
+  label: '\udfd0\u4cf0\u127e\u{1f7d9}\u1cf8\u1d2b\u9fd5\u5c36',
+  size: [160, 2, 77],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder88 = commandEncoder168.beginComputePass({label: '\u1b7d\uc430\u0fa2\u015c\u{1fe4e}\u9613\u9a46\u0ba5\u{1fdd5}\u0e9a'});
+try {
+renderBundleEncoder78.drawIndexed(1016043937, 677156882);
+} catch {}
+try {
+commandEncoder177.resolveQuerySet(querySet81, 100, 59, buffer43, 11008);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer3), /* required buffer size: 306958 */
+{offset: 431, bytesPerRow: 73, rowsPerImage: 247}, {width: 19, height: 0, depthOrArrayLayers: 18});
+} catch {}
+try {
+  await promise42;
+} catch {}
+let videoFrame23 = new VideoFrame(offscreenCanvas23, {timestamp: 0});
+let commandEncoder194 = device2.createCommandEncoder({});
+let textureView244 = texture114.createView({label: '\u03d9\ucab3', format: 'r32uint', baseMipLevel: 5});
+let sampler95 = device2.createSampler({
+  label: '\uf1ce\u6c90\u65e5\u0d99\u{1faba}\u{1f986}\u059e\u{1fe75}\u7fc6\u42ad',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.39,
+  lodMaxClamp: 55.33,
+});
+try {
+renderBundleEncoder103.setVertexBuffer(6163, undefined);
+} catch {}
+try {
+commandEncoder184.copyBufferToBuffer(buffer52, 24172, buffer54, 291080, 13380);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+commandEncoder181.clearBuffer(buffer54, 94496, 181092);
+dissociateBuffer(device2, buffer54);
+} catch {}
+let pipeline166 = device2.createComputePipeline({
+  label: '\u8159\u16c1',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule42, entryPoint: 'compute0', constants: {}},
+});
+let querySet95 = device3.createQuerySet({label: '\u{1fa07}\u0402\u5c76\u71de\u08cf\u645d\ud318\u{1fcde}', type: 'occlusion', count: 2200});
+let commandBuffer49 = commandEncoder190.finish({label: '\u0a38\u04f1\u{1fea5}\ue729\uf276\u089f\u854b\u32f7\u061d\u{1f701}\u048a'});
+let textureView245 = texture117.createView({
+  label: '\udb23\u0651\u07bd\u00a6\u523a\ucabc\u18dc',
+  mipLevelCount: 5,
+  baseArrayLayer: 113,
+  arrayLayerCount: 1,
+});
+let externalTexture87 = device3.importExternalTexture({label: '\ue661\u2299\u4755\u6376\u057c', source: video21, colorSpace: 'srgb'});
+try {
+device3.queue.submit([commandBuffer48, commandBuffer49]);
+} catch {}
+try {
+device3.destroy();
+} catch {}
+let commandEncoder195 = device1.createCommandEncoder({label: '\u45d8\u2415\u65a2\u0883\u0650\u04d3\u{1f698}\u{1fd11}'});
+try {
+renderBundleEncoder71.drawIndirect(buffer49, 153768);
+} catch {}
+try {
+commandEncoder177.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 1, depthOrArrayLayers: 30});
+} catch {}
+offscreenCanvas7.height = 717;
+try {
+canvas36.getContext('webgl');
+} catch {}
+let externalTexture88 = device3.importExternalTexture({
+  label: '\u017c\u9faa\u{1f8e7}\uc6f4\u56f0\u9457\u50cf\ube4f\u67b2\u{1ffc5}',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+let bindGroup35 = device1.createBindGroup({
+  label: '\u{1f68f}\u0f5d\u0cbd\u141b\u0a5b\ub548\u451d\ufc38\u506c\u95f1\u156c',
+  layout: bindGroupLayout38,
+  entries: [{binding: 9059, resource: textureView217}],
+});
+let textureView246 = texture81.createView({dimension: '2d', baseMipLevel: 3, baseArrayLayer: 146});
+try {
+computePassEncoder71.setPipeline(pipeline159);
+} catch {}
+try {
+renderBundleEncoder77.draw(932698156, 568038866, 69955177, 567086684);
+} catch {}
+try {
+renderBundleEncoder75.drawIndexed(261914405, 781658247, 86977889);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(0, buffer47, 258024, 31389);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder188.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 346 */
+  offset: 346,
+  bytesPerRow: 512,
+  buffer: buffer56,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer56);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 5,
+  origin: {x: 5, y: 0, z: 11},
+  aspect: 'all',
+}, new ArrayBuffer(1089899), /* required buffer size: 1089899 */
+{offset: 345, bytesPerRow: 64, rowsPerImage: 266}, {width: 9, height: 1, depthOrArrayLayers: 65});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 555, height: 5, depthOrArrayLayers: 168}
+*/
+{
+  source: canvas9,
+  origin: { x: 27, y: 21 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 385, y: 1, z: 29},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 17, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline167 = await device1.createComputePipelineAsync({
+  label: '\u298f\u08f6',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule40, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame24 = new VideoFrame(video10, {timestamp: 0});
+let buffer57 = device1.createBuffer({
+  label: '\u1bb3\u{1fef3}\u0730\ud7a8\u716b\uf1e5\u8060\u{1fd55}\uf4e4\u5ab9\u9718',
+  size: 507068,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView247 = texture98.createView({label: '\u074e\u0654', dimension: '2d-array', aspect: 'all', baseMipLevel: 3});
+let computePassEncoder89 = commandEncoder175.beginComputePass({label: '\u971a\u096f'});
+let sampler96 = device1.createSampler({
+  label: '\u9fe1\u029d\u0a71\ub496\u7b63\uf3e1',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 51.33,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup30, []);
+} catch {}
+try {
+renderBundleEncoder86.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder78.drawIndirect(buffer49, 162040);
+} catch {}
+try {
+renderBundleEncoder75.setPipeline(pipeline140);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder160.clearBuffer(buffer42, 43432, 170172);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer57, 46620, new BigUint64Array(43480));
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 128},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 31071891 */
+{offset: 109, bytesPerRow: 172, rowsPerImage: 197}, {width: 77, height: 1, depthOrArrayLayers: 918});
+} catch {}
+gc();
+try {
+canvas35.getContext('webgpu');
+} catch {}
+let canvas37 = document.createElement('canvas');
+let video27 = await videoWithData();
+let offscreenCanvas29 = new OffscreenCanvas(133, 240);
+let querySet96 = device2.createQuerySet({label: '\u68f7\u3be4\u{1f908}\u6ba8\u0e2b\u7b4e\u8502', type: 'occlusion', count: 2724});
+let commandBuffer50 = commandEncoder181.finish();
+let textureView248 = texture114.createView({
+  label: '\u0ca7\u2958\u09a3\uf73c\u{1fa42}\u{1ffc4}\u0b15',
+  format: 'r32uint',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+});
+try {
+computePassEncoder82.setPipeline(pipeline163);
+} catch {}
+try {
+commandEncoder182.copyBufferToBuffer(buffer52, 8940, buffer54, 164036, 12212);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 895, height: 1, depthOrArrayLayers: 83}
+*/
+{
+  source: imageBitmap28,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 57},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let imageData26 = new ImageData(12, 96);
+let querySet97 = device1.createQuerySet({label: '\u0e6f\ud3e7\u4714\u0c4d\u23ff\ubc28\u659f\u0df9', type: 'occlusion', count: 3894});
+let renderBundleEncoder104 = device1.createRenderBundleEncoder({
+  label: '\u{1ff09}\ufe50\ub134\u0b5f\u9788\u00e3\u{1faa8}\ue993\u3627\u1206\ua4d0',
+  colorFormats: ['r8unorm', 'r16uint', 'rg32sint', 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle111 = renderBundleEncoder88.finish({label: '\u{1f9f7}\u{1fe71}\u6ed3\u05b2\u0ad3\u0e8c\u{1feb4}'});
+let sampler97 = device1.createSampler({
+  label: '\u{1f688}\uf687\u{1f85a}\u{1fec9}\u029a',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.36,
+  lodMaxClamp: 36.00,
+});
+try {
+renderBundleEncoder98.setBindGroup(4, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(5, buffer47);
+} catch {}
+try {
+commandEncoder177.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 11184 */
+  offset: 11184,
+  buffer: buffer47,
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder187.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 212, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 97, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 990, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 24692, new Float32Array(4887), 4681, 4);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 174, y: 0, z: 54},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer10), /* required buffer size: 19768161 */
+{offset: 169, bytesPerRow: 680, rowsPerImage: 153}, {width: 196, height: 1, depthOrArrayLayers: 191});
+} catch {}
+let gpuCanvasContext31 = offscreenCanvas29.getContext('webgpu');
+let textureView249 = texture120.createView({
+  label: '\u746f\u2535\u0a2b\ufbd2\u{1f765}\u5f09',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+commandEncoder191.insertDebugMarker('\u3415');
+} catch {}
+let pipeline168 = device2.createRenderPipeline({
+  label: '\u{1f6c2}\u{1fdeb}\u{1f884}\uf4f1\u0f89\u0d73\u04d2',
+  layout: pipelineLayout21,
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2104, attributes: [{format: 'sint32x4', offset: 500, shaderLocation: 10}]},
+      {arrayStride: 2276, attributes: [{format: 'sint8x4', offset: 704, shaderLocation: 11}]},
+    ],
+  },
+});
+let bindGroup36 = device1.createBindGroup({
+  label: '\ue07e\u{1f84e}\u0149\u{1faa7}\u{1f676}\u2db3',
+  layout: bindGroupLayout34,
+  entries: [{binding: 2060, resource: {buffer: buffer50, offset: 51072, size: 2180}}],
+});
+let querySet98 = device1.createQuerySet({label: '\u326d\u0b42', type: 'occlusion', count: 2839});
+try {
+renderBundleEncoder77.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder72.drawIndexed(590180190);
+} catch {}
+try {
+renderBundleEncoder72.setPipeline(pipeline122);
+} catch {}
+try {
+commandEncoder160.copyTextureToTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 11},
+  aspect: 'all',
+},
+{width: 243, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise45 = device1.createComputePipelineAsync({layout: pipelineLayout18, compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}}});
+try {
+canvas37.getContext('2d');
+} catch {}
+let shaderModule44 = device2.createShaderModule({
+  label: '\u{1f8c5}\u{1fc97}\u{1f7eb}',
+  code: `@group(0) @binding(365)
+var<storage, read_write> field36: array<u32>;
+
+@compute @workgroup_size(1, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let buffer58 = device2.createBuffer({
+  label: '\u030c\u2126\u0d67\u47b1\u0da1',
+  size: 130108,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let texture122 = device2.createTexture({
+  size: {width: 1790, height: 1, depthOrArrayLayers: 1927},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint'],
+});
+let textureView250 = texture122.createView({label: '\u882f\u074a', aspect: 'all', baseMipLevel: 2, arrayLayerCount: 1});
+let renderPassEncoder0 = commandEncoder182.beginRenderPass({
+  label: '\u{1fdeb}\u{1fcb3}\u5264\u{1fa3b}\uef32',
+  colorAttachments: [{view: textureView240, depthSlice: 34, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet92,
+  maxDrawCount: 885168926,
+});
+let renderBundle112 = renderBundleEncoder96.finish({label: '\u0c76\u6757'});
+let sampler98 = device2.createSampler({
+  label: '\u00fb\ua885\u6219',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.01,
+  lodMaxClamp: 82.31,
+});
+try {
+renderPassEncoder0.setScissorRect(1755, 1, 10, 0);
+} catch {}
+try {
+commandEncoder194.copyBufferToBuffer(buffer55, 9260, buffer54, 138464, 7596);
+dissociateBuffer(device2, buffer55);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+commandEncoder191.clearBuffer(buffer54, 180808, 10740);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+commandEncoder184.insertDebugMarker('\u71c4');
+} catch {}
+let pipeline169 = await device2.createRenderPipelineAsync({
+  label: '\u4588\uda23\u7b4f\u976f\u5ba5\u0169\u4d6d\u080f\uf59b\u2264',
+  layout: pipelineLayout21,
+  fragment: {
+  module: shaderModule42,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}, {format: 'rg32sint'}, {format: 'rg16sint'}],
+},
+  vertex: {
+    module: shaderModule42,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9108,
+        attributes: [
+          {format: 'snorm16x4', offset: 344, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 3432, shaderLocation: 15},
+          {format: 'uint16x2', offset: 2408, shaderLocation: 12},
+          {format: 'sint8x2', offset: 9106, shaderLocation: 11},
+          {format: 'sint32', offset: 208, shaderLocation: 8},
+          {format: 'sint16x2', offset: 20, shaderLocation: 1},
+          {format: 'float32x2', offset: 664, shaderLocation: 10},
+          {format: 'sint16x2', offset: 84, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 6904, shaderLocation: 6},
+          {format: 'float16x4', offset: 3240, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 88, shaderLocation: 0},
+          {format: 'float32x4', offset: 1620, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 1280, shaderLocation: 7},
+          {format: 'uint32x4', offset: 2328, shaderLocation: 4},
+          {format: 'uint32x4', offset: 9092, shaderLocation: 9},
+          {format: 'sint32x3', offset: 6800, shaderLocation: 5},
+          {format: 'float16x4', offset: 6248, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let offscreenCanvas30 = new OffscreenCanvas(550, 136);
+try {
+offscreenCanvas30.getContext('bitmaprenderer');
+} catch {}
+canvas35.width = 1205;
+try {
+  await promise43;
+} catch {}
+canvas37.width = 822;
+let querySet99 = device2.createQuerySet({label: '\u0edb\ufdd2\u9e8b\u0795\u0f0c\u1ea2\uf91d\u0612\u60d7', type: 'occlusion', count: 1087});
+let textureView251 = texture119.createView({format: 'bgra8unorm', baseMipLevel: 1, mipLevelCount: 7});
+let computePassEncoder90 = commandEncoder194.beginComputePass();
+let renderPassEncoder1 = commandEncoder184.beginRenderPass({
+  label: '\u{1faff}\u0198\u3b2d\uae62\u{1f919}',
+  colorAttachments: [{view: textureView240, depthSlice: 64, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 386737748,
+});
+let renderBundle113 = renderBundleEncoder103.finish({label: '\u0325\ud287\u{1fa3b}\u0660\u312d\u{1fadc}\uac24\u7aeb\u07ef'});
+try {
+computePassEncoder79.setPipeline(pipeline166);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -581.4, g: 968.1, b: 203.6, a: -546.3, });
+} catch {}
+try {
+commandEncoder191.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1752 */
+  offset: 1736,
+  buffer: buffer55,
+}, {
+  texture: texture114,
+  mipLevel: 5,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer55);
+} catch {}
+let textureView252 = texture114.createView({label: '\uee9a\ub271\u68b9\uaf52\ud88e\u{1f704}\u061f', baseMipLevel: 2, mipLevelCount: 4});
+let renderBundle114 = renderBundleEncoder96.finish({label: '\u7d58\u526a\uaea2\u0865\ue65f\u{1f697}\uf32a\ud700\u0549\u{1f962}'});
+try {
+computePassEncoder90.setPipeline(pipeline166);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(1607);
+} catch {}
+try {
+commandEncoder191.copyBufferToBuffer(buffer52, 32092, buffer58, 113872, 11604);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer58);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 143, y: 48 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 8,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img40 = await imageWithData(60, 148, '#ad25e22d', '#0f0b7173');
+let videoFrame25 = new VideoFrame(video10, {timestamp: 0});
+let computePassEncoder91 = commandEncoder187.beginComputePass({label: '\u5479\u057f\u0110\ub8b8\u06d9'});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup31, []);
+} catch {}
+try {
+renderBundleEncoder98.setBindGroup(2, bindGroup30, new Uint32Array(6712), 3617, 0);
+} catch {}
+let promise46 = device1.queue.onSubmittedWorkDone();
+let imageBitmap35 = await createImageBitmap(video0);
+let commandEncoder196 = device2.createCommandEncoder();
+let querySet100 = device2.createQuerySet({label: '\u3622\udb62\u132c\u04ea\u52d7\u0ccd\u{1f845}\ue0f6', type: 'occlusion', count: 1053});
+let textureView253 = texture114.createView({label: '\u{1f81e}\u0413\u14aa\u01be\ufe26\u0f9b', mipLevelCount: 5});
+let externalTexture89 = device2.importExternalTexture({label: '\u673f\u2dff\ua756', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder82.setPipeline(pipeline163);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(336);
+} catch {}
+try {
+commandEncoder191.copyBufferToBuffer(buffer55, 3296, buffer58, 115476, 4152);
+dissociateBuffer(device2, buffer55);
+dissociateBuffer(device2, buffer58);
+} catch {}
+try {
+commandEncoder196.copyTextureToTexture({
+  texture: texture119,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 25, y: 0, z: 11},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder191.clearBuffer(buffer54, 112964, 199052);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+computePassEncoder81.pushDebugGroup('\u001b');
+} catch {}
+try {
+gpuCanvasContext20.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 3},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(24)), /* required buffer size: 1706051 */
+{offset: 100, bytesPerRow: 833, rowsPerImage: 89}, {width: 200, height: 1, depthOrArrayLayers: 24});
+} catch {}
+let img41 = await imageWithData(136, 246, '#eec33aeb', '#5d69a4ca');
+let video28 = await videoWithData();
+video23.height = 23;
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [{binding: 2120, resource: {buffer: buffer30, offset: 28032, size: 1320}}],
+});
+let querySet101 = device0.createQuerySet({label: '\u64fa\ube0b\u{1fee7}\u032d', type: 'occlusion', count: 3644});
+let sampler99 = device0.createSampler({
+  label: '\u790a\u00eb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.86,
+});
+try {
+computePassEncoder32.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder49.draw(243130970, 687600082, 20835010);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer5, 11452);
+} catch {}
+try {
+renderBundleEncoder56.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(2, buffer22, 27700, 39641);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer11, 129312, buffer36, 123288, 24240);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet15, 2772, 117, buffer1, 243456);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img22,
+  origin: { x: 29, y: 3 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise47 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8unorm-srgb'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilWriteMask: 1444480921,
+    depthBiasClamp: -98.03263765441942,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 12516,
+        attributes: [
+          {format: 'uint16x4', offset: 3176, shaderLocation: 11},
+          {format: 'sint32', offset: 3600, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 11464,
+        attributes: [
+          {format: 'float32x3', offset: 2984, shaderLocation: 13},
+          {format: 'uint16x2', offset: 3532, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 11896,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 1368, shaderLocation: 5}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: false},
+});
+try {
+computePassEncoder84.label = '\ue89c\ube2e\u{1f94b}\u1933\u0108\u0975';
+} catch {}
+canvas16.height = 5301;
+let video29 = await videoWithData();
+gc();
+let offscreenCanvas31 = new OffscreenCanvas(845, 449);
+try {
+offscreenCanvas31.getContext('webgl2');
+} catch {}
+let textureView254 = texture122.createView({label: '\u004e\u{1fb55}\ub6a3\u6fd6', format: 'rg16sint', baseMipLevel: 2, arrayLayerCount: 1});
+let renderBundle115 = renderBundleEncoder96.finish({});
+try {
+computePassEncoder81.setPipeline(pipeline163);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle114, renderBundle109, renderBundle109, renderBundle109, renderBundle114, renderBundle112]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(599.2, 0.4996, 198.0, 0.2075, 0.9679, 0.9906);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u0211');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img42 = await imageWithData(217, 165, '#8962262d', '#1ea7a30a');
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+  await promise46;
+} catch {}
+document.body.prepend(img30);
+let commandEncoder197 = device1.createCommandEncoder({label: '\u14d9\u{1fad7}\u17e9'});
+let textureView255 = texture115.createView({label: '\u014f\u0acb', baseMipLevel: 0});
+try {
+computePassEncoder88.setPipeline(pipeline142);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder78.setBindGroup(2, bindGroup33, new Uint32Array(1667), 1533, 0);
+} catch {}
+try {
+renderBundleEncoder80.drawIndexedIndirect(buffer56, 880);
+} catch {}
+try {
+renderBundleEncoder78.drawIndirect(buffer49, 14908);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder177.copyBufferToBuffer(buffer56, 73528, buffer46, 66888, 54532);
+dissociateBuffer(device1, buffer56);
+dissociateBuffer(device1, buffer46);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer15), /* required buffer size: 792267 */
+{offset: 58, bytesPerRow: 807, rowsPerImage: 98}, {width: 271, height: 2, depthOrArrayLayers: 11});
+} catch {}
+let pipeline170 = await device1.createRenderPipelineAsync({
+  label: '\u75e1\u8226\u{1f861}\u0339\u{1ffca}\u6e5d\u0d37\u{1feb1}\udbba\u304d',
+  layout: pipelineLayout19,
+  multisample: {mask: 0xffffffff},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm'}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL}, {format: 'rg8sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-wrap',
+    },
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 1544976668,
+    stencilWriteMask: 1247328392,
+    depthBiasClamp: 244.31975836751724,
+  },
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3636, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2780,
+        attributes: [
+          {format: 'unorm8x4', offset: 704, shaderLocation: 21},
+          {format: 'float32x3', offset: 84, shaderLocation: 11},
+          {format: 'sint32x3', offset: 8, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 3872,
+        attributes: [
+          {format: 'float32x3', offset: 244, shaderLocation: 23},
+          {format: 'sint16x4', offset: 640, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas0);
+try {
+device2.label = '\u71a6\u2e0f\u8c26\u8ebb\u3e67\u0c3c\u{1fef0}\u8b14\u81b6\u9a8f';
+} catch {}
+let querySet102 = device2.createQuerySet({
+  label: '\u{1f79b}\uf508\uc828\u913e\u0549\u04bf\u7362\u3e78\u{1fd55}\u0bce',
+  type: 'occlusion',
+  count: 1110,
+});
+let texture123 = device2.createTexture({
+  size: {width: 1790, height: 1, depthOrArrayLayers: 1044},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle109, renderBundle109, renderBundle114]);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u{1f7b4}');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 13, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 16, y: 20 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let bindGroupLayout46 = device2.createBindGroupLayout({
+  label: '\u7163\u{1fb02}\u0d6e\u072b\u685d\u0d87\ubd6e\u0193\ua6bd\u676c\u{1fe96}',
+  entries: [
+    {
+      binding: 3694,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet103 = device2.createQuerySet({label: '\u00a5\ua598\u{1f77c}\u{1f980}\ub8a5\u60f3\u5cb7', type: 'occlusion', count: 1868});
+let textureView256 = texture122.createView({label: '\u2d94\u{1ffa9}\u{1f8cc}\u{1fd90}', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderPassEncoder1.executeBundles([renderBundle112, renderBundle112, renderBundle114, renderBundle109, renderBundle115, renderBundle115, renderBundle114, renderBundle109]);
+} catch {}
+try {
+commandEncoder196.copyBufferToBuffer(buffer52, 20376, buffer58, 59980, 11436);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer58);
+} catch {}
+offscreenCanvas4.height = 3811;
+let commandEncoder198 = device1.createCommandEncoder({label: '\ue340\u0942\u{1fe05}\ubc56\u662b\u75a5\u{1fb9f}\ue135\u0ca4\udc25'});
+let querySet104 = device1.createQuerySet({label: '\u{1f751}\u0cdf\ua6ee\u813b\u0bce\uebc0\ua426', type: 'occlusion', count: 290});
+let externalTexture90 = device1.importExternalTexture({label: '\u237b\u0136\ue626\u0c5b', source: video23, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder71.draw(736946750);
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer38, 235784, buffer43, 12380, 6352);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder198.copyTextureToBuffer({
+  texture: texture106,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 502128 */
+  offset: 9584,
+  bytesPerRow: 256,
+  rowsPerImage: 148,
+  buffer: buffer57,
+}, {width: 8, height: 0, depthOrArrayLayers: 14});
+dissociateBuffer(device1, buffer57);
+} catch {}
+try {
+commandEncoder198.clearBuffer(buffer48, 38496, 78552);
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder177.resolveQuerySet(querySet68, 2935, 257, buffer56, 199936);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 872 */
+{offset: 872, bytesPerRow: 243}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 203, y: 0 },
+  flipY: false,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline171 = device1.createComputePipeline({
+  label: '\u39d0\u0d78\u0e66\u6144\udabe\u{1fc2d}\u0289',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}},
+});
+let computePassEncoder92 = commandEncoder191.beginComputePass({label: '\u6815\u0a39\u0c29\u0e5a\uf3a5\u68dc\u61aa\uf6ac'});
+let renderBundle116 = renderBundleEncoder96.finish({label: '\ubcd3\u0525\u2d89\uecb8\u0c02\u{1f6ae}'});
+try {
+renderPassEncoder1.setScissorRect(858, 1, 674, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(634.7, 0.5179, 396.1, 0.3720, 0.3167, 0.9738);
+} catch {}
+try {
+renderBundleEncoder72.draw(1102596714, 549598861, 131371345);
+} catch {}
+try {
+renderBundleEncoder89.setVertexBuffer(2, buffer47, 0, 136215);
+} catch {}
+try {
+commandEncoder160.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 211, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 2,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 76, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 16, y: 1 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap36 = await createImageBitmap(imageBitmap9);
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder100.setBindGroup(0, bindGroup36, [59648]);
+} catch {}
+try {
+renderBundleEncoder78.drawIndexed(369348956, 511894023, 321273267, 332966200, 546929083);
+} catch {}
+try {
+  await buffer57.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+device1.queue.submit([commandBuffer47]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 54388, new DataView(new ArrayBuffer(33054)), 16703, 1324);
+} catch {}
+let pipeline172 = device1.createComputePipeline({layout: pipelineLayout19, compute: {module: shaderModule35, entryPoint: 'compute0', constants: {}}});
+let pipeline173 = device1.createRenderPipeline({
+  label: '\u04a7\u{1fd6a}\u{1f604}\u5cd5',
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule40,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm'}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {failOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-wrap'},
+    stencilReadMask: 3239164958,
+    stencilWriteMask: 1121759170,
+    depthBias: 490581,
+    depthBiasSlopeScale: 461.49945960964715,
+    depthBiasClamp: 776.4775549827758,
+  },
+  vertex: {
+    module: shaderModule40,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3872,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 208, shaderLocation: 6},
+          {format: 'sint32x4', offset: 1512, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 324,
+        attributes: [
+          {format: 'float16x4', offset: 88, shaderLocation: 9},
+          {format: 'uint32', offset: 0, shaderLocation: 2},
+          {format: 'sint32x2', offset: 60, shaderLocation: 14},
+          {format: 'sint32x2', offset: 16, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 320, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 120, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 586, shaderLocation: 3},
+          {format: 'sint8x2', offset: 1510, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 268, shaderLocation: 18},
+          {format: 'uint32x3', offset: 5104, shaderLocation: 21},
+          {format: 'sint16x2', offset: 1248, shaderLocation: 17},
+          {format: 'float32x3', offset: 632, shaderLocation: 13},
+          {format: 'float32x2', offset: 564, shaderLocation: 12},
+          {format: 'uint16x4', offset: 628, shaderLocation: 24},
+          {format: 'sint32', offset: 1996, shaderLocation: 4},
+          {format: 'sint16x4', offset: 6892, shaderLocation: 25},
+          {format: 'uint32x4', offset: 456, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 2420, shaderLocation: 20},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 4, shaderLocation: 5},
+          {format: 'sint32', offset: 8, shaderLocation: 11},
+          {format: 'uint32x3', offset: 0, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint8x2', offset: 4674, shaderLocation: 0}]},
+      {
+        arrayStride: 680,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 208, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let imageBitmap37 = await createImageBitmap(offscreenCanvas21);
+let buffer59 = device2.createBuffer({
+  label: '\u04ec\u624f\u72e6\u0aca\u282c\u00bb\u0146',
+  size: 102368,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let textureView257 = texture119.createView({
+  label: '\ubd2e\u0d00\u{1fac2}\u735f\ua4b2\ufa05\u0d83\u0a09\ua7a7\u0a29',
+  baseMipLevel: 4,
+  mipLevelCount: 6,
+});
+let renderBundleEncoder105 = device2.createRenderBundleEncoder({colorFormats: ['rg8uint'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle117 = renderBundleEncoder96.finish({label: '\u0a17\ub2af\u{1fd40}\u0976\u69d9'});
+let sampler100 = device2.createSampler({
+  label: '\u59be\u0f98\u803d\u30fb\u6673',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.13,
+  lodMaxClamp: 83.12,
+  maxAnisotropy: 11,
+});
+let externalTexture91 = device2.importExternalTexture({label: '\u0ae3\u744c\uab9c\uce13\u07c1\u249e', source: videoFrame9, colorSpace: 'srgb'});
+try {
+renderPassEncoder1.end();
+} catch {}
+let promise48 = buffer55.mapAsync(GPUMapMode.WRITE, 25440, 1560);
+try {
+commandEncoder196.clearBuffer(buffer58, 20236);
+dissociateBuffer(device2, buffer58);
+} catch {}
+try {
+computePassEncoder81.popDebugGroup();
+} catch {}
+try {
+computePassEncoder82.insertDebugMarker('\ud263');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas31,
+  origin: { x: 69, y: 18 },
+  flipY: true,
+}, {
+  texture: texture119,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline174 = device2.createComputePipeline({
+  label: '\u1ff5\u04cb\u1eb7',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule42, entryPoint: 'compute0', constants: {}},
+});
+let textureView258 = texture111.createView({dimension: '2d', baseArrayLayer: 228});
+let renderBundleEncoder106 = device1.createRenderBundleEncoder({
+  label: '\ufae3\u60c8\u0002\u5cb9\u{1fcb3}\u{1fd73}\u{1fa79}\u8f85\ud3d4\u{1f784}',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder90.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder90.setBindGroup(2, bindGroup35, new Uint32Array(3426), 2803, 0);
+} catch {}
+try {
+commandEncoder171.resolveQuerySet(querySet81, 181, 22, buffer56, 206592);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer48, 63260, new DataView(new ArrayBuffer(20680)), 11582, 40);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 183 */
+{offset: 183, bytesPerRow: 175}, {width: 43, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas38 = document.createElement('canvas');
+let video30 = await videoWithData();
+let buffer60 = device2.createBuffer({
+  label: '\u44b1\u437d\u{1fa42}\u033c\u092c\uf051\u0f90\ub814',
+  size: 482909,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture124 = device2.createTexture({
+  label: '\uc88c\u{1f977}\u{1fc4c}\u0519\u0fac\ue845\ua815\u{1f6b2}\u0a5c',
+  size: [895, 1, 1],
+  mipLevelCount: 9,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+commandEncoder196.copyTextureToBuffer({
+  texture: texture120,
+  mipLevel: 3,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 824 widthInBlocks: 103 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 34360 */
+  offset: 34360,
+  buffer: buffer60,
+}, {width: 103, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer60);
+} catch {}
+gc();
+let querySet105 = device2.createQuerySet({label: '\u{1fe50}\u{1f612}\u09f0\u9adc\u1243\u091d\u0cd6\ua4c8\uab52', type: 'occlusion', count: 3423});
+let textureView259 = texture123.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 1, baseArrayLayer: 4, arrayLayerCount: 1});
+try {
+device2.queue.writeBuffer(buffer60, 25044, new BigUint64Array(5119), 1128, 1660);
+} catch {}
+let pipeline175 = device2.createComputePipeline({
+  label: '\u0bf2\u0c81\u0d5e\u090b\u12e5',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule44, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext32 = canvas38.getContext('webgpu');
+document.body.prepend(canvas15);
+let buffer61 = device2.createBuffer({
+  label: '\ua52c\u{1fafb}\ub4d2\u9b11\u05df\u7d5b\uc3c7\ufe94\u{1f8e9}\u{1f7ff}',
+  size: 316742,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView260 = texture123.createView({
+  label: '\u01b2\ue657\u0fb1\u79a9\u{1f6ef}\u{1f893}\u4e0a\u0e4f\u{1f972}',
+  dimension: '2d',
+  aspect: 'all',
+  baseArrayLayer: 716,
+});
+let renderBundleEncoder107 = device2.createRenderBundleEncoder({
+  label: '\ua732\u0d09\uca0a\u1809\u3d95\u{1f756}\u0da3',
+  colorFormats: ['rg8unorm', 'rgba16sint', 'rgba16sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+commandEncoder196.copyTextureToBuffer({
+  texture: texture114,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 112460 */
+  offset: 30540,
+  bytesPerRow: 512,
+  rowsPerImage: 80,
+  buffer: buffer60,
+}, {width: 27, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer60, 166044, new DataView(new ArrayBuffer(56693)), 56268, 4);
+} catch {}
+let promise49 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 895, height: 1, depthOrArrayLayers: 83}
+*/
+{
+  source: offscreenCanvas28,
+  origin: { x: 9, y: 7 },
+  flipY: true,
+}, {
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 257, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter();
+let computePassEncoder93 = commandEncoder197.beginComputePass({label: '\u037f\u010e'});
+let externalTexture92 = device1.importExternalTexture({
+  label: '\u0cbb\u8d68\u9001\u3dee\u03e2\u2ee2\u0221\ub1e6\u67ce\u5a02\u{1ffff}',
+  source: video18,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder83.setPipeline(pipeline167);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(285209085, 58969386);
+} catch {}
+let promise50 = device1.popErrorScope();
+try {
+commandEncoder160.clearBuffer(buffer51);
+dissociateBuffer(device1, buffer51);
+} catch {}
+try {
+commandEncoder158.resolveQuerySet(querySet89, 2266, 227, buffer56, 116224);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.destroy();
+} catch {}
+try {
+  await promise48;
+} catch {}
+let canvas39 = document.createElement('canvas');
+let buffer62 = device2.createBuffer({
+  label: '\uca5b\uce67\u8a85\uefc8\uaec1\uff72\u9257',
+  size: 43113,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+});
+let sampler101 = device2.createSampler({
+  label: '\udfae\u0fd0\u8797\uc0e6\u209e\uc773\u7747\u4d2c',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.68,
+  lodMaxClamp: 94.21,
+});
+try {
+renderBundleEncoder107.setVertexBuffer(2712, undefined, 1454485562);
+} catch {}
+try {
+commandEncoder196.copyBufferToBuffer(buffer52, 42200, buffer58, 130076, 4);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer58);
+} catch {}
+try {
+commandEncoder196.copyTextureToBuffer({
+  texture: texture119,
+  mipLevel: 9,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 57684 */
+  offset: 57684,
+  buffer: buffer60,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer60, 14920, new BigUint64Array(19905), 11177, 2692);
+} catch {}
+let imageBitmap38 = await createImageBitmap(imageBitmap5);
+let pipelineLayout22 = device1.createPipelineLayout({label: '\u{1fdb1}\u{1ff34}\u{1fbec}', bindGroupLayouts: [bindGroupLayout40, bindGroupLayout42]});
+let textureView261 = texture113.createView({label: '\u071e\u2399\uf6aa\uf529\ucb8a\uc7f7\ud48c\u{1f860}', dimension: '2d-array'});
+let computePassEncoder94 = commandEncoder177.beginComputePass({label: '\u{1fbf9}\ub6c0\u3098\u{1f63e}\u8098'});
+let renderBundle118 = renderBundleEncoder66.finish({label: '\ua0a5\u026a\u0e5a\u1399\u010e\u58d4\u1551\u5831\u782f\ua36b\u9b36'});
+try {
+computePassEncoder68.setPipeline(pipeline172);
+} catch {}
+try {
+renderBundleEncoder80.drawIndirect(buffer56, 9556);
+} catch {}
+try {
+renderBundleEncoder72.setPipeline(pipeline133);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(5, buffer56);
+} catch {}
+try {
+commandEncoder188.clearBuffer(buffer48, 88932, 31912);
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder188.resolveQuerySet(querySet62, 27, 0, buffer56, 179200);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 277, height: 2, depthOrArrayLayers: 343}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture109,
+  mipLevel: 2,
+  origin: {x: 22, y: 0, z: 119},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline176 = await promise39;
+let videoFrame26 = new VideoFrame(canvas3, {timestamp: 0});
+let buffer63 = device2.createBuffer({
+  label: '\u0873\u00e5\u{1f993}\u0927\u2dd9',
+  size: 26944,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let texture125 = gpuCanvasContext5.getCurrentTexture();
+let textureView262 = texture124.createView({label: '\u0506\u7efb\u792b\ua2a0\ud156\u5d1a\u014a\u3f0a\u{1f6f9}\u4994\u{1f615}', baseMipLevel: 8});
+let computePassEncoder95 = commandEncoder196.beginComputePass({});
+let renderBundleEncoder108 = device2.createRenderBundleEncoder({
+  label: '\u00f8\u0780\ufbf6\u0ca7',
+  colorFormats: ['rg8unorm', 'rgba16sint', 'rgba16sint', 'r8unorm'],
+  sampleCount: 1,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 223, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 97, y: 649 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 3,
+  origin: {x: 30, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 62, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas38.width = 230;
+let img43 = await imageWithData(70, 258, '#f36dc93c', '#a468a652');
+let texture126 = device2.createTexture({
+  label: '\uf018\u819e\u93d7\u39cb\u851c',
+  size: [7160, 1, 1],
+  mipLevelCount: 7,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView263 = texture119.createView({label: '\u1b65\u{1fcd8}\u{1f619}\u8181\u5c6f\ud881\u{1fc11}\u6ffe\u0921\u7f1b', baseMipLevel: 6});
+let pipeline177 = device2.createComputePipeline({
+  label: '\u02cb\u045a\u15c3\u{1fc7a}',
+  layout: 'auto',
+  compute: {module: shaderModule42, entryPoint: 'compute0', constants: {}},
+});
+gc();
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+video21.width = 243;
+let shaderModule45 = device2.createShaderModule({
+  label: '\u{1ff2e}\u{1fbf7}\u0b41\u{1f6d5}\u{1f8a5}',
+  code: `@group(0) @binding(365)
+var<storage, read_write> type32: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S34 {
+  @builtin(front_facing) f0: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, a3: S34) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S33 {
+  @location(12) f0: vec4<u32>,
+  @location(15) f1: vec2<u32>,
+  @location(0) f2: vec2<i32>,
+  @builtin(vertex_index) f3: u32
+}
+
+@vertex
+fn vertex0(@location(4) a0: u32, @location(3) a1: f32, @location(14) a2: vec2<f16>, @location(5) a3: vec4<u32>, @location(9) a4: vec3<f32>, @location(2) a5: vec4<f32>, @location(11) a6: i32, @location(7) a7: vec2<u32>, a8: S33, @location(10) a9: i32, @location(16) a10: f32, @location(6) a11: vec2<f32>, @location(1) a12: vec2<f16>, @location(8) a13: f16, @location(13) a14: u32, @builtin(instance_index) a15: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let buffer64 = device2.createBuffer({
+  size: 229856,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let externalTexture93 = device2.importExternalTexture({label: '\u06e1\u{1feb9}\ub9c4\u{1f96c}\ue89f\ue703', source: videoFrame25, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder107.insertDebugMarker('\u3813');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData26,
+  origin: { x: 2, y: 30 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline178 = await device2.createRenderPipelineAsync({
+  label: '\u{1fb7b}\u8a79\u5c29\u4e3e\u1660\u033e\ub833\u1cb5\u0d05\u0b17',
+  layout: pipelineLayout21,
+  multisample: {count: 4, mask: 0xf3c382fd},
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', passOp: 'replace'},
+    stencilReadMask: 2437985785,
+    stencilWriteMask: 1869772996,
+    depthBiasSlopeScale: -51.93147587668623,
+    depthBiasClamp: 149.5081740671634,
+  },
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 16420, stepMode: 'instance', attributes: []},
+      {arrayStride: 588, attributes: []},
+      {arrayStride: 7864, attributes: [{format: 'sint16x2', offset: 420, shaderLocation: 11}]},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x4', offset: 15352, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let offscreenCanvas32 = new OffscreenCanvas(352, 1006);
+let video31 = await videoWithData();
+let gpuCanvasContext33 = canvas39.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise49;
+} catch {}
+let canvas40 = document.createElement('canvas');
+let texture127 = device0.createTexture({
+  label: '\ub4a1\u0c6f\ub39c\u0e08\ucaf9\u5252',
+  size: {width: 160},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let computePassEncoder96 = commandEncoder87.beginComputePass({label: '\u0b72\u0c99\u1a11\u{1f697}\u6277'});
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer19, 191620);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer37, 29788);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 76044 */
+  offset: 76044,
+  buffer: buffer10,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder89.resolveQuerySet(querySet22, 2772, 114, buffer3, 34560);
+} catch {}
+let promise51 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext34 = canvas40.getContext('webgpu');
+let canvas41 = document.createElement('canvas');
+let textureView264 = texture125.createView({label: '\u0448\u0d9b\u0db9\u{1f684}\u0040', dimension: '2d-array', format: 'rgba16float'});
+let renderBundleEncoder109 = device2.createRenderBundleEncoder({
+  label: '\u{1f79c}\u{1fb47}\u{1ff44}\u{1f9c1}\u4870\u86c6\u0929\u7c07\ua959\ua29b\u0eb2',
+  colorFormats: ['rg8unorm', 'rgba16sint', 'rgba16sint', 'r8unorm'],
+});
+let renderBundle119 = renderBundleEncoder108.finish({});
+let sampler102 = device2.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+let promise52 = device2.queue.onSubmittedWorkDone();
+let textureView265 = texture120.createView({
+  label: '\u4c8b\uc500\u{1ffa0}\uabf4\u0344\u55fe\u039d\u063c\u0d62\u3fe2',
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+});
+let sampler103 = device2.createSampler({
+  label: '\u14eb\u0bc7\u01ee\u3678\uee98\u00ad',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.97,
+  lodMaxClamp: 42.21,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder90.setPipeline(pipeline166);
+} catch {}
+try {
+renderBundleEncoder107.setVertexBuffer(475, undefined, 0, 2847097061);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer60, 34968, new Float32Array(4720), 829, 72);
+} catch {}
+try {
+  await promise50;
+} catch {}
+document.body.prepend(img8);
+let videoFrame27 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let videoFrame28 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+adapter5.label = '\u0ee8\u421d\u{1ff9f}\u06a6\u03bd\u{1ff80}\u0d35\u22df\ufca7\u3308';
+} catch {}
+let bindGroupLayout47 = device0.createBindGroupLayout({label: '\uf444\u0270\u2d06\uf028\u7c1c\u1d64\ub3e4\u06b4\u09a4', entries: []});
+let texture128 = device0.createTexture({
+  label: '\u303e\u74c8',
+  size: {width: 320},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+let textureView266 = texture40.createView({
+  label: '\u0073\u061b\u8571\u36a3\u{1f8a8}\ue64e\u{1fb41}\u{1faf5}\u{1ffdc}',
+  baseMipLevel: 2,
+  baseArrayLayer: 200,
+  arrayLayerCount: 11,
+});
+try {
+renderBundleEncoder60.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+  await promise51;
+} catch {}
+let imageData27 = new ImageData(92, 216);
+let offscreenCanvas33 = new OffscreenCanvas(16, 1010);
+try {
+adapter2.label = '\u{1f6f3}\u{1fedc}\u908f\u{1fe1c}\u020e\u{1f7e1}\u{1fa24}\u{1fcfb}\ueeba\u0e98';
+} catch {}
+try {
+offscreenCanvas33.getContext('webgl2');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas42 = document.createElement('canvas');
+let bindGroupLayout48 = device2.createBindGroupLayout({
+  label: '\uc1d8\ufcaa',
+  entries: [
+    {binding: 669, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 2665,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 1250,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer65 = device2.createBuffer({
+  label: '\u1227\u406f\u09e6\u6ad7\u099b\u01cc\u075d\u01a0\u5d6a\u67b4',
+  size: 256148,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let textureView267 = texture123.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 1, baseArrayLayer: 806});
+try {
+computePassEncoder82.setPipeline(pipeline163);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder199 = device2.createCommandEncoder({label: '\u{1fe9a}\u{1fbba}\u{1face}\ud4ed\u{1f7fe}'});
+let texture129 = device2.createTexture({
+  label: '\u{1f968}\u0c7b\u6708\u0b73\u89b0\uf866\u{1f6b2}\u84a3\u{1ffb4}\u0a2e\u0593',
+  size: {width: 1790},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder110 = device2.createRenderBundleEncoder({
+  label: '\u0610\u0294\u41ef\u02dc\u887f',
+  colorFormats: ['rg8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder199.copyTextureToBuffer({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 18464 */
+  offset: 18464,
+  bytesPerRow: 0,
+  buffer: buffer60,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas9,
+  origin: { x: 81, y: 18 },
+  flipY: true,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder97 = commandEncoder192.beginComputePass({});
+try {
+renderBundleEncoder102.setVertexBuffer(5451, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let imageBitmap39 = await createImageBitmap(imageData22);
+let bindGroupLayout49 = pipeline163.getBindGroupLayout(0);
+let commandEncoder200 = device2.createCommandEncoder();
+try {
+renderBundleEncoder110.setVertexBuffer(6141, undefined);
+} catch {}
+try {
+commandEncoder200.copyBufferToBuffer(buffer59, 29300, buffer54, 126552, 58944);
+dissociateBuffer(device2, buffer59);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let canvas43 = document.createElement('canvas');
+let offscreenCanvas34 = new OffscreenCanvas(122, 1023);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let video32 = await videoWithData();
+let commandEncoder201 = device2.createCommandEncoder({label: '\u76a4\uf4d4'});
+let commandBuffer51 = commandEncoder200.finish({label: '\u098b\u0dd5\u7468\ua724\u03b3\uc937\u037e\uc9a5\u{1f9c7}'});
+let texture130 = device2.createTexture({
+  label: '\u52d2\u646e\u{1fd39}\u0459\u836d\u0aa8\ue340\u0899\ubbc7\u002e',
+  size: [895, 1, 1],
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView268 = texture122.createView({
+  label: '\ub939\u2acd\ud1d9\u7bcd\u0a4c\u013c\uf5e9',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let renderBundle120 = renderBundleEncoder109.finish();
+try {
+computePassEncoder81.setPipeline(pipeline174);
+} catch {}
+try {
+commandEncoder199.resolveQuerySet(querySet100, 441, 229, buffer64, 34048);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(32)), /* required buffer size: 68686 */
+{offset: 692, bytesPerRow: 169, rowsPerImage: 201}, {width: 14, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 43, y: 2 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline179 = device2.createComputePipeline({
+  label: '\uc779\uf0f8\u76eb\u02d8\ua6b3',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule44, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video4);
+let shaderModule46 = device2.createShaderModule({
+  code: `
+
+@compute @workgroup_size(5, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S36 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(3) f2: vec3<i32>,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(a0: S36) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S35 {
+  @location(11) f0: vec4<f16>,
+  @location(4) f1: vec3<f16>,
+  @location(5) f2: vec4<f32>,
+  @location(12) f3: vec3<f16>,
+  @builtin(instance_index) f4: u32,
+  @location(14) f5: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: i32, @location(16) a1: vec2<i32>, @location(2) a2: vec3<u32>, @location(13) a3: vec4<f32>, @location(8) a4: vec4<i32>, a5: S35, @location(9) a6: vec3<f32>, @location(0) a7: vec4<u32>, @location(1) a8: vec3<i32>, @location(7) a9: vec2<f16>, @location(15) a10: i32, @location(3) a11: vec3<f16>, @builtin(vertex_index) a12: u32, @location(6) a13: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let querySet106 = device2.createQuerySet({label: '\u0f32\u{1fe75}\u{1fc66}\ufdf2', type: 'occlusion', count: 1623});
+let commandBuffer52 = commandEncoder201.finish({label: '\ua551\u7c07\u09c6\ud43d\u0bf1\ucb20'});
+let textureView269 = texture125.createView({
+  label: '\u8f0b\u{1f952}\u8ea5\ua788\u{1f909}\u0806\u{1fbde}\u{1fba2}\u{1f7b5}\ueff5',
+  arrayLayerCount: 1,
+});
+let renderBundle121 = renderBundleEncoder96.finish({});
+let sampler104 = device2.createSampler({
+  label: '\u1faa\u{1f6ab}\u12aa\u0c12\u4e5c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.03,
+  lodMaxClamp: 91.66,
+});
+try {
+computePassEncoder92.setPipeline(pipeline166);
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer63);
+dissociateBuffer(device2, buffer63);
+} catch {}
+try {
+commandEncoder199.resolveQuerySet(querySet88, 543, 1138, buffer64, 20480);
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+video17.width = 278;
+let buffer66 = device2.createBuffer({
+  label: '\u83ea\ue369\ua505\u{1fd99}\u{1f9a9}\u08c8\u081b',
+  size: 25408,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let externalTexture94 = device2.importExternalTexture({source: video10, colorSpace: 'display-p3'});
+try {
+computePassEncoder90.setPipeline(pipeline163);
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer52, 46520, buffer63, 9924, 5904);
+dissociateBuffer(device2, buffer52);
+dissociateBuffer(device2, buffer63);
+} catch {}
+try {
+gpuCanvasContext34.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture131 = device2.createTexture({
+  label: '\u0b4d\u057d',
+  size: {width: 895, height: 1, depthOrArrayLayers: 799},
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView270 = texture125.createView({label: '\u163a\u0d69', dimension: '2d-array', aspect: 'all', baseMipLevel: 0});
+let externalTexture95 = device2.importExternalTexture({
+  label: '\u9c0b\u0b75\u0294\u099a\ucc16\u04fb\ueac0\u{1fbb2}',
+  source: videoFrame20,
+  colorSpace: 'display-p3',
+});
+try {
+device2.queue.writeBuffer(buffer60, 24116, new DataView(new ArrayBuffer(11574)), 6887, 1976);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 2,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1700594), /* required buffer size: 1700594 */
+{offset: 625, bytesPerRow: 263, rowsPerImage: 281}, {width: 50, height: 1, depthOrArrayLayers: 24});
+} catch {}
+try {
+  await promise52;
+} catch {}
+try {
+offscreenCanvas34.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(794, 212);
+let imageBitmap40 = await createImageBitmap(img28);
+let canvas44 = document.createElement('canvas');
+let imageBitmap41 = await createImageBitmap(img12);
+let querySet107 = device2.createQuerySet({label: '\uf375\uddc9\u4a09\u0002\u033d', type: 'occlusion', count: 3242});
+let textureView271 = texture123.createView({label: '\u{1fa4f}\u{1fd49}\u{1ff37}\u0316', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 47});
+try {
+computePassEncoder81.setPipeline(pipeline175);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer15, /* required buffer size: 616 */
+{offset: 616, rowsPerImage: 243}, {width: 533, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(46, 83);
+let img44 = await imageWithData(183, 38, '#b112153d', '#48049817');
+let imageData28 = new ImageData(180, 40);
+try {
+window.someLabel = externalTexture71.label;
+} catch {}
+let gpuCanvasContext35 = canvas41.getContext('webgpu');
+let video33 = await videoWithData();
+let textureView272 = texture123.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 1, baseArrayLayer: 319});
+let renderBundle122 = renderBundleEncoder109.finish({label: '\u5e24\u7c55\u05d0'});
+let sampler105 = device2.createSampler({
+  label: '\u037e\u{1fe96}\u3687',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 49.94,
+  lodMaxClamp: 96.24,
+});
+let externalTexture96 = device2.importExternalTexture({source: videoFrame15, colorSpace: 'srgb'});
+let promise53 = device2.queue.onSubmittedWorkDone();
+let pipeline180 = await device2.createComputePipelineAsync({layout: pipelineLayout21, compute: {module: shaderModule43, entryPoint: 'compute0'}});
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(558, 769);
+try {
+canvas43.getContext('webgl');
+} catch {}
+let shaderModule47 = device2.createShaderModule({
+  code: `@group(0) @binding(365)
+var<storage, read_write> type33: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S37 {
+  @location(68) f0: vec3<i32>,
+  @location(39) f1: vec3<f32>,
+  @location(10) f2: vec3<u32>,
+  @location(22) f3: f32,
+  @location(33) f4: vec3<f32>,
+  @builtin(position) f5: vec4<f32>,
+  @location(65) f6: u32,
+  @builtin(front_facing) f7: bool,
+  @location(12) f8: vec4<f32>,
+  @location(2) f9: f16,
+  @location(1) f10: f32,
+  @location(38) f11: vec3<f32>,
+  @location(14) f12: vec4<f32>,
+  @location(62) f13: vec4<i32>,
+  @location(42) f14: f16,
+  @location(7) f15: f32,
+  @location(47) f16: vec4<f32>,
+  @location(43) f17: vec2<f32>,
+  @location(28) f18: vec2<u32>,
+  @location(15) f19: i32,
+  @location(5) f20: u32,
+  @location(46) f21: vec4<u32>,
+  @location(9) f22: i32,
+  @location(64) f23: vec2<f32>,
+  @location(11) f24: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(4) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec3<f32>, @location(8) a1: vec2<u32>, @location(20) a2: f32, @builtin(sample_index) a3: u32, a4: S37, @location(59) a5: i32, @location(40) a6: vec3<u32>, @location(58) a7: vec3<u32>, @location(36) a8: vec4<f16>, @location(44) a9: vec2<u32>, @location(48) a10: vec3<f16>, @location(41) a11: vec2<f32>, @location(3) a12: vec3<u32>, @builtin(sample_mask) a13: u32, @location(32) a14: i32, @location(66) a15: u32, @location(55) a16: vec3<f32>, @location(21) a17: vec4<f32>, @location(16) a18: vec3<f32>, @location(45) a19: vec4<u32>, @location(31) a20: u32, @location(18) a21: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(68) f635: vec3<i32>,
+  @location(10) f636: vec3<u32>,
+  @location(59) f637: i32,
+  @location(43) f638: vec2<f32>,
+  @location(39) f639: vec3<f32>,
+  @location(16) f640: vec3<f32>,
+  @location(47) f641: vec4<f32>,
+  @location(31) f642: u32,
+  @location(41) f643: vec2<f32>,
+  @location(36) f644: vec4<f16>,
+  @location(12) f645: vec4<f32>,
+  @location(7) f646: f32,
+  @location(54) f647: u32,
+  @location(55) f648: vec3<f32>,
+  @location(33) f649: vec3<f32>,
+  @location(20) f650: f32,
+  @location(56) f651: f16,
+  @builtin(position) f652: vec4<f32>,
+  @location(11) f653: i32,
+  @location(42) f654: f16,
+  @location(22) f655: f32,
+  @location(62) f656: vec4<i32>,
+  @location(2) f657: f16,
+  @location(3) f658: vec3<u32>,
+  @location(1) f659: f32,
+  @location(15) f660: i32,
+  @location(38) f661: vec3<f32>,
+  @location(21) f662: vec4<f32>,
+  @location(0) f663: vec3<f32>,
+  @location(9) f664: i32,
+  @location(40) f665: vec3<u32>,
+  @location(66) f666: u32,
+  @location(65) f667: u32,
+  @location(8) f668: vec2<u32>,
+  @location(45) f669: vec4<u32>,
+  @location(46) f670: vec4<u32>,
+  @location(32) f671: i32,
+  @location(5) f672: u32,
+  @location(58) f673: vec3<u32>,
+  @location(48) f674: vec3<f16>,
+  @location(14) f675: vec4<f32>,
+  @location(64) f676: vec2<f32>,
+  @location(44) f677: vec2<u32>,
+  @location(18) f678: vec3<i32>,
+  @location(28) f679: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: u32, @location(14) a1: vec3<f32>, @location(7) a2: vec3<f32>, @location(9) a3: vec3<f16>, @location(0) a4: vec4<f32>, @builtin(instance_index) a5: u32, @location(8) a6: vec3<f16>, @location(6) a7: i32, @location(2) a8: u32, @location(4) a9: u32, @location(13) a10: vec2<i32>, @location(1) a11: vec2<f16>, @location(12) a12: u32, @location(5) a13: vec2<i32>, @location(3) a14: vec2<i32>, @location(15) a15: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder202 = device2.createCommandEncoder({label: '\u0b4f\u293e\u{1f7b9}\u0b92\u033a\u0009\u00d1\u056c\u04bc\u1580\u63cc'});
+let texture132 = device2.createTexture({
+  label: '\u2f33\u0361',
+  size: [895],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+let textureView273 = texture114.createView({
+  label: '\u957f\u{1fac1}\ua99a\ua761\u0f16\u46b8\u04c8\u0f6a\ude49\u7e0d',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+});
+let renderBundle123 = renderBundleEncoder107.finish({label: '\ub25a\u{1f66b}\u1cf8\uc44b\u0d64\udbf9\u4de8\u{1fbac}'});
+let externalTexture97 = device2.importExternalTexture({label: '\u{1fb9c}\uaea1\u69d1\u3a40\ueab5\uce71', source: video14, colorSpace: 'display-p3'});
+try {
+commandEncoder199.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 13},
+  aspect: 'all',
+},
+{width: 26, height: 0, depthOrArrayLayers: 19});
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer58);
+dissociateBuffer(device2, buffer58);
+} catch {}
+try {
+commandEncoder199.resolveQuerySet(querySet87, 1286, 197, buffer64, 224768);
+} catch {}
+let device4 = await adapter5.requestDevice({
+  label: '\u4cbf\u{1fccc}\u{1fa7a}\uf38b\u324c\uc84b\u7eb3\u{1f93d}',
+  defaultQueue: {label: '\u0020\u0cad\u2e89\u54dc\u0bfc\u{1fbac}\u06bc\ue5ac\u90af\u2715'},
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+});
+let renderBundle124 = renderBundleEncoder103.finish();
+try {
+commandEncoder199.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 1,
+  origin: {x: 76, y: 0, z: 16},
+  aspect: 'all',
+},
+{width: 41, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer59);
+dissociateBuffer(device2, buffer59);
+} catch {}
+let pipeline181 = await device2.createRenderPipelineAsync({
+  label: '\u82cd\u7ad0\u{1f8a5}\u{1f9a3}\ub531\u6aba\u{1fcfa}',
+  layout: pipelineLayout21,
+  fragment: {
+  module: shaderModule42,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {
+      compare: 'always',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'always', failOp: 'zero', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 2255483059,
+    stencilWriteMask: 2296175674,
+    depthBias: 560237697,
+  },
+  vertex: {
+    module: shaderModule42,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4388,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 536, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 116, shaderLocation: 0},
+          {format: 'sint16x2', offset: 644, shaderLocation: 3},
+          {format: 'float32x2', offset: 1500, shaderLocation: 10},
+          {format: 'float16x2', offset: 352, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 424, shaderLocation: 15},
+          {format: 'sint32', offset: 512, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 88, shaderLocation: 2},
+          {format: 'sint32', offset: 3472, shaderLocation: 5},
+          {format: 'float32', offset: 924, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 274, shaderLocation: 7},
+          {format: 'uint8x4', offset: 840, shaderLocation: 4},
+          {format: 'sint32x4', offset: 1048, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 1668, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 1712, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 5772,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 1088, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 21224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 4368, shaderLocation: 11},
+          {format: 'uint8x4', offset: 1564, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+  await promise53;
+} catch {}
+let videoFrame29 = new VideoFrame(offscreenCanvas20, {timestamp: 0});
+try {
+adapter7.label = '\ubd0e\u1b32\u0d50\ufea9\u2681\u7ef0\u2a49';
+} catch {}
+let commandEncoder203 = device4.createCommandEncoder({label: '\u02ff\u1ae0\u2667\ufbc6'});
+try {
+gpuCanvasContext3.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let videoFrame30 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+let gpuCanvasContext36 = offscreenCanvas35.getContext('webgpu');
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let querySet108 = device4.createQuerySet({label: '\u5a56\u47c9\u{1f67b}\u02c8\u{1fc66}\u39f3', type: 'occlusion', count: 1860});
+let videoFrame31 = new VideoFrame(img29, {timestamp: 0});
+try {
+canvas44.getContext('2d');
+} catch {}
+let buffer67 = device4.createBuffer({
+  label: '\u0286\u9ce7\u{1f6f1}\u{1f8c6}\ud495\ud20f',
+  size: 37320,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let promise54 = device4.queue.onSubmittedWorkDone();
+let canvas45 = document.createElement('canvas');
+let video34 = await videoWithData();
+try {
+adapter6.label = '\u0a44\ucefa\u0da4\u5fed\u148a\u{1fd2e}\ubb40\u625b';
+} catch {}
+try {
+offscreenCanvas36.getContext('webgl2');
+} catch {}
+let computePassEncoder98 = commandEncoder203.beginComputePass({label: '\u0e75\u0c26\uda36\u596e\u5a41\u8e2f\u0915\u37ec\u{1fdc8}'});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet109 = device4.createQuerySet({type: 'occlusion', count: 2480});
+try {
+computePassEncoder98.end();
+} catch {}
+let promise55 = device4.queue.onSubmittedWorkDone();
+let gpuCanvasContext37 = offscreenCanvas37.getContext('webgpu');
+let video35 = await videoWithData();
+let imageBitmap42 = await createImageBitmap(offscreenCanvas15);
+let commandBuffer53 = commandEncoder203.finish({});
+let texture133 = device4.createTexture({
+  label: '\u08b0\ufc58\u{1fd16}\u7b9b\u4824\u{1fb79}\u0e41\u2e12',
+  size: {width: 960},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView274 = texture133.createView({baseArrayLayer: 0});
+let arrayBuffer18 = buffer67.getMappedRange();
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 146, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 592 */
+{offset: 592}, {width: 475, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video36 = await videoWithData();
+let querySet110 = device2.createQuerySet({label: '\u{1f990}\ub90d', type: 'occlusion', count: 561});
+let renderBundleEncoder111 = device2.createRenderBundleEncoder({colorFormats: ['rg8unorm', 'rgba16sint', 'rgba16sint', 'r8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder82.setPipeline(pipeline174);
+} catch {}
+let pipeline182 = device2.createComputePipeline({
+  label: '\u7cfb\u531b\u{1fe38}',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule42, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas32.getContext('webgl2');
+} catch {}
+try {
+canvas45.getContext('webgl2');
+} catch {}
+let texture134 = device2.createTexture({
+  size: {width: 7160},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8unorm'],
+});
+let textureView275 = texture124.createView({
+  label: '\u{1fd0a}\u0236\u{1fcd0}\u7144\u0664\uabd5\u{1fc68}\u{1fbd9}\ude2e\u{1fa1e}\u{1ff38}',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+try {
+commandEncoder199.copyTextureToBuffer({
+  texture: texture114,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26120 */
+  offset: 25936,
+  buffer: buffer60,
+}, {width: 46, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 447, height: 1, depthOrArrayLayers: 41}
+*/
+{
+  source: canvas10,
+  origin: { x: 4, y: 20 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 2,
+  origin: {x: 125, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(283, 840);
+let gpuCanvasContext38 = canvas42.getContext('webgpu');
+let imageData29 = new ImageData(148, 16);
+let commandEncoder204 = device4.createCommandEncoder({label: '\u3660\u90d1\ucdc9\u{1fab3}\u0171'});
+let querySet111 = device4.createQuerySet({label: '\udb7e\u0fbe\uf498\u001a\u0fa1', type: 'occlusion', count: 3761});
+let externalTexture98 = device4.importExternalTexture({
+  label: '\uaf93\u594f\u9b04\u39de\u0729\uc9d4\u{1fd2f}\ua68a',
+  source: video17,
+  colorSpace: 'display-p3',
+});
+try {
+device4.queue.submit([commandBuffer53]);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 113 */
+{offset: 113}, {width: 931, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let videoFrame32 = new VideoFrame(offscreenCanvas36, {timestamp: 0});
+let canvas46 = document.createElement('canvas');
+let bindGroupLayout50 = device2.createBindGroupLayout({
+  label: '\u06b4\u01b6\u0e35\u{1f604}\u84a3\u{1f7ad}\uc615\u282c\uc5f2\ud96e\u9799',
+  entries: [{binding: 4874, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let textureView276 = texture131.createView({
+  label: '\uef82\u58a9\u{1fdab}\u7f7c\u0ed3\u3dd2\u605f\uad95\ua3a4\u{1fe7f}\u288c',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 521,
+});
+let sampler106 = device2.createSampler({
+  label: '\ud629\u7949\u6db5\u5be2\u{1f9bd}\u0089\u{1f6a6}\u76e7\u5c0e\u0d78',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.96,
+  lodMaxClamp: 70.08,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder95.setPipeline(pipeline180);
+} catch {}
+try {
+renderBundleEncoder111.setVertexBuffer(2880, undefined, 0, 4092439903);
+} catch {}
+try {
+commandEncoder199.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56056 */
+  offset: 56036,
+  bytesPerRow: 256,
+  buffer: buffer61,
+}, {
+  texture: texture119,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer61);
+} catch {}
+try {
+device2.queue.submit([commandBuffer50]);
+} catch {}
+let imageBitmap43 = await createImageBitmap(canvas13);
+let gpuCanvasContext39 = offscreenCanvas38.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas47 = document.createElement('canvas');
+let bindGroupLayout51 = device2.createBindGroupLayout({
+  label: '\u39ce\u0261\u01ea\u3702\u{1f854}\u0a61',
+  entries: [
+    {binding: 1739, visibility: 0, sampler: { type: 'filtering' }},
+    {
+      binding: 3138,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 4046,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let buffer68 = device2.createBuffer({
+  label: '\u{1f83a}\uc5c6\u{1f69b}\u75c9\u{1ff66}\u{1ff52}\ub424',
+  size: 62807,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder205 = device2.createCommandEncoder({label: '\u0a33\ucb11\u7c72\u{1fa31}\uca12\u3e76\u0a85\u0b91'});
+let texture135 = device2.createTexture({
+  label: '\u5733\ubdba\u0344\u007f\u831f\u96e3\u{1fb7d}\u0093\u{1f8f6}',
+  size: {width: 3580},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1616 */
+  offset: 1616,
+  buffer: buffer62,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer62);
+} catch {}
+try {
+commandEncoder202.resolveQuerySet(querySet92, 856, 222, buffer64, 217088);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let canvas48 = document.createElement('canvas');
+try {
+canvas47.getContext('webgl');
+} catch {}
+let gpuCanvasContext40 = canvas48.getContext('webgpu');
+let externalTexture99 = device2.importExternalTexture({
+  label: '\ud0ae\u8056\u0080\uaee7\u39a9\u6086\u08fb\u5c7e\u{1ffa0}\u{1fb42}',
+  source: videoFrame25,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder199.copyTextureToBuffer({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2685 widthInBlocks: 2685 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10175 */
+  offset: 10175,
+  bytesPerRow: 2816,
+  buffer: buffer60,
+}, {width: 2685, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+commandEncoder202.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 21 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView277 = texture132.createView({label: '\u2be1\u330e\u71b9\u0c2a\ud514\u0574', dimension: '1d', aspect: 'all', mipLevelCount: 1});
+try {
+commandEncoder202.copyBufferToBuffer(buffer59, 66896, buffer60, 32128, 1508);
+dissociateBuffer(device2, buffer59);
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+commandEncoder205.clearBuffer(buffer59);
+dissociateBuffer(device2, buffer59);
+} catch {}
+try {
+commandEncoder205.resolveQuerySet(querySet88, 1198, 242, buffer68, 45568);
+} catch {}
+let pipeline183 = device2.createRenderPipeline({
+  label: '\u2296\ue94c\u9426\u2b77\u7c9d\ua08f\u{1f9c2}\u01c8\u{1f92a}',
+  layout: pipelineLayout21,
+  multisample: {count: 1},
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgb10a2uint'}, {format: 'rg32sint', writeMask: 0}, {format: 'rg16sint'}],
+},
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7652,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 2416, shaderLocation: 11},
+          {format: 'sint32x3', offset: 2456, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+try {
+canvas46.getContext('webgl');
+} catch {}
+let textureView278 = texture133.createView({label: '\u1e1e\u9221\u0057\u013c\uecca\u81a3\u04de'});
+let computePassEncoder99 = commandEncoder204.beginComputePass({label: '\uf4fd\u0e70'});
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 269 */
+{offset: 269, bytesPerRow: 2491}, {width: 277, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout52 = pipeline182.getBindGroupLayout(0);
+let pipelineLayout23 = device2.createPipelineLayout({
+  label: '\u{1fcc5}\u{1fd5e}\uda01',
+  bindGroupLayouts: [bindGroupLayout49, bindGroupLayout48, bindGroupLayout41, bindGroupLayout48],
+});
+try {
+commandEncoder205.copyTextureToBuffer({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 354, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3566 widthInBlocks: 3566 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 27257 */
+  offset: 27257,
+  buffer: buffer60,
+}, {width: 3566, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer60, 135888, new BigUint64Array(55858), 51713, 1412);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline184 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout23,
+  fragment: {
+  module: shaderModule46,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule46,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 16204,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 264, shaderLocation: 16},
+          {format: 'float16x2', offset: 3592, shaderLocation: 5},
+          {format: 'uint32x3', offset: 116, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 14406, shaderLocation: 12},
+          {format: 'sint32x2', offset: 11208, shaderLocation: 1},
+          {format: 'sint32x4', offset: 536, shaderLocation: 8},
+          {format: 'float16x2', offset: 8244, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 1906, shaderLocation: 13},
+          {format: 'float32', offset: 1648, shaderLocation: 7},
+          {format: 'uint32', offset: 272, shaderLocation: 2},
+          {format: 'uint32x4', offset: 16188, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7752,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 1544, shaderLocation: 4},
+          {format: 'sint32x3', offset: 140, shaderLocation: 10},
+          {format: 'float16x2', offset: 1892, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 572, shaderLocation: 6},
+          {format: 'sint8x4', offset: 732, shaderLocation: 15},
+          {format: 'float32x3', offset: 2384, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let querySet112 = device4.createQuerySet({label: '\u0e6f\u{1fccf}\u4a56', type: 'occlusion', count: 1772});
+let textureView279 = texture133.createView({label: '\u9495\ua1f2\uc294', aspect: 'all'});
+try {
+gpuCanvasContext39.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.submit([]);
+} catch {}
+let buffer69 = device4.createBuffer({size: 20200, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder206 = device4.createCommandEncoder({label: '\u59f8\uc33a'});
+let commandBuffer54 = commandEncoder206.finish({label: '\u1ffb\uece1\u0651\u05d4\uf5fc'});
+let sampler107 = device4.createSampler({
+  label: '\ub384\u039e\uebb5\u0ea1\u0d6e\u04a4\u4a8d\u{1f68c}\ueb88\u09ae',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.86,
+  lodMaxClamp: 50.42,
+});
+let externalTexture100 = device4.importExternalTexture({label: '\u4a3e\u42e2\u4e22\u{1fece}\u1bbc', source: video23, colorSpace: 'display-p3'});
+try {
+device4.queue.writeBuffer(buffer69, 8564, new BigUint64Array(42388), 36956, 1036);
+} catch {}
+let renderBundleEncoder112 = device4.createRenderBundleEncoder({
+  label: '\u49cf\u568b\u9200\u67f3\u0789\u047f',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+});
+try {
+device4.queue.writeBuffer(buffer69, 11928, new Float32Array(29503), 3222, 468);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise54;
+} catch {}
+gc();
+let offscreenCanvas39 = new OffscreenCanvas(368, 491);
+let video37 = await videoWithData();
+gc();
+let offscreenCanvas40 = new OffscreenCanvas(826, 513);
+let textureView280 = texture97.createView({
+  label: '\u06c8\u{1f62f}\ud827\u8107\u4ebe\u5470\u0739',
+  dimension: '2d',
+  baseMipLevel: 8,
+  mipLevelCount: 1,
+  baseArrayLayer: 471,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder113 = device1.createRenderBundleEncoder({
+  label: '\uef61\u0717\u{1feec}\u{1fe2b}\u007c',
+  colorFormats: ['rg16sint', 'r8unorm', 'rgba8unorm'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder86.draw(1018567327, 7591280);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(121047403, 248409562, 68413490, 12338055);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexedIndirect(buffer56, 79936);
+} catch {}
+try {
+renderBundleEncoder78.drawIndirect(buffer56, 163932);
+} catch {}
+try {
+renderBundleEncoder71.setIndexBuffer(buffer56, 'uint32', 25156, 120183);
+} catch {}
+try {
+commandEncoder188.copyTextureToBuffer({
+  texture: texture121,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 91444 */
+  offset: 37652,
+  bytesPerRow: 256,
+  rowsPerImage: 70,
+  buffer: buffer48,
+}, {width: 16, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder195.resolveQuerySet(querySet71, 1797, 313, buffer43, 15104);
+} catch {}
+document.body.prepend(img1);
+canvas3.height = 181;
+let textureView281 = texture133.createView({label: '\u{1fd90}\u2b17\u0d79\uc64e\u0ea8\ue435\u0176\ua21b\u{1f77c}\u08b6'});
+let sampler108 = device4.createSampler({
+  label: '\ud391\u675d',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  lodMinClamp: 32.34,
+  lodMaxClamp: 82.81,
+});
+try {
+computePassEncoder99.insertDebugMarker('\uedc4');
+} catch {}
+try {
+window.someLabel = texture0.label;
+} catch {}
+let commandBuffer55 = commandEncoder199.finish({label: '\u0ff5\u0fb0\u{1fc0b}\u909c\u2fb5\u{1fb74}\u8aed\u{1f60c}'});
+let textureView282 = texture122.createView({dimension: '3d', baseMipLevel: 3});
+try {
+device2.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer5), /* required buffer size: 446 */
+{offset: 446, bytesPerRow: 7030}, {width: 1738, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise56 = device2.queue.onSubmittedWorkDone();
+let img45 = await imageWithData(263, 252, '#81fb4ff8', '#7fe9ebf0');
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas40.getContext('webgl');
+} catch {}
+try {
+device4.label = '\u2ab7\u{1fd0f}\u854b\u739c\u2832\u0c3f\u0096\u0c1c\u0938\u27c6';
+} catch {}
+let buffer70 = device4.createBuffer({label: '\u{1f742}\uf5c6\ub9d4\u0b9d\u09af', size: 214301, usage: GPUBufferUsage.STORAGE});
+let textureView283 = texture133.createView({label: '\u2b8a\u057d\u{1ff26}\u{1fd2b}\ud551\u3257\ue9b3\u04a7\ue006\u{1fe6b}'});
+let renderBundleEncoder114 = device4.createRenderBundleEncoder({
+  label: '\u0cc7\u04f4\ua793',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+  stencilReadOnly: true,
+});
+let gpuCanvasContext41 = offscreenCanvas39.getContext('webgpu');
+let video38 = await videoWithData();
+let textureView284 = texture120.createView({label: '\u6e84\u0111\u{1f84f}\u06ac', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+let externalTexture101 = device2.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+commandEncoder202.copyTextureToBuffer({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 100000 */
+  offset: 100000,
+  bytesPerRow: 256,
+  buffer: buffer60,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer60);
+} catch {}
+gc();
+let canvas49 = document.createElement('canvas');
+let imageData30 = new ImageData(224, 132);
+let shaderModule48 = device2.createShaderModule({
+  label: '\u{1f6e9}\u{1fedf}\u62ba\u6035\u{1f904}',
+  code: `@group(1) @binding(669)
+var<storage, read_write> parameter32: array<u32>;
+@group(2) @binding(365)
+var<storage, read_write> n29: array<u32>;
+@group(3) @binding(669)
+var<storage, read_write> type34: array<u32>;
+@group(0) @binding(365)
+var<storage, read_write> parameter33: array<u32>;
+@group(3) @binding(1250)
+var<storage, read_write> n30: array<u32>;
+@group(3) @binding(2665)
+var<storage, read_write> parameter34: array<u32>;
+@group(1) @binding(1250)
+var<storage, read_write> type35: array<u32>;
+@group(1) @binding(2665)
+var<storage, read_write> type36: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S38 {
+  @location(16) f0: vec3<u32>,
+  @location(55) f1: vec3<u32>,
+  @location(38) f2: vec3<f32>,
+  @location(63) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(65) f5: vec3<f32>,
+  @location(70) f6: f16,
+  @location(67) f7: vec4<i32>,
+  @location(71) f8: u32,
+  @location(1) f9: i32,
+  @location(5) f10: vec2<u32>,
+  @location(6) f11: i32,
+  @location(24) f12: vec3<f32>,
+  @location(64) f13: vec3<f16>,
+  @location(18) f14: vec2<i32>,
+  @location(27) f15: i32,
+  @location(53) f16: vec3<i32>,
+  @builtin(position) f17: vec4<f32>,
+  @builtin(front_facing) f18: bool
+}
+
+@fragment
+fn fragment0(@location(59) a0: u32, @location(17) a1: vec4<f16>, @builtin(sample_index) a2: u32, a3: S38, @location(20) a4: vec4<u32>, @location(36) a5: vec4<i32>, @location(54) a6: vec4<f32>, @location(29) a7: f16, @location(28) a8: vec2<f32>, @location(51) a9: vec2<u32>, @location(37) a10: f16, @location(44) a11: vec4<f32>, @location(66) a12: vec2<f16>, @location(45) a13: i32, @location(13) a14: vec4<f16>, @location(10) a15: u32, @location(58) a16: u32, @location(50) a17: vec2<f16>, @location(35) a18: vec4<f32>, @location(47) a19: u32, @location(15) a20: f32, @location(11) a21: vec2<f16>, @location(41) a22: f16, @location(39) a23: vec2<i32>, @location(8) a24: vec3<f32>, @location(56) a25: vec3<u32>, @location(4) a26: vec2<u32>, @location(2) a27: vec2<i32>, @location(32) a28: vec3<u32>) -> @location(200) vec4<f32> {
+return vec4<f32>();
+}
+
+struct VertexOutput0 {
+  @location(70) f680: f16,
+  @location(63) f681: vec4<f32>,
+  @location(53) f682: vec3<i32>,
+  @location(2) f683: vec2<i32>,
+  @location(28) f684: vec2<f32>,
+  @location(71) f685: u32,
+  @location(54) f686: vec4<f32>,
+  @location(6) f687: i32,
+  @location(38) f688: vec3<f32>,
+  @location(36) f689: vec4<i32>,
+  @location(55) f690: vec3<u32>,
+  @location(65) f691: vec3<f32>,
+  @location(16) f692: vec3<u32>,
+  @location(24) f693: vec3<f32>,
+  @location(11) f694: vec2<f16>,
+  @location(66) f695: vec2<f16>,
+  @location(39) f696: vec2<i32>,
+  @location(64) f697: vec3<f16>,
+  @location(5) f698: vec2<u32>,
+  @location(10) f699: u32,
+  @location(27) f700: i32,
+  @location(15) f701: f32,
+  @location(1) f702: i32,
+  @location(37) f703: f16,
+  @location(17) f704: vec4<f16>,
+  @location(45) f705: i32,
+  @location(13) f706: vec4<f16>,
+  @location(41) f707: f16,
+  @location(59) f708: u32,
+  @location(50) f709: vec2<f16>,
+  @location(44) f710: vec4<f32>,
+  @location(29) f711: f16,
+  @location(32) f712: vec3<u32>,
+  @location(58) f713: u32,
+  @location(8) f714: vec3<f32>,
+  @location(35) f715: vec4<f32>,
+  @location(18) f716: vec2<i32>,
+  @location(67) f717: vec4<i32>,
+  @location(56) f718: vec3<u32>,
+  @location(47) f719: u32,
+  @location(51) f720: vec2<u32>,
+  @location(20) f721: vec4<u32>,
+  @location(4) f722: vec2<u32>,
+  @builtin(position) f723: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: f16, @location(1) a1: vec3<f16>, @location(4) a2: vec2<f16>, @location(7) a3: vec3<f16>, @location(9) a4: f16, @location(12) a5: vec2<u32>, @location(2) a6: f32, @location(0) a7: vec4<i32>, @builtin(instance_index) a8: u32, @location(13) a9: vec2<i32>, @location(16) a10: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout53 = device2.createBindGroupLayout({
+  label: '\uc79f\u0f33\u4cfc\uf6c9\u{1fdd8}\uad6d\uf66d\u674f\u{1fe03}',
+  entries: [
+    {
+      binding: 5235,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 392078, hasDynamicOffset: false },
+    },
+    {
+      binding: 5020,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup38 = device2.createBindGroup({
+  label: '\u2e37\u04ba',
+  layout: bindGroupLayout50,
+  entries: [{binding: 4874, resource: externalTexture93}],
+});
+let renderBundleEncoder115 = device2.createRenderBundleEncoder({
+  label: '\u9835\uf39a\u26f2\u0968\u{1f95d}\u5fcc\u{1f91d}\u0cd1\u0776\u6853',
+  colorFormats: ['bgra8unorm'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder111.setBindGroup(6, bindGroup38);
+} catch {}
+try {
+commandEncoder205.clearBuffer(buffer60, 210272, 147584);
+dissociateBuffer(device2, buffer60);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer13), /* required buffer size: 462 */
+{offset: 462}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise56;
+} catch {}
+let shaderModule49 = device2.createShaderModule({
+  label: '\u{1f8c2}\u0ccc\u{1fc4b}\u{1fa2c}\uac9b\u0292\u8b9f\u{1f684}',
+  code: `@group(3) @binding(1250)
+var<storage, read_write> function37: array<u32>;
+@group(1) @binding(2665)
+var<storage, read_write> type37: array<u32>;
+@group(2) @binding(365)
+var<storage, read_write> field37: array<u32>;
+@group(3) @binding(2665)
+var<storage, read_write> function38: array<u32>;
+@group(3) @binding(669)
+var<storage, read_write> field38: array<u32>;
+@group(1) @binding(669)
+var<storage, read_write> global32: array<u32>;
+@group(0) @binding(365)
+var<storage, read_write> global33: array<u32>;
+@group(1) @binding(1250)
+var<storage, read_write> parameter35: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(29) a0: vec2<f16>, @location(13) a1: i32, @location(15) a2: vec2<i32>, @location(44) a3: u32, @location(32) a4: vec2<f16>) -> @location(200) vec3<u32> {
+return vec3<u32>();
+}
+
+struct S39 {
+  @location(14) f0: vec4<i32>,
+  @location(13) f1: vec3<i32>,
+  @location(10) f2: f16,
+  @location(7) f3: vec3<u32>,
+  @location(1) f4: vec4<u32>,
+  @builtin(vertex_index) f5: u32,
+  @location(5) f6: vec2<f32>,
+  @location(12) f7: vec3<f32>,
+  @location(2) f8: f16
+}
+struct VertexOutput0 {
+  @location(32) f724: vec2<f16>,
+  @location(49) f725: vec4<f16>,
+  @builtin(position) f726: vec4<f32>,
+  @location(51) f727: vec4<u32>,
+  @location(42) f728: vec4<f32>,
+  @location(50) f729: vec2<f16>,
+  @location(37) f730: vec2<f16>,
+  @location(40) f731: vec3<i32>,
+  @location(70) f732: vec2<i32>,
+  @location(39) f733: i32,
+  @location(71) f734: vec3<i32>,
+  @location(30) f735: vec3<f32>,
+  @location(60) f736: vec4<u32>,
+  @location(48) f737: vec2<f32>,
+  @location(63) f738: vec2<i32>,
+  @location(62) f739: f32,
+  @location(46) f740: vec3<u32>,
+  @location(15) f741: vec2<i32>,
+  @location(22) f742: vec4<f32>,
+  @location(4) f743: vec4<f16>,
+  @location(7) f744: f16,
+  @location(24) f745: vec3<i32>,
+  @location(44) f746: u32,
+  @location(58) f747: vec3<u32>,
+  @location(54) f748: f32,
+  @location(36) f749: vec2<f16>,
+  @location(47) f750: vec2<f32>,
+  @location(65) f751: vec3<f32>,
+  @location(13) f752: i32,
+  @location(29) f753: vec2<f16>,
+  @location(12) f754: vec3<f16>,
+  @location(53) f755: vec3<u32>,
+  @location(20) f756: vec2<u32>,
+  @location(34) f757: vec3<f32>,
+  @location(57) f758: vec2<f32>,
+  @location(28) f759: f32,
+  @location(5) f760: vec4<f16>,
+  @location(45) f761: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec4<i32>, @location(3) a1: vec4<f32>, @builtin(instance_index) a2: u32, @location(9) a3: vec4<u32>, @location(4) a4: vec2<u32>, @location(6) a5: vec3<i32>, @location(15) a6: vec3<f32>, @location(0) a7: vec3<f16>, a8: S39, @location(11) a9: vec3<u32>, @location(16) a10: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder82.end();
+} catch {}
+try {
+renderBundleEncoder110.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+buffer66.destroy();
+} catch {}
+try {
+commandEncoder205.clearBuffer(buffer59);
+dissociateBuffer(device2, buffer59);
+} catch {}
+try {
+gpuCanvasContext38.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise57 = device2.queue.onSubmittedWorkDone();
+let pipeline185 = await device2.createComputePipelineAsync({layout: pipelineLayout21, compute: {module: shaderModule48, entryPoint: 'compute0', constants: {}}});
+let pipeline186 = device2.createRenderPipeline({
+  label: '\u073b\u7d5a\u0671\ueafa\u01bb\u331b\ub94f\ude3a\u8c08\u{1f699}',
+  layout: pipelineLayout23,
+  multisample: {count: 4, mask: 0xd9744eb7},
+  fragment: {
+  module: shaderModule45,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule45,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18972,
+        attributes: [
+          {format: 'uint8x2', offset: 11816, shaderLocation: 15},
+          {format: 'uint32x4', offset: 6400, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 1924, shaderLocation: 3},
+          {format: 'uint32x4', offset: 7620, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 1656,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 324, shaderLocation: 7},
+          {format: 'uint8x2', offset: 816, shaderLocation: 13},
+          {format: 'sint32x2', offset: 12, shaderLocation: 10},
+          {format: 'float32', offset: 328, shaderLocation: 8},
+          {format: 'float32x2', offset: 484, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 1},
+          {format: 'float32x4', offset: 216, shaderLocation: 2},
+          {format: 'sint32', offset: 104, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 772, shaderLocation: 9},
+          {format: 'uint32', offset: 292, shaderLocation: 4},
+          {format: 'sint32', offset: 60, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 552, shaderLocation: 14},
+          {format: 'float32x4', offset: 148, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+});
+let querySet113 = device2.createQuerySet({label: '\u0427\u60d2\ub577\u948e\u0751\u0ae1\u0390\u0af4', type: 'occlusion', count: 4034});
+try {
+commandEncoder202.copyBufferToBuffer(buffer62, 4132, buffer63, 16808, 7364);
+dissociateBuffer(device2, buffer62);
+dissociateBuffer(device2, buffer63);
+} catch {}
+try {
+commandEncoder205.copyBufferToTexture({
+  /* bytesInLastRow: 2392 widthInBlocks: 598 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13724 */
+  offset: 13724,
+  buffer: buffer68,
+}, {
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 160, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 598, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer68);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 847641 */
+{offset: 236, bytesPerRow: 627, rowsPerImage: 193}, {width: 82, height: 1, depthOrArrayLayers: 8});
+} catch {}
+try {
+  await promise55;
+} catch {}
+let bindGroupLayout54 = device2.createBindGroupLayout({
+  label: '\udead\ua155\u27cf\u0a8d',
+  entries: [
+    {
+      binding: 4513,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 4476, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {binding: 460, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let buffer71 = device2.createBuffer({
+  label: '\ub740\u4167\u0fbe\u0bbf',
+  size: 41182,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView285 = texture124.createView({
+  label: '\u{1fe70}\ufb61\u3074\uf5e0\ue88d\ucc25',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+try {
+computePassEncoder92.setPipeline(pipeline180);
+} catch {}
+try {
+renderBundleEncoder110.setBindGroup(5, bindGroup38);
+} catch {}
+let pipeline187 = await device2.createComputePipelineAsync({
+  label: '\ufe7f\uafee',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule47, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise57;
+} catch {}
+canvas34.height = 1379;
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let canvas50 = document.createElement('canvas');
+let computePassEncoder100 = commandEncoder183.beginComputePass({label: '\u5595\uaa84\u0586\u0116\u{1fe3a}'});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(2, bindGroup38, new Uint32Array(2320), 966, 0);
+} catch {}
+try {
+commandEncoder205.copyBufferToBuffer(buffer61, 121148, buffer71, 35696, 4884);
+dissociateBuffer(device2, buffer61);
+dissociateBuffer(device2, buffer71);
+} catch {}
+try {
+commandEncoder202.copyTextureToBuffer({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 3973, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2346 widthInBlocks: 2346 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10992 */
+  offset: 10992,
+  buffer: buffer71,
+}, {width: 2346, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer71);
+} catch {}
+try {
+commandEncoder205.copyTextureToTexture({
+  texture: texture119,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture119,
+  mipLevel: 5,
+  origin: {x: 20, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder205.resolveQuerySet(querySet113, 2174, 1012, buffer68, 43776);
+} catch {}
+try {
+device2.destroy();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+canvas25.width = 615;
+gc();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video5.width = 154;
+let commandEncoder207 = device4.createCommandEncoder();
+let querySet114 = device4.createQuerySet({type: 'occlusion', count: 1202});
+let textureView286 = texture133.createView({label: '\u0273\u{1fdf8}\u030b'});
+let renderBundle125 = renderBundleEncoder114.finish({});
+let bindGroupLayout55 = device4.createBindGroupLayout({entries: []});
+let textureView287 = texture133.createView({label: '\u5806\u{1fd9f}\udfa4\u0430\u0b65\uce37\u{1ff3e}\udad0\u9fc2\u0e82', arrayLayerCount: 1});
+let renderBundleEncoder116 = device4.createRenderBundleEncoder({
+  label: '\u4c84\uad14',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder116.setVertexBuffer(608, undefined, 1970021083, 1875703805);
+} catch {}
+let promise58 = buffer69.mapAsync(GPUMapMode.READ, 4936);
+let commandEncoder208 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder49.drawIndexed(1167155543, 1042373811, 935387463);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer19, 528520);
+} catch {}
+try {
+commandEncoder169.copyBufferToBuffer(buffer3, 17928, buffer6, 151552, 8064);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder113.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 297, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas23,
+  origin: { x: 20, y: 18 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img46 = await imageWithData(27, 184, '#6f5a352b', '#98364ed6');
+try {
+canvas50.getContext('2d');
+} catch {}
+let canvas51 = document.createElement('canvas');
+try {
+  await promise58;
+} catch {}
+let imageBitmap44 = await createImageBitmap(canvas11);
+let offscreenCanvas41 = new OffscreenCanvas(458, 748);
+video20.height = 129;
+try {
+window.someLabel = commandEncoder192.label;
+} catch {}
+let video39 = await videoWithData();
+let bindGroup39 = device4.createBindGroup({label: '\u{1f966}\u{1f605}\u38ad\u{1fa3b}\ucb2c', layout: bindGroupLayout55, entries: []});
+let pipelineLayout24 = device4.createPipelineLayout({bindGroupLayouts: []});
+let textureView288 = texture133.createView({label: '\u0c18\ub033\u0afa\u3f84\ue743\u04ff\u6f5b\uc4d3\u4f57\u06e7', aspect: 'all'});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup39, new Uint32Array(6644), 4154, 0);
+} catch {}
+try {
+renderBundleEncoder112.setVertexBuffer(2159, undefined, 0, 2865000882);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 2354 */
+{offset: 882, rowsPerImage: 130}, {width: 184, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext42 = canvas49.getContext('webgpu');
+let img47 = await imageWithData(49, 82, '#3bea61f1', '#582e24cc');
+try {
+window.someLabel = texture119.label;
+} catch {}
+video17.height = 21;
+let video40 = await videoWithData();
+let buffer72 = device4.createBuffer({
+  label: '\u6dcc\u094d\u{1fdce}\u0601\u073d',
+  size: 24212,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder209 = device4.createCommandEncoder({});
+let querySet115 = device4.createQuerySet({label: '\u{1fbd1}\u2492\u4f37\u02de\u0c92\u2dd1\u0f1a', type: 'occlusion', count: 2938});
+let sampler109 = device4.createSampler({
+  label: '\u0356\u028b\u719a\ufaca',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.90,
+  lodMaxClamp: 83.57,
+});
+try {
+commandEncoder209.clearBuffer(buffer72, 22952);
+dissociateBuffer(device4, buffer72);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 824 */
+{offset: 824}, {width: 881, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let buffer73 = device4.createBuffer({
+  label: '\u{1ff91}\u0503\u0e38\u{1fffa}',
+  size: 103618,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder210 = device4.createCommandEncoder({label: '\u6d9c\ufc10\u0356\uc516\u2e32\u9592\u4c47\u06d7\u82e6'});
+let querySet116 = device4.createQuerySet({
+  label: '\u{1f70f}\u{1fb3b}\u0320\u63cb\u0cc8\u4b9d\u{1f78b}\u0027\u0d05',
+  type: 'occlusion',
+  count: 657,
+});
+let textureView289 = texture133.createView({label: '\ubb9a\u5fca\u0f0c\u67c7\u{1f8de}', format: 'rgba16uint'});
+try {
+commandEncoder210.clearBuffer(buffer69, 13544);
+dissociateBuffer(device4, buffer69);
+} catch {}
+let img48 = await imageWithData(279, 46, '#014183ed', '#6206c754');
+try {
+window.someLabel = externalTexture95.label;
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(430, 734);
+let commandEncoder211 = device3.createCommandEncoder({label: '\u{1fb79}\u7893\u0a0b\u{1fbbd}'});
+let texture136 = device3.createTexture({
+  label: '\u033d\u0a11\u{1fa54}\u7bda\u40b2\u2a6e\u{1f652}\u{1fcfe}\u82fa',
+  size: [60, 120, 1],
+  mipLevelCount: 5,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg32uint'],
+});
+let textureView290 = texture117.createView({
+  label: '\u09db\uaebb\u0e3f\u0841',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 43,
+  arrayLayerCount: 29,
+});
+let renderBundleEncoder117 = device3.createRenderBundleEncoder({
+  label: '\u22d0\ud57c\ua4ca',
+  colorFormats: ['rgba8unorm', 'rg32sint', 'rg32uint', 'rgba16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle126 = renderBundleEncoder117.finish({label: '\u0479\u944a\u1559\u0fb9\uf6a8\u92da\u{1fde3}\u0539\u0c37\u{1f95c}'});
+let canvas52 = document.createElement('canvas');
+let canvas53 = document.createElement('canvas');
+let videoFrame33 = new VideoFrame(img17, {timestamp: 0});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+window.someLabel = pipeline183.label;
+} catch {}
+video40.width = 239;
+gc();
+try {
+canvas53.getContext('webgl2');
+} catch {}
+document.body.prepend(img22);
+document.body.prepend(canvas29);
+let commandEncoder212 = device4.createCommandEncoder({label: '\uca63\u{1fad7}\ue140\uab44\u1db6\u{1f770}'});
+let textureView291 = texture133.createView({label: '\u3b11\u0cf6\u0566'});
+let renderBundle127 = renderBundleEncoder114.finish({label: '\udd33\u{1fd53}\ufe74\u2b9f\ued73\u7b70\u0092\u{1fa8a}\u1686\u90ed'});
+try {
+computePassEncoder99.end();
+} catch {}
+try {
+  await device4.popErrorScope();
+} catch {}
+let arrayBuffer19 = buffer67.getMappedRange(37320, 0);
+try {
+commandEncoder209.copyBufferToBuffer(buffer73, 19848, buffer69, 6032, 11516);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer69);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(612, 868);
+let imageData31 = new ImageData(228, 196);
+video18.height = 10;
+gc();
+let video41 = await videoWithData();
+canvas39.height = 738;
+let commandEncoder213 = device1.createCommandEncoder();
+try {
+renderBundleEncoder86.setBindGroup(4, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder71.draw(438022186, 99776455, 1017309389);
+} catch {}
+try {
+renderBundleEncoder69.drawIndexed(114445557, 721014065, 396642135, 576047875, 872576335);
+} catch {}
+try {
+renderBundleEncoder69.drawIndexedIndirect(buffer56, 72844);
+} catch {}
+try {
+commandEncoder188.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder158.clearBuffer(buffer42, 218116, 3260);
+dissociateBuffer(device1, buffer42);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 41},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 10815175 */
+{offset: 679, bytesPerRow: 231, rowsPerImage: 77}, {width: 11, height: 0, depthOrArrayLayers: 609});
+} catch {}
+let pipeline188 = await promise45;
+let pipeline189 = device1.createRenderPipeline({
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 11576711,
+    stencilWriteMask: 2991203980,
+    depthBias: -1512088455,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2460, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 492,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 20, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroup40 = device4.createBindGroup({label: '\u79e3\u2178\u{1f8f8}\u9352\u{1f8b5}\ucceb\ue24a', layout: bindGroupLayout55, entries: []});
+let commandEncoder214 = device4.createCommandEncoder({label: '\u0d73\ue368\u208e\u{1ffe1}\u30c0\u098e\u{1ff04}\u{1ffc7}\u{1f708}'});
+let textureView292 = texture133.createView({label: '\u1467\u0132', baseArrayLayer: 0});
+try {
+renderBundleEncoder116.setBindGroup(3, bindGroup39, new Uint32Array(7090), 946, 0);
+} catch {}
+let promise59 = device4.queue.onSubmittedWorkDone();
+let promise60 = adapter0.requestAdapterInfo();
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+try {
+  await promise59;
+} catch {}
+offscreenCanvas27.width = 353;
+let imageBitmap45 = await createImageBitmap(video32);
+let videoFrame34 = new VideoFrame(imageBitmap35, {timestamp: 0});
+let videoFrame35 = new VideoFrame(canvas39, {timestamp: 0});
+try {
+  await promise60;
+} catch {}
+try {
+adapter4.label = '\u83be\u0a60';
+} catch {}
+try {
+window.someLabel = textureView279.label;
+} catch {}
+let bindGroup41 = device4.createBindGroup({label: '\u05e5\u0c06', layout: bindGroupLayout55, entries: []});
+let renderBundle128 = renderBundleEncoder116.finish({label: '\uf453\u{1fd84}'});
+let externalTexture102 = device4.importExternalTexture({source: videoFrame29});
+try {
+renderBundleEncoder112.setBindGroup(2, bindGroup41, new Uint32Array(6596), 5015, 0);
+} catch {}
+try {
+  await buffer73.mapAsync(GPUMapMode.WRITE, 25968, 15580);
+} catch {}
+try {
+commandEncoder214.copyBufferToBuffer(buffer73, 87404, buffer69, 7732, 6776);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer69);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 232 */
+{offset: 232}, {width: 941, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext43 = offscreenCanvas43.getContext('webgpu');
+let video42 = await videoWithData();
+try {
+offscreenCanvas41.getContext('bitmaprenderer');
+} catch {}
+document.body.prepend(canvas16);
+try {
+canvas51.getContext('webgpu');
+} catch {}
+try {
+adapter4.label = '\ua19d\u{1fb49}\u344a\u25a1\u{1f75d}\u85af\ua116';
+} catch {}
+let gpuCanvasContext44 = offscreenCanvas42.getContext('webgpu');
+let video43 = await videoWithData();
+let videoFrame36 = new VideoFrame(img27, {timestamp: 0});
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let commandEncoder215 = device4.createCommandEncoder();
+let textureView293 = texture133.createView({label: '\u033f\u087d\u061a\udc80\u8d4d\ufc87\u01a2\uabbb\u{1f87b}\u456f'});
+let externalTexture103 = device4.importExternalTexture({
+  label: '\u0d70\u0b83\ua038\u4573\u0402\u{1fc90}\u{1fc8a}\u0232\u{1fb88}',
+  source: videoFrame9,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder112.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+buffer73.unmap();
+} catch {}
+try {
+commandEncoder207.copyBufferToBuffer(buffer73, 70388, buffer72, 15208, 2476);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer72);
+} catch {}
+let gpuCanvasContext45 = canvas52.getContext('webgpu');
+let bindGroup42 = device4.createBindGroup({
+  label: '\u{1fb51}\u9a87\u0a8d\uece8\uafb4\u04f1\u7fe2\u0fd8\ud67f',
+  layout: bindGroupLayout55,
+  entries: [],
+});
+let commandEncoder216 = device4.createCommandEncoder({label: '\u0ce9\u0cf3\uc6f9\u0f9c\u{1fdfb}\ud073\u0425\ub43b'});
+let renderBundleEncoder118 = device4.createRenderBundleEncoder({
+  label: '\u063d\u29bf\ub111\u3c61\ufc2c\u0c64\u0e0b',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+});
+let renderBundle129 = renderBundleEncoder112.finish({label: '\u02ec\u04f6'});
+let sampler110 = device4.createSampler({
+  label: '\ue813\u9c00\u{1f6a2}\u{1f616}\u26b5\u{1fbf4}\uf260\u08f3\u6fa1\u0147',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.77,
+  lodMaxClamp: 91.23,
+});
+try {
+renderBundleEncoder118.setVertexBuffer(2055, undefined, 2658865581, 1226732520);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer10), /* required buffer size: 978 */
+{offset: 978}, {width: 847, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext33.unconfigure();
+} catch {}
+let img49 = await imageWithData(54, 259, '#988ca0f9', '#0f74c6f7');
+let textureView294 = texture133.createView({label: '\u0486\udd54\ube73\u0665\u789f\u03a8\u267e\u{1ff0a}\u06ac\uc6b2\u0802', mipLevelCount: 1});
+let externalTexture104 = device4.importExternalTexture({label: '\u551f\u{1f6ea}\u0f6e\u01cf\u{1fb95}\u9086\u0cb1', source: videoFrame10, colorSpace: 'srgb'});
+try {
+renderBundleEncoder118.setVertexBuffer(945, undefined);
+} catch {}
+let device5 = await adapter7.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 33,
+    maxVertexAttributes: 22,
+    maxVertexBufferArrayStride: 26567,
+    maxStorageTexturesPerShaderStage: 23,
+    maxStorageBuffersPerShaderStage: 32,
+    maxDynamicStorageBuffersPerPipelineLayout: 39478,
+    maxDynamicUniformBuffersPerPipelineLayout: 42347,
+    maxBindingsPerBindGroup: 5702,
+    maxTextureArrayLayers: 1163,
+    maxTextureDimension1D: 13639,
+    maxTextureDimension2D: 14469,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 179815496,
+    maxUniformBuffersPerShaderStage: 14,
+    maxSampledTexturesPerShaderStage: 20,
+    maxInterStageShaderVariables: 67,
+    maxInterStageShaderComponents: 81,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let offscreenCanvas44 = new OffscreenCanvas(159, 271);
+try {
+offscreenCanvas44.getContext('2d');
+} catch {}
+try {
+externalTexture76.label = '\uc896\u0694\u2a0d\u51f9\u32c4\udcaa\uf721\uf5d3\u051a';
+} catch {}
+gc();
+let commandEncoder217 = device4.createCommandEncoder({label: '\u{1fa47}\u0772'});
+let textureView295 = texture133.createView({label: '\u{1f735}\uc23f\u945d\u9d4e\u05d4'});
+let computePassEncoder101 = commandEncoder214.beginComputePass({label: '\ua11b\u0aaa\u72c3\u3d0a\u{1f761}\u8bef\u{1f9c8}\u73ee\u{1fcd0}\u{1f906}\u0784'});
+let renderBundle130 = renderBundleEncoder118.finish();
+let externalTexture105 = device4.importExternalTexture({label: '\u02cb\ucfff\u5eba\u4aa8\u0765\u36db\u17ac\u04a8\ue65c', source: video12, colorSpace: 'srgb'});
+try {
+gpuCanvasContext36.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas28);
+let img50 = await imageWithData(35, 34, '#82255b44', '#587a8104');
+let imageData32 = new ImageData(172, 132);
+try {
+window.someLabel = computePassEncoder50.label;
+} catch {}
+document.body.prepend(canvas30);
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let canvas54 = document.createElement('canvas');
+let commandEncoder218 = device5.createCommandEncoder();
+let gpuCanvasContext46 = canvas54.getContext('webgpu');
+try {
+window.someLabel = externalTexture93.label;
+} catch {}
+let commandEncoder219 = device2.createCommandEncoder({label: '\ucd23\u1fd3'});
+let textureView296 = texture131.createView({
+  label: '\ue62d\uef7f\ua838\uefe8',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 615,
+});
+try {
+  await buffer60.mapAsync(GPUMapMode.READ, 389408, 9972);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer71, 20956, new BigUint64Array(27633), 26467, 300);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 1353, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer9), /* required buffer size: 8 */
+{offset: 8}, {width: 640, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let video44 = await videoWithData();
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55) };
+} catch {}
+offscreenCanvas13.height = 759;
+let commandEncoder220 = device5.createCommandEncoder({});
+let commandBuffer56 = commandEncoder218.finish({label: '\u{1fdb3}\u098b\u0417\u1ad7\uacba'});
+let promise61 = device5.queue.onSubmittedWorkDone();
+let video45 = await videoWithData();
+try {
+  await promise61;
+} catch {}
+let canvas55 = document.createElement('canvas');
+let video46 = await videoWithData();
+let videoFrame37 = new VideoFrame(img24, {timestamp: 0});
+gc();
+try {
+canvas55.getContext('webgl');
+} catch {}
+let canvas56 = document.createElement('canvas');
+let bindGroup43 = device4.createBindGroup({label: '\u4ab4\uab9b\u0a09\ueb98\u0519\u{1fff1}\u{1fec9}', layout: bindGroupLayout55, entries: []});
+let buffer74 = device4.createBuffer({
+  label: '\u792c\udd3e\u3213\u0d44\u3ebf\ud573\uf008\u208a\uefc5\u2895\u{1fcff}',
+  size: 49774,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder221 = device4.createCommandEncoder({label: '\u940a\u039a\u5622\u{1f759}\u0d1e\ud131\u3f52\u23ec\uf6d2\uce21\u3d09'});
+let computePassEncoder102 = commandEncoder215.beginComputePass({label: '\u0782\ud089\ua000\u0a99'});
+try {
+commandEncoder217.copyBufferToBuffer(buffer73, 43264, buffer74, 29220, 17320);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer74);
+} catch {}
+try {
+commandEncoder217.clearBuffer(buffer74, 14316, 12940);
+dissociateBuffer(device4, buffer74);
+} catch {}
+let img51 = await imageWithData(63, 155, '#1dfb5cba', '#399b7237');
+let imageBitmap46 = await createImageBitmap(imageBitmap7);
+try {
+adapter6.label = '\u{1ff01}\u763e\u0fe5\u70ec\ua454';
+} catch {}
+try {
+canvas56.getContext('webgpu');
+} catch {}
+try {
+device4.queue.label = '\u0b74\u0e88\u5115\u{1f997}\u{1fa73}\ub8f0\u2951\u{1fe72}\u{1fe17}\u0c1c';
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+buffer67.destroy();
+} catch {}
+try {
+commandEncoder221.copyBufferToBuffer(buffer73, 14848, buffer74, 25656, 22896);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer74);
+} catch {}
+let img52 = await imageWithData(174, 201, '#b12d20d0', '#e8549917');
+let commandEncoder222 = device4.createCommandEncoder({label: '\ued41\u0aeb'});
+let querySet117 = device4.createQuerySet({label: '\u85df\u0f4d\u{1ffd8}\u0f79\u73e2\u{1f640}\ud687\u0ab4', type: 'occlusion', count: 883});
+try {
+buffer72.unmap();
+} catch {}
+let buffer75 = device5.createBuffer({size: 177255, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let texture137 = device5.createTexture({
+  label: '\u52ac\u98fc\ua71e\u008b\u4574\u07c0\u{1fb7b}',
+  size: {width: 60, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint'],
+});
+let texture138 = gpuCanvasContext11.getCurrentTexture();
+let textureView297 = texture137.createView({label: '\u410c\u00c8', dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 0});
+try {
+device5.queue.writeBuffer(buffer75, 177044, new Int16Array(27295), 14539, 76);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let canvas57 = document.createElement('canvas');
+let img53 = await imageWithData(60, 72, '#c0c663ee', '#c6eaa57f');
+let video47 = await videoWithData();
+try {
+adapter0.label = '\u0955\u02dc\ubfe0\uccb4';
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let canvas58 = document.createElement('canvas');
+let bindGroupLayout56 = device5.createBindGroupLayout({label: '\u8ddc\u9e84\u{1ffb6}', entries: []});
+let querySet118 = device5.createQuerySet({
+  label: '\u01cb\u0525\u3be7\u46fa\u{1fa8f}\u16ba\u9b07\u94d3\u8169\u9e51',
+  type: 'occlusion',
+  count: 313,
+});
+let textureView298 = texture137.createView({label: '\u09ea\u0195\u{1fb4e}\u496e\ud558\u726d\uc73b\u{1f764}\u21e1\u537e'});
+try {
+device5.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder220.copyTextureToBuffer({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12604 */
+  offset: 12604,
+  rowsPerImage: 270,
+  buffer: buffer75,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device5, buffer75);
+} catch {}
+try {
+commandEncoder220.clearBuffer(buffer75, 72816, 25576);
+dissociateBuffer(device5, buffer75);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device5,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 84, y: 61 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext47 = canvas58.getContext('webgpu');
+let promise62 = adapter1.requestAdapterInfo();
+video2.height = 196;
+try {
+  await promise62;
+} catch {}
+let img54 = await imageWithData(131, 244, '#411f7539', '#d0bfaeae');
+let videoFrame38 = new VideoFrame(imageBitmap31, {timestamp: 0});
+try {
+canvas57.getContext('webgl2');
+} catch {}
+let pipelineLayout25 = device5.createPipelineLayout({label: '\u7d05\u{1f845}\u0488', bindGroupLayouts: [bindGroupLayout56, bindGroupLayout56]});
+let commandEncoder223 = device5.createCommandEncoder({});
+let sampler111 = device5.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.398,
+  maxAnisotropy: 12,
+});
+canvas12.width = 467;
+let computePassEncoder103 = commandEncoder217.beginComputePass({});
+let externalTexture106 = device4.importExternalTexture({
+  label: '\u0101\u3ac1\u3e74\ud468\u{1f8f3}\u018b\u0a69\ubc9c\u3f90',
+  source: video47,
+  colorSpace: 'srgb',
+});
+let bindGroup44 = device5.createBindGroup({label: '\u{1f68a}\uc5d9\u05ca\ud438\u{1fee2}', layout: bindGroupLayout56, entries: []});
+let textureView299 = texture137.createView({
+  label: '\u0630\u{1ff1c}\u444a\udf43\u{1ff9d}\u{1f67e}\uef5a\u{1fbf2}',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+commandEncoder220.copyTextureToBuffer({
+  texture: texture137,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 13 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 33235 */
+  offset: 33222,
+  buffer: buffer75,
+}, {width: 13, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device5, buffer75);
+} catch {}
+let textureView300 = texture133.createView({label: '\u{1f864}\uff31\u{1fd51}\u074f\u9e4f\u04cf\u0a4d\u0910\u{1fa9a}\u013e\u2ae7'});
+let computePassEncoder104 = commandEncoder207.beginComputePass({label: '\u626a\u0688\u5461'});
+try {
+texture133.destroy();
+} catch {}
+try {
+commandEncoder221.clearBuffer(buffer72);
+dissociateBuffer(device4, buffer72);
+} catch {}
+let img55 = await imageWithData(141, 270, '#baeb55f7', '#553d7d37');
+let promise63 = adapter7.requestAdapterInfo();
+let texture139 = device5.createTexture({
+  label: '\u5859\u1187\u9e65\u4931\u2a8a',
+  size: [2496],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView301 = texture138.createView({format: 'rgba8unorm-srgb'});
+let sampler112 = device5.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.11,
+  lodMaxClamp: 98.99,
+  compare: 'not-equal',
+});
+try {
+commandEncoder223.copyTextureToBuffer({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 57204 */
+  offset: 57204,
+  buffer: buffer75,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device5, buffer75);
+} catch {}
+try {
+commandEncoder223.copyTextureToTexture({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise63;
+} catch {}
+try {
+computePassEncoder23.label = '\u{1ffa1}\u{1fa78}\u0319\u62e8';
+} catch {}
+let videoFrame39 = new VideoFrame(img8, {timestamp: 0});
+try {
+adapter6.label = '\u0e62\u49f1';
+} catch {}
+let textureView302 = texture137.createView({label: '\u1137\u6d24\u087b\u4074\ue595', baseMipLevel: 2, baseArrayLayer: 0});
+let computePassEncoder105 = commandEncoder223.beginComputePass({label: '\u2375\uf45e\u062d'});
+let renderBundleEncoder119 = device5.createRenderBundleEncoder({
+  label: '\ub2cd\u01c0\u0a76\u{1fa0b}\u{1f805}\u{1f7f3}',
+  colorFormats: ['rgba8unorm', 'rgba16uint', 'r8sint', 'r32float', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder105.setBindGroup(4, bindGroup44, new Uint32Array(6253), 1048, 0);
+} catch {}
+try {
+commandEncoder220.copyTextureToTexture({
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 942, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture137,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device5,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+gc();
+let imageBitmap47 = await createImageBitmap(offscreenCanvas22);
+let commandEncoder224 = device4.createCommandEncoder({label: '\uee1c\uc92a'});
+let textureView303 = texture133.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let externalTexture107 = device4.importExternalTexture({label: '\u109a\u3529\ufb5a\ufa81\u018f\u{1f807}\u{1fb26}\u0dc5', source: video26, colorSpace: 'srgb'});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder222.copyBufferToBuffer(buffer73, 43248, buffer69, 4840, 12512);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer69);
+} catch {}
+try {
+commandEncoder221.copyBufferToTexture({
+  /* bytesInLastRow: 456 widthInBlocks: 57 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7224 */
+  offset: 6768,
+  buffer: buffer73,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 57, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer73);
+} catch {}
+try {
+commandEncoder210.clearBuffer(buffer72);
+dissociateBuffer(device4, buffer72);
+} catch {}
+let commandBuffer57 = commandEncoder220.finish({label: '\u00ce\u{1fff4}\u{1f601}\u0f6c\u0d2a\u0bd7\u0eba\u{1f698}\u87a1'});
+try {
+renderBundleEncoder119.setBindGroup(5, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder119.setBindGroup(0, bindGroup44, new Uint32Array(9144), 342, 0);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas19,
+  origin: { x: 15, y: 60 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup45 = device4.createBindGroup({label: '\uea10\u{1ff4c}\u5d7a', layout: bindGroupLayout55, entries: []});
+let renderBundleEncoder120 = device4.createRenderBundleEncoder({
+  label: '\u05d2\u{1fe8d}\u008d\u7aa7\ucbae\u68ef\ucfb2\u{1fec7}',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+});
+let externalTexture108 = device4.importExternalTexture({source: video17, colorSpace: 'srgb'});
+try {
+renderBundleEncoder120.setIndexBuffer(buffer67, 'uint32', 22292);
+} catch {}
+let bindGroup46 = device4.createBindGroup({
+  label: '\u{1f844}\uabad\ub239\u3522\u083f\u678a\uf53f\u0a30\u07a5\u1791',
+  layout: bindGroupLayout55,
+  entries: [],
+});
+let querySet119 = device4.createQuerySet({label: '\u4193\u{1f665}\u441b\u07ee\u{1fea4}\u0954\udacd', type: 'occlusion', count: 3883});
+let textureView304 = texture133.createView({dimension: '1d'});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder120.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer74, 8484, new DataView(new ArrayBuffer(59446)), 10968, 17392);
+} catch {}
+let img56 = await imageWithData(135, 109, '#596a9c9e', '#e7d359df');
+let bindGroupLayout57 = device4.createBindGroupLayout({
+  label: '\u765e\u29c8\u04ac\u27c7\u8eec\ub637\uaf31\u74cf\u{1fe16}\uc6e2\u{1fe0b}',
+  entries: [
+    {
+      binding: 60,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 861,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 255287, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup47 = device4.createBindGroup({
+  label: '\u{1f6f0}\ue8cb\u94e6\u0c3e\u9a8a\u00c0\u{1fc5a}\u0c33\u05cc\u{1faee}\ud3ed',
+  layout: bindGroupLayout55,
+  entries: [],
+});
+let renderBundleEncoder121 = device4.createRenderBundleEncoder({
+  label: '\u9ef0\u{1fe46}',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle131 = renderBundleEncoder114.finish();
+try {
+renderBundleEncoder120.setIndexBuffer(buffer67, 'uint32', 28644, 5579);
+} catch {}
+let commandEncoder225 = device4.createCommandEncoder();
+let commandBuffer58 = commandEncoder209.finish({label: '\ueb31\u113e\u2bd1\u5a96\u0755\ub836'});
+let texture140 = device4.createTexture({size: {width: 160}, dimension: '1d', format: 'bgra8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let renderBundleEncoder122 = device4.createRenderBundleEncoder({colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'], depthReadOnly: true});
+video4.width = 144;
+try {
+renderBundleEncoder120.setBindGroup(2, bindGroup39);
+} catch {}
+let promise64 = buffer73.mapAsync(GPUMapMode.WRITE, 0, 53636);
+try {
+commandEncoder222.copyBufferToBuffer(buffer73, 332, buffer69, 9020, 7768);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer69);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer74, 8592, new Float32Array(44006), 18793, 512);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 521 */
+{offset: 293}, {width: 57, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder226 = device5.createCommandEncoder({});
+let textureView305 = texture138.createView({label: '\ue1fc\u3c3b\u0c08\u00a8', dimension: '2d-array', arrayLayerCount: 1});
+try {
+renderBundleEncoder119.setBindGroup(4, bindGroup44, new Uint32Array(5086), 4429, 0);
+} catch {}
+try {
+commandEncoder226.clearBuffer(buffer75, 149072, 16940);
+dissociateBuffer(device5, buffer75);
+} catch {}
+let querySet120 = device5.createQuerySet({type: 'occlusion', count: 2349});
+let textureView306 = texture139.createView({baseArrayLayer: 0});
+let renderBundle132 = renderBundleEncoder119.finish({label: '\u43dd\u1d8e\ud953\u8f4b\u0bc8\uc8eb\u7883\u10bc\ua9d6\ud4c1'});
+try {
+device5.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer17), /* required buffer size: 209 */
+{offset: 209}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise64;
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(550, 563);
+gc();
+let bindGroupLayout58 = device5.createBindGroupLayout({label: '\u{1ff2c}\ufc7d', entries: []});
+let textureView307 = texture139.createView({});
+let sampler113 = device5.createSampler({
+  label: '\ufae6\uc9a2\u032a\u07d7\u{1f829}\u0033\u{1fb25}\u0720\u0075\u0b9e\ud6de',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.14,
+  lodMaxClamp: 52.33,
+  maxAnisotropy: 16,
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let img57 = await imageWithData(84, 228, '#161dc1cb', '#103bea6b');
+let video48 = await videoWithData();
+let querySet121 = device5.createQuerySet({label: '\uad69\u{1fd1c}\u0c3f\u{1fc72}', type: 'occlusion', count: 2859});
+pseudoSubmit(device5, commandEncoder226);
+let texture141 = device5.createTexture({
+  label: '\uc9ca\u088e\u{1ff00}\u{1f9a2}\u0892\u5d5e\ua1c5\u5889\uc2b2',
+  size: {width: 1248, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 10,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView308 = texture138.createView({
+  label: '\u0da7\u{1fdf0}\ud8b6\u8cc4\uf360\u{1fa32}\u29ae\u62ff\u{1fa82}\uc7c0',
+  format: 'rgba8unorm-srgb',
+});
+let externalTexture109 = device5.importExternalTexture({label: '\u5284\ucb0e\u0bf8\u089f\ue949\u5195\u{1ffb2}', source: video16, colorSpace: 'display-p3'});
+try {
+gpuCanvasContext42.configure({
+  device: device5,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device5.queue.submit([commandBuffer56]);
+} catch {}
+document.body.prepend(video19);
+let commandEncoder227 = device4.createCommandEncoder();
+let commandBuffer59 = commandEncoder212.finish({});
+let texture142 = device4.createTexture({
+  label: '\ued4d\u03f1\u{1fb80}',
+  size: {width: 384, height: 1, depthOrArrayLayers: 80},
+  mipLevelCount: 7,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder106 = commandEncoder227.beginComputePass({label: '\uc083\u78c9\u0b80\u{1f6db}\u{1f638}'});
+let renderBundleEncoder123 = device4.createRenderBundleEncoder({label: '\u0c91\u0f9d\u4385', colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float']});
+let externalTexture110 = device4.importExternalTexture({label: '\u5134\u0afa\u0623\u0606', source: video24, colorSpace: 'srgb'});
+let gpuCanvasContext48 = offscreenCanvas45.getContext('webgpu');
+let bindGroup48 = device5.createBindGroup({layout: bindGroupLayout56, entries: []});
+let commandEncoder228 = device5.createCommandEncoder({label: '\u0f0b\u{1fa51}\u7d50\u01df\u8745\uc9c7\u{1fe5a}'});
+let commandBuffer60 = commandEncoder228.finish({label: '\u9646\u04c9\u3bbf\u42e3\uf203\u03d4\u{1fa07}\u0e9a'});
+let texture143 = device5.createTexture({
+  label: '\u0e93\u0167\u{1f795}\u{1fc20}\u7059\u3362',
+  size: [1248, 8, 1],
+  mipLevelCount: 6,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let externalTexture111 = device5.importExternalTexture({label: '\u0dfb\u{1f625}\u{1f800}\uf6c2', source: video15, colorSpace: 'srgb'});
+let canvas59 = document.createElement('canvas');
+try {
+canvas59.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = externalTexture58.label;
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let texture144 = device1.createTexture({
+  label: '\u0098\u07ad\u23f6\ub8f9\u08e9\u0288\u6dc0\uf276\ufeb2\u{1fa0c}',
+  size: {width: 2220, height: 20, depthOrArrayLayers: 1703},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle133 = renderBundleEncoder98.finish({label: '\u0e4e\u{1f67e}\u4d81\uf8c1\u{1fcc6}\u0591'});
+let sampler114 = device1.createSampler({
+  label: '\uabaf\ub0ab\u5152\u40c6\u2baa\ued04\u0e0f\ua6f9\u0094',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.95,
+  lodMaxClamp: 37.74,
+});
+try {
+computePassEncoder68.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline143);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(1, bindGroup34, new Uint32Array(8000), 6015, 0);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder160.clearBuffer(buffer48, 27072, 76720);
+dissociateBuffer(device1, buffer48);
+} catch {}
+try {
+commandEncoder213.resolveQuerySet(querySet90, 446, 1496, buffer43, 12544);
+} catch {}
+let commandEncoder229 = device4.createCommandEncoder({label: '\ub52b\u127a\u{1ff43}\uef13\u7a5d\ua19a\u066b\u{1fb3d}\u683f'});
+let texture145 = device4.createTexture({
+  label: '\u0f31\u{1ffb0}',
+  size: [192, 1, 46],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16uint'],
+});
+let textureView309 = texture142.createView({
+  label: '\u4b2e\u91fa\u{1fe2d}\udbf3\u{1f91f}\u5a9f\u0e1c\u7ea7',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+  baseArrayLayer: 73,
+  arrayLayerCount: 5,
+});
+try {
+computePassEncoder103.insertDebugMarker('\u1365');
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture142,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer13), /* required buffer size: 1127492 */
+{offset: 122, bytesPerRow: 174, rowsPerImage: 209}, {width: 3, height: 1, depthOrArrayLayers: 32});
+} catch {}
+let imageData33 = new ImageData(200, 116);
+document.body.prepend(canvas28);
+try {
+querySet115.destroy();
+} catch {}
+let querySet122 = device4.createQuerySet({label: '\ua6b6\u{1fe16}\u41dd\u922c\u{1fefb}', type: 'occlusion', count: 1073});
+let textureView310 = texture145.createView({
+  label: '\ud373\ub1a4\u0409\uafe0\u{1fe5e}\ub62f\u5f23\u06f2\u{1fc17}',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let sampler115 = device4.createSampler({
+  label: '\ua15e\ude24\u{1fad9}\u7f2e\u8133\u077e\u{1fe92}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.785,
+  lodMaxClamp: 6.356,
+});
+try {
+computePassEncoder104.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+commandEncoder216.copyBufferToBuffer(buffer73, 55656, buffer69, 2828, 9916);
+dissociateBuffer(device4, buffer73);
+dissociateBuffer(device4, buffer69);
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55) };
+} catch {}
+let video49 = await videoWithData();
+video45.width = 243;
+let canvas60 = document.createElement('canvas');
+let video50 = await videoWithData();
+let buffer76 = device4.createBuffer({
+  label: '\u9832\u4c6a\u{1fbd9}\u{1fdd7}\u7e78\u660e\u045b\u022e\u5279\u0bcb',
+  size: 722933,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: false,
+});
+let commandEncoder230 = device4.createCommandEncoder({});
+let texture146 = device4.createTexture({
+  size: [480],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let textureView311 = texture145.createView({label: '\u30f8\u10c1\ub085\u04a1\uedcf\uabde', baseMipLevel: 1});
+let renderBundleEncoder124 = device4.createRenderBundleEncoder({
+  label: '\u{1fbc0}\u05f8\u{1fed4}\u7a14',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle134 = renderBundleEncoder124.finish({label: '\u266c\u616e\u0d60'});
+try {
+renderBundleEncoder121.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+commandEncoder216.copyTextureToTexture({
+  texture: texture142,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture145,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 86, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer74, 13280, new DataView(new ArrayBuffer(62143)), 17189, 6424);
+} catch {}
+video24.width = 291;
+let buffer77 = device3.createBuffer({
+  label: '\u{1fc3f}\u047d\u3072\u01c9\u00cc\u022d\u0e06\u{1f672}\u9042\u793b\u071a',
+  size: 607044,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+  mappedAtCreation: true,
+});
+let computePassEncoder107 = commandEncoder211.beginComputePass();
+try {
+renderBundleEncoder97.setVertexBuffer(98, undefined, 1230486105, 1521237955);
+} catch {}
+let commandEncoder231 = device4.createCommandEncoder({label: '\u0058\udb65\u68ee'});
+let externalTexture112 = device4.importExternalTexture({label: '\ubf93\u{1f9d0}\u0f32\ub174\u08af\u35fd\u05c9\u0364', source: video20, colorSpace: 'srgb'});
+try {
+commandEncoder222.copyBufferToTexture({
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 54388 */
+  offset: 54152,
+  rowsPerImage: 128,
+  buffer: buffer76,
+}, {
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 59, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer76);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture142,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(6548310), /* required buffer size: 6548310 */
+{offset: 270, bytesPerRow: 423, rowsPerImage: 258}, {width: 41, height: 0, depthOrArrayLayers: 61});
+} catch {}
+let renderBundle135 = renderBundleEncoder119.finish();
+let commandEncoder232 = device5.createCommandEncoder({label: '\u7805\udff9\u8788\u4af1\uf2a1\u06c9\uee1a\u00a3\u70ad'});
+let querySet123 = device5.createQuerySet({label: '\ud770\u7bc8\u1410\u005a\u04ee\ub119\udf66\u09f5\u71d0', type: 'occlusion', count: 1054});
+let textureView312 = texture141.createView({
+  label: '\u061b\u{1f643}\u064c\u9758\u{1f86d}\u{1fb4c}\u{1fbd0}',
+  dimension: '2d-array',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+});
+let renderBundle136 = renderBundleEncoder119.finish({});
+try {
+commandEncoder232.clearBuffer(buffer75, 84920, 26308);
+dissociateBuffer(device5, buffer75);
+} catch {}
+document.body.prepend(canvas26);
+try {
+canvas60.getContext('bitmaprenderer');
+} catch {}
+gc();
+let commandEncoder233 = device5.createCommandEncoder();
+let commandBuffer61 = commandEncoder232.finish();
+let computePassEncoder108 = commandEncoder233.beginComputePass({label: '\u08d0\u{1fc61}\u0a8b\u66fd\u1be9\u{1ff3c}\u{1f8a0}\u6d77'});
+let sampler116 = device5.createSampler({
+  label: '\u09f4\u8c26\u9b01\ua53f\uff03\u{1faef}\u35c2\u09fd\ub670\u3d4f',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 87.39,
+});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup48);
+} catch {}
+document.body.prepend(canvas7);
+try {
+pipeline79.label = '\ua377\u0f63';
+} catch {}
+let video51 = await videoWithData();
+try {
+window.someLabel = device3.label;
+} catch {}
+let commandEncoder234 = device4.createCommandEncoder();
+let textureView313 = texture133.createView({mipLevelCount: 1});
+let renderBundleEncoder125 = device4.createRenderBundleEncoder({
+  label: '\u0647\u{1fe2a}\u08ee\u06ba\u4a7a\u06d5\u8f9d\u0aad\u89b9\u0749\u8bda',
+  colorFormats: ['r16sint', 'rgba32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle137 = renderBundleEncoder114.finish({label: '\u0447\u0a41\u6906'});
+let sampler117 = device4.createSampler({
+  label: '\u028d\u059b\u2d30\ua00e\u{1fa07}\u20ea\u6773\u7e75\u0c55',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.98,
+  lodMaxClamp: 97.77,
+});
+try {
+buffer70.unmap();
+} catch {}
+try {
+commandEncoder210.copyBufferToBuffer(buffer76, 483432, buffer74, 18604, 20844);
+dissociateBuffer(device4, buffer76);
+dissociateBuffer(device4, buffer74);
+} catch {}
+try {
+device4.destroy();
+} catch {}
+let img58 = await imageWithData(195, 9, '#ab337bcc', '#198fdc7c');
+let imageBitmap48 = await createImageBitmap(video44);
+let videoFrame40 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let canvas61 = document.createElement('canvas');
+let videoFrame41 = new VideoFrame(imageBitmap18, {timestamp: 0});
+try {
+canvas61.getContext('webgl');
+} catch {}
+let offscreenCanvas46 = new OffscreenCanvas(260, 111);
+let img59 = await imageWithData(297, 240, '#4677316e', '#d88ecbbf');
+offscreenCanvas33.width = 3;
+try {
+commandEncoder226.label = '\u04be\u7708';
+} catch {}
+let texture147 = device5.createTexture({
+  label: '\uae06\u{1fb4f}\u{1fcf6}\uda7e\udc79\u15f5\u{1f7cf}',
+  size: {width: 624},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint'],
+});
+try {
+computePassEncoder105.setBindGroup(4, bindGroup48, new Uint32Array(402), 37, 0);
+} catch {}
+try {
+device5.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture147,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer19), /* required buffer size: 586 */
+{offset: 586}, {width: 552, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+offscreenCanvas46.getContext('webgpu');
+} catch {}
+let offscreenCanvas47 = new OffscreenCanvas(960, 1015);
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+try {
+offscreenCanvas47.getContext('webgpu');
+} catch {}
+let imageData34 = new ImageData(80, 212);
+let commandEncoder235 = device5.createCommandEncoder({});
+let querySet124 = device5.createQuerySet({label: '\u0338\u04fd\u7059\u0401\u0f5b\uc4df', type: 'occlusion', count: 2430});
+let textureView314 = texture138.createView({label: '\u0853\u{1fc2b}\u{1fbf0}\u{1f81e}\u036c', baseMipLevel: 0});
+let renderBundleEncoder126 = device5.createRenderBundleEncoder({
+  label: '\u0ef0\u74fd\u06ca\ud942\u185e\u11fe\u0929\uff55\u{1f6df}\u10ca',
+  colorFormats: ['rgba8unorm', 'rgba16uint', 'r8sint', 'r32float', 'r16sint'],
+  stencilReadOnly: true,
+});
+let externalTexture113 = device5.importExternalTexture({
+  label: '\u{1f74a}\u{1ff3f}\u6702\u00b7\u5722\u8664\u01ff\u1e6f\u0b69',
+  source: videoFrame41,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder235.clearBuffer(buffer75, 172772, 3604);
+dissociateBuffer(device5, buffer75);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img11,
+  origin: { x: 86, y: 3 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video23.width = 189;
+let textureView315 = texture139.createView({label: '\u{1fe65}\u3868\uc677\ud8c5\u28df\u{1fc23}'});
+let externalTexture114 = device5.importExternalTexture({
+  label: '\u057d\u{1ff55}\u7ee3\ubfab\u{1fc92}\ue053\ub339\u63b5\u0e0e\u135f\u084e',
+  source: videoFrame28,
+  colorSpace: 'display-p3',
+});
+try {
+device5.queue.writeBuffer(buffer75, 36140, new BigUint64Array(63141), 17131, 3440);
+} catch {}
+let promise65 = device5.queue.onSubmittedWorkDone();
+let imageBitmap49 = await createImageBitmap(canvas54);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+gc();
+let canvas62 = document.createElement('canvas');
+let commandEncoder236 = device5.createCommandEncoder({label: '\u{1f9be}\uccce\u01c8\uf3c7\u{1f8df}\ufe03\u413b\u0b09\u0150\u{1fb04}\uc6c1'});
+let querySet125 = device5.createQuerySet({label: '\u0051\u4d4b\u{1f9cb}\uedc5\u74f1', type: 'occlusion', count: 2400});
+let texture148 = device5.createTexture({
+  label: '\u0625\u5cb7\u527b\u0f9f\u{1f8f9}\u4e33\ua583\u{1fd94}',
+  size: [537, 2, 182],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let computePassEncoder109 = commandEncoder236.beginComputePass({});
+try {
+commandEncoder235.copyTextureToTexture({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture141,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer12), /* required buffer size: 722 */
+{offset: 722}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas63 = document.createElement('canvas');
+let gpuCanvasContext49 = canvas63.getContext('webgpu');
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55) };
+} catch {}
+let bindGroupLayout59 = device5.createBindGroupLayout({
+  label: '\u0ebf\ubc0e\u{1fbcd}\u0717\u68cc\u4b1f',
+  entries: [
+    {
+      binding: 4438,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet126 = device5.createQuerySet({
+  label: '\u3d9b\u9e90\u7c90\u0559\u003b\u20d1\u0b7d\udb00\u75cb\uca8d\u05a9',
+  type: 'occlusion',
+  count: 1110,
+});
+let commandBuffer62 = commandEncoder235.finish({label: '\u1631\u0440\u{1f89a}\u{1f9ea}\u06ae\u{1fcbf}\u9865\u0279\u053a\u99fd\u32bc'});
+let textureView316 = texture141.createView({label: '\u00cf\uc007\u07f8\u06a5', dimension: '2d-array', baseMipLevel: 5, mipLevelCount: 2});
+let renderBundle138 = renderBundleEncoder126.finish({label: '\u7ae5\u{1fee2}\u0084\u0c5e\u50f2\u0e09\u0d52'});
+try {
+device5.queue.submit([commandBuffer60, commandBuffer62]);
+} catch {}
+try {
+device5.queue.writeBuffer(buffer75, 77900, new BigUint64Array(40490), 31941, 632);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame39,
+  origin: { x: 13, y: 80 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap50 = await createImageBitmap(videoFrame21);
+let textureView317 = texture143.createView({label: '\u{1fb6f}\u067a', aspect: 'all', baseMipLevel: 4});
+let externalTexture115 = device5.importExternalTexture({
+  label: '\u{1fba4}\u{1f708}\uad96\u06c4\u64ac\u{1fb79}\u697b\uae05\u070e\u01fc\ud4b8',
+  source: videoFrame15,
+  colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext4.configure({
+  device: device5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device5.queue.writeBuffer(buffer75, 22372, new DataView(new ArrayBuffer(45558)), 18566, 3636);
+} catch {}
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+let commandEncoder237 = device5.createCommandEncoder({label: '\u{1f9b3}\u0d5c\u0981\uab29\u6d51\u010a\u{1ff9e}\ua6a7\u0f75\u02f1\u0433'});
+let texture149 = device5.createTexture({
+  label: '\uc7ad\u021e\u458c\u052c\u2791\u0b81\u8408\u6ef7',
+  size: [4296],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder110 = commandEncoder237.beginComputePass();
+try {
+computePassEncoder108.setBindGroup(2, bindGroup48, new Uint32Array(4318), 3016, 0);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device5,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap26,
+  origin: { x: 3, y: 44 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext50 = canvas62.getContext('webgpu');
+document.body.prepend(canvas2);
+canvas59.height = 1631;
+gc();
+let offscreenCanvas48 = new OffscreenCanvas(600, 211);
+try {
+offscreenCanvas48.getContext('webgpu');
+} catch {}
+let canvas64 = document.createElement('canvas');
+let imageBitmap51 = await createImageBitmap(video9);
+let bindGroup49 = device5.createBindGroup({layout: bindGroupLayout58, entries: []});
+let pipelineLayout26 = device5.createPipelineLayout({label: '\u48fb\u6e9c\u{1f70d}\ube5c', bindGroupLayouts: [bindGroupLayout58]});
+let textureView318 = texture148.createView({
+  label: '\u{1ff2d}\u2e22\ueb68\uc095\u{1fe26}\uecd5\ua65e\ue7ab\u77e1\u0b29\u0b39',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let externalTexture116 = device5.importExternalTexture({
+  label: '\uabe4\u5c14\u1b5a\ue608\u{1fa2c}\u05b5\u{1fa93}\uace5\u{1fabf}\u55f4',
+  source: video6,
+  colorSpace: 'srgb',
+});
+try {
+querySet121.destroy();
+} catch {}
+try {
+buffer75.destroy();
+} catch {}
+let gpuCanvasContext51 = canvas64.getContext('webgpu');
+let img60 = await imageWithData(251, 196, '#3f270d44', '#b96a342d');
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas49 = new OffscreenCanvas(111, 819);
+let gpuCanvasContext52 = offscreenCanvas49.getContext('webgpu');
+gc();
+let video52 = await videoWithData();
+let img61 = await imageWithData(261, 192, '#3a205007', '#f9e29397');
+let offscreenCanvas50 = new OffscreenCanvas(255, 469);
+let commandEncoder238 = device3.createCommandEncoder({label: '\u0c8e\u{1fd1b}\u5131\u003c\u01ed\u1018\u{1f94f}\u10f2\ub450\u3a55\u01ea'});
+let commandBuffer63 = commandEncoder238.finish();
+let textureView319 = texture136.createView({
+  label: '\u{1f691}\u{1fe2e}\u15f6\u{1f953}\u079d',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 4,
+});
+let imageBitmap52 = await createImageBitmap(img30);
+let gpuCanvasContext53 = offscreenCanvas50.getContext('webgpu');
+let bindGroup50 = device5.createBindGroup({
+  label: '\u5e3d\u2f0d\u052f\u0e1f\u{1fdd3}\u{1ff7d}\u2c57\u3f4c\u0baa\u{1fd55}\u5348',
+  layout: bindGroupLayout58,
+  entries: [],
+});
+let texture150 = device5.createTexture({
+  label: '\uc3cb\u{1f61b}',
+  size: {width: 240, height: 20, depthOrArrayLayers: 73},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let textureView320 = texture138.createView({label: '\uac74\u{1fb7e}\u518d\udebe\u097f', dimension: '2d-array', arrayLayerCount: 1});
+let renderBundleEncoder127 = device5.createRenderBundleEncoder({colorFormats: ['rgba8unorm', 'rgba16uint', 'r8sint', 'r32float', 'r16sint'], stencilReadOnly: true});
+try {
+renderBundleEncoder127.setBindGroup(1, bindGroup44);
+} catch {}
+canvas35.height = 457;
+document.body.prepend(video32);
+let canvas65 = document.createElement('canvas');
+document.body.prepend(video37);
+let textureView321 = texture148.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder128 = device5.createRenderBundleEncoder({
+  label: '\u{1f7d1}\u0ce1\uaeeb\u6e84\u13e1\u{1f8bc}\ue702\u1183',
+  colorFormats: ['rgba8unorm', 'rgba16uint', 'r8sint', 'r32float', 'r16sint'],
+  stencilReadOnly: false,
+});
+let renderBundle139 = renderBundleEncoder126.finish({label: '\u095e\u8bbb\u08ce\u{1fda3}\ue834\u{1ff0e}\u37f9\u15bb'});
+try {
+device5.queue.writeTexture({
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 322, y: 0, z: 1},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 601 */
+{offset: 601}, {width: 483, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas33.width = 4988;
+let img62 = await imageWithData(257, 216, '#c74f3d43', '#52338acc');
+let imageData35 = new ImageData(4, 160);
+let imageData36 = new ImageData(148, 120);
+let img63 = await imageWithData(132, 232, '#bee360c4', '#60df1ee0');
+video51.width = 197;
+let bindGroupLayout60 = device2.createBindGroupLayout({
+  label: '\u{1f656}\u6956\u63a1\u290b\u13fc\u{1fa6c}\u{1f9d1}\u8a8a\u36eb\u0062\u41de',
+  entries: [{binding: 272, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let textureView322 = texture132.createView({label: '\u50ea\u4a19\ud949', mipLevelCount: 1});
+let sampler118 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.46,
+  lodMaxClamp: 82.16,
+  maxAnisotropy: 6,
+});
+try {
+commandEncoder219.copyTextureToTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 45},
+  aspect: 'all',
+},
+{
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1579, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder202.resolveQuerySet(querySet96, 4, 281, buffer68, 14848);
+} catch {}
+let videoFrame42 = new VideoFrame(canvas21, {timestamp: 0});
+let img64 = await imageWithData(95, 272, '#251836f3', '#022f3468');
+let texture151 = device5.createTexture({
+  label: '\u{1fa75}\ueba1\u{1f8f6}\u0a8f\u{1fd40}\uf146',
+  size: {width: 82, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup50, new Uint32Array(7927), 4941, 0);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 320, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 511 */
+{offset: 511}, {width: 1903, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let imageData37 = new ImageData(60, 152);
+let promise66 = adapter3.requestAdapterInfo();
+let textureView323 = texture151.createView({label: '\ua003\u{1f787}\u{1fc67}', dimension: '2d-array', baseMipLevel: 1});
+let externalTexture117 = device5.importExternalTexture({label: '\u5602\u094f\u03cb\u{1f744}\uf6d3\u051e\udcc5', source: video17, colorSpace: 'srgb'});
+try {
+renderBundleEncoder128.setBindGroup(5, bindGroup44);
+} catch {}
+let gpuCanvasContext54 = canvas65.getContext('webgpu');
+let canvas66 = document.createElement('canvas');
+let imageData38 = new ImageData(80, 200);
+try {
+canvas66.getContext('bitmaprenderer');
+} catch {}
+try {
+  await promise66;
+} catch {}
+let canvas67 = document.createElement('canvas');
+gc();
+try {
+canvas67.getContext('2d');
+} catch {}
+let texture152 = gpuCanvasContext42.getCurrentTexture();
+try {
+  await promise65;
+} catch {}
+let offscreenCanvas51 = new OffscreenCanvas(159, 846);
+let texture153 = device5.createTexture({
+  label: '\u03d9\u{1f7ba}\uc4d4',
+  size: {width: 480, height: 40, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder127.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder128.setBindGroup(2, bindGroup44, new Uint32Array(4982), 3594, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas4.height = 1494;
+let imageData39 = new ImageData(136, 156);
+let commandEncoder239 = device5.createCommandEncoder({label: '\u0286\u{1fb60}'});
+let texture154 = device5.createTexture({
+  label: '\u{1f82e}\u{1fd3b}\u77da\u5866',
+  size: {width: 240},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let renderBundle140 = renderBundleEncoder119.finish({label: '\u8326\u57f0\u081d\u{1f922}\u46c8'});
+try {
+renderBundleEncoder128.setVertexBuffer(7639, undefined, 2274074862, 48476361);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture141,
+  mipLevel: 3,
+  origin: {x: 95, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 34 */
+{offset: 34, rowsPerImage: 19}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img52,
+  origin: { x: 34, y: 34 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext55 = offscreenCanvas51.getContext('webgpu');
+let img65 = await imageWithData(135, 162, '#9ae87b37', '#7d77c86f');
+video16.height = 214;
+let textureView324 = texture148.createView({label: '\u142f\udc1b\u0f1a\u8e75', baseMipLevel: 1, mipLevelCount: 1});
+try {
+device5.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 446 */
+{offset: 446, rowsPerImage: 208}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55) };
+} catch {}
+let imageBitmap53 = await createImageBitmap(videoFrame13);
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let commandEncoder240 = device0.createCommandEncoder({label: '\ua166\ufd44'});
+let commandBuffer64 = commandEncoder96.finish({label: '\u0a3e\u{1faa9}\u887c\u6fbe\u0ab9\u0d73\u6379\u{1f858}\u9b12'});
+let textureView325 = texture32.createView({
+  label: '\ueb87\u2874\u{1f662}\ud686\u0396\u64a8\ufa01',
+  baseMipLevel: 10,
+  baseArrayLayer: 152,
+  arrayLayerCount: 76,
+});
+let sampler119 = device0.createSampler({
+  label: '\u1e7f\u0d68\u{1f67f}\u9a71\u42e9\u7fab\u009e\u0df7',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 34.51,
+  lodMaxClamp: 82.76,
+});
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer5, 39392);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer37, 23840, 159570);
+} catch {}
+let promise67 = device0.popErrorScope();
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 400 widthInBlocks: 200 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2758 */
+  offset: 2758,
+  buffer: buffer10,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 381, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 200, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer18, 279896, 143508);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 25036, new DataView(new ArrayBuffer(14461)), 11997, 1820);
+} catch {}
+document.body.prepend(canvas66);
+let img66 = await imageWithData(106, 300, '#75adaddc', '#73115563');
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -190,7 +190,6 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
 #else
     textureDescriptor.storageMode = MTLStorageModeShared;
 #endif
-    bool needsLuminanceClampFunction = false;
     for (IOSurface *iosurface in m_ioSurfaces) {
         if (iosurface.height != static_cast<NSInteger>(height) || iosurface.width != static_cast<NSInteger>(width))
             return generateAValidationError(device, [NSString stringWithFormat:@"Invalid surface size. Backing surface has size (%d, %d) but attempting to configure a size of (%u, %u)", static_cast<int>(iosurface.width), static_cast<int>(iosurface.height), width, height], reportValidationErrors);
@@ -230,10 +229,14 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     }
 
     textureDescriptor.usage |= MTLTextureUsageRenderTarget;
+    bool needsLuminanceClampFunction = textureDescriptor.pixelFormat == MTLPixelFormatRGBA16Float;
+    auto existingUsage = textureDescriptor.usage;
     for (IOSurface *iosurface in m_ioSurfaces) {
         RefPtr<Texture> parentLuminanceClampTexture;
-        if (textureDescriptor.pixelFormat == MTLPixelFormatRGBA16Float) {
-            auto existingUsage = textureDescriptor.usage;
+        if (needsLuminanceClampFunction) {
+            textureDescriptor.pixelFormat = MTLPixelFormatRGBA16Float;
+            wgpuTextureDescriptor.format = WGPUTextureFormat_RGBA16Float;
+            textureDescriptor.usage = existingUsage;
             textureDescriptor.usage |= MTLTextureUsageShaderRead;
             id<MTLTexture> luminanceClampTexture = device.newTextureWithDescriptor(textureDescriptor);
             luminanceClampTexture.label = fromAPI(descriptor.label);
@@ -243,7 +246,6 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
             textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
             wgpuTextureDescriptor.format = WGPUTextureFormat_BGRA8Unorm;
             textureDescriptor.usage = existingUsage | MTLTextureUsageShaderWrite;
-            needsLuminanceClampFunction = true;
         }
 
         id<MTLTexture> texture = device.newTextureWithDescriptor(textureDescriptor, bridge_cast(iosurface));


### PR DESCRIPTION
#### 8e0baadf0cb47493889b908015010623cf586658
<pre>
[WebGPU] RGBA16Float canvas context isn&apos;t created correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=274270">https://bugs.webkit.org/show_bug.cgi?id=274270</a>
radar://128064803

Reviewed by Dan Glastonbury.

Logic for creating RGBA16Float backings was wrong for the double
and triple buffer, correct and add regression test.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274270-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274270.html: Added.
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):

Canonical link: <a href="https://commits.webkit.org/278955@main">https://commits.webkit.org/278955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/153e6e5fd431e5c6d50be6ef0aafd506e64ce0e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2498 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42159 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23289 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1945 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56665 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11397 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->