### PR TITLE
[WebGPU] RenderBundleEncoder::endCurrentICB may assert in ASAN builds on invalid bundle encoder

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2121,6 +2121,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274270.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274161.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274161.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274271.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274271.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274271-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274271-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274271.html
+++ b/LayoutTests/fast/webgpu/fuzz-274271.html
@@ -1,0 +1,24285 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let device0 = await adapter0.requestDevice({
+  label: '\uc13e\u40cb\u0f6e\u5055\u{1f936}\u59f8\uc0ac\u03d0\u72c5\u0a93\u{1f6d2}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+});
+let texture0 = device0.createTexture({
+  label: '\u11b7\ue434\u0d02\u8052\u553a\u06ec\u{1f899}\ude70\u0545',
+  size: {width: 2532, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'astc-12x12-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+let textureView0 = texture0.createView({
+  dimension: '2d-array',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u33ad\ue82e\u{1ffac}\u0266\u0222\u0c76\u8912\u8116\uc42c\u0d21',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+let texture1 = device0.createTexture({
+  label: '\u0956\u332c\udf0b\u0f5a\u146d\u6c2b\u1579\u4031\u8ff8',
+  size: {width: 112, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView1 = texture1.createView({label: '\ud3b4\u{1fac4}\ua6a7\u73d6\u1e1b\uad8f\u{1fd45}', dimension: '2d-array', baseMipLevel: 2});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(56), /* required buffer size: 1258 */
+{offset: 145, bytesPerRow: 143}, {width: 112, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let imageData0 = new ImageData(92, 172);
+try {
+renderBundleEncoder0.setVertexBuffer(4919, undefined, 577808876, 1440092679);
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\u0bda\u039c\u0d9b\u20a8\ua2bb\ua46f\u0ed7\uc87b\u9763\u{1f982}\u043b', entries: []});
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout0, entries: []});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u7867\u0757\u{1f78a}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 1983});
+let canvas0 = document.createElement('canvas');
+try {
+canvas0.getContext('2d');
+} catch {}
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 2871});
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(7432), 3934, 0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(3882, undefined, 857701837, 455108010);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(32), /* required buffer size: 517 */
+{offset: 517}, {width: 112, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+canvas0.height = 85;
+let videoFrame0 = new VideoFrame(canvas0, {timestamp: 0});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u1001\ub4d3\u{1fc4d}\u9612\u0952\u7cf9\u{1f893}\u1cbe'});
+let querySet2 = device0.createQuerySet({label: '\u009d\u0687\u{1fd76}\u87c1\u8628\ud1f0\u0706\u{1febb}\u0b82', type: 'occlusion', count: 2909});
+let texture2 = device0.createTexture({
+  label: '\u{1f6f7}\u03a8\u{1fe7c}\u{1faba}\u4efb\u{1f884}\u{1f7a6}\u03da\u2c61\u8a42',
+  size: {width: 903, height: 64, depthOrArrayLayers: 108},
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let externalTexture0 = device0.importExternalTexture({
+  label: '\u9354\u0a66\u080b\ucdf7\ua4a7\uafc6\u0d9b\ud02b\u24b8\ubf3d\u{1f821}',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder0.setVertexBuffer(251, undefined, 0, 3802085632);
+} catch {}
+let bindGroup1 = device0.createBindGroup({label: '\u0b4d\u631e\u7d3b\u{1f60f}\u02ee\u0184', layout: bindGroupLayout0, entries: []});
+let buffer0 = device0.createBuffer({
+  label: '\u{1f65b}\u0ca9\u0f60\u9be1\u{1fa50}\u08b4',
+  size: 307996,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let textureView2 = texture2.createView({
+  label: '\u067b\u{1fdd5}\uba01\u0327\u06ad\u4247\ubcfc\u3aae\u{1fcf8}',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 45,
+  arrayLayerCount: 47,
+});
+try {
+buffer0.unmap();
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u0417\u04ba\uc92d\u8cbc\u0c4d\u{1f7ce}\ubc55\u{1fa3c}\u6e9b\u1626\u2ba5',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u870c\u237e\u0f4f\u8c74\u6da4\u236e\u0ca4\u7d98\u{1f949}'});
+let querySet3 = device0.createQuerySet({label: '\u{1f60c}\u0460\ue7be', type: 'occlusion', count: 1992});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', stencilReadOnly: false});
+let textureView3 = texture1.createView({
+  label: '\u0d0e\u5cac\u0b65\u0ee8\u239a\u3eff',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundle0 = renderBundleEncoder1.finish({label: '\u1117\u1264\u0fdb\u0887\u{1f71f}\u8f0c'});
+let sampler0 = device0.createSampler({
+  label: '\u0ffa\uc9e3\u04b3\u{1fb04}\u41cf\u{1f9d3}\u046b\u{1ff5e}\u7506\ud89d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.86,
+  lodMaxClamp: 92.64,
+});
+try {
+device0.queue.writeBuffer(buffer0, 1312, new Int16Array(47527), 41245, 956);
+} catch {}
+document.body.prepend(canvas0);
+let imageBitmap0 = await createImageBitmap(canvas0);
+let texture3 = device0.createTexture({
+  label: '\u{1fb10}\ud13b\u0d1d\u0829\u5953\u0d8b\u8884',
+  size: [960, 4, 1],
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView4 = texture0.createView({
+  label: '\u{1f883}\u{1ff51}\u192c\ue548\u44d9\u0fd4\u3b14\u{1f746}\u9f43\u{1f66b}',
+  dimension: '2d-array',
+  format: 'astc-12x12-unorm',
+  baseMipLevel: 5,
+});
+let sampler1 = device0.createSampler({
+  label: '\ue5ba\u0666\uf36b\uc684\u94f6\u5db5',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 21.61,
+  lodMaxClamp: 69.90,
+});
+try {
+texture3.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 2, z: 5},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(48), /* required buffer size: 1646992 */
+{offset: 227, bytesPerRow: 205, rowsPerImage: 277}, {width: 112, height: 0, depthOrArrayLayers: 30});
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: bindGroupLayout0, entries: []});
+let commandEncoder3 = device0.createCommandEncoder({label: '\u58cc\u0402'});
+let texture4 = device0.createTexture({
+  label: '\u{1fc14}\ue74d',
+  size: {width: 2120, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView5 = texture2.createView({
+  label: '\u{1f9c6}\u0dc8\u{1f7ab}\u4129\u082f\u797e',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+  baseArrayLayer: 57,
+});
+try {
+commandEncoder1.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder3.insertDebugMarker('\u0375');
+} catch {}
+let bindGroup3 = device0.createBindGroup({label: '\u7de9\u86f1\u5093', layout: bindGroupLayout0, entries: []});
+let pipelineLayout2 = device0.createPipelineLayout({label: '\uf4a3\ucc22\u0f7f', bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0]});
+let buffer1 = device0.createBuffer({
+  label: '\u5fcb\uf03c\u1a00\ue67d\u0a5a',
+  size: 140210,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\uf3a9\u4df1\u41b0\ub628'});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 3248});
+let textureView6 = texture0.createView({label: '\u48da\u{1f8f9}\u2f6b', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 3});
+let computePassEncoder0 = commandEncoder2.beginComputePass();
+let externalTexture1 = device0.importExternalTexture({
+  label: '\ub5b9\ue056\u4186\u{1f815}\u048e\u0c2b\u{1ffb3}\u0cf7',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+device0.queue.writeBuffer(buffer0, 38148, new Float32Array(53044), 48580);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(735, 109);
+try {
+offscreenCanvas0.getContext('bitmaprenderer');
+} catch {}
+let bindGroup4 = device0.createBindGroup({label: '\u{1fa32}\u01a4', layout: bindGroupLayout0, entries: []});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 2184});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u0d45\u0c55\u4a6d'});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 31},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(64)), /* required buffer size: 521309 */
+{offset: 893, bytesPerRow: 104, rowsPerImage: 278}, {width: 56, height: 0, depthOrArrayLayers: 19});
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u02c4\u382e\u02fc\u8ccd\u00e6\u{1fd41}\u008e\uc6a2\u{1f840}\udc7f'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(6767), 1310, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 19628 */
+  offset: 19628,
+  bytesPerRow: 256,
+  rowsPerImage: 253,
+  buffer: buffer1,
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder0.finish({});
+let texture5 = device0.createTexture({
+  label: '\u0fb2\u027f\u{1fd8d}\u{1fbc2}\u7681\u01d6\u008a\u9f48',
+  size: [240, 1, 185],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView7 = texture1.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder1 = commandEncoder4.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 300, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 49012, new Float32Array(25531), 21541, 736);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(229, 763);
+try {
+texture5.label = '\u122b\u98cd\u073e';
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({label: '\u0c17\u{1fa7d}\u3017\u0f13\u0802\u0a45'});
+let renderBundle2 = renderBundleEncoder1.finish({});
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 960 widthInBlocks: 960 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4592 */
+  offset: 4592,
+  bytesPerRow: 1024,
+  buffer: buffer1,
+}, {width: 960, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({label: '\u1c0c\ua66c\u0cce', colorFormats: [], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let renderBundle3 = renderBundleEncoder2.finish({label: '\u8bff\u{1f916}\u67a5\u{1f608}\u069d\u0e78'});
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1584 widthInBlocks: 99 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3472 */
+  offset: 3472,
+  buffer: buffer1,
+}, {width: 1188, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 81 */
+{offset: 81}, {width: 1440, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let textureView8 = texture4.createView({label: '\u5333\u{1f805}\u9a70\u0274', dimension: '2d-array', baseMipLevel: 5});
+let computePassEncoder2 = commandEncoder8.beginComputePass({label: '\uf9ec\u0739'});
+try {
+device0.queue.writeBuffer(buffer1, 56780, new Int16Array(48419), 11272, 7424);
+} catch {}
+gc();
+let bindGroup5 = device0.createBindGroup({label: '\u{1f673}\u04ec\u79ed\ue1b4', layout: bindGroupLayout0, entries: []});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1f9f7}\u{1fc11}\u5e40\u29e2\u586f'});
+let textureView9 = texture1.createView({label: '\u{1ffc7}\u{1ffe6}\u{1fb10}\u0005\ud99b\u0442', aspect: 'stencil-only', baseMipLevel: 2});
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 50968 */
+  offset: 50968,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 52260, new Int16Array(7270), 3967, 1136);
+} catch {}
+try {
+adapter0.label = '\u06fe\u0a37\u6116\udc4c\u0224\u2c35';
+} catch {}
+let commandBuffer1 = commandEncoder3.finish({});
+try {
+  await buffer0.mapAsync(GPUMapMode.READ);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(724, 362);
+let imageData1 = new ImageData(172, 36);
+let commandEncoder10 = device0.createCommandEncoder({label: '\u73c8\u0d3b\u00f5\ub79d\u38f0\u{1fe14}\uda18'});
+let texture6 = device0.createTexture({
+  label: '\u{1f64e}\udaa2\u0b90',
+  size: {width: 903, height: 64, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView10 = texture5.createView({label: '\uf8ff\u077c\u{1ff9b}', baseArrayLayer: 62, arrayLayerCount: 104});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(7266), 6013, 0);
+} catch {}
+let texture7 = device0.createTexture({
+  label: '\udac8\ub100\u0f30\u3bab\u6455\u22d9\u2fa1',
+  size: {width: 120, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler2 = device0.createSampler({
+  label: '\uea29\u{1ff31}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 99.52,
+  lodMaxClamp: 99.66,
+  compare: 'greater-equal',
+});
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 50836 */
+  offset: 50836,
+  buffer: buffer1,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+offscreenCanvas1.getContext('webgl2');
+} catch {}
+let bindGroup6 = device0.createBindGroup({label: '\ua196\ua1a6\u2c25\u07df', layout: bindGroupLayout0, entries: []});
+let commandEncoder11 = device0.createCommandEncoder({label: '\u0f97\u{1fcb0}\uaf1d\u{1fe58}\u059e\u06c3\u0cac'});
+let texture8 = device0.createTexture({
+  label: '\u{1fb04}\u1db4',
+  size: [451, 32, 224],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView11 = texture0.createView({
+  label: '\u1030\u7c23',
+  dimension: '2d-array',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let sampler3 = device0.createSampler({
+  label: '\u3948\u{1fbe9}\u87cc\u400d\u461d',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 22.30,
+  lodMaxClamp: 55.28,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(2550), 1799, 0);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 160, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u{1fb98}\u0881\u0e37\udfaf\u72b6\u0a5c\u79d7\ud265',
+  entries: [
+    {
+      binding: 457,
+      visibility: 0,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 348,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let buffer2 = device0.createBuffer({
+  label: '\u072f\u0830\u{1f639}\u{1fac0}\uab86\u870a\u0ee0',
+  size: 65996,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u027a\u5ad7\ucc86\u5d86\u3b77\u73d1\u02cc\u8b53\u64ad'});
+let renderBundle4 = renderBundleEncoder0.finish({label: '\u0a2f\ubb66\u9c10\u0ab3'});
+let sampler4 = device0.createSampler({
+  label: '\u0706\ud966\u6769\u0ea5\u{1f7c8}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 55.53,
+  lodMaxClamp: 82.63,
+});
+try {
+device0.queue.writeBuffer(buffer1, 11056, new Float32Array(64006), 45793, 5148);
+} catch {}
+offscreenCanvas0.height = 667;
+let commandEncoder13 = device0.createCommandEncoder();
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', sampleCount: 1, depthReadOnly: true});
+let sampler5 = device0.createSampler({
+  label: '\u0021\u0b18\u11dd\u04db\u{1feed}\ue9fd',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.93,
+  lodMaxClamp: 74.93,
+  maxAnisotropy: 12,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u{1fa59}\ue03f\u3bc4', source: videoFrame0});
+let arrayBuffer0 = buffer2.getMappedRange(3512);
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 201},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(80)), /* required buffer size: 2585372 */
+{offset: 691, bytesPerRow: 573, rowsPerImage: 205}, {width: 451, height: 1, depthOrArrayLayers: 23});
+} catch {}
+let textureView12 = texture4.createView({label: '\u1817\u856c\u{1f87d}', baseMipLevel: 4, mipLevelCount: 1});
+let computePassEncoder3 = commandEncoder10.beginComputePass({label: '\u0a2e\u1393\u09c8\u95d9\uf8d9'});
+let canvas1 = document.createElement('canvas');
+let commandEncoder14 = device0.createCommandEncoder({label: '\u{1fe86}\u019f\u5426\u4c0e\u{1fd33}\udbae\uc400\ucc78\u4452\u{1fdfe}\u122c'});
+try {
+commandEncoder12.insertDebugMarker('\uc4db');
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(1007, 75);
+let imageData2 = new ImageData(244, 124);
+let bindGroup7 = device0.createBindGroup({label: '\uc6f5\u507b\u6b2c\uf3b3\u0faf\ub258', layout: bindGroupLayout0, entries: []});
+let buffer3 = device0.createBuffer({
+  label: '\u5ef4\ucc40\u{1fc4d}\uf102\u057f\u{1ff02}\u{1ff09}\u859a\u{1f885}\u9a99',
+  size: 532680,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer2 = commandEncoder1.finish({label: '\u0334\u2027\u0c8d\u11a5\u159a\u617c\u6429\u0f31\u{1f91c}\u48f3'});
+let textureView13 = texture6.createView({label: '\ucecc\uf35e\u77df\u0b1d\u{1fb65}\u{1f789}\u{1f8b8}\ua594\u{1ff32}\uf161\u{1faf6}'});
+let renderBundle5 = renderBundleEncoder0.finish({label: '\u0d3e\ub58f\ue18a\u0f1a\uac44\u556c\u7ec3\u7ae0'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData1);
+let videoFrame1 = new VideoFrame(imageBitmap1, {timestamp: 0});
+try {
+sampler4.label = '\ub311\u08a4\u0485\u{1feca}';
+} catch {}
+let buffer4 = device0.createBuffer({
+  label: '\u06f8\u0149\ucab9\u7ec7\u9a7a\u7ac3\u15e4\u{1fa75}\u7e19\u5403\u051a',
+  size: 523199,
+  usage: GPUBufferUsage.VERTEX,
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u{1ffbf}\u808c\u{1fda9}\u{1ff9d}'});
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\uedb9\u{1f6c7}\u44e4\u52c2'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u5e2e\u0f32\u7bb9\u2ee1\u3324\uff0f\u12b2\u22f4\u0972',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let renderBundle6 = renderBundleEncoder2.finish();
+document.body.prepend(canvas0);
+let commandEncoder16 = device0.createCommandEncoder({label: '\u{1fed5}\udaba\u{1f6f7}\ue7c1\u{1f8b4}'});
+let renderBundle7 = renderBundleEncoder3.finish({label: '\uf263\u8c44\u0439\uedad\u{1fb74}'});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer4, 492684, 12679);
+} catch {}
+let buffer5 = device0.createBuffer({
+  label: '\u1f1c\u4931\u0068\u1678\u{1fe9e}\u0fa5\ufe6e\u7a93\u0c80',
+  size: 127529,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder17 = device0.createCommandEncoder({label: '\uf9c7\u08ac\u6900\u0d98\u0e09\u{1fa79}\u{1fc31}\u{1fbf3}\u6ad1'});
+let renderBundle8 = renderBundleEncoder2.finish({label: '\u4e88\u8ed2\u{1fe48}\u76bb\u0d8b\u0a76'});
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5968 */
+  offset: 5968,
+  rowsPerImage: 140,
+  buffer: buffer1,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer1, 120728, 15096);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder15.finish({});
+let sampler6 = device0.createSampler({
+  label: '\u{1fa45}\u22ca\u{1fdb8}\u{1fb91}\u74a5\u1916\u5448\u7304\u{1ff45}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 64.26,
+});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint32', 33964, 71830);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer3, 36884, buffer0, 3872, 186584);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet4, 3233, 0, buffer5, 33792);
+} catch {}
+try {
+commandEncoder17.insertDebugMarker('\uc835');
+} catch {}
+let bindGroup8 = device0.createBindGroup({label: '\u{1f86a}\u56e1', layout: bindGroupLayout0, entries: []});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u06a3\u08b3\ud9f5\u7a2e\u0730\u9319\u{1fa1b}\u0554\u{1f935}'});
+let textureView14 = texture1.createView({
+  label: '\u0488\ub649\u036b\u107e',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer4, 221636, 6510);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+gc();
+let texture9 = device0.createTexture({
+  label: '\u094d\u3abf\u00a5\u0885\u05cb\u0ca0\u0c7c\u4eda\ucf0c',
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView15 = texture7.createView({label: '\u{1fa5b}\u{1f9d0}\u0398\u42e9\ud7f0\u025a\u2de3\ufb91\u1a91\u{1fb01}', baseMipLevel: 4});
+let renderBundle9 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer4, 72872, 192281);
+} catch {}
+let imageData3 = new ImageData(64, 148);
+let textureView16 = texture4.createView({
+  label: '\uaa3f\u{1f66b}\u{1f984}\ufcdf\u0ef4\u8cda',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderBundle10 = renderBundleEncoder3.finish({label: '\u0017\ud698\u{1fcb2}\u0a51'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint32', 111620);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet1, 2716, 46, buffer5, 110592);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas2.getContext('webgpu');
+let commandBuffer4 = commandEncoder7.finish({label: '\u320c\u28f0\u3bc0\u{1f861}\udba6\u{1f788}'});
+let texture10 = device0.createTexture({
+  label: '\u6704\u0c37\ue1a5\u8610\u{1fa83}\u886c',
+  size: [451],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let renderPassEncoder0 = commandEncoder19.beginRenderPass({
+  label: '\u8bfa\u1b33\ueee0\u0f95\ud19b\u{1fe97}\ubed0\uff32\u02e6',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView15, depthClearValue: 6.784911795834354, stencilReadOnly: true},
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 1010346283,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(8248), 3495, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4, renderBundle4, renderBundle1, renderBundle5, renderBundle9, renderBundle5, renderBundle4, renderBundle6, renderBundle8, renderBundle9]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer3]);
+} catch {}
+try {
+offscreenCanvas3.getContext('2d');
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u0b45\u0326\u030e\u0934\u8776\u3436\u46ca\u0bc7\u1744\ue000\u05a0',
+  entries: [
+    {
+      binding: 96,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 63, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 250, visibility: 0, sampler: { type: 'non-filtering' }},
+  ],
+});
+let texture11 = device0.createTexture({
+  label: '\u04fd\ue7b2\u3af3\u0185\u01d8\ub8e9\u1d8d',
+  size: {width: 864, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let computePassEncoder5 = commandEncoder5.beginComputePass();
+try {
+renderPassEncoder0.setScissorRect(2, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1920);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer4, 355720, 82878);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\u097b');
+} catch {}
+let textureView17 = texture0.createView({label: '\u0a4a\u{1fdef}\u40a1\u52c0', format: 'astc-12x12-unorm-srgb', baseMipLevel: 1});
+let renderPassEncoder1 = commandEncoder13.beginRenderPass({
+  label: '\u1f44\u{1f851}\u0c37',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView15, depthReadOnly: false, stencilClearValue: 23736, stencilReadOnly: true},
+  maxDrawCount: 1075060081,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer4, 0, 266812);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint16', 104706, 16812);
+} catch {}
+try {
+commandEncoder9.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 25952 */
+  offset: 25952,
+  buffer: buffer1,
+}, {width: 50, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 430, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet4, 2671, 320, buffer5, 5376);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 24856, new Float32Array(53648), 29499, 9468);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img0 = await imageWithData(201, 109, '#250b7a22', '#5d320c75');
+let textureView18 = texture3.createView({
+  label: '\u2d8f\u{1fd50}\u21a2\u{1f66b}\u1436\u8774\u63d7',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  mipLevelCount: 3,
+});
+let computePassEncoder6 = commandEncoder12.beginComputePass({label: '\ud252\u{1ff0c}\u926b\u{1fdca}\u0e3f\u{1fc25}\u9f6d\u2f26\ue911'});
+let externalTexture4 = device0.importExternalTexture({
+  label: '\u09b2\uadf4\u06d8\u0f4a\u0fda\uc2fb\ua43d\u6248\u5f14',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup7, new Uint32Array(7136), 4647, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 6, y: 3, z: 12},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet2, 2398, 60, buffer5, 48896);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 66444, new BigUint64Array(7774), 1075, 552);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\u5127\u{1fd93}\u{1f7b5}\ud4d5\u0a39\u04d3\ua93f\uec71\u{1fe44}\u03b1\u4ef0'});
+let textureView19 = texture2.createView({baseMipLevel: 7, mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 78});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u{1fc7d}\u02f6\uca78\uf4fd\u{1f9db}\u{1fe41}\ufcb0\u00ee',
+  colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'],
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -234.5, g: -194.9, b: 852.1, a: 121.9, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(3.653, 0.2878, 2.406, 0.1934, 0.9577, 0.9908);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5900 */
+  offset: 5900,
+  buffer: buffer1,
+}, {width: 120, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: {x: 117, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture9,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 21643747 */
+{offset: 213, bytesPerRow: 473, rowsPerImage: 274}, {width: 240, height: 0, depthOrArrayLayers: 168});
+} catch {}
+document.body.prepend(canvas1);
+let img1 = await imageWithData(244, 189, '#0f047636', '#67d47005');
+let commandEncoder21 = device0.createCommandEncoder({label: '\uf4c6\u{1faed}\uded5\u1ff2\u2e1e\ub3b6\u367f\u16a3\u93ee\u9162'});
+let querySet6 = device0.createQuerySet({
+  label: '\u{1fb96}\u0ddd\u0aa8\u{1fef2}\u{1fcf4}\u5352\u218e\u10f5\u0e4e\u630b',
+  type: 'occlusion',
+  count: 3079,
+});
+let computePassEncoder7 = commandEncoder16.beginComputePass({label: '\udc6b\uff3e\uef34\u53c5\u884b\u{1f85c}\u75fb\uf800'});
+let renderPassEncoder2 = commandEncoder18.beginRenderPass({
+  label: '\u0a9b\u0464\u7619\uef25\u{1fb05}',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView15, depthReadOnly: false, stencilClearValue: 3336, stencilReadOnly: true},
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder2.beginOcclusionQuery(2171);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 768,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 278,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandBuffer5 = commandEncoder20.finish({label: '\uf427\u0d20\u66a2\u{1fc8d}\u{1fe72}\u{1f908}\u0d5b\u6c03\u05bc'});
+let textureView20 = texture6.createView({label: '\u2911\uf382\u0b26', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let sampler7 = device0.createSampler({
+  label: '\u7324\u8cc0\u{1ff1c}\u{1fd68}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.75,
+  lodMaxClamp: 62.47,
+  compare: 'not-equal',
+  maxAnisotropy: 19,
+});
+let externalTexture5 = device0.importExternalTexture({
+  label: '\u2fe9\u9ce2\u0c32\uba81\u1904\u0653\ua896\u918f\u0e7a',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(431);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(7, 0, 0, 1);
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let bindGroup9 = device0.createBindGroup({
+  label: '\u842b\u{1f6a3}\uf1dc\u{1fc24}\u0be9',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 96, resource: sampler1},
+    {binding: 63, resource: externalTexture3},
+    {binding: 250, resource: sampler6},
+  ],
+});
+let textureView21 = texture11.createView({label: '\u032f\uf90d\u{1f61e}', baseMipLevel: 8});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.97,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(2.166, 0.7938, 1.206, 0.1188, 0.4634, 0.5925);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 133 */
+{offset: 133}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 2358});
+let texture12 = device0.createTexture({
+  label: '\u{1fd9e}\u07dc\u8788',
+  size: [240, 1, 186],
+  mipLevelCount: 7,
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler9 = device0.createSampler({
+  label: '\u0597\u{1f87b}\u2a53\ued1a\u3cb3\u{1fbf8}\u7758\u0c20\u9079\u{1fe3b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.05,
+  lodMaxClamp: 82.50,
+});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(5, 0, 0, 1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet1, 2553, 24, buffer5, 4864);
+} catch {}
+document.body.prepend(canvas1);
+let pipelineLayout4 = device0.createPipelineLayout({label: '\u20c5\u{1f61a}\u0651\u883c\uae32\u604c\ub02c\u0a08', bindGroupLayouts: [bindGroupLayout1]});
+let commandEncoder22 = device0.createCommandEncoder();
+let textureView22 = texture5.createView({
+  label: '\u0254\u024a\ucdbf\u{1fbf3}\u2ad1\u{1f75f}\u0253\uca5a\u{1fb76}',
+  baseArrayLayer: 162,
+  arrayLayerCount: 16,
+});
+let renderBundle11 = renderBundleEncoder2.finish({label: '\u672f\ue570\u{1fc41}\u9549\u4634\u0e48\u013f\u0c1d\u0497\ud2fe'});
+try {
+renderPassEncoder0.setViewport(3.958, 0.5588, 1.345, 0.1400, 0.4296, 0.5969);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup7, new Uint32Array(9103), 4483, 0);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'stencil-only',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 13177326 */
+{offset: 510, bytesPerRow: 504, rowsPerImage: 152}, {width: 240, height: 1, depthOrArrayLayers: 173});
+} catch {}
+document.body.prepend(img0);
+try {
+adapter0.label = '\u0de7\ud5a4\uda86\u3d5c';
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u9aea\u0b4d\u{1fa72}', bindGroupLayouts: []});
+let textureView23 = texture7.createView({
+  label: '\u09f8\u919b\uc91f\uc426\u0add\u0b99\ub45d\ue552\uf31b\ue040\u905f',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+});
+let computePassEncoder8 = commandEncoder2.beginComputePass({label: '\u8e46\u{1f759}\ue321'});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup7, new Uint32Array(1119), 832, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1925);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint32');
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(buffer3, 62488, buffer0, 86940, 181280);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 493,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView24 = texture8.createView({
+  label: '\u6d5a\u{1f905}\u{1fca5}\u0307\u0e0b\u2d6e\u{1fc5c}\ud03a',
+  mipLevelCount: 2,
+  baseArrayLayer: 146,
+  arrayLayerCount: 41,
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer5, 'uint32', 30824, 8538);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer4, 257480, 162083);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 240 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5792 */
+  offset: 5792,
+  buffer: buffer1,
+}, {width: 180, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 21296, new Float32Array(37954), 18351, 340);
+} catch {}
+let buffer6 = device0.createBuffer({size: 1048576, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup9, new Uint32Array(3546), 3027, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(3, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let imageData4 = new ImageData(136, 52);
+let shaderModule0 = device0.createShaderModule({
+  label: '\u0815\u3745\u0748',
+  code: `@group(0) @binding(457)
+var<storage, read_write> parameter0: array<u32>;
+@group(0) @binding(348)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(6) f2: i32,
+  @location(1) f3: vec4<f32>,
+  @location(2) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(0) a1: vec2<f16>, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool, @location(6) a4: vec3<f32>, @builtin(sample_mask) a5: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(5) f0: vec2<i32>,
+  @location(9) f1: vec4<f32>,
+  @location(10) f2: vec4<f16>,
+  @location(14) f3: vec3<f32>,
+  @location(13) f4: vec2<f16>,
+  @location(8) f5: i32,
+  @location(0) f6: vec2<f16>,
+  @location(4) f7: u32,
+  @location(12) f8: f32,
+  @location(2) f9: f32,
+  @location(11) f10: u32,
+  @location(6) f11: vec3<f32>,
+  @location(3) f12: vec3<f32>,
+  @builtin(position) f13: vec4<f32>,
+  @location(15) f14: vec2<u32>,
+  @location(1) f15: vec3<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer7 = device0.createBuffer({
+  label: '\u4c85\u90fe\ud270\ud079\u0ffe\ue45d',
+  size: 248376,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup1, new Uint32Array(9687), 5264, 0);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(6, 0, 1, 1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 5236, new Float32Array(25103), 7394, 11036);
+} catch {}
+let img2 = await imageWithData(241, 256, '#44563a98', '#e6940923');
+let videoFrame2 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let textureView25 = texture1.createView({
+  label: '\uf88e\u0823\uef07\u{1fed3}\u{1fef1}\u3abb\u0e05\u6fc8\u{1f617}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  mipLevelCount: 2,
+});
+let renderPassEncoder3 = commandEncoder14.beginRenderPass({
+  label: '\u1226\u3ad9\u4dc4\u{1fab0}\u715b\u0529\u0db7\u{1ffdb}\uaa9a',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: 3.9742773741501107,
+    stencilClearValue: 50256,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup9, new Uint32Array(1015), 45, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1962);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -275.6, g: -104.9, b: -861.7, a: -105.9, });
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer4, 136500);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1144 widthInBlocks: 286 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15764 */
+  offset: 14620,
+  bytesPerRow: 1280,
+  buffer: buffer1,
+}, {width: 286, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+gc();
+let offscreenCanvas4 = new OffscreenCanvas(383, 24);
+try {
+offscreenCanvas4.getContext('bitmaprenderer');
+} catch {}
+let texture13 = device0.createTexture({
+  label: '\u64eb\u3291\u0f5d\u{1f820}\u{1f819}',
+  size: {width: 112, height: 8, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView26 = texture6.createView({
+  label: '\u53d2\u0bd0\u7458\u{1f7ab}',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder2.setViewport(4.854, 0.02112, 0.8059, 0.6058, 0.07776, 0.6762);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer3, 93732, buffer1, 95804, 9864);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData5 = new ImageData(104, 72);
+let bindGroup10 = device0.createBindGroup({label: '\ucb8d\u{1fce0}', layout: bindGroupLayout0, entries: []});
+let buffer8 = device0.createBuffer({
+  label: '\u{1f711}\ud6c3\u0b4f\u{1fd00}',
+  size: 179242,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet8 = device0.createQuerySet({
+  label: '\u{1fdd4}\u1026\u3ba6\uf0c5\ud805\u{1f7db}\ufc31\u9488\u{1f7c0}\u0bfe',
+  type: 'occlusion',
+  count: 635,
+});
+let computePassEncoder9 = commandEncoder22.beginComputePass({label: '\ub04d\u703f\u0e08'});
+try {
+renderPassEncoder2.setScissorRect(6, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2814);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+  await buffer8.mapAsync(GPUMapMode.WRITE, 52584, 83344);
+} catch {}
+let textureView27 = texture13.createView({label: '\u9659\u{1fda2}\uafc0', aspect: 'stencil-only'});
+let sampler10 = device0.createSampler({
+  label: '\ub699\u043a\udc70\u201f\u{1f8fa}\u8d03\u1a79\u{1fb7c}\ueae1',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.54,
+  lodMaxClamp: 75.93,
+});
+try {
+renderPassEncoder1.setScissorRect(6, 1, 1, 0);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 23424 */
+  offset: 23424,
+  rowsPerImage: 212,
+  buffer: buffer1,
+}, {width: 30, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+adapter0.label = '\u{1fd98}\u{1fb28}\u0d46\u0987\udee6\u{1fe4d}\u0a32\uc524\udd8e\u3e9e\uf2ea';
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  label: '\u{1f8ba}\u192b\u0957\u7f92\u0412\u02a1\u{1f978}\ue358',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let commandEncoder23 = device0.createCommandEncoder({label: '\u{1fa2b}\u1dd8\u{1f7bf}\u{1fe55}\u072c'});
+let textureView28 = texture10.createView({label: '\u{1ffe2}\u08b2\u6c86\u1c7c\u27d4\u9a35', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder10 = commandEncoder9.beginComputePass({label: '\ub683\u0db6\u791f\uf5cc'});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(3, 0, 0, 0);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 240, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet2, 1080, 948, buffer5, 12544);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+} catch {}
+let texture14 = gpuCanvasContext1.getCurrentTexture();
+let textureView29 = texture0.createView({format: 'astc-12x12-unorm-srgb', baseMipLevel: 2, mipLevelCount: 3});
+try {
+renderPassEncoder3.executeBundles([renderBundle2]);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet3, 527, 865, buffer5, 3840);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 57},
+  aspect: 'all',
+}, new ArrayBuffer(177665), /* required buffer size: 177665 */
+{offset: 629, bytesPerRow: 208, rowsPerImage: 34}, {width: 28, height: 2, depthOrArrayLayers: 26});
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  label: '\u0a7c\u4780\u0ed8\u562a\u0d5e',
+  layout: pipelineLayout2,
+  multisample: {mask: 0xc74dfe1e},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let texture15 = device0.createTexture({
+  label: '\u{1f80a}\u{1f947}\u{1f788}\u377c\u0754',
+  size: {width: 112, height: 8, depthOrArrayLayers: 190},
+  mipLevelCount: 7,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture16 = gpuCanvasContext0.getCurrentTexture();
+let textureView30 = texture10.createView({label: '\u3cb4\u9846\uefa9\u0955\u9622\u0efe\u03c7\u17e4\u{1fcaf}\u4577\u07f4'});
+let sampler11 = device0.createSampler({
+  label: '\u77ad\u033a\u0c77\u09ea',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 46.65,
+});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u29d3\u0f3b\u6f0b\u4d27\u35d3\u0237\u{1f74b}\u9651',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup1, new Uint32Array(9581), 6923, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u047e\u505b',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 1789559355,
+    stencilWriteMask: 3153102142,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', unclippedDepth: false},
+});
+let imageBitmap2 = await createImageBitmap(imageData4);
+let commandEncoder24 = device0.createCommandEncoder({label: '\u73d9\u1525\u0825\u0774\u010e\u66c2\u0b3a\u0da3'});
+let renderPassEncoder4 = commandEncoder24.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: 1.9835428043958085,
+    depthReadOnly: true,
+    stencilClearValue: 9379,
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 439611127,
+});
+let externalTexture7 = device0.importExternalTexture({label: '\ubd77\u{1fc66}', source: videoFrame1});
+try {
+computePassEncoder3.end();
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(35672, 3492);
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({
+  label: '\uaf67\u6c60\u009e\u{1fa18}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u396a\u{1f95f}\ub461\u{1fd23}\u2426\ubca8'});
+let textureView31 = texture12.createView({
+  label: '\u1982\u6431\u4ddf\u{1fc2e}\u{1f9d6}\u{1fa46}\u915f',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 170,
+});
+let externalTexture8 = device0.importExternalTexture({label: '\u054c\u0c8a\u4e00', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder4.setScissorRect(6, 0, 1, 0);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2752 */
+  offset: 2752,
+  bytesPerRow: 256,
+  rowsPerImage: 133,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 35 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u62c1\u{1fba0}'});
+try {
+renderPassEncoder2.setScissorRect(3, 1, 4, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(5.216, 0.9138, 0.4187, 0.04958, 0.07200, 0.9220);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint32', 71776, 33916);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint32', 125160);
+} catch {}
+let promise1 = device0.popErrorScope();
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 112, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(56)), /* required buffer size: 402 */
+{offset: 402}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+  label: '\u3937\u287f\u01bf\ub6d4\u71f8\u{1ff5e}\u8934\u{1f7de}\u0475',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let textureView32 = texture11.createView({
+  label: '\ubb96\u695e\ucade\u{1ff45}\u8185\u0ed8\u9dec\u354e\u01e9',
+  dimension: '2d-array',
+  baseMipLevel: 8,
+});
+let computePassEncoder11 = commandEncoder21.beginComputePass({label: '\u0133\u14fe\u0b8e\u008d\u0baf\ucc35\u0a3c'});
+let renderPassEncoder5 = commandEncoder25.beginRenderPass({
+  label: '\u{1f997}\u{1f8b8}',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView15, stencilClearValue: 60542, stencilLoadOp: 'clear', stencilStoreOp: 'store'},
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 65914243,
+});
+let sampler12 = device0.createSampler({
+  label: '\u3d50\u09ef\u06b5\u{1fa22}\ub34a\u08d9\u{1f830}\u3c40\u{1faab}\ub4e0',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 15.15,
+  lodMaxClamp: 55.30,
+});
+let externalTexture9 = device0.importExternalTexture({
+  label: '\u55c1\u01a0\u00fc\u03f6\ue083\uc1a1\u{1facb}\u0ff8',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup9, new Uint32Array(1127), 219, 0);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 821.3, g: 719.2, b: 563.4, a: -278.5, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(2.458, 0.08149, 1.691, 0.3219, 0.5483, 0.9305);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup2);
+} catch {}
+let arrayBuffer2 = buffer0.getMappedRange(0, 21832);
+try {
+commandEncoder6.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({
+  label: '\u{1fbbf}\u5d84\uf1c3\u9ebc\ubd51\u06a3',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder28 = device0.createCommandEncoder({label: '\u90d4\u4bb5\u0ed7\u8481\u{1fda7}\u{1ff43}\u65bb\ub724\u9184\u0711'});
+let textureView33 = texture15.createView({dimension: '2d', baseArrayLayer: 89});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer4, 0, 324666);
+} catch {}
+let arrayBuffer3 = buffer6.getMappedRange(90464);
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 52472 */
+  offset: 52472,
+  buffer: buffer1,
+}, {width: 120, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet7, 129, 788, buffer5, 78336);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(32)), /* required buffer size: 721 */
+{offset: 721, rowsPerImage: 107}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+gc();
+let texture17 = device0.createTexture({
+  label: '\u0e42\u{1fc86}',
+  size: [960, 4, 233],
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle12 = renderBundleEncoder1.finish({label: '\uffd2\u{1ff8c}\u0069\u{1fad6}\u{1feb2}'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 208.3, g: 169.7, b: 913.0, a: -969.1, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(1.258, 0.5917, 3.070, 0.1287, 0.3719, 0.3951);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer1, 50768, 49488);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 21192, new Float32Array(56374), 26549, 1544);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 44, y: 105 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let commandEncoder29 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({label: '\ue5b5\u07b1\u0014\u7214\uf8ce\u0b59\uaf43', type: 'occlusion', count: 295});
+let renderBundle13 = renderBundleEncoder5.finish({label: '\u{1fc0e}\u04af\u0e22'});
+let sampler13 = device0.createSampler({
+  label: '\u5077\u{1fd28}\u96e7\u0f77',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 79.93,
+  lodMaxClamp: 79.97,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup6, new Uint32Array(8272), 5596, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup7, new Uint32Array(8557), 1144, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17178 */
+  offset: 17148,
+  rowsPerImage: 43,
+  buffer: buffer2,
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 119, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer2, 22892);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u03c6');
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  label: '\u8fa3\u03a0\u946d\u{1fa1b}\u38f0\ub5d5\u0271\ua947',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap'},
+    stencilReadMask: 4080037855,
+    stencilWriteMask: 2032302372,
+    depthBiasClamp: 772.1239889082688,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+offscreenCanvas4.width = 3324;
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder6.label = '\ue785\u0e54\u0bdd\u6fbb\uf988\u9ebe\ud28b\u0a51\u02f4';
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u4e0c\u0943\u126b\u{1fc96}\u0470\u72a8\u{1f6b1}\uaccc'});
+let textureView34 = texture2.createView({
+  label: '\uda02\u9ff0\u{1f706}\u637e\u1186\u54b3\uccd7\ud55f',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 67,
+  arrayLayerCount: 18,
+});
+try {
+computePassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer3, 250240, buffer6, 518908, 128260);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet3, 1617, 222, buffer5, 102656);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer1, /* required buffer size: 561 */
+{offset: 531, bytesPerRow: 103}, {width: 30, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video0 = await videoWithData();
+let textureView35 = texture12.createView({
+  label: '\u9b6b\u119a\u{1fa12}\u0b6a\u{1f91b}\u07b5\u{1f752}\u5335\u9d0b\u29f4\u1481',
+  dimension: '2d',
+  format: 'rgba16float',
+  baseMipLevel: 4,
+  baseArrayLayer: 5,
+});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(496);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup7, new Uint32Array(6871), 328, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet8, 544, 40, buffer5, 44544);
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+  label: '\u{1f8dd}\u{1ff72}\uff2e\uf897\u9d5a\u0d22\u7828',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline9 = device0.createRenderPipeline({
+  label: '\u0338\u5f46\u0c93\u0b6d\u0d10\u092a\u06c3',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {failOp: 'zero', depthFailOp: 'replace', passOp: 'replace'},
+    depthBiasSlopeScale: 919.331050941507,
+    depthBiasClamp: 509.02116776168293,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+try {
+  await promise1;
+} catch {}
+let videoFrame3 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let textureView36 = texture8.createView({
+  label: '\u58af\u96a0\u96c8',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  baseArrayLayer: 9,
+});
+let computePassEncoder12 = commandEncoder29.beginComputePass({label: '\u0c7f\u03ac\u{1f87d}\u{1fe60}\u05ab\u0499\u{1fa6e}\u0ced\u{1f7ca}\u0728'});
+let renderPassEncoder6 = commandEncoder26.beginRenderPass({
+  label: '\udb14\u0980\u0c0b\uf4b9\u{1fd0e}\u1b6d\u0073\u65ad\ue9f6',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: -1.4361366483834654,
+    stencilClearValue: 31453,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 1102810120,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({label: '\u565e\u004c\u4bcc', colorFormats: [], depthStencilFormat: 'stencil8'});
+let renderBundle14 = renderBundleEncoder6.finish({label: '\u{1fc4d}\u53a7\ube7c\u0bbb\u94f0\u907d'});
+try {
+computePassEncoder12.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5, new Uint32Array(7655), 6055, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(5597), 3771, 0);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer7, 184212, 56016);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(querySet6, 306, 1459, buffer5, 50688);
+} catch {}
+let commandBuffer6 = commandEncoder6.finish({label: '\ueb5d\u72fe\u2549\u{1f91b}\u{1fabe}\u2531\u0f99\u0288\u5ec7'});
+let computePassEncoder13 = commandEncoder23.beginComputePass({});
+let renderPassEncoder7 = commandEncoder27.beginRenderPass({
+  label: '\u110f\ubb9f\u0f86\u71aa\ud2b5\ud090\u0c88\u04bb\ubb0f',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView36,
+    depthClearValue: -9.251361870074476,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 36828448,
+});
+let sampler14 = device0.createSampler({
+  label: '\uefab\ufe4c\u5b84\u0458\u{1fe53}\u617c\u0fb2\u0b66',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.01,
+  lodMaxClamp: 37.86,
+  compare: 'greater-equal',
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(1862);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1650);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5071, undefined, 573803537, 1731291074);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet2, 359, 202, buffer5, 26368);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 27788, new Float32Array(7085));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 319 */
+{offset: 319}, {width: 696, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer3, 281816, buffer6, 378632, 158284);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 15420, new BigUint64Array(43741), 41074);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 33},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(612), /* required buffer size: 612 */
+{offset: 612, bytesPerRow: 486}, {width: 451, height: 32, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({label: '\u0c5b\u0cec\u0ba0\u948d'});
+let textureView37 = texture1.createView({label: '\u8c12\u085e\ub14e', dimension: '2d', aspect: 'stencil-only', baseMipLevel: 2});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder0.setBlendConstant({ r: 518.2, g: 843.8, b: 321.0, a: 472.2, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(6, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(3.026, 0.2519, 1.479, 0.3220, 0.3720, 0.9309);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 9, y: 44 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u{1fd3a}\udb36\u0444\u0eb7\ub2d7\u0b5b\u{1fc39}\u07a6\u469c', bindGroupLayouts: []});
+let texture18 = device0.createTexture({
+  label: '\u{1fef0}\u{1fe07}\ua730\u775e\ua35e\ue858\u{1fe47}',
+  size: {width: 264, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\uf1cb\u0e2a\uc62f\u09f1\u17ec\u8767\u088d\u66b0\u{1f7cf}',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+let renderBundle15 = renderBundleEncoder3.finish();
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -394.2, g: 183.3, b: -813.4, a: 850.7, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer5, 'uint16', 43696);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 198, y: 91 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video0);
+let commandEncoder32 = device0.createCommandEncoder({label: '\u000d\u07d9\u0a56\u8702\u{1f938}\u0cfc\u4b5e\u9df5\u{1f90f}\u{1fc68}\u{1fa95}'});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1397});
+let textureView38 = texture3.createView({
+  label: '\u0f98\uf855\ud25c\u01b9\u{1f9fe}\ud561\ua34a\u{1fc34}\u0605\u80f6',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 3,
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+});
+let renderPassEncoder8 = commandEncoder31.beginRenderPass({
+  label: '\ud064\u{1f90b}\u{1f785}\u062d\u{1fa13}\u7a7b',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: -4.853902908594161,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 1122034388,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({label: '\u1a2a\u0752', colorFormats: [], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let sampler15 = device0.createSampler({
+  label: '\u{1f86f}\u7925\u0f5c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.18,
+  lodMaxClamp: 83.22,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(2502);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer4, 107844, 46809);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder32.clearBuffer(buffer1, 98824, 23088);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u00f1');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 47, y: 216 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilBack: {compare: 'equal', depthFailOp: 'zero', passOp: 'zero'},
+    depthBias: 738320600,
+    depthBiasClamp: 837.1848523737368,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+document.body.prepend(video0);
+video0.width = 96;
+offscreenCanvas1.width = 1328;
+let texture19 = device0.createTexture({
+  label: '\u6328\u0c24\u8908',
+  size: {width: 225, height: 16, depthOrArrayLayers: 90},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView39 = texture9.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 4});
+let computePassEncoder14 = commandEncoder16.beginComputePass({label: '\ubcdd\u0ae8\uabbd\u5878\u7fdf\u74cb\ub5a3\u{1fd12}\ube1b\u{1fb0e}\u684f'});
+let renderPassEncoder9 = commandEncoder17.beginRenderPass({
+  label: '\u{1fc51}\u22b5\u{1fc3f}\u{1f726}\u0b41\u4516\u014c\u0988\u885b\ueff5',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: 7.9084195542423465,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet3,
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(1903);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle1, renderBundle10, renderBundle11, renderBundle10, renderBundle3, renderBundle3, renderBundle1, renderBundle10, renderBundle10, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer5, 'uint32', 126476, 446);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup9, new Uint32Array(629), 287, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(966748728, 521300702);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(1176059214, 87187444, 149915703, -600795138, 759689113);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u{1f7c1}\u08ba\u0382\u2783'});
+let computePassEncoder15 = commandEncoder30.beginComputePass({label: '\u562f\u6b1d\uc271\u4a4b\u{1f802}\uf4e5\u0906\u2112\uee57\u3ac8'});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(1015526481, 262431617);
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+  label: '\u03b3\uc3a8\u08a8\uac42\u072a\u15b5\u0faa\u{1f8ed}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let canvas2 = document.createElement('canvas');
+let commandEncoder34 = device0.createCommandEncoder({});
+let textureView40 = texture4.createView({
+  label: '\u{1ff4f}\u8d43\u5d95\u{1f85b}\u90fc\u0fb5\u79ea\u7f4e\u035d\ue12f\u{1fe03}',
+  dimension: '2d-array',
+  format: 'astc-10x5-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u638d\u8a91\u5e5e\u0637',
+  colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(441);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(4, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet3, 1633, 266, buffer5, 24576);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer0), /* required buffer size: 393 */
+{offset: 393}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(137, 226, '#1fe3aa4c', '#95a8488d');
+let buffer9 = device0.createBuffer({size: 798203, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture20 = device0.createTexture({
+  label: '\u8d05\ub09d\u{1f93f}\u{1fd75}\u9c59\u00aa\ua4b8\u03c4\ucf42',
+  size: {width: 240, height: 1, depthOrArrayLayers: 52},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView41 = texture15.createView({label: '\u611e\u43c7\u3dfa\u{1f956}\ucc5e', dimension: '2d', baseMipLevel: 4, baseArrayLayer: 141});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup11, new Uint32Array(5755), 2076, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(871350225, 192156855, 30160920, -898795492, 516200658);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView42 = texture0.createView({label: '\u{1fed6}\u4633\u0edb\u0c24\u35af', baseMipLevel: 1, mipLevelCount: 2});
+let renderPassEncoder10 = commandEncoder28.beginRenderPass({
+  label: '\u0aba\u0ed0\u014a\ub40e',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView36,
+    depthReadOnly: true,
+    stencilClearValue: 64479,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 1149484835,
+});
+try {
+renderPassEncoder7.beginOcclusionQuery(1289);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 353.8, g: -275.3, b: 774.5, a: -199.6, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 67016, 12892);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 26856);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 22744 */
+  offset: 22744,
+  buffer: buffer7,
+}, {width: 120, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  label: '\u{1ff9f}\u0cca\uce21\u534d',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let pipelineLayout7 = device0.createPipelineLayout({label: '\uac7d\u3dcf', bindGroupLayouts: []});
+let commandEncoder35 = device0.createCommandEncoder({label: '\u0e4a\u033b\u3462\u{1fda8}\u7a51'});
+let externalTexture12 = device0.importExternalTexture({
+  label: '\u2211\u0510\u5bb9\u052c\uaf83\uecd2\u{1fd86}\u087c\u894f',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder10.setScissorRect(94, 0, 14, 7);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(962);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 77536 */
+  offset: 77536,
+  bytesPerRow: 0,
+  rowsPerImage: 36,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 21});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer1, 68820, 17584);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 36020, new Float32Array(22643));
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 15, y: 8 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u{1fc52}\u82b1\u7ca9\u{1fed2}\u8509\u{1f616}\uef7f',
+  colorFormats: ['rgb10a2uint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let renderBundle16 = renderBundleEncoder7.finish({label: '\u{1fe67}\ud33d\u04ec\u49bc\u{1f606}\u26b6\u6416\ua664\ub748\uccf3\u0dca'});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup0, new Uint32Array(9498), 5817, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(7, 0, 0, 1);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 26804);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let video1 = await videoWithData();
+try {
+externalTexture4.label = '\u0aa8\u026a\u06a6\u00a3';
+} catch {}
+let buffer10 = device0.createBuffer({size: 18244, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+let commandEncoder37 = device0.createCommandEncoder({label: '\ue8c1\u676a\u13a9\u2cf5\ue503\ud040\ub509'});
+let renderBundle17 = renderBundleEncoder5.finish({label: '\u0bc5\u87ec\u0982\u338f\u{1f876}\u437e\u{1ff44}'});
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(0, 0, 5, 1);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet7, 443, 1451, buffer5, 36352);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 16, y: 0 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+  label: '\u{1f938}\u{1fbef}\u06aa\u218f\u{1f9a2}\u0f4d\u74c6\u0465\u1988',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline14 = device0.createRenderPipeline({
+  label: '\u082c\u{1f6a0}\u06cb\u{1f7a2}\u36aa\u3b28\u{1f63e}',
+  layout: pipelineLayout2,
+  multisample: {},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint'}, {format: 'rgb10a2unorm', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 2134976970,
+    stencilWriteMask: 3782134133,
+    depthBias: -1936470297,
+    depthBiasClamp: 829.360876391768,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+let commandEncoder38 = device0.createCommandEncoder({label: '\ucfcd\u3cbd\u{1f81d}\ua1a2\u0cfd\u{1feab}\u65dd\u045c\u089a\u3425'});
+let renderPassEncoder11 = commandEncoder10.beginRenderPass({
+  label: '\u{1ff2c}\u9ebf\ubeeb\u6555\u0f35\u0230\ua307\u0aa2\u{1f65d}\u4df6',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView36,
+    depthReadOnly: false,
+    stencilClearValue: 11299,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet6,
+});
+try {
+computePassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 534.7, g: 729.7, b: 761.4, a: -487.3, });
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer4, 469484, 21155);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder4.draw(1004202135, 820065563, 23936537, 515040261);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer5, 'uint16', 6818, 116964);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 77540 */
+  offset: 77540,
+  bytesPerRow: 512,
+  buffer: buffer0,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 12968, new Float32Array(27592));
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\ufc83\ufa9a\u{1fa72}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+offscreenCanvas3.width = 941;
+try {
+videoFrame1.close();
+} catch {}
+let textureView43 = texture1.createView({dimension: '2d-array', baseMipLevel: 2});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u0ea6\u0bd8\u{1f711}\u39d3',
+  colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'],
+});
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer5, 'uint32', 124240);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup3);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({
+  label: '\u06cf\u923f\u0384\u37ad\ued93\u23b0\u0ce1\u6ea4',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas5 = new OffscreenCanvas(433, 947);
+let buffer11 = device0.createBuffer({
+  label: '\u{1feb6}\u48c9\u3ca7',
+  size: 190027,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer7 = commandEncoder33.finish({label: '\u{1f99b}\uf8fd\ubb7f\u5b72\u0cdf\u4b09\u3d08\u4fa2'});
+let textureView44 = texture4.createView({dimension: '2d-array', mipLevelCount: 4});
+let externalTexture13 = device0.importExternalTexture({label: '\u3bfa\u0176\u{1fe31}', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 714.9, g: -623.0, b: -429.1, a: 292.4, });
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup8, new Uint32Array(5466), 1746, 0);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 451 widthInBlocks: 451 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 48435 */
+  offset: 5488,
+  bytesPerRow: 512,
+  rowsPerImage: 52,
+  buffer: buffer8,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 60},
+  aspect: 'all',
+}, {width: 451, height: 32, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+  },
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let buffer12 = device0.createBuffer({
+  label: '\u7570\uc4fe\u6e38\u0bf0\u{1f633}\u08b6\u27e4\u2f69\u769d',
+  size: 154660,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder39 = device0.createCommandEncoder();
+let texture21 = device0.createTexture({
+  label: '\u0570\ubc08\u0de3\u{1fd01}\u{1fe33}\u8a26\u{1f9ab}\ucec3\ufbaa\u8c47\u009c',
+  size: [225],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView45 = texture0.createView({label: '\u{1fda2}\u{1f8cb}\ua41f\u564b', aspect: 'all', mipLevelCount: 3});
+let computePassEncoder16 = commandEncoder37.beginComputePass();
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup9, new Uint32Array(165), 53, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer5, 'uint16', 24718, 33379);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(1153298906, 1128670525, 1039783891, 1173303357, 147101210);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 48216);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 696 */
+{offset: 696, bytesPerRow: 270}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = await device0.createComputePipelineAsync({
+  label: '\u3f87\u{1fc4d}\u0169\u25a1\ude51\u5108\u0c7a\u{1fca7}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline19 = await device0.createRenderPipelineAsync({
+  label: '\u0ad9\u{1f76a}\uaf67\u90ef\uf2af',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0xc1b77a9a},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'dst'},
+  },
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'keep', passOp: 'replace'},
+    stencilReadMask: 1242779105,
+    stencilWriteMask: 2676410761,
+    depthBias: -108077842,
+    depthBiasClamp: 477.6861546684303,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u0b5c\u{1fae4}\u8a83',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout4, bindGroupLayout1],
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\ufd95\u0eb6\u7086\u4db8\ud79c\u3db9\u066f\u3d90'});
+let textureView46 = texture6.createView({label: '\u{1ff9e}\uab8e', dimension: '2d-array', format: 'stencil8', mipLevelCount: 2});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+let renderBundle18 = renderBundleEncoder2.finish();
+try {
+computePassEncoder6.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder4.draw(1010908319, 168211997, 452959875, 1109864926);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(326418886);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 45752);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\uaa3a');
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+  label: '\u06d9\u0c93\u{1fc47}\ubbc8\ub716\u01d8',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: 0}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+let sampler16 = device0.createSampler({
+  label: '\u2e9b\ue61d\u2802\u11ac',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.68,
+  compare: 'always',
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder9.setViewport(5.584, 0.4380, 0.8789, 0.3583, 0.2196, 0.2558);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer5, 'uint32', 10212);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let textureView47 = texture20.createView({baseMipLevel: 3, mipLevelCount: 3});
+let computePassEncoder17 = commandEncoder30.beginComputePass({label: '\u6ca0\u{1fc11}\u0d8d\u{1fe80}\u{1f97c}\u9740'});
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.704,
+  lodMaxClamp: 30.00,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(2563);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer5, 'uint16', 22716, 76651);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(183672540, 444683713, 738907258);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 10464);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 10076);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(5, buffer9, 0, 643072);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture3,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\udab1');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 164672, new Float32Array(49155), 37574, 3620);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 703 */
+{offset: 703}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0xbee2687d},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 289667457,
+    depthBiasSlopeScale: 396.28596514333486,
+    depthBiasClamp: 437.78750138841383,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+let querySet11 = device0.createQuerySet({label: '\u3f35\uec97\u02d0\u7202\u3427\ub815\ubf5a\u60a3', type: 'occlusion', count: 3885});
+let computePassEncoder18 = commandEncoder32.beginComputePass({label: '\ud103\u0b03'});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(2137);
+} catch {}
+try {
+renderPassEncoder1.setViewport(3.942, 0.8853, 1.205, 0.1091, 0.06461, 0.8676);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 55332);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer3, 83096, buffer1, 94960, 4040);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\u0b5c');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 117104, new BigUint64Array(36452), 26887);
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({
+  label: '\u0313\u025d',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas6 = new OffscreenCanvas(809, 238);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let buffer13 = device0.createBuffer({size: 109425, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let computePassEncoder19 = commandEncoder35.beginComputePass({label: '\u6a92\u701e\u0fc2\uaf85\u{1fa7c}\u{1fe7b}\u08eb\u0b0f\u8e44\u0fa0\u8dc5'});
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer5, 'uint32', 49520, 41537);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer4, 0, 100438);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup2, new Uint32Array(2811), 2676, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(152245884, 731498049, 586384755, 569230912);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(26253730);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer5, 'uint32');
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer11, 87460, buffer0, 154764, 50464);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet4, 1779, 932, buffer13, 83968);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 293284, new Float32Array(23431), 250, 76);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img3);
+let imageData6 = new ImageData(172, 128);
+let commandEncoder41 = device0.createCommandEncoder({label: '\u8c1f\ued1f\u17ce\u062c\u{1fe60}\u03d5\u05d4\u{1fed3}\u0874\u5932\u0487'});
+let querySet12 = device0.createQuerySet({label: '\u0842\u703b\u{1fa1a}\u01d2\u0e40\u5d57', type: 'occlusion', count: 2885});
+let computePassEncoder20 = commandEncoder36.beginComputePass();
+let renderBundle19 = renderBundleEncoder13.finish({label: '\u07ac\ub22a\u5b41\u{1f645}\u0575\uc0c6\u06ba\u1084\u8a53\u6f52'});
+try {
+renderPassEncoder3.beginOcclusionQuery(1449);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 126832);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 880 widthInBlocks: 55 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 14320 */
+  offset: 14320,
+  rowsPerImage: 186,
+  buffer: buffer11,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 660, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+offscreenCanvas4.height = 120;
+let textureView48 = texture18.createView({dimension: '2d', aspect: 'all', baseMipLevel: 2, arrayLayerCount: 1});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer9, 716880, 70192);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(359970748);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 1120);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer4, 0, 306987);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 23172 */
+  offset: 23172,
+  buffer: buffer11,
+}, {
+  texture: texture9,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+  label: '\u8c92\u4f78\u6714\u0ece',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline24 = await device0.createRenderPipelineAsync({
+  label: '\ue6b2\uca85\u{1f7f2}\u0c57\u54c3\udcdb\u05e4\u0185',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 2595224367,
+    stencilWriteMask: 2244316574,
+    depthBiasSlopeScale: -94.5874281345026,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+offscreenCanvas4.height = 3190;
+gc();
+try {
+offscreenCanvas6.getContext('webgl');
+} catch {}
+let querySet13 = device0.createQuerySet({label: '\u5766\u7b35\ub834\u0e6e\ue182', type: 'occlusion', count: 1434});
+let commandBuffer8 = commandEncoder34.finish();
+let renderPassEncoder12 = commandEncoder41.beginRenderPass({
+  label: '\u06af\u05c1\ud42f\uae2f\u{1f6ac}\u0968\u0dfd\u9d6b\u0e87\u{1fed9}',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: -1.4591877442540007,
+    depthReadOnly: true,
+    stencilClearValue: 35656,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 386547252,
+});
+let sampler18 = device0.createSampler({
+  label: '\u08ce\u708f\u{1fd4f}\u0157\ucd1b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 58.11,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder12.setBlendConstant({ r: 766.3, g: -500.4, b: 179.8, a: -294.3, });
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer11, 130052, buffer12, 33224, 44252);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(78, 3, 19, 5);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 79384);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 320 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 40528 */
+  offset: 40528,
+  buffer: buffer7,
+}, {width: 80, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setViewport(1.438, 0.4045, 4.162, 0.1244, 0.00689, 0.1667);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer4, 0, 66824);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 14200);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline12);
+} catch {}
+let promise2 = buffer7.mapAsync(GPUMapMode.READ, 84704, 48604);
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8960 */
+  offset: 8960,
+  bytesPerRow: 0,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 184 */
+{offset: 184}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+  label: '\u{1f979}\u98c1\ubafb\u0325\u4ffb',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint'}, {
+  format: 'rgb10a2unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\ud82c\u423e\u{1f9a6}\u90af\u06da',
+  entries: [
+    {
+      binding: 900,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 141,
+      visibility: 0,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 569,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup12 = device0.createBindGroup({layout: bindGroupLayout0, entries: []});
+let commandEncoder42 = device0.createCommandEncoder({label: '\ue8c1\u0617\u{1fd3b}\u3178\u{1ff70}'});
+let sampler19 = device0.createSampler({
+  label: '\u0898\u0013\u0919\u18a6\u774b\u5293\u1e0e\u3955\u5206\u0a9c',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.94,
+  lodMaxClamp: 85.35,
+});
+try {
+renderPassEncoder11.beginOcclusionQuery(1605);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 22, y: 14, z: 114},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'stencil-only',
+},
+{width: 240, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder39.insertDebugMarker('\uac23');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 92788, new BigUint64Array(25714), 13746);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 42},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer3), /* required buffer size: 501993 */
+{offset: 340, bytesPerRow: 263, rowsPerImage: 100}, {width: 112, height: 8, depthOrArrayLayers: 20});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 186, y: 317 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas5.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer14 = device0.createBuffer({
+  size: 315328,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView49 = texture2.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 3, baseArrayLayer: 55});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(237);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer4, 0, 203460);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer5, 26680);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer4, 488996);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture22 = device0.createTexture({
+  label: '\u54bb\u96c4\u96cd\u0c3d\u1445\u{1ffef}\u5fb0\u7b29\ued2a\u1e3f\ub3cd',
+  size: {width: 112},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let renderPassEncoder13 = commandEncoder40.beginRenderPass({
+  label: '\u8556\uea9c\u0e61\u1053\u3550\u028e',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: -4.280356982912641,
+    depthReadOnly: true,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  maxDrawCount: 716502812,
+});
+let renderBundle20 = renderBundleEncoder11.finish({label: '\u{1fb23}\u7adf\u{1fa2a}\u3446\u0e1b\u{1fcdc}\u67a6\u{1f903}'});
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 44472);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet5, 1456, 183, buffer13, 87552);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xa8b38df3},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2uint'}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+let textureView50 = texture21.createView({label: '\u{1ffc4}\u8d19'});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1570);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer4, 95944, 318245);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.draw(821869589, 788922338, 444116453, 1055533038);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 49088);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 12175 */
+  offset: 12160,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 15, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: 0}, {format: 'rgb10a2uint'}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'ccw'},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video1.width = 271;
+let computePassEncoder21 = commandEncoder38.beginComputePass({label: '\u0aa5\u1b1c'});
+let renderBundle21 = renderBundleEncoder5.finish({label: '\u9424\u1421\uddc3\u2ccc\ud70c\u{1fdc2}\ud54d\u0710\u{1fc19}\u1f97'});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(1, 1, 4, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer4, 70940, 25857);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer14, 'uint32', 173948, 30607);
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder42.resolveQuerySet(querySet11, 1847, 1747, buffer9, 602880);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 33080, new Float32Array(50859), 34388, 104);
+} catch {}
+let texture23 = device0.createTexture({
+  label: '\u70d3\u9ce5\u368e\u2036\uc5b5\u031c\u{1fc85}\uda3a\u0c0d\u0867',
+  size: {width: 451, height: 32, depthOrArrayLayers: 180},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16uint'],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0c95\u9c7f\u72d3\u{1f99f}',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+try {
+computePassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle18, renderBundle11, renderBundle3, renderBundle6, renderBundle16, renderBundle5, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1688);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(990073921);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer9, 76836, 700728);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 976 widthInBlocks: 61 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 39696 */
+  offset: 39696,
+  rowsPerImage: 143,
+  buffer: buffer1,
+}, {width: 732, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 709 */
+{offset: 649}, {width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({label: '\u0fb2\u8275'});
+let textureView51 = texture8.createView({
+  label: '\u3c8e\u0531\u04ba\u0174\ud6cc\u9c41\uc0b8',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 161,
+});
+let computePassEncoder22 = commandEncoder42.beginComputePass();
+let sampler20 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 3.198,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(2410);
+} catch {}
+try {
+commandEncoder43.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 19456 */
+  offset: 19456,
+  buffer: buffer1,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 27, y: 116 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame4 = new VideoFrame(canvas1, {timestamp: 0});
+try {
+renderBundleEncoder12.label = '\u{1fa13}\ue98e\u0fbf\u07af\ubcf6\u6324\u8a0a\u{1fb71}\u36c5\u00cc';
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder();
+let texture24 = device0.createTexture({
+  size: {width: 225, height: 16, depthOrArrayLayers: 90},
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+});
+let textureView52 = texture2.createView({label: '\u6fa4\uf2eb\u36a4', dimension: '2d', baseMipLevel: 4, mipLevelCount: 4, baseArrayLayer: 98});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup10, new Uint32Array(3576), 3485, 0);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1239);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer5, 'uint16', 70630, 11103);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 38136 */
+  offset: 38108,
+  buffer: buffer1,
+}, {width: 28, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 1,
+  origin: {x: 123, y: 14, z: 203},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 3},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(40)), /* required buffer size: 5602197 */
+{offset: 629, bytesPerRow: 272, rowsPerImage: 248}, {width: 0, height: 11, depthOrArrayLayers: 84});
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync({
+  label: '\ua527\u1847\uf50d\u{1f97e}\u{1fa3e}\uee63',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder1.dispatchWorkgroups(1, 4);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(1319);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 533.5, g: -547.4, b: 389.5, a: 66.50, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(54, 3, 30, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup10, new Uint32Array(209), 179, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(809966782, 694934429, 984829111);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer4, 0, 281256);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer9, 244156, buffer2, 1452, 22880);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 192776, new DataView(new ArrayBuffer(53896)));
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: imageData3,
+  origin: { x: 18, y: 12 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 39, y: 2, z: 85},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise3 = device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+try {
+adapter0.label = '\ufdb3\u3d44';
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u{1fcfb}\u6695'});
+let computePassEncoder23 = commandEncoder45.beginComputePass({label: '\ua0f4\u894f\uf545\u1751\u4b86'});
+let renderBundle22 = renderBundleEncoder7.finish({label: '\u{1fe66}\u29f4'});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer14, 'uint32', 107228, 74875);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup3, new Uint32Array(5582), 712, 0);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(1059405837, 237394606, 252991957);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 25348);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 15136);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer9, 0, 253698);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer14, 23476);
+dissociateBuffer(device0, buffer14);
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({});
+let videoFrame5 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let commandEncoder46 = device0.createCommandEncoder({label: '\u0734\u{1f626}\uc045\u6614\uac4a\u{1f784}\udeb7'});
+let querySet14 = device0.createQuerySet({label: '\u0211\u6876\u66e6', type: 'occlusion', count: 2365});
+let texture25 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder24 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(4, 1, 3, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(3146);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer5, 'uint32', 125676, 747);
+} catch {}
+try {
+renderBundleEncoder9.draw(652782936, 957548909, 788829745, 1049717065);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer5, 24284);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 20868);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer14, 'uint16', 237268, 35746);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17324 */
+  offset: 17324,
+  buffer: buffer9,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 56, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer1, 101360, 36664);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 101, y: 933 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = await device0.createRenderPipelineAsync({
+  label: '\u6fb3\u14e1\ucb9c\u{1fdb2}\u85b1\u{1fe97}\u{1f6ba}\u02d9\u{1fcfa}',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 1087827928,
+    depthBiasSlopeScale: 696.3855621512645,
+    depthBiasClamp: 818.0825166359069,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {unclippedDepth: true},
+});
+let canvas3 = document.createElement('canvas');
+let bindGroupLayout6 = device0.createBindGroupLayout({entries: []});
+let sampler21 = device0.createSampler({
+  label: '\ue42e\u0ca1\u2a91\u{1f81a}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 2.060,
+});
+let externalTexture14 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder1.dispatchWorkgroups(2, 5, 3);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer5, 39760);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -967.3, g: 532.1, b: 354.7, a: 513.4, });
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(1118913029, 209894300, 316204306);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 15756);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer4, 157996);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 23165 */
+  offset: 23165,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder44.resolveQuerySet(querySet4, 2553, 272, buffer13, 59648);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+document.body.prepend(img1);
+let commandEncoder47 = device0.createCommandEncoder({label: '\u0c68\u1396\u{1fedb}\u024b\u{1f744}\u0523\u{1fa03}\ufdc8\u0cdf'});
+let querySet15 = device0.createQuerySet({label: '\ue86b\u3770\u1d91\u7992\u0ed9', type: 'occlusion', count: 903});
+let textureView53 = texture0.createView({label: '\u{1f95c}\u0593\u050d', format: 'astc-12x12-unorm-srgb', baseMipLevel: 1, mipLevelCount: 5});
+try {
+renderPassEncoder9.setBlendConstant({ r: 195.6, g: -952.8, b: -796.4, a: -750.1, });
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer9, 663864, 25782);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(184171184, 587840169, 757651831, -612305586, 1117445224);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer14, 'uint32', 295652, 2671);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer6, 37172, 393592);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let video2 = await videoWithData();
+let commandEncoder48 = device0.createCommandEncoder({label: '\u0e29\ub013\u0458\u95ce\uaed6\u0ec0\u3f23\ud8b7\u{1fd7c}'});
+let commandBuffer9 = commandEncoder44.finish({label: '\u5019\u08f3\ufa7d\u0a77\u{1f653}\u09c1\u92cb\u{1f839}'});
+let textureView54 = texture3.createView({label: '\ubaf3\u0102\u{1f95b}', aspect: 'stencil-only', baseMipLevel: 4, arrayLayerCount: 1});
+let renderBundle23 = renderBundleEncoder13.finish();
+try {
+renderPassEncoder12.setScissorRect(4, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer14, 'uint16', 305318, 7337);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup9, new Uint32Array(8293), 7702, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(1033582155);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 109260, new Float32Array(21803), 19672, 4);
+} catch {}
+let pipeline30 = device0.createComputePipeline({
+  label: '\ucc0a\uc127\u9258\ued5f',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+try {
+adapter1.label = '\u0a7a\uf7dc';
+} catch {}
+let texture26 = device0.createTexture({
+  label: '\ub3b3\u05ca\u01bb',
+  size: [112, 8, 45],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView55 = texture10.createView({label: '\u0642\u{1f69a}', dimension: '1d', baseArrayLayer: 0});
+let renderBundle24 = renderBundleEncoder0.finish({label: '\u1f19\u51ac\u2a92\u04c8\u64da\u{1fc2a}\ub978\u443e\u64d0'});
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer5, 82200);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(1306);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -570.0, g: -523.3, b: 540.8, a: -288.5, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(3, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(618);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer4, 100712, 196767);
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(buffer3, 384684, buffer6, 392340, 56924);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder46.resolveQuerySet(querySet9, 105, 116, buffer5, 52992);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 8916, new BigUint64Array(20089), 310, 428);
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u3cfe\u5e93\u8fd6\u{1ffc1}\u5a3f\u026b\u1c4d\u07d6\u08ad\u3bdb',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout4],
+});
+let texture27 = device0.createTexture({
+  label: '\u2258\ue5de\u{1fe3d}\uf697\u5c87\ueb33\u8984\u64f3\ub275\u6fdc',
+  size: [480, 2, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder25 = commandEncoder39.beginComputePass({label: '\u{1fd1c}\u0df3'});
+let sampler22 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 66.61,
+});
+let externalTexture15 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2090);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer14, 'uint16');
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet3, 898, 204, buffer9, 626944);
+} catch {}
+let querySet16 = device0.createQuerySet({label: '\u{1f92e}\u1575\u5e99\u3c7f', type: 'occlusion', count: 682});
+let computePassEncoder26 = commandEncoder46.beginComputePass({label: '\u{1fa41}\uff07\u{1f7f9}\u0e53\u{1f8b1}\u094c\u0ff1\u{1fe0f}\ua231'});
+let sampler23 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.57,
+  lodMaxClamp: 79.60,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder1.dispatchWorkgroupsIndirect(buffer5, 124876);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 705.6, g: 988.2, b: 551.8, a: 446.4, });
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer5, 'uint32', 88296, 15330);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer3, 150604, buffer7, 210920, 7648);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 99 widthInBlocks: 99 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 45310 */
+  offset: 45310,
+  rowsPerImage: 159,
+  buffer: buffer9,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 99, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 45628, new Float32Array(25786));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(8)), /* required buffer size: 291 */
+{offset: 291}, {width: 96, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle11, renderBundle9, renderBundle16, renderBundle16, renderBundle3, renderBundle7, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(5.431, 0.4028, 1.420, 0.08808, 0.5396, 0.5686);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer14, 'uint16', 307158, 7525);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer9, 0);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 1684);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1092 */
+  offset: 1092,
+  buffer: buffer3,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 4, y: 2, z: 1},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(querySet4, 1891, 1246, buffer13, 37376);
+} catch {}
+let imageBitmap3 = await createImageBitmap(offscreenCanvas4);
+let commandBuffer10 = commandEncoder43.finish({label: '\u004f\u28cc\u06bf\ufc5c\u350e\u{1fa47}'});
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer4, 390832, 117243);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(725457937, 657458904, 296427240, -751882972, 1097416448);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 404);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet12, 142, 434, buffer5, 51200);
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u01be\u2758\uf31d\ucb7f\u5456\u{1ff82}\ud715\u{1f605}\u0acb\udecf',
+  size: 202628,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let commandBuffer11 = commandEncoder49.finish({label: '\u{1f9d7}\u{1f7a0}\u{1fcbb}\udbcc\u4a0f\u0291\u3054'});
+let textureView56 = texture9.createView({label: '\u0dc0\ud41c\u083d\u0431\u{1ffcc}\u02c0\u3746', baseMipLevel: 6});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u494a\u0447\u8059\u{1fcc0}\u1a94\u{1f83d}\u7bd5\ue97b\u384c',
+  colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'],
+  sampleCount: 1,
+  stencilReadOnly: false,
+});
+let sampler24 = device0.createSampler({
+  label: '\uf008\ud311\uc176\ub172\u0fa6\u6619\u2540\ue4a8\ub15c',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.09,
+  lodMaxClamp: 74.54,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -362.0, g: -455.8, b: -484.0, a: 91.35, });
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer5, 'uint32', 91908, 2405);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(678129866, 5962819, 54257941, -569401507);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 37784);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 21808);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 928 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 24992 */
+  offset: 24992,
+  buffer: buffer8,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 580, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: img0,
+  origin: { x: 3, y: 25 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 130, y: 4, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet17 = device0.createQuerySet({label: '\u{1f658}\u675d\u7b38', type: 'occlusion', count: 1220});
+let computePassEncoder27 = commandEncoder47.beginComputePass({label: '\u1c34\ud5d9\u7351\u3dd7\ua0fb\uc246'});
+let externalTexture16 = device0.importExternalTexture({label: '\ua5e1\u{1fe44}\u40e0\uafd2\u{1ffdf}\u74c1', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1770);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer5, 'uint32', 90324, 4441);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+renderBundleEncoder9.draw(831093346, 1076924721, 818195414);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(1009258246, 165755304, 540614236, -927629736, 1124923418);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer5, 336);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(7, buffer9, 0, 432147);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 496 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 19080 */
+  offset: 19080,
+  rowsPerImage: 126,
+  buffer: buffer9,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 124, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 384 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 47328 */
+  offset: 47328,
+  buffer: buffer1,
+}, {width: 288, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9, commandBuffer10]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 29968, new Int16Array(21681), 17520, 324);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: imageData5,
+  origin: { x: 21, y: 4 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 17, y: 4, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout7 = pipeline13.getBindGroupLayout(0);
+let buffer16 = device0.createBuffer({
+  label: '\u{1ff1a}\u0f1a',
+  size: 476721,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture28 = gpuCanvasContext2.getCurrentTexture();
+let externalTexture17 = device0.importExternalTexture({label: '\ue910\u7a51\ue746\u8e5e\u{1f730}\u03ef\u08c7', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer4, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer6, commandBuffer1]);
+} catch {}
+let img4 = await imageWithData(101, 123, '#155042a1', '#1c380b35');
+let shaderModule1 = device0.createShaderModule({
+  label: '\u01fb\u5a00\u7a7c\u057e\ue42b\ub654\u6cf0\u09a3\u{1f8cf}\u0893',
+  code: `@group(1) @binding(493)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(493)
+var<storage, read_write> n0: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec2<f32>,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(12) f16: vec4<u32>,
+  @builtin(position) f17: vec4<f32>,
+  @location(6) f18: vec2<f32>,
+  @location(5) f19: vec3<u32>,
+  @location(7) f20: vec2<f16>,
+  @location(14) f21: f16,
+  @location(15) f22: vec3<u32>,
+  @location(3) f23: vec3<f16>,
+  @location(8) f24: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f16>, @location(9) a1: f32, @location(3) a2: vec4<i32>, @location(10) a3: vec2<f32>, @location(13) a4: u32, @location(15) a5: vec3<i32>, @location(0) a6: vec2<f32>, @location(12) a7: vec4<u32>, @location(6) a8: i32, @location(8) a9: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder51 = device0.createCommandEncoder();
+let textureView57 = texture18.createView({label: '\u5e88\udf82\ue4b7\ue029', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 3});
+let sampler25 = device0.createSampler({
+  label: '\u{1fdcc}\u{1ffc2}\uae00\u514b\u057b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.675,
+  lodMaxClamp: 86.84,
+  maxAnisotropy: 17,
+});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 897.5, g: -810.3, b: 953.9, a: -547.0, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3725);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer9, 207984, 322867);
+} catch {}
+try {
+renderBundleEncoder4.draw(20358076, 32840134, 85790041);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer12);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 75752, new Int16Array(21104));
+} catch {}
+let pipeline31 = await promise3;
+let commandEncoder52 = device0.createCommandEncoder({});
+let textureView58 = texture1.createView({aspect: 'stencil-only', baseMipLevel: 1, baseArrayLayer: 0});
+let computePassEncoder28 = commandEncoder51.beginComputePass();
+let renderBundle25 = renderBundleEncoder5.finish();
+try {
+computePassEncoder22.dispatchWorkgroups(2, 2, 3);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.draw(171722555, 559873256, 691933942, 432350032);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer14, 'uint32', 147448, 79008);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 34900, new Int16Array(19015), 5701, 4256);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 1086 */
+{offset: 541, bytesPerRow: 163}, {width: 56, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline32 = device0.createRenderPipeline({
+  label: '\u0f68\u0584\ua701',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x3a0f9c2f},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: 0}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let texture29 = device0.createTexture({
+  label: '\u{1f69b}\u76dc\uf543\ud74f\u{1fbfc}\udab9\u829a',
+  size: {width: 960, height: 4, depthOrArrayLayers: 211},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder29 = commandEncoder48.beginComputePass({label: '\u3894\uf59a\u{1ff91}\u1de7\uc8d9\ua800\ue062\u01c9\u0d24\ub42c\u{1f665}'});
+let renderPassEncoder14 = commandEncoder50.beginRenderPass({
+  label: '\u{1f6fd}\u3cb2\u07c4\u{1f7af}\u{1fbc3}\u{1fd91}\u0f81\ua595',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView36, stencilClearValue: 30874, stencilLoadOp: 'load', stencilStoreOp: 'store'},
+  maxDrawCount: 973072028,
+});
+let renderBundle26 = renderBundleEncoder10.finish({label: '\u1850\uc9e7\ud63a\u0f40\u04a6'});
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3586);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup1, new Uint32Array(7587), 38, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(67420774, 337960152, 159698045, 1129781686, 264408731);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 24552);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 17512);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer9, 0, 300421);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 8928, new DataView(new ArrayBuffer(56217)), 221, 38412);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let canvas4 = document.createElement('canvas');
+let offscreenCanvas7 = new OffscreenCanvas(475, 916);
+let img5 = await imageWithData(295, 27, '#232be7e9', '#dc527790');
+let commandEncoder53 = device0.createCommandEncoder({label: '\u0cf3\u8cd6\u{1fce3}\u00cf\u0f56\u{1fa4e}\u9603'});
+let textureView59 = texture22.createView({
+  label: '\u59b8\u{1f915}\u55b0\u0a58\ue1dd\ue6f2\u{1faa4}\u{1f679}\u{1f94a}\u23ab\u0119',
+  aspect: 'all',
+  arrayLayerCount: 1,
+});
+let renderPassEncoder15 = commandEncoder53.beginRenderPass({
+  label: '\u{1f8f6}\u19a2\u664a\u0fb4\u{1f8de}\ucfd3\u3b53\uee13\u706e',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView51, depthReadOnly: true, stencilReadOnly: true},
+  maxDrawCount: 1031925702,
+});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 94.63,
+});
+try {
+renderPassEncoder10.setBlendConstant({ r: -399.6, g: -36.43, b: 318.1, a: -805.1, });
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 7848);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 37696);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: img5,
+  origin: { x: 21, y: 6 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 58, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let commandBuffer12 = commandEncoder52.finish({label: '\u0c87\u{1fed9}\u5671'});
+let computePassEncoder30 = commandEncoder4.beginComputePass({label: '\ua4f6\u{1fae5}\u{1f88e}\ue255\uc0e9\u4763\ue1d1\ua6df\u96f9\u0961'});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(2778);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer4, 0, 349920);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(1080328094, 443147386, 346582386, 681569911);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 1648);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 32300);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer4, 518688, 815);
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.READ, 0, 442052);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 5772, new Int16Array(64735), 1306, 5600);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let video3 = await videoWithData();
+let commandEncoder54 = device0.createCommandEncoder({label: '\uecca\u{1fc59}\u{1fd42}\ub163'});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup6, new Uint32Array(4918), 2168, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle18, renderBundle15, renderBundle11, renderBundle1, renderBundle11, renderBundle7, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -658.3, g: 393.1, b: 201.4, a: 213.9, });
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.draw(376794912);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(226027764, 961265400, 393342878);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 66484);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet0, 511, 740, buffer13, 54016);
+} catch {}
+let video4 = await videoWithData();
+let bindGroup13 = device0.createBindGroup({
+  label: '\ud6d0\udc3f\u3afe\u0ac3\u{1ff8f}\u{1ff76}\u0c33\u003b\u7ceb\u7029\ud1b8',
+  layout: bindGroupLayout6,
+  entries: [],
+});
+let querySet18 = device0.createQuerySet({
+  label: '\ua3c4\ufdc0\u{1ffe8}\u{1f708}\ucaac\u{1fed2}\u{1ffed}\u0928\ufbc7\u87f8',
+  type: 'occlusion',
+  count: 992,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u0598\u{1facf}\u46ea\u{1fdfb}\u3450\u0f11\u92f8\u2be7\ubcdc\uc6d3\u{1f944}',
+  colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'],
+  stencilReadOnly: true,
+});
+let sampler27 = device0.createSampler({
+  label: '\u0010\u0edc',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.026,
+  lodMaxClamp: 27.27,
+});
+let externalTexture19 = device0.importExternalTexture({label: '\ub03c\u{1f625}\u4c3f\uef85\uc532', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+renderPassEncoder13.setScissorRect(6, 1, 1, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(30607708, 263080328, 72166431, 412374613, 225456103);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer5, 'uint32', 46876);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 55},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 451 widthInBlocks: 451 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 63955 */
+  offset: 47632,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {width: 451, height: 32, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let gpuCanvasContext5 = canvas4.getContext('webgpu');
+try {
+textureView51.label = '\u015c\uc727\u228f';
+} catch {}
+let texture30 = gpuCanvasContext1.getCurrentTexture();
+let textureView60 = texture15.createView({baseMipLevel: 1, mipLevelCount: 4, baseArrayLayer: 80, arrayLayerCount: 48});
+let renderBundle27 = renderBundleEncoder15.finish({});
+let sampler28 = device0.createSampler({
+  label: '\u0ef6\u{1fae4}\ue216\u0c16\ud277\u{1fdcd}\u02c3\u{1fc52}\u{1ffd5}\u{1f729}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.67,
+  lodMaxClamp: 24.77,
+});
+try {
+renderBundleEncoder9.draw(773819965, 620998970, 206374818, 745981353);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer11, 65712, buffer14, 13040, 92596);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16256 */
+  offset: 16256,
+  bytesPerRow: 0,
+  rowsPerImage: 2,
+  buffer: buffer8,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 122, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet1, 2783, 66, buffer5, 28160);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 21},
+  aspect: 'stencil-only',
+}, arrayBuffer1, /* required buffer size: 1171973 */
+{offset: 788, bytesPerRow: 42, rowsPerImage: 143}, {width: 15, height: 1, depthOrArrayLayers: 196});
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(900, 715);
+let bindGroupLayout8 = pipeline20.getBindGroupLayout(1);
+let texture31 = device0.createTexture({
+  label: '\u0e26\u6d43\u{1f9d3}\u041d\u051d\u{1fede}\uaa3a\u01ea',
+  size: {width: 903, height: 64, depthOrArrayLayers: 245},
+  mipLevelCount: 6,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let computePassEncoder31 = commandEncoder54.beginComputePass({label: '\u2a8c\uf1fe'});
+let renderBundle28 = renderBundleEncoder5.finish();
+let externalTexture20 = device0.importExternalTexture({label: '\u4e66\u5c82\u{1fdea}\uee4d\u5523\ud0fa\u051d', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder29.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer4, 397668, 100075);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder9.draw(1122112850, 530467641, 1128718030);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 38468);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 44632);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer9, 0, 56131);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 71044, new BigUint64Array(64236), 29396, 2812);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({label: '\u0807\uaebd\u0c33'});
+let textureView61 = texture19.createView({label: '\u0045\u5359\ua1e6\u8e8d\ub150\u01db\u3261\u04fc\u{1f605}\uff79\u{1f7a0}', mipLevelCount: 3});
+try {
+computePassEncoder8.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(1150);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle11, renderBundle24, renderBundle3, renderBundle22, renderBundle15, renderBundle11, renderBundle1, renderBundle15, renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 31884);
+} catch {}
+try {
+commandEncoder55.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 4,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1392 */
+  offset: 1392,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {width: 108, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync({
+  label: '\u0390\u0441\u1a21\u829c\u0e46\udf74\u1c07\u5c50',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({label: '\u14fa\u0dc9\u1c24\ub06d\u0ccd\u0d5e\u01d5', colorFormats: ['rgb10a2uint']});
+try {
+renderPassEncoder9.setViewport(5.147, 0.1929, 0.9981, 0.7490, 0.04437, 0.2958);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 137, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer16, 21460, 67752);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline35 = device0.createComputePipeline({
+  label: '\u0c97\uf573\u21be\u{1fe9b}\u3143\u21ca\u6eab',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout7, entries: []});
+let buffer17 = device0.createBuffer({size: 192553, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandBuffer13 = commandEncoder55.finish({label: '\u{1fb3b}\u{1fd84}\ue9ba\u14a3\u0999\u0da5\u{1f7c3}\u{1f69e}\u{1fa3f}\u67a1'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder22.dispatchWorkgroups(3, 2);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle22, renderBundle6, renderBundle22, renderBundle1, renderBundle1, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(753);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup9, new Uint32Array(6444), 3752, 0);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 764);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline29);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+canvas4.height = 1192;
+let commandEncoder56 = device0.createCommandEncoder({label: '\ube06\u88fc'});
+let texture32 = device0.createTexture({
+  label: '\u5de6\uea13\u{1ff45}\u1289\u6ff0',
+  size: {width: 960},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView62 = texture32.createView({label: '\ubb06\u48a2'});
+let computePassEncoder32 = commandEncoder56.beginComputePass({label: '\u464c\ud45a\ue331\u1db8'});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u02fa\u0a1e\u04a9\u978d\u06e9\ubdcb\u0f80\u{1fd12}\u1314',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder30.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(0, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer9, 0, 623804);
+} catch {}
+try {
+renderBundleEncoder14.draw(758509732, 88145993, 121232325);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(824003770);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 21840);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 86080, new DataView(new ArrayBuffer(55366)), 39788, 2560);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline36 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let img6 = await imageWithData(261, 72, '#8ac4546f', '#d7982ab7');
+let texture33 = device0.createTexture({
+  label: '\uaa20\u3f7b\u003e\u{1f901}\u98ba\ue178\uf9aa\u21a2\u05a8\u8936\u{1ffaf}',
+  size: [451],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(89, 5, 3, 2);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder14.draw(997873523, 476926342, 975285137, 312992498);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 11, y: 2 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas1.width = 369;
+let canvas5 = document.createElement('canvas');
+try {
+canvas5.getContext('webgpu');
+} catch {}
+let buffer18 = device0.createBuffer({
+  label: '\u{1ff1c}\u{1fb5c}\u{1f956}\u06e8\u2054\u0119\u01fc\u0e9f',
+  size: 86043,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: false,
+});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 920});
+let texture34 = device0.createTexture({
+  label: '\u8221\udf2c\u{1f820}',
+  size: {width: 112, height: 8, depthOrArrayLayers: 45},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView63 = texture11.createView({
+  label: '\u{1f7c6}\ub4c7\u472a\uad61\u092c\u03da',
+  format: 'astc-12x10-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder33 = commandEncoder30.beginComputePass({label: '\u2b93\u74f8\u006c\uef45\u8fea\u22af'});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder14.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle14, renderBundle7, renderBundle1, renderBundle6, renderBundle1, renderBundle4, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint32');
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 69244);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer9, 549296, 40252);
+} catch {}
+let promise4 = device0.popErrorScope();
+offscreenCanvas3.width = 2767;
+let offscreenCanvas9 = new OffscreenCanvas(386, 488);
+let bindGroupLayout9 = device0.createBindGroupLayout({entries: []});
+let textureView64 = texture18.createView({label: '\u0a0a\u0eb7', dimension: '2d-array', baseMipLevel: 4, arrayLayerCount: 1});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u{1ff34}\u{1fc66}\u62a1\u2761\u{1f75b}',
+  colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup13, new Uint32Array(7709), 4856, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer4, 508768, 4023);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup13, new Uint32Array(2220), 295, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(627723973);
+} catch {}
+let arrayBuffer4 = buffer12.getMappedRange(21864, 21668);
+try {
+device0.queue.writeBuffer(buffer16, 29948, new Float32Array(60001), 44928, 480);
+} catch {}
+let imageData7 = new ImageData(168, 204);
+try {
+offscreenCanvas9.getContext('webgpu');
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `@group(0) @binding(457)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(348)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S0 {
+  @location(2) f0: i32,
+  @location(11) f1: vec2<f16>,
+  @location(7) f2: u32,
+  @location(4) f3: vec2<u32>,
+  @location(15) f4: vec3<f16>,
+  @builtin(front_facing) f5: bool,
+  @location(10) f6: vec4<i32>,
+  @location(8) f7: vec4<i32>,
+  @location(9) f8: i32,
+  @location(13) f9: vec3<f32>,
+  @location(5) f10: f32,
+  @location(12) f11: vec4<f16>,
+  @builtin(sample_index) f12: u32,
+  @location(14) f13: vec2<f32>,
+  @location(3) f14: f16,
+  @location(6) f15: vec3<f16>,
+  @location(1) f16: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S0, @builtin(position) a1: vec4<f32>) {
+
+}
+
+struct VertexOutput0 {
+  @location(2) f25: i32,
+  @location(7) f26: u32,
+  @location(8) f27: vec4<i32>,
+  @builtin(position) f28: vec4<f32>,
+  @location(4) f29: vec2<u32>,
+  @location(15) f30: vec3<f16>,
+  @location(10) f31: vec4<i32>,
+  @location(1) f32: vec3<u32>,
+  @location(12) f33: vec4<f16>,
+  @location(6) f34: vec3<f16>,
+  @location(14) f35: vec2<f32>,
+  @location(11) f36: vec2<f16>,
+  @location(5) f37: f32,
+  @location(13) f38: vec3<f32>,
+  @location(9) f39: i32,
+  @location(3) f40: f16
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f32>, @location(14) a1: vec4<u32>, @location(0) a2: vec4<i32>, @location(1) a3: vec3<i32>, @location(11) a4: vec4<i32>, @location(4) a5: vec3<i32>, @location(6) a6: i32, @location(3) a7: vec2<i32>, @location(5) a8: vec2<i32>, @location(12) a9: vec3<f16>, @location(10) a10: u32, @location(8) a11: f32, @builtin(instance_index) a12: u32, @location(13) a13: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture35 = device0.createTexture({
+  size: {width: 903, height: 64, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16sint'],
+});
+let renderBundle29 = renderBundleEncoder18.finish({label: '\u{1f656}\ud639\u63c5\u08f6\u6d8c'});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup5, new Uint32Array(5454), 1009, 0);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -869.7, g: -298.7, b: -974.6, a: 622.3, });
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(620);
+} catch {}
+try {
+renderBundleEncoder14.draw(374845303, 721809175, 965821007, 1058332634);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(333421053);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer5, 20068);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(1, buffer9, 0, 57287);
+} catch {}
+let pipeline37 = await device0.createRenderPipelineAsync({
+  label: '\u{1fe5d}\u0aa4\u{1fdbf}\u6aff\u95fd',
+  layout: pipelineLayout8,
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'invert'},
+    stencilWriteMask: 3258098331,
+    depthBias: 453677968,
+    depthBiasSlopeScale: -33.109871775613826,
+    depthBiasClamp: -96.71795620584001,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 512, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 1340,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 544, shaderLocation: 11},
+          {format: 'uint16x2', offset: 328, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 13},
+          {format: 'sint32', offset: 20, shaderLocation: 0},
+          {format: 'sint32x3', offset: 244, shaderLocation: 4},
+          {format: 'float32', offset: 368, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 1144,
+        attributes: [{format: 'sint32', offset: 80, shaderLocation: 5}, {format: 'sint16x4', offset: 80, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 124, shaderLocation: 8}],
+      },
+      {arrayStride: 836, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 80, shaderLocation: 3}],
+      },
+      {
+        arrayStride: 376,
+        attributes: [
+          {format: 'sint8x2', offset: 20, shaderLocation: 1},
+          {format: 'uint32x4', offset: 4, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas8.getContext('bitmaprenderer');
+} catch {}
+let querySet20 = device0.createQuerySet({label: '\u065a\u8dd0\u6c51\u9a72\u00bc\u{1f8fc}\u2c0f', type: 'occlusion', count: 1387});
+let textureView65 = texture0.createView({
+  label: '\u{1fb46}\u0cf4\u0345\u0a68\u99ac\ua737\u07d9\u0b12\u1242',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup7, new Uint32Array(3137), 2899, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setViewport(47.06, 3.290, 32.00, 2.007, 0.3700, 0.6967);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer4, 0, 351218);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise4;
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({label: '\ucbf5\u8700\u{1fe9b}\u03a6\u{1ffc9}\u0da4\u0a33\u0e56'});
+let commandBuffer14 = commandEncoder57.finish({});
+try {
+renderPassEncoder15.setScissorRect(91, 3, 4, 4);
+} catch {}
+try {
+renderPassEncoder2.setViewport(2.681, 0.5857, 1.069, 0.3115, 0.8915, 0.9723);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 2385570 */
+{offset: 208, bytesPerRow: 785, rowsPerImage: 126}, {width: 133, height: 15, depthOrArrayLayers: 25});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 21, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture36 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView66 = texture21.createView({label: '\u41b0\u0769\u054e\u00b8', format: 'rg16uint'});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -906.7, g: -573.5, b: -706.5, a: 725.7, });
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(267534239, 1088303589, 1033081159, -748972078, 647200228);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 101244);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer5, 81748);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 151484, new DataView(new ArrayBuffer(1901)), 1471, 36);
+} catch {}
+let buffer19 = device0.createBuffer({
+  label: '\ua9db\ud581\u011c\u7fab',
+  size: 104546,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView67 = texture9.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 2, mipLevelCount: 3});
+try {
+computePassEncoder19.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder3.setViewport(4.861, 0.1961, 0.2314, 0.8029, 0.7718, 0.7891);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer9, 0, 14884);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup7, new Uint32Array(2381), 1147, 0);
+} catch {}
+try {
+renderBundleEncoder14.drawIndexed(728726531, 920120114, 641182529);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer19, 35228);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer4, 0, 191987);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 29, y: 14 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u{1f6c6}\u0757\ue14a\u007b\ud670',
+  entries: [
+    {
+      binding: 159,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let renderBundle30 = renderBundleEncoder20.finish();
+try {
+computePassEncoder22.dispatchWorkgroups(4, 3, 4);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(2, 1, 2, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(86180822);
+} catch {}
+try {
+renderBundleEncoder14.drawIndirect(buffer19, 260);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline38 = await device0.createComputePipelineAsync({
+  label: '\u687e\u974a\u97fa\u3600',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline39 = device0.createRenderPipeline({
+  label: '\u{1fbc8}\uabbf\uc839\u9bf3',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0x9fdfe4bd},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let commandEncoder58 = device0.createCommandEncoder({label: '\u03e3\u{1fec2}\u02b7\u0d2c\u{1f789}'});
+let querySet21 = device0.createQuerySet({label: '\u3d67\u146f\u0a0d\ud2cc', type: 'occlusion', count: 1218});
+let textureView68 = texture25.createView({
+  label: '\u{1fa33}\u0a54\u{1fd20}\u{1f783}\u77f8\u{1f836}\u8b2c\u0f3e\u0756\ua618',
+  dimension: '2d-array',
+  aspect: 'all',
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let renderBundle31 = renderBundleEncoder14.finish({label: '\u0ddc\u{1f74e}\u44b5\u0f1f\u0ba2'});
+let sampler29 = device0.createSampler({
+  label: '\u9b1f\u2d2e\u{1fab4}\u00e0\u9317\u0737\ube8b\u{1ff91}\u1dcf\u519d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.24,
+  lodMaxClamp: 46.09,
+});
+try {
+renderPassEncoder5.beginOcclusionQuery(1912);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer4);
+} catch {}
+let promise6 = buffer16.mapAsync(GPUMapMode.READ, 0, 250056);
+try {
+commandEncoder58.resolveQuerySet(querySet11, 2519, 857, buffer9, 262656);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 15912, new DataView(new ArrayBuffer(60777)), 25292, 4560);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas7.getContext('webgpu');
+let texture37 = device0.createTexture({
+  size: {width: 451},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let textureView69 = texture20.createView({mipLevelCount: 2});
+let renderPassEncoder16 = commandEncoder58.beginRenderPass({
+  label: '\u040a\u8196\u5011\u68b2\u533c\u06ca\u0bc2\u17e5\u02bd\u8877\u33d2',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView51, stencilLoadOp: 'clear', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 7367214,
+});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer19, 85432, 18180);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5, commandBuffer8]);
+} catch {}
+let pipeline40 = device0.createComputePipeline({
+  label: '\u{1fc34}\u461b\u02e8\u05f1\uc955',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let pipeline41 = await device0.createRenderPipelineAsync({
+  label: '\uc4e4\u08de\ud94f\u0fa3',
+  layout: pipelineLayout2,
+  multisample: {mask: 0x3782eb78},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm'}, {format: 'rgb10a2uint'}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+  await promise6;
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({label: '\u0e64\u{1f65d}\u{1fd84}\u0bfc\u0b84\u0cec\u327f\u0044\u7cc2\u81aa\u05d8', entries: []});
+let commandEncoder59 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({label: '\ua3dc\u0633\u{1f81e}\u2b19\u{1febe}', type: 'occlusion', count: 1003});
+let texture38 = device0.createTexture({
+  label: '\ufcda\u0774\u81b6',
+  size: [451, 32, 180],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 41.11,
+  lodMaxClamp: 50.15,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup12, new Uint32Array(6293), 3347, 0);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(47);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(104, 6, 4, 1);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint16', 165536, 90660);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(308101832, 216230781, 488900026, 971277152, 669598431);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer8, 168580, buffer15, 115292, 9824);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer19, 42176, 8076);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 8804, new Float32Array(8449), 6121, 1504);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas4,
+  origin: { x: 0, y: 170 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView70 = texture27.createView({label: '\uaedf\u8b9c\u0266\u6254\ude8e\u{1fc4c}', dimension: '2d-array', baseMipLevel: 1});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint', 'rg32sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 801.0, g: -759.6, b: 707.3, a: 423.3, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(8, 6, 55, 1);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(94);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer19, 'uint16', 84934, 10914);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer11, 134716, buffer15, 141016, 30208);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 106, y: 78 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline42 = await device0.createComputePipelineAsync({
+  label: '\u5edc\u943b\u026a',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let bindGroupLayout12 = device0.createBindGroupLayout({label: '\u0da7\u02d2\u6e18\u{1fa75}\u0f22\u96b9', entries: []});
+let sampler31 = device0.createSampler({
+  label: '\ubffd\u052c\u{1ff0c}\ub218\u01a1\u96ed',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.82,
+  lodMaxClamp: 67.52,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder2.dispatchWorkgroups(1, 3, 1);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle12, renderBundle0, renderBundle18, renderBundle10, renderBundle1, renderBundle3, renderBundle6, renderBundle11, renderBundle0, renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer14, 'uint16', 18434, 275113);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer9, 0, 682848);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13504 */
+  offset: 13504,
+  rowsPerImage: 3,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 18, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 4,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 32008, new Int16Array(51878), 13070, 6556);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({label: '\u0adf\ue87a\u{1fd71}\u{1fbfe}\udba4\u{1f804}\u{1f707}\u{1f966}\ua96b\u{1f730}', entries: []});
+let commandEncoder60 = device0.createCommandEncoder({});
+let textureView71 = texture14.createView({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u065d\ua912\u{1f83a}\u0b4f\ua1d6\u8814\u1428\u6645\u05ab\u7da9',
+  colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let sampler32 = device0.createSampler({
+  label: '\ua41e\u{1ff7e}\u1870\u0d71\u4589',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.92,
+  lodMaxClamp: 96.95,
+});
+try {
+renderBundleEncoder16.drawIndirect(buffer5, 19592);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer9, 459844, 185013);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer18, 49304, buffer0, 31480, 6284);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 375, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 48, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 122, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder60.resolveQuerySet(querySet19, 432, 68, buffer13, 23552);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13, commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(16)), /* required buffer size: 8611491 */
+{offset: 51, bytesPerRow: 240, rowsPerImage: 260}, {width: 240, height: 1, depthOrArrayLayers: 139});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+  label: '\u{1f789}\ub1bd\u017c',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap4 = await createImageBitmap(offscreenCanvas4);
+let texture39 = device0.createTexture({
+  label: '\u0cc1\u{1f88e}\u{1feee}\u{1fffc}',
+  size: [112, 8, 213],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder34 = commandEncoder47.beginComputePass({});
+let renderPassEncoder17 = commandEncoder59.beginRenderPass({
+  label: '\u047e\u1b64\u9ec5\u0331\u026d\u0670\u0efe\u7e95\uf245\u0ab4',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView15, depthReadOnly: true, stencilLoadOp: 'load', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet22,
+  maxDrawCount: 786790085,
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u3c98\u2596\u1cc3\u4822\ucadd\u0c29\u9795\u011e\u2adb\u5f24\u074f',
+  colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'],
+  stencilReadOnly: true,
+});
+let renderBundle32 = renderBundleEncoder14.finish({label: '\u{1fdf6}\u0687'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup5, new Uint32Array(917), 204, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer9, 90144, 695265);
+} catch {}
+try {
+renderBundleEncoder23.drawIndirect(buffer19, 22136);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer4, 0, 476009);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet17, 1004, 166, buffer5, 88064);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 124332, new BigUint64Array(25217), 4588, 1924);
+} catch {}
+try {
+window.someLabel = externalTexture19.label;
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({label: '\u0f10\u0764\u{1f95e}\ua9b3\u{1ff8f}'});
+let textureView72 = texture10.createView({label: '\u2d65\u1c76\ue099'});
+let renderPassEncoder18 = commandEncoder61.beginRenderPass({
+  label: '\u63b7\u934a',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView36, depthReadOnly: false, stencilLoadOp: 'clear', stencilStoreOp: 'discard'},
+});
+let renderBundle33 = renderBundleEncoder6.finish();
+try {
+computePassEncoder6.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 199.0, g: -929.6, b: 20.20, a: -325.2, });
+} catch {}
+try {
+renderPassEncoder17.setViewport(3.992, 0.3027, 2.342, 0.2965, 0.9596, 0.9953);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer9);
+} catch {}
+try {
+renderBundleEncoder23.drawIndirect(buffer5, 9324);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 4092, new Int16Array(4213), 2492, 316);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 745374 */
+{offset: 174, bytesPerRow: 207, rowsPerImage: 180}, {width: 30, height: 0, depthOrArrayLayers: 21});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 1263, y: 58 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 31, y: 3, z: 50},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\u7d44\ubb49\ue899\u0b27\u6f94\u0ae0'});
+let computePassEncoder35 = commandEncoder60.beginComputePass();
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u0665\u4e45\ud473\u1393\u{1f6cd}\u{1f9da}\u014b\uce2e',
+  colorFormats: ['rgb10a2uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer11, 112976, buffer0, 21688, 23676);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 147},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 139216 */
+  offset: 18272,
+  bytesPerRow: 256,
+  rowsPerImage: 93,
+  buffer: buffer17,
+}, {width: 112, height: 8, depthOrArrayLayers: 6});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer15, 74688);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 94, y: 177 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 24, y: 1, z: 36},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 112, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let img7 = await imageWithData(243, 152, '#7cd5d7a1', '#25d7b2c2');
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u556a\u075f\u021f', bindGroupLayouts: []});
+try {
+renderPassEncoder3.setStencilReference(24);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer9);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup4, new Uint32Array(152), 137, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(721373103, 1097174150, 449621536, 929999457, 393468878);
+} catch {}
+try {
+commandEncoder62.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 932 widthInBlocks: 233 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26136 */
+  offset: 25204,
+  buffer: buffer0,
+}, {width: 233, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 82 */
+{offset: 82, bytesPerRow: 138}, {width: 0, height: 10, depthOrArrayLayers: 1});
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let buffer20 = device0.createBuffer({size: 33356, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder63 = device0.createCommandEncoder({label: '\u{1f8b4}\u1207\u130d\u6f84\u09d6\u02b0\uff13'});
+let querySet23 = device0.createQuerySet({label: '\u8e31\ua261', type: 'occlusion', count: 328});
+let texture40 = device0.createTexture({
+  label: '\uc877\u{1f9ea}\u88f7\u0010',
+  size: {width: 120, height: 1, depthOrArrayLayers: 26},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let computePassEncoder36 = commandEncoder36.beginComputePass({label: '\u4e9b\u0b1c\u9edc\u0b6b\u0566\u83e9\u47ef\u9aaa\u4e99\u7499'});
+let externalTexture21 = device0.importExternalTexture({label: '\u2044\u03b2', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(1731);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer5, 8784);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer8, 62192, buffer2, 8876, 23016);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandEncoder64 = device0.createCommandEncoder({label: '\u0d08\u0864'});
+let textureView73 = texture25.createView({mipLevelCount: 1});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u170f\u1054\u{1fdb7}\ua286\u4121\u015b\u{1fcee}\u0150\u{1fc20}\u0084',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(32, 8, 41, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder64.copyBufferToBuffer(buffer18, 67668, buffer16, 203272, 16332);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 60000 */
+  offset: 60000,
+  buffer: buffer3,
+}, {
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 3020, new Float32Array(4634));
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+  label: '\u2cc6\ud005\ud1ba\ua25e\u939a\u8277\u{1fa8d}\u{1fa09}\u{1fb2e}\u088d',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline45 = await device0.createRenderPipelineAsync({
+  label: '\u051d\ue5c7\u0283\u8591\u4d1d\u{1fe18}\u{1fda3}\u0259',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0xeb6ae5b2},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {failOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 779542225,
+    stencilWriteMask: 2390309300,
+    depthBiasSlopeScale: 591.551045194636,
+    depthBiasClamp: 892.9085657692603,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+let gpuCanvasContext7 = canvas6.getContext('webgpu');
+let canvas7 = document.createElement('canvas');
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5, bindGroupLayout5]});
+let textureView74 = texture14.createView({label: '\u9ab6\u000a\u582d'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(3, bindGroup1, new Uint32Array(718), 462, 0);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer19, 85656);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup14, new Uint32Array(9462), 4292, 0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup9, []);
+} catch {}
+try {
+renderBundleEncoder9.draw(464575890);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 548 widthInBlocks: 137 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24932 */
+  offset: 24932,
+  buffer: buffer0,
+}, {width: 137, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 6188, new DataView(new ArrayBuffer(9782)), 8119, 792);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer2), /* required buffer size: 3925581 */
+{offset: 265, bytesPerRow: 691, rowsPerImage: 284}, {width: 109, height: 1, depthOrArrayLayers: 21});
+} catch {}
+let gpuCanvasContext8 = canvas7.getContext('webgpu');
+try {
+  await promise7;
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(520, 28);
+let videoFrame6 = new VideoFrame(canvas4, {timestamp: 0});
+let bindGroup15 = device0.createBindGroup({label: '\uea7d\u3cfb\u{1f9a6}\u{1fd0b}\u{1f879}', layout: bindGroupLayout0, entries: []});
+let commandEncoder65 = device0.createCommandEncoder({label: '\ufedd\u08e1\u0868\u0326\u{1f8ca}\u9198'});
+let textureView75 = texture1.createView({label: '\u6acf\u06a2\u05c8\u7cf1\ud3e1\u1bab\u{1fba4}\u0102\u{1fe23}'});
+try {
+computePassEncoder13.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: 655.5, g: 376.7, b: 660.0, a: -830.0, });
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer4, 178800);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexed(60269179, 216012084, 499307887, -327958927, 11396803);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 86288 */
+  offset: 86288,
+  rowsPerImage: 51,
+  buffer: buffer19,
+}, {width: 48, height: 10, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer19);
+} catch {}
+let querySet24 = device0.createQuerySet({label: '\u{1fb65}\u1d07\u49d0\u0b2a\u1307', type: 'occlusion', count: 2237});
+let commandBuffer15 = commandEncoder65.finish({});
+let texture41 = device0.createTexture({
+  label: '\u0222\u0ace\u0b31',
+  size: [451, 32, 1],
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer4, 0, 152911);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 29483 */
+  offset: 29468,
+  buffer: buffer18,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+renderPassEncoder18.insertDebugMarker('\u0f90');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise8 = adapter1.requestAdapterInfo();
+let buffer21 = device0.createBuffer({
+  label: '\u81f9\u{1ff36}\u0f23\u93a6\u2cc2\ued21\u2693',
+  size: 79784,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder66 = device0.createCommandEncoder({});
+let textureView76 = texture8.createView({
+  label: '\ufa43\u54b8\u7165\ub885',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 118,
+});
+let externalTexture22 = device0.importExternalTexture({label: '\u8ad1\u{1fdda}', source: video3});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup5, new Uint32Array(4356), 1337, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1953);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(28, 1, 63, 7);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer19, 0, 92379);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(108477448, 214767401, 362753817, 508963369, 408802065);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexedIndirect(buffer19, 4572);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(4, buffer4, 292208);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 3968, new Int16Array(39146), 906, 5968);
+} catch {}
+gc();
+let buffer22 = device0.createBuffer({
+  label: '\u3b0c\u074a\u0d17\u{1ff46}\u2154\ue1e0\uf60d\u{1ff75}\u5eee\u0e60',
+  size: 67830,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet25 = device0.createQuerySet({label: '\u04aa\u01fc\u8ce0\u{1fe26}\u0414\u0d0e\u{1fa56}\uea52', type: 'occlusion', count: 2629});
+let texture42 = device0.createTexture({
+  label: '\u9727\uf2d7\u0da9\u{1f83b}\u8367\u02e9',
+  size: [240, 1, 52],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView77 = texture12.createView({
+  label: '\u82a4\u{1faa9}\u79fc\ucb49',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 96,
+  arrayLayerCount: 26,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u3182\u3a96\u06c7\u63d5\u{1f712}',
+  colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'],
+});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer19, 27452);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(2001);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer19, 0, 21806);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer19, 10272);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer18, 69992, buffer17, 143164, 5396);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 20681 */
+  offset: 20681,
+  buffer: buffer3,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline46 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext9 = offscreenCanvas10.getContext('webgpu');
+let bindGroup16 = device0.createBindGroup({
+  label: '\uf002\u{1fe58}\u{1fec8}\u8f08\u78b0\ucf57\u{1ffec}\uf602',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let pipelineLayout12 = device0.createPipelineLayout({label: '\u{1fdb8}\u0c7b', bindGroupLayouts: []});
+let querySet26 = device0.createQuerySet({
+  label: '\ue195\uec2e\ueea8\u8e11\ub872\ua869\u{1f9d3}\u9e5f\ue3fd\u{1f6d3}\ua450',
+  type: 'occlusion',
+  count: 405,
+});
+let commandBuffer16 = commandEncoder66.finish({label: '\ue1a1\u{1fb04}\u{1fc92}\u125e\u1fbc\u1751\u{1fe38}\u43c4\u48b7\uf6ca'});
+let texture43 = device0.createTexture({
+  size: [225, 16, 90],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let textureView78 = texture7.createView({aspect: 'stencil-only', baseMipLevel: 3});
+let sampler33 = device0.createSampler({
+  label: '\u86c7\u0d7d\u06e1\ud8d3\uc79c\u0d15\u7a87\u30af\u1e82\u{1fc06}\u8e90',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.53,
+  lodMaxClamp: 93.83,
+});
+try {
+renderPassEncoder9.setScissorRect(7, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer19, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(129129938, 297295562);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(3, buffer9, 0, 338410);
+} catch {}
+try {
+texture29.destroy();
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer20);
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 62, y: 32 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\ud907\u32db\ufc17\u{1fe49}\u9266\u{1fee0}\u5ce9\ubfce\u{1f9b0}',
+  layout: bindGroupLayout13,
+  entries: [],
+});
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.30,
+  lodMaxClamp: 89.27,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup1, new Uint32Array(3340), 1083, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup10, new Uint32Array(8127), 7144, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer19, 45696);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer19, 58748);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet10, 884, 503, buffer5, 99328);
+} catch {}
+let pipeline47 = await device0.createRenderPipelineAsync({
+  label: '\ua51f\u0c41\ucd18\u1d30\u0a13\uf481\u0000\u{1fb6c}\u0c0d\u6554\u0540',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'zero'},
+  },
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'never', failOp: 'zero', passOp: 'increment-clamp'},
+    stencilWriteMask: 2113919494,
+    depthBias: 1555077686,
+    depthBiasSlopeScale: 991.9488160129031,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+document.body.prepend(img5);
+let textureView79 = texture39.createView({
+  label: '\u02bd\u05d7\u048a\u000c\ucd25\u4ca5\ud970\u{1fb91}\u03e6\u{1f9b1}',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseArrayLayer: 199,
+});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({label: '\u6e92\uae6c\u01fb', colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup1, new Uint32Array(7941), 1422, 0);
+} catch {}
+try {
+computePassEncoder13.dispatchWorkgroupsIndirect(buffer19, 33224);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(1832);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(455769793, 552095460, 1156514916, -967999788, 962784919);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 8896);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer9, 28796, buffer7, 153828, 47484);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 266360, new Int16Array(42973), 40340, 2632);
+} catch {}
+let pipeline48 = await device0.createComputePipelineAsync({
+  label: '\u99b4\udef3\u6675\uebb4',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder67 = device0.createCommandEncoder();
+let textureView80 = texture11.createView({baseMipLevel: 4});
+let computePassEncoder37 = commandEncoder62.beginComputePass({label: '\u8243\u61f8\u{1ff28}\u{1feef}\u{1f8ae}\u{1fd60}\udf83\u8154\u8cfb'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u{1f6a3}\u9f86\ue914\u0f15',
+  colorFormats: ['rg32float', 'rg11b10ufloat', 'r32float', 'r16uint', 'rgba8sint', 'r8unorm', 'rg8uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder16.setViewport(88.83, 5.035, 2.050, 2.030, 0.4946, 0.8110);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexedIndirect(buffer5, 1148);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4, buffer19, 0, 6968);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({label: '\u{1fab7}\u9d13\u9b11\u6de4\u777f\uab0e'});
+let textureView81 = texture20.createView({label: '\u8b1c\u0b6e\uea52', aspect: 'all', format: 'rg16uint', baseMipLevel: 1, mipLevelCount: 5});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup6, new Uint32Array(6606), 6556, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer19, 0, 87518);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 7204);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer4, 140264, 365923);
+} catch {}
+let pipeline49 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let pipeline50 = await device0.createRenderPipelineAsync({
+  label: '\uf614\uf453\u090e\u0cd6\u{1ffe7}\u0e32\ufa0c\u4afd\u32b7\u{1fd12}\ua241',
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule1, entryPoint: 'fragment0', targets: [{format: 'rgb10a2uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 140,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 56, shaderLocation: 12},
+          {format: 'float32', offset: 40, shaderLocation: 9},
+          {format: 'float16x2', offset: 52, shaderLocation: 10},
+          {format: 'float32', offset: 12, shaderLocation: 0},
+          {format: 'float16x2', offset: 8, shaderLocation: 11},
+          {format: 'sint32x3', offset: 28, shaderLocation: 3},
+          {format: 'uint32x4', offset: 28, shaderLocation: 8},
+          {format: 'sint32x2', offset: 16, shaderLocation: 6},
+          {format: 'sint8x4', offset: 0, shaderLocation: 15},
+          {format: 'uint16x4', offset: 92, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas2);
+let texture44 = device0.createTexture({
+  label: '\u{1fdd8}\u20fb\u5086\ua27b\u4b48',
+  size: {width: 120, height: 1, depthOrArrayLayers: 46},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundle34 = renderBundleEncoder18.finish({label: '\u{1fce7}\u{1f7b5}\uc86a\u86cd\u07e3\ua75d\u003a\ub54f'});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle6, renderBundle5, renderBundle5, renderBundle1, renderBundle18, renderBundle24, renderBundle8, renderBundle1, renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer19, 0);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet21, 472, 60, buffer5, 61440);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 1292, new Int16Array(36926), 12560, 10724);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 90 */
+{offset: 90}, {width: 109, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView82 = texture5.createView({aspect: 'stencil-only', baseArrayLayer: 169, arrayLayerCount: 8});
+try {
+renderPassEncoder10.executeBundles([renderBundle32, renderBundle5, renderBundle5, renderBundle33, renderBundle3, renderBundle12, renderBundle15, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 126.4, g: 800.6, b: 831.1, a: 44.86, });
+} catch {}
+try {
+renderPassEncoder9.setViewport(0.09265, 0.2969, 6.337, 0.5134, 0.6654, 0.7652);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint32', 6504, 64259);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer4, 473752, 11070);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.draw(368667262, 821657359);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 10508);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer9, 328668, 6762);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u7bb7');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 5,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 336 */
+{offset: 336, rowsPerImage: 171}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\ud583\u98ca\u0dce\uff6b\u{1fe56}\u2dac\uc07a\uda3e',
+  entries: [
+    {
+      binding: 533,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 831,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 480,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup18 = device0.createBindGroup({
+  label: '\u01a9\ud41c\u04bc\udb9b\u6e2d\ue5fa\u3091\u00e8\u55d7\u02d4',
+  layout: bindGroupLayout12,
+  entries: [],
+});
+let texture45 = device0.createTexture({
+  label: '\u{1f9b7}\u926c\u082e\u1566\ub110\u1866\u5f3f\uf4dd\u0f9b\uf43e\u7ac0',
+  size: {width: 225, height: 16, depthOrArrayLayers: 90},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder11.beginOcclusionQuery(455);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 158.8, g: -548.1, b: -534.6, a: -881.3, });
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 10560);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer19, 72320);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 26840, new BigUint64Array(62254), 36844, 300);
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  label: '\ue92d\u{1fa1f}\uceb3\u0fb0\u{1fee7}\u{1f929}\u{1fe12}\u997f\u{1fd4c}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 973175823,
+    stencilWriteMask: 1836115884,
+    depthBias: 0,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 609.3493742056284,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let offscreenCanvas11 = new OffscreenCanvas(889, 484);
+let bindGroup19 = device0.createBindGroup({label: '\u05d7\u234c\u11e0\u0979\u2662\u0ab2\u4d5b\u0e8a', layout: bindGroupLayout0, entries: []});
+let commandBuffer17 = commandEncoder64.finish({label: '\u2064\u08b2\u0892\uc435\u7f7f'});
+let textureView83 = texture33.createView({label: '\u1477\u{1f9fc}\u166f\u0e50\u{1fe3e}\u2594\u2e72\uecce', format: 'r8uint'});
+try {
+computePassEncoder22.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup14);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder();
+let commandBuffer18 = commandEncoder69.finish({});
+let texture46 = device0.createTexture({
+  label: '\u8286\ud9e1\u{1fa84}\u0570',
+  size: {width: 903, height: 64, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32float'],
+});
+let textureView84 = texture30.createView({dimension: '2d-array'});
+let computePassEncoder38 = commandEncoder63.beginComputePass({label: '\u78f4\ueeca\u{1fd4d}\u0d0a\u42b7\u3ca0'});
+let externalTexture23 = device0.importExternalTexture({label: '\u6402\u{1f63f}\u0060\u{1f7fd}\u734c\ub3f8\u04e3', source: videoFrame6, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(517);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer9, 613800, 157820);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(903915901, 1204153240, 878688252, -372176883, 368318254);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer5, 1724);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer19, 59948, 19148);
+} catch {}
+try {
+commandEncoder68.copyBufferToBuffer(buffer8, 129540, buffer16, 325916, 4076);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 5, y: 9 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 127, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let pipeline52 = device0.createComputePipeline({
+  label: '\u2b95\uf764\u09e1\u07d1\u0be2\u{1fc1a}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let device1 = await adapter1.requestDevice({
+  label: '\u024b\u9aba\u{1f9a6}\u98e1\u0c54\u{1fe19}\u{1f7c7}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 48,
+    maxVertexAttributes: 20,
+    maxVertexBufferArrayStride: 6770,
+    maxStorageTexturesPerShaderStage: 22,
+    maxStorageBuffersPerShaderStage: 32,
+    maxDynamicStorageBuffersPerPipelineLayout: 42736,
+    maxDynamicUniformBuffersPerPipelineLayout: 233,
+    maxBindingsPerBindGroup: 5862,
+    maxTextureArrayLayers: 1441,
+    maxTextureDimension1D: 14974,
+    maxTextureDimension2D: 10501,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 50628564,
+    maxUniformBuffersPerShaderStage: 27,
+    maxSampledTexturesPerShaderStage: 30,
+    maxInterStageShaderVariables: 108,
+    maxInterStageShaderComponents: 122,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let bindGroupLayout15 = device1.createBindGroupLayout({
+  label: '\u{1ff84}\u3fab\ufb26\u0067',
+  entries: [
+    {
+      binding: 2110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 366,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 612735, hasDynamicOffset: true },
+    },
+    {
+      binding: 4274,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let buffer23 = device1.createBuffer({size: 147007, usage: GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let querySet27 = device1.createQuerySet({label: '\uec91\u0738\uaf75\ue558\udca0\u9215\ud080\ub9b8\u3d0e\uffdf', type: 'occlusion', count: 3369});
+let texture47 = device1.createTexture({
+  size: {width: 5376, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16float'],
+});
+let textureView85 = texture47.createView({
+  label: '\u01f7\u011a\u06de\u5e5d\u368a\u96c5\uab27\u{1f7c4}\u0921\ucb56\u1abf',
+  dimension: '2d-array',
+  mipLevelCount: 7,
+});
+let externalTexture24 = device1.importExternalTexture({label: '\u5d7c\ue155\u{1fe8e}\u82ed\u0f8f\u0351\uee0a\u1069\u91cc\u1717\ude54', source: videoFrame4});
+let computePassEncoder39 = commandEncoder68.beginComputePass({});
+try {
+renderPassEncoder2.executeBundles([renderBundle6, renderBundle1, renderBundle9, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(1579);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(575706557, 1063514995, 639711750, -509912530, 668893654);
+} catch {}
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 4, y: 5, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 111, y: 29, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline53 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext10 = offscreenCanvas11.getContext('webgpu');
+let bindGroupLayout16 = pipeline41.getBindGroupLayout(0);
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView86 = texture13.createView({mipLevelCount: 1});
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer5, 94896);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer9, 516984, 165265);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexed(587709079, 859626409);
+} catch {}
+try {
+renderBundleEncoder23.drawIndirect(buffer19, 4900);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 38, y: 7 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({
+  label: '\ue4f4\u062c\ub0bc\u8dc6\u0005\u{1ffc6}\u00dc\u4468\u3b80\u0376',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder32.setVertexBuffer(3403, undefined, 0, 1790722807);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let querySet28 = device1.createQuerySet({label: '\u{1f6c2}\ua232\u26c3\u7a62\ub840\u{1fed6}', type: 'occlusion', count: 4010});
+let sampler35 = device1.createSampler({
+  label: '\u6e7b\u{1fecc}\u0171\u0104\u227a\u0e97\u0a07\u{1fcdb}\u7d73\u01fd\u{1f7cd}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.68,
+});
+video2.width = 14;
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout7, bindGroupLayout9, bindGroupLayout9, bindGroupLayout12]});
+let textureView87 = texture32.createView({label: '\u{1f783}\u08dd\ucc46\ua23d\u4779\u{1ff73}\u{1f878}\u05ae\u{1fd1e}\u{1fe6d}\u{1f8ec}'});
+let renderBundle35 = renderBundleEncoder14.finish({label: '\u155a\u39ce\u5dad\u{1fa41}\uef3a'});
+try {
+renderPassEncoder2.beginOcclusionQuery(1308);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup2, new Uint32Array(3065), 2097, 0);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(1225743555, 1202760545, 385171091, 1233855733, 922520895);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline50);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7176 */
+  offset: 7176,
+  buffer: buffer21,
+}, {width: 120, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet6, 1603, 1254, buffer19, 50688);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise8;
+} catch {}
+let video5 = await videoWithData();
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\u0bba\u5b01\u2ec1\u{1fbd8}\ue2e4\u6315\u{1f851}\u{1ffa4}\ub705\u0f57',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout15, bindGroupLayout15],
+});
+let textureView88 = texture47.createView({
+  label: '\u{1fa08}\u{1faa0}\uc084\u1797\u8d29\uf8d4',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 3,
+});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  stencilReadOnly: true,
+});
+let externalTexture25 = device1.importExternalTexture({label: '\ua9f4\ub4fe', source: video5, colorSpace: 'display-p3'});
+let sampler36 = device1.createSampler({
+  label: '\u{1fb57}\u{1f773}\u12ac\u0fdc\u8faf',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.82,
+  lodMaxClamp: 87.88,
+  maxAnisotropy: 15,
+});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let img8 = await imageWithData(144, 37, '#67c51182', '#ba88eedb');
+let bindGroupLayout17 = device0.createBindGroupLayout({label: '\u7e5f\u25f1\u6b24\u{1f6f7}\uc9e2\u15b2\u{1fbfe}\u195b\u5a0d', entries: []});
+let texture48 = device0.createTexture({
+  label: '\u6a18\u0e58\u0d38\u095c\u7a2f\u9185\u{1f617}',
+  size: [960, 4, 1],
+  mipLevelCount: 3,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint'],
+});
+let renderBundle36 = renderBundleEncoder5.finish({label: '\u6ed0\u{1f847}\u844a\u{1f907}\uc9ff\u3617'});
+try {
+computePassEncoder19.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder9.draw(1106636532, 945438737);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer19, 19428);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer19, 0, 80323);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 55 widthInBlocks: 55 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 131499 */
+  offset: 3700,
+  bytesPerRow: 256,
+  rowsPerImage: 29,
+  buffer: buffer3,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 55, height: 7, depthOrArrayLayers: 18});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 23264 */
+  offset: 23264,
+  rowsPerImage: 162,
+  buffer: buffer13,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 33, y: 12, z: 37},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer15, commandBuffer14, commandBuffer17]);
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({label: '\u{1f80a}\u{1f841}\u5c6c\ua3b0\u13e1\u4160'});
+let computePassEncoder40 = commandEncoder71.beginComputePass({label: '\u{1fdb3}\u6c8d'});
+let renderBundle37 = renderBundleEncoder6.finish({label: '\u4b14\u8a82\u0b06\uacf9\u0f80\uec5b\u069f\u0e3d\u{1fef0}\u0710\u0207'});
+try {
+renderPassEncoder11.setIndexBuffer(buffer5, 'uint16', 120822, 5621);
+} catch {}
+try {
+renderBundleEncoder16.draw(1007404291, 252335327);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(466117132, 218228033);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 79},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture3,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 120, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  label: '\u78ca\u3da7\uafef\u2812\u700a',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+  },
+  writeMask: 0,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'ccw', cullMode: 'none', unclippedDepth: true},
+});
+let textureView89 = texture17.createView({
+  label: '\ub7fd\u0d6c\u07b1\u0230\u5f00\ud1d9\u0a6b',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseMipLevel: 6,
+  baseArrayLayer: 142,
+});
+try {
+renderBundleEncoder30.drawIndexed(506572004, 142482278);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer5, 18184);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer19, 53252);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3396 */
+  offset: 3396,
+  buffer: buffer9,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 74},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 69718 */
+{offset: 948, bytesPerRow: 26, rowsPerImage: 23}, {width: 0, height: 0, depthOrArrayLayers: 116});
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(466, 959);
+let querySet29 = device1.createQuerySet({label: '\udceb\u{1ff1d}\u{1fa64}\u{1fa8c}\u6df5', type: 'occlusion', count: 808});
+let texture49 = device1.createTexture({
+  label: '\u{1f65b}\u5a9f\ud99a\u0cdb',
+  size: [480],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let renderBundle38 = renderBundleEncoder32.finish({label: '\u{1fce5}\u0bb5\u0f45'});
+let externalTexture26 = device1.importExternalTexture({
+  label: '\u0e1c\u{1f6cc}\uff5b\u0dd8\u{1f9eb}\uac61\u0d1d\u0049\u1784\ud0fe',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+let shaderModule3 = device1.createShaderModule({
+  label: '\u{1f8d5}\u683d\u44d3\ud9ee',
+  code: `@group(0) @binding(366)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(4274)
+var<storage, read_write> field0: array<u32>;
+@group(2) @binding(2110)
+var<storage, read_write> global2: array<u32>;
+@group(2) @binding(366)
+var<storage, read_write> type0: array<u32>;
+@group(1) @binding(4274)
+var<storage, read_write> parameter3: array<u32>;
+@group(0) @binding(2110)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(2110)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(4274)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(1) f1: vec4<u32>,
+  @location(5) f2: i32,
+  @location(4) f3: u32,
+  @location(2) f4: vec3<u32>,
+  @location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(17) f0: vec4<u32>,
+  @builtin(vertex_index) f1: u32,
+  @location(6) f2: vec2<f32>,
+  @location(10) f3: vec3<u32>,
+  @location(5) f4: vec2<f16>,
+  @location(13) f5: vec4<i32>,
+  @location(0) f6: i32,
+  @builtin(instance_index) f7: u32,
+  @location(7) f8: vec2<u32>,
+  @location(4) f9: f32,
+  @location(19) f10: vec2<f16>,
+  @location(12) f11: vec4<i32>,
+  @location(3) f12: vec3<i32>,
+  @location(8) f13: vec2<i32>,
+  @location(1) f14: vec4<f32>,
+  @location(16) f15: vec4<f32>,
+  @location(11) f16: vec4<i32>,
+  @location(15) f17: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(106) f41: f32,
+  @location(92) f42: vec4<f32>,
+  @location(100) f43: vec2<u32>,
+  @location(46) f44: vec3<i32>,
+  @location(57) f45: f32,
+  @builtin(position) f46: vec4<f32>,
+  @location(4) f47: vec2<u32>,
+  @location(79) f48: u32,
+  @location(44) f49: vec3<i32>,
+  @location(15) f50: vec3<i32>,
+  @location(11) f51: vec3<f16>,
+  @location(27) f52: f16,
+  @location(53) f53: vec4<f16>,
+  @location(7) f54: f16,
+  @location(21) f55: f16,
+  @location(69) f56: vec4<f32>,
+  @location(87) f57: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f32>, @location(14) a1: vec3<f32>, a2: S1, @location(18) a3: i32, @location(9) a4: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet30 = device1.createQuerySet({type: 'occlusion', count: 1803});
+let texture50 = device0.createTexture({
+  label: '\u{1fec2}\u0f4f\u8ff6\u{1fc7b}',
+  size: {width: 451, height: 32, depthOrArrayLayers: 180},
+  mipLevelCount: 8,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+let computePassEncoder41 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder13.dispatchWorkgroupsIndirect(buffer5, 58940);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer9, 333108, 42797);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder56.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 66 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 23908 */
+  offset: 23908,
+  buffer: buffer21,
+}, {width: 66, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer20);
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'stencil-only',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 1723246 */
+{offset: 534, bytesPerRow: 396, rowsPerImage: 101}, {width: 112, height: 8, depthOrArrayLayers: 44});
+} catch {}
+let commandEncoder72 = device1.createCommandEncoder({});
+let textureView90 = texture47.createView({label: '\u1667\u{1fc43}\u{1f750}\u{1f9b8}\u0e5a', dimension: '2d', baseMipLevel: 6});
+let pipeline55 = device1.createRenderPipeline({
+  layout: pipelineLayout14,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r16uint'}, {format: 'rg8sint'}, {format: 'r32uint', writeMask: 0}, {format: 'r32sint'}, undefined],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1156,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 116, shaderLocation: 4},
+          {format: 'sint16x4', offset: 364, shaderLocation: 12},
+          {format: 'uint16x2', offset: 100, shaderLocation: 7},
+          {format: 'sint32x3', offset: 804, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 2},
+          {format: 'sint8x4', offset: 468, shaderLocation: 11},
+          {format: 'uint32x4', offset: 632, shaderLocation: 9},
+          {format: 'sint16x4', offset: 428, shaderLocation: 0},
+          {format: 'sint8x2', offset: 182, shaderLocation: 18},
+          {format: 'sint8x2', offset: 1048, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 20, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 4692,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 1048, shaderLocation: 16},
+          {format: 'uint32x4', offset: 1512, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 1132,
+        attributes: [
+          {format: 'snorm16x2', offset: 40, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 128, shaderLocation: 1},
+          {format: 'float32', offset: 328, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 264, shaderLocation: 15},
+          {format: 'uint32', offset: 184, shaderLocation: 17},
+          {format: 'sint8x4', offset: 288, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 384, attributes: []},
+      {
+        arrayStride: 868,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 64, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let img9 = await imageWithData(268, 131, '#b9d28d15', '#3bc18710');
+let buffer24 = device0.createBuffer({
+  label: '\u0185\u00c1\u072c\u{1fd33}\uec44\u7d3c\u2b6d\u0ffb\uf01e\ud0f5\u767d',
+  size: 103524,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle39 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder14.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(261);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer19, 62364, 15655);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder23.draw(278711999, 200594098, 289809994, 874607579);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexedIndirect(buffer19, 31776);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 45, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 88 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21268 */
+  offset: 10340,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 88, height: 43, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet5, 260, 1517, buffer9, 477440);
+} catch {}
+try {
+renderBundleEncoder8.insertDebugMarker('\u3e14');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 8024, new BigUint64Array(27019), 19427, 1148);
+} catch {}
+let pipeline56 = device0.createComputePipeline({
+  label: '\uee0a\u903e',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas6.height = 1589;
+let buffer25 = device1.createBuffer({label: '\u2340\udf05\ufc0b', size: 17776, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let renderBundle40 = renderBundleEncoder33.finish({label: '\u03a9\u7ca6\u4c80\u{1fcc0}\ua2cb\ua465\u{1f95a}\u{1ff81}\u{1f9d0}'});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 982 */
+{offset: 982}, {width: 197, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+video2.height = 139;
+let shaderModule4 = device1.createShaderModule({
+  label: '\u0184\u{1ff4c}\u0e34\uf277\u022e\u9615',
+  code: `@group(2) @binding(366)
+var<storage, read_write> function1: array<u32>;
+@group(0) @binding(366)
+var<storage, read_write> local1: array<u32>;
+@group(2) @binding(4274)
+var<storage, read_write> global4: array<u32>;
+@group(0) @binding(4274)
+var<storage, read_write> type1: array<u32>;
+@group(1) @binding(366)
+var<storage, read_write> global5: array<u32>;
+@group(1) @binding(2110)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec2<u32>,
+  @location(3) f1: vec3<i32>,
+  @location(2) f2: u32,
+  @location(1) f3: vec4<u32>,
+  @location(0) f4: vec4<f32>,
+  @location(5) f5: i32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(1) f0: vec4<f32>,
+  @location(12) f1: i32,
+  @location(3) f2: vec4<u32>,
+  @location(18) f3: vec2<u32>,
+  @builtin(instance_index) f4: u32,
+  @location(6) f5: i32,
+  @builtin(vertex_index) f6: u32,
+  @location(5) f7: vec3<i32>,
+  @location(8) f8: vec2<f16>,
+  @location(11) f9: vec2<u32>,
+  @location(17) f10: vec2<f16>,
+  @location(13) f11: vec4<i32>,
+  @location(15) f12: vec4<u32>,
+  @location(0) f13: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec3<f16>, a1: S2, @location(16) a2: vec4<u32>, @location(10) a3: vec2<f16>, @location(2) a4: vec2<f32>, @location(19) a5: f32, @location(7) a6: vec3<i32>, @location(14) a7: f32, @location(9) a8: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\uc413\u75a9\u{1f9ae}\u{1ffea}\u0fec\u{1f64c}\u6d49\u{1fa8d}\u{1f646}\uef49',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout15, bindGroupLayout15],
+});
+let commandBuffer19 = commandEncoder72.finish();
+let textureView91 = texture49.createView({label: '\u85cf\u0e91\u0b4f\u5659\ud7ab\u{1f637}'});
+let sampler37 = device1.createSampler({
+  label: '\u01b3\ubb1c\uce47\u32fb\u0aba\u{1fb83}\u0da7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.65,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 376, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer4), /* required buffer size: 648 */
+{offset: 648, bytesPerRow: 236}, {width: 74, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline57 = device1.createComputePipeline({
+  label: '\u0f41\u79b5\u{1fb2f}',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer26 = device0.createBuffer({
+  label: '\ub189\ub84b',
+  size: 200024,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder73 = device0.createCommandEncoder({});
+try {
+computePassEncoder2.dispatchWorkgroupsIndirect(buffer19, 49168);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder4.draw(339558035, 511228818, 304794315);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(450419460, 85439352);
+} catch {}
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 35312 */
+  offset: 35312,
+  rowsPerImage: 98,
+  buffer: buffer15,
+}, {width: 72, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet9, 52, 215, buffer5, 32768);
+} catch {}
+let querySet31 = device0.createQuerySet({
+  label: '\u{1f62a}\ua091\u80b8\uade2\u140c\u0839\u{1fe4d}\u3e9a\u{1fe18}\u1f1a\u{1fefc}',
+  type: 'occlusion',
+  count: 3745,
+});
+let texture51 = device0.createTexture({
+  label: '\u4919\u095b\u2ed4\u0583\u4d9b\u{1f856}\u1abd\u{1fb05}\u0287\u0216',
+  size: [480],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView92 = texture39.createView({
+  label: '\uc22b\u9ed4\u41d7\u06af\ue3d6\u0647\u4784\u{1fe9d}\u38ba',
+  aspect: 'stencil-only',
+  baseMipLevel: 0,
+  baseArrayLayer: 41,
+  arrayLayerCount: 156,
+});
+let renderPassEncoder19 = commandEncoder73.beginRenderPass({
+  label: '\ue31b\ub03c\u2f45\ub0c4\u{1f886}\u6f5c\u0e13\u059d\ufcf0',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView76, stencilLoadOp: 'load', stencilStoreOp: 'store', stencilReadOnly: false},
+  maxDrawCount: 790453393,
+});
+try {
+renderPassEncoder10.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer9, 427080, 32117);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexed(123739450, 364820937, 117025856, 439722764, 292871353);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer9);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 8158 */
+  offset: 8128,
+  rowsPerImage: 156,
+  buffer: buffer13,
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(0)), /* required buffer size: 1571 */
+{offset: 591, bytesPerRow: 1022, rowsPerImage: 202}, {width: 245, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: video3,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 7, y: 7, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+canvas7.width = 1167;
+let img10 = await imageWithData(75, 128, '#60298a34', '#af5608d9');
+try {
+adapter1.label = '\ua140\ube09\u{1fbde}\u{1f622}\u{1fa9d}\u0fff\udeae\uca5e\u{1fba4}\u7990\ucc43';
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({});
+let commandBuffer20 = commandEncoder70.finish();
+let texture52 = device0.createTexture({
+  label: '\u3292\u{1f6f8}',
+  size: {width: 903, height: 64, depthOrArrayLayers: 216},
+  mipLevelCount: 7,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView93 = texture31.createView({baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 226, arrayLayerCount: 18});
+let computePassEncoder42 = commandEncoder56.beginComputePass({label: '\u87eb\u8485\u9a88\u2603\u1877'});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\uab85\u46cc\ua9ef\u14fc\u9bea\u0628\u06d9\u4454',
+  colorFormats: ['rgba16uint', 'rg32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler38 = device0.createSampler({
+  label: '\u{1fdb7}\u{1f9a3}\u0474\ud6f2\u{1f6dd}\u031a\u49db\u1248\u307b',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.991,
+  lodMaxClamp: 44.93,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(2335);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(455);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint16', 19364, 58829);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(578518601, 683713518);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 10592, new BigUint64Array(24573), 12303, 1364);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 6, y: 24 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline58 = device0.createComputePipeline({layout: pipelineLayout11, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+canvas4.height = 1807;
+let img11 = await imageWithData(61, 110, '#f33cb26e', '#d0b5f322');
+let pipelineLayout16 = device0.createPipelineLayout({
+  label: '\u0909\u8cf2\u6d4b\u34c7\u{1ffdd}\u8f5d',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout3, bindGroupLayout7],
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+let commandBuffer21 = commandEncoder75.finish({});
+let texture53 = device0.createTexture({
+  label: '\u71b0\u0ca5\uc4b5\u7b9c',
+  size: [112],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(5, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer19, 'uint32', 70248, 5847);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder16.draw(615484873, 1196085941, 554715173);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer19, 3652);
+} catch {}
+let videoFrame7 = new VideoFrame(videoFrame2, {timestamp: 0});
+let commandEncoder76 = device1.createCommandEncoder({label: '\u6b72\u0dba'});
+let texture54 = device1.createTexture({
+  label: '\u20ae\ua1e9\u{1fff8}\ue1f4\u0bb2\u87c6\u{1fdc3}\u2d59\u5994',
+  size: [2688, 1, 1261],
+  mipLevelCount: 10,
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let textureView94 = texture49.createView({label: '\u013b\u92c7\u09bd\u1334\u0c82\u0266\u7a40', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle41 = renderBundleEncoder33.finish({label: '\u{1f8dc}\u077a\u2e7a\ue26b\u{1f9b9}\ucec6\ucc35\u{1f920}'});
+let externalTexture27 = device1.importExternalTexture({source: video2});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer23.destroy();
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline59 = await device1.createComputePipelineAsync({
+  label: '\u{1fae9}\u13ac\uc9ad\u1567\u121c',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let pipeline60 = await device1.createRenderPipelineAsync({
+  label: '\u8868\u01e6',
+  layout: pipelineLayout14,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm'}, {format: 'rgba16uint'}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 719468361,
+    stencilWriteMask: 1650462806,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3868,
+        attributes: [
+          {format: 'snorm16x4', offset: 1448, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 1536, shaderLocation: 4},
+          {format: 'sint8x2', offset: 3866, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 220, shaderLocation: 2},
+          {format: 'uint8x2', offset: 3184, shaderLocation: 9},
+          {format: 'float32', offset: 56, shaderLocation: 6},
+          {format: 'sint16x4', offset: 572, shaderLocation: 12},
+          {format: 'uint32', offset: 412, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 970, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 2122, shaderLocation: 1},
+          {format: 'uint32x2', offset: 2180, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1700,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 584, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 180, shaderLocation: 5},
+          {format: 'sint16x4', offset: 664, shaderLocation: 0},
+          {format: 'sint32x4', offset: 64, shaderLocation: 3},
+          {format: 'sint16x2', offset: 264, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 804, attributes: [{format: 'sint32x2', offset: 148, shaderLocation: 13}]},
+      {arrayStride: 2884, stepMode: 'instance', attributes: []},
+      {arrayStride: 2748, attributes: []},
+      {arrayStride: 2776, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 3432, shaderLocation: 18},
+          {format: 'uint8x4', offset: 980, shaderLocation: 10},
+          {format: 'float16x2', offset: 3616, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let commandEncoder77 = device0.createCommandEncoder({label: '\uf7e3\u{1fa83}\u31b0\uf8bb\ud881\u79ab'});
+let textureView95 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler39 = device0.createSampler({
+  label: '\uf4ee\u0cf1\u0efe\ue9c2\u{1f83d}\u0313\uc2dd\u87c1\uac57\u0ab0',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.23,
+  lodMaxClamp: 98.08,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder9.dispatchWorkgroupsIndirect(buffer5, 4128);
+} catch {}
+try {
+renderPassEncoder9.setViewport(6.748, 0.5107, 0.1407, 0.3474, 0.5078, 0.9218);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer4, 0, 182603);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 17, y: 8 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline61 = await device0.createComputePipelineAsync({
+  label: '\u{1f749}\u{1fd5d}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let imageData8 = new ImageData(56, 64);
+let texture55 = device0.createTexture({
+  label: '\u5b5f\uc5b8\ua225\u29d9\u7396\u8e3d\u044e',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView96 = texture10.createView({
+  label: '\ubd73\u1ce1\u69c0\u0612\u036f\u6c6c\u71fd\uf07d\uab32\u8f8d\u{1fe5c}',
+  format: 'rg16uint',
+  mipLevelCount: 1,
+});
+let computePassEncoder43 = commandEncoder74.beginComputePass();
+try {
+renderPassEncoder15.setScissorRect(50, 4, 59, 4);
+} catch {}
+try {
+renderPassEncoder13.setViewport(3.448, 0.6227, 0.5949, 0.00625, 0.9677, 0.9898);
+} catch {}
+try {
+renderBundleEncoder4.draw(499845419, 571940587, 1139838455, 260330552);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 7428);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline50);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6832 */
+  offset: 6832,
+  rowsPerImage: 38,
+  buffer: buffer24,
+}, {width: 120, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 456, new Float32Array(16617));
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline62 = device0.createRenderPipeline({
+  label: '\u{1fccd}\u{1f765}\ua9c3\ucb21\u6ea3\u08c0\u26a8\u0242\ueb1c\udee9',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0xea2fc8a4},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 1796374510,
+    stencilWriteMask: 3805787485,
+    depthBias: 2070885427,
+    depthBiasSlopeScale: 52.62852982126776,
+    depthBiasClamp: 837.7002170029173,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 672,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 172, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 92, shaderLocation: 9},
+          {format: 'uint16x2', offset: 36, shaderLocation: 8},
+          {format: 'float16x2', offset: 272, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 284,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 10},
+          {format: 'sint8x4', offset: 0, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 656,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 136, shaderLocation: 13},
+          {format: 'uint16x2', offset: 132, shaderLocation: 12},
+          {format: 'sint32x3', offset: 76, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 320, stepMode: 'instance', attributes: []},
+      {arrayStride: 1420, attributes: [{format: 'float16x4', offset: 436, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u0eca\udf34\u{1f732}\u{1ffed}\u{1f923}\u02e6\u053d\uf416\u{1f93c}',
+  entries: [
+    {
+      binding: 866,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 643,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+try {
+computePassEncoder14.dispatchWorkgroups(5, 4);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(21, 1, 47, 2);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 38240 */
+  offset: 38240,
+  buffer: buffer22,
+}, {
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer22);
+} catch {}
+let pipeline63 = await device0.createRenderPipelineAsync({
+  label: '\u{1f621}\uac22',
+  layout: pipelineLayout16,
+  multisample: {mask: 0x67363336},
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 2202210461,
+    stencilWriteMask: 25603801,
+    depthBias: 1480151130,
+    depthBiasClamp: 393.8946050841303,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 368,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 28, shaderLocation: 5},
+          {format: 'uint16x4', offset: 16, shaderLocation: 10},
+          {format: 'float32x4', offset: 88, shaderLocation: 2},
+          {format: 'sint32x3', offset: 36, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 1156,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 400, shaderLocation: 3},
+          {format: 'sint16x4', offset: 188, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 1480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 28, shaderLocation: 0},
+          {format: 'float32x2', offset: 128, shaderLocation: 8},
+          {format: 'float16x2', offset: 232, shaderLocation: 12},
+          {format: 'sint32x4', offset: 12, shaderLocation: 1},
+          {format: 'uint8x4', offset: 12, shaderLocation: 14},
+          {format: 'sint16x2', offset: 240, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup20 = device0.createBindGroup({label: '\u17e7\u{1fda5}', layout: bindGroupLayout12, entries: []});
+let textureView97 = texture45.createView({baseMipLevel: 2});
+let renderBundle42 = renderBundleEncoder5.finish({label: '\u815c\u4b0a\u1be7\u83f8\u{1fd1c}'});
+try {
+renderPassEncoder19.setStencilReference(477);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(845621188, 394201410, 612280748, -81597201, 1140221259);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(buffer8, 123068, buffer16, 456772, 16960);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet5, 529, 1063, buffer13, 55552);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 182, y: 3 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+let buffer27 = device0.createBuffer({
+  label: '\u0fad\u{1fcf0}\u03c9\ud021\u{1ffea}\ubfdd\u5e63\u{1fe93}\u0643',
+  size: 164848,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder78 = device0.createCommandEncoder({label: '\u0ee4\u1ea2\u{1f965}\u{1f826}\uad3a\ub3cb'});
+let texture56 = device0.createTexture({
+  label: '\u0718\u5ce9\u07ee\u671f\u7f32\u{1fbe7}',
+  size: [903, 64, 1],
+  mipLevelCount: 5,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle43 = renderBundleEncoder3.finish({label: '\u0eaa\ufe08\ue231\u{1fa42}\u8e77\u04f6\u{1f88e}\u{1ffd4}'});
+let externalTexture28 = device0.importExternalTexture({label: '\u0bec\u0ad2', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder6.dispatchWorkgroups(5, 3, 4);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(115);
+} catch {}
+try {
+renderPassEncoder16.setViewport(23.59, 1.939, 85.02, 3.680, 0.1850, 0.6675);
+} catch {}
+try {
+renderBundleEncoder16.draw(119761697, 974398579, 725383153, 1165431882);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer5, 5672);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 33 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 67326 */
+  offset: 67326,
+  buffer: buffer18,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 33, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer12, 119676);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet19, 279, 157, buffer27, 80896);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11, commandBuffer20, commandBuffer16]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 23, y: 2 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout19 = device1.createBindGroupLayout({label: '\u6ca3\u{1fdab}\u0256\u{1fc3f}\u81d7\u24f1\u0179\u0c77\u3669\ubaaf', entries: []});
+let buffer28 = device1.createBuffer({
+  label: '\u{1f89a}\u{1f92e}\u02a0\u0218\u055e\u5154\u{1fb60}\uff9b\u{1fe41}',
+  size: 69721,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let sampler40 = device1.createSampler({
+  label: '\u0249\u0a21\uf3f0\u06f7\u0e98\u0aeb\u0355',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.02,
+  lodMaxClamp: 95.46,
+});
+let externalTexture29 = device1.importExternalTexture({
+  label: '\u3550\u0e01\u7549\uffcc\u{1f955}\u0589\u086b\u0d0b\ue8d2\u3a66\u3d4f',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 868 widthInBlocks: 434 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2066 */
+  offset: 2066,
+  buffer: buffer28,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 434, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer28);
+} catch {}
+let pipeline64 = device1.createComputePipeline({
+  label: '\uf756\u08ab\u5340\u0fbf',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let canvas8 = document.createElement('canvas');
+let buffer29 = device0.createBuffer({
+  label: '\uc135\u{1f76a}\uf6b8\u43ce\u068d\u099a\u0abc\u5269\u3148\u0005',
+  size: 522185,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder79 = device0.createCommandEncoder();
+let querySet32 = device0.createQuerySet({label: '\uddb4\u7589\ua5ac', type: 'occlusion', count: 906});
+let commandBuffer22 = commandEncoder79.finish({});
+let renderBundle44 = renderBundleEncoder21.finish({label: '\u097f\uc2a7\u34c2\uf7fe\u03cf'});
+let sampler41 = device0.createSampler({
+  label: '\u{1f8e3}\u{1fc5d}\u0827\u{1fcb9}',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.58,
+  lodMaxClamp: 85.67,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(1, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer9);
+} catch {}
+try {
+renderBundleEncoder4.draw(1221971302, 460841652, 592096884, 1165495438);
+} catch {}
+let arrayBuffer5 = buffer12.getMappedRange(9000, 7812);
+try {
+commandEncoder77.copyBufferToBuffer(buffer26, 66712, buffer20, 25780, 4348);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20800 */
+  offset: 20800,
+  buffer: buffer22,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 100004 */
+  offset: 100000,
+  buffer: buffer13,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 3,
+  origin: {x: 8, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 127, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 51, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 27148, new DataView(new ArrayBuffer(44861)), 794, 18292);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 77946 */
+{offset: 946, bytesPerRow: 50, rowsPerImage: 154}, {width: 23, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let video6 = await videoWithData();
+let imageBitmap5 = await createImageBitmap(canvas7);
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\u46e1\u0a8b\u99d6\u2c12\ub126\ub3f6\u{1fcc9}\u6f2b\u0fa9\u1a55\u{1f74b}',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout15, bindGroupLayout15, bindGroupLayout19],
+});
+let querySet33 = device1.createQuerySet({type: 'occlusion', count: 2266});
+let textureView98 = texture47.createView({label: '\u35e1\ub990\u10bf\uebbd\ub54e', baseMipLevel: 6, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+buffer25.unmap();
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer28, 30852, buffer25, 13440, 2632);
+dissociateBuffer(device1, buffer28);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+offscreenCanvas8.width = 1518;
+try {
+externalTexture26.label = '\u17ce\u64c5\u081a\ua3df\u{1ff7e}\u0880\u{1f757}\u0247\u2d32';
+} catch {}
+let texture57 = device1.createTexture({
+  label: '\u5550\u8812\ua94f\u1232\ua1a2\u{1fe45}\uf207\u679f',
+  size: [2281],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView99 = texture47.createView({
+  label: '\u5b44\u{1ffb1}\u{1ff0c}\u87fd\u0f17\uc2ef\ue5a0\uf4e1\u{1ff8c}',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+});
+try {
+device1.queue.writeBuffer(buffer25, 8436, new Float32Array(3320), 892, 136);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let texture58 = device1.createTexture({
+  label: '\u1cc1\u0460\u5c4b\u43ec\u0323\u0df6\u6979\u091f',
+  size: [120],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+});
+let textureView100 = texture58.createView({
+  label: '\udcec\u{1fc0f}\u5abe\ua5d4\u{1fe5f}\u09ef\u065e\uc54a\u43e3\u{1fe91}',
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 0,
+});
+let computePassEncoder44 = commandEncoder76.beginComputePass();
+try {
+computePassEncoder44.setPipeline(pipeline57);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(canvas3);
+let videoFrame8 = new VideoFrame(canvas0, {timestamp: 0});
+let bindGroupLayout20 = device1.createBindGroupLayout({
+  label: '\ub152\u{1f9c7}\u9bc5\ue5fe\u{1fce8}\u60b1',
+  entries: [
+    {
+      binding: 3041,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 5206,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 1096, visibility: 0, sampler: { type: 'comparison' }},
+  ],
+});
+let buffer30 = device1.createBuffer({
+  label: '\u{1f95f}\u12b5\u2538\u0ef6\u2ce0\ud69d',
+  size: 560858,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet34 = device1.createQuerySet({label: '\u61ee\uf976\u884c\u111f\u{1f705}\u0304\u4ef2', type: 'occlusion', count: 3643});
+try {
+  await buffer30.mapAsync(GPUMapMode.READ, 0, 369920);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 2096, new DataView(new ArrayBuffer(8710)), 832, 2152);
+} catch {}
+let pipeline65 = await device1.createComputePipelineAsync({
+  label: '\u0184\u{1fbe3}\u008b\u{1f682}\uc19f\u0ca3\ue4f4\ub1d8\u1ccd',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline66 = device1.createRenderPipeline({
+  layout: pipelineLayout15,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: 0,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r16uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, undefined],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 40, shaderLocation: 15},
+          {format: 'sint16x2', offset: 692, shaderLocation: 6},
+          {format: 'sint8x2', offset: 178, shaderLocation: 7},
+          {format: 'float32', offset: 12, shaderLocation: 10},
+          {format: 'float32x4', offset: 512, shaderLocation: 19},
+          {format: 'sint32', offset: 3140, shaderLocation: 12},
+          {format: 'uint16x4', offset: 2116, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 1212, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 760, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 936, shaderLocation: 1},
+          {format: 'uint32x3', offset: 1316, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 4708,
+        attributes: [
+          {format: 'sint32x3', offset: 1564, shaderLocation: 13},
+          {format: 'float32', offset: 1320, shaderLocation: 0},
+          {format: 'sint16x2', offset: 528, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 436, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 3866, shaderLocation: 8},
+          {format: 'uint8x4', offset: 1884, shaderLocation: 16},
+          {format: 'uint16x4', offset: 208, shaderLocation: 18},
+          {format: 'uint32x4', offset: 356, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 824, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder80 = device1.createCommandEncoder({});
+let textureView101 = texture49.createView({label: '\u3d93\uf2c3\ud3e8\u001d\u15eb\u0e03\u{1f75b}\u0866\u4dd2', format: 'r16uint'});
+let computePassEncoder45 = commandEncoder80.beginComputePass({label: '\u0890\ud668\ucd90\u744f\u{1fb3f}'});
+let renderBundle45 = renderBundleEncoder33.finish({label: '\uc151\uc84b'});
+let sampler42 = device0.createSampler({
+  label: '\u{1fb40}\u{1f795}\u14be\u9d50\u9f7f\u{1fd62}\u4474\u805a\ub058\u06cd\u0295',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.32,
+  lodMaxClamp: 62.26,
+});
+try {
+renderPassEncoder12.executeBundles([renderBundle9, renderBundle5, renderBundle12, renderBundle35, renderBundle24]);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexed(1017317597, 397646957, 271061229, 59863881, 1045775591);
+} catch {}
+try {
+renderBundleEncoder23.drawIndirect(buffer5, 26336);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer29);
+} catch {}
+let arrayBuffer6 = buffer6.getMappedRange(326560, 85028);
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline67 = await device0.createComputePipelineAsync({
+  label: '\u5cd4\u0104\u{1f632}\u7449\u25d6',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap6 = await createImageBitmap(img6);
+let bindGroupLayout21 = device1.createBindGroupLayout({entries: []});
+let bindGroup21 = device1.createBindGroup({layout: bindGroupLayout19, entries: []});
+try {
+querySet28.destroy();
+} catch {}
+let commandEncoder81 = device1.createCommandEncoder();
+let texture59 = device1.createTexture({
+  label: '\u437b\u032b\u77e5\u099e\u000b\u5b98\ubb8b\u{1fdcc}',
+  size: {width: 9126},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView102 = texture59.createView({});
+let computePassEncoder46 = commandEncoder81.beginComputePass({label: '\u1660\u{1f867}\u0ad9\u051b\u174d\u0ee9\uee9a'});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer28.destroy();
+} catch {}
+try {
+canvas8.getContext('webgpu');
+} catch {}
+let textureView103 = texture49.createView({});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder({
+  label: '\u{1fd09}\u05c5',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder35.setVertexBuffer(3682, undefined);
+} catch {}
+try {
+querySet27.destroy();
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let pipeline68 = device1.createRenderPipeline({
+  label: '\ua5b7\u{1fb7e}',
+  layout: pipelineLayout17,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 388,
+        attributes: [
+          {format: 'unorm8x2', offset: 386, shaderLocation: 2},
+          {format: 'sint8x4', offset: 20, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 48, shaderLocation: 10},
+          {format: 'uint32', offset: 40, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 28, shaderLocation: 14},
+          {format: 'sint8x4', offset: 60, shaderLocation: 12},
+          {format: 'float32x2', offset: 20, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 1960,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 1958, shaderLocation: 8},
+          {format: 'sint16x4', offset: 108, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 50, shaderLocation: 19},
+          {format: 'uint32x4', offset: 48, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 224, shaderLocation: 1},
+          {format: 'sint32x2', offset: 4, shaderLocation: 7},
+          {format: 'float32x4', offset: 272, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 0},
+          {format: 'uint16x4', offset: 64, shaderLocation: 15},
+          {format: 'sint32', offset: 248, shaderLocation: 13},
+          {format: 'uint32x4', offset: 216, shaderLocation: 3},
+          {format: 'uint32x3', offset: 0, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 3028,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x2', offset: 388, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let shaderModule5 = device1.createShaderModule({
+  code: `@group(1) @binding(4274)
+var<storage, read_write> n1: array<u32>;
+@group(0) @binding(2110)
+var<storage, read_write> n2: array<u32>;
+@group(2) @binding(2110)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(2110)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(4274)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(366)
+var<storage, read_write> parameter5: array<u32>;
+@group(2) @binding(4274)
+var<storage, read_write> global6: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @location(50) f0: vec3<u32>,
+  @location(40) f1: vec2<f16>,
+  @location(55) f2: vec3<i32>,
+  @location(88) f3: vec3<f16>,
+  @location(45) f4: i32,
+  @location(96) f5: vec4<u32>,
+  @location(83) f6: vec2<f32>,
+  @builtin(sample_mask) f7: u32,
+  @location(6) f8: vec3<i32>,
+  @location(34) f9: f16,
+  @location(68) f10: vec2<i32>,
+  @location(87) f11: vec4<u32>,
+  @builtin(position) f12: vec4<f32>,
+  @location(86) f13: i32,
+  @location(46) f14: vec3<i32>,
+  @location(93) f15: vec3<u32>,
+  @location(84) f16: f32,
+  @location(95) f17: vec3<i32>,
+  @location(74) f18: i32,
+  @location(66) f19: i32,
+  @builtin(sample_index) f20: u32,
+  @location(27) f21: vec2<u32>,
+  @location(69) f22: vec2<u32>,
+  @location(85) f23: vec3<u32>,
+  @location(41) f24: f32,
+  @location(91) f25: vec2<u32>,
+  @location(44) f26: vec4<f16>,
+  @location(0) f27: vec4<u32>,
+  @location(79) f28: f16,
+  @location(35) f29: vec2<u32>,
+  @location(15) f30: vec3<f32>,
+  @location(64) f31: u32,
+  @location(77) f32: vec4<f16>,
+  @location(75) f33: vec4<f32>,
+  @location(16) f34: vec4<i32>,
+  @location(21) f35: vec4<f16>,
+  @location(92) f36: vec4<f16>,
+  @location(90) f37: vec4<f16>,
+  @location(94) f38: vec3<f32>,
+  @location(61) f39: vec2<f16>,
+  @location(29) f40: vec2<f32>,
+  @location(25) f41: vec3<i32>,
+  @location(9) f42: vec3<f16>,
+  @location(62) f43: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: u32,
+  @location(0) f2: vec4<f32>,
+  @location(5) f3: i32,
+  @location(3) f4: vec2<i32>,
+  @location(4) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(80) a0: vec2<u32>, a1: S4, @location(38) a2: vec3<f32>, @location(22) a3: vec2<f32>, @location(57) a4: vec2<i32>, @location(56) a5: vec2<i32>, @builtin(front_facing) a6: bool, @location(13) a7: f32, @location(99) a8: vec3<f16>, @location(4) a9: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(3) f0: vec3<f16>,
+  @location(18) f1: f32,
+  @location(17) f2: vec3<u32>,
+  @location(14) f3: vec2<i32>,
+  @location(16) f4: i32,
+  @builtin(vertex_index) f5: u32,
+  @location(13) f6: vec4<i32>,
+  @location(19) f7: vec4<u32>,
+  @location(8) f8: vec4<u32>,
+  @location(9) f9: vec3<u32>,
+  @location(0) f10: f32,
+  @location(15) f11: vec4<i32>,
+  @location(12) f12: vec2<f16>,
+  @location(1) f13: u32,
+  @location(7) f14: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(64) f58: u32,
+  @location(95) f59: vec3<i32>,
+  @location(22) f60: vec2<f32>,
+  @location(75) f61: vec4<f32>,
+  @location(55) f62: vec3<i32>,
+  @location(62) f63: vec2<u32>,
+  @location(15) f64: vec3<f32>,
+  @location(6) f65: vec3<i32>,
+  @location(83) f66: vec2<f32>,
+  @location(0) f67: vec4<u32>,
+  @location(84) f68: f32,
+  @location(88) f69: vec3<f16>,
+  @location(68) f70: vec2<i32>,
+  @builtin(position) f71: vec4<f32>,
+  @location(40) f72: vec2<f16>,
+  @location(74) f73: i32,
+  @location(25) f74: vec3<i32>,
+  @location(13) f75: f32,
+  @location(93) f76: vec3<u32>,
+  @location(21) f77: vec4<f16>,
+  @location(38) f78: vec3<f32>,
+  @location(94) f79: vec3<f32>,
+  @location(86) f80: i32,
+  @location(66) f81: i32,
+  @location(56) f82: vec2<i32>,
+  @location(41) f83: f32,
+  @location(87) f84: vec4<u32>,
+  @location(45) f85: i32,
+  @location(34) f86: f16,
+  @location(9) f87: vec3<f16>,
+  @location(29) f88: vec2<f32>,
+  @location(80) f89: vec2<u32>,
+  @location(85) f90: vec3<u32>,
+  @location(35) f91: vec2<u32>,
+  @location(77) f92: vec4<f16>,
+  @location(44) f93: vec4<f16>,
+  @location(90) f94: vec4<f16>,
+  @location(57) f95: vec2<i32>,
+  @location(50) f96: vec3<u32>,
+  @location(27) f97: vec2<u32>,
+  @location(91) f98: vec2<u32>,
+  @location(16) f99: vec4<i32>,
+  @location(79) f100: f16,
+  @location(99) f101: vec3<f16>,
+  @location(61) f102: vec2<f16>,
+  @location(4) f103: vec2<u32>,
+  @location(92) f104: vec4<f16>,
+  @location(69) f105: vec2<u32>,
+  @location(46) f106: vec3<i32>,
+  @location(96) f107: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<f32>, @location(11) a1: vec2<f32>, @location(5) a2: vec3<i32>, @builtin(instance_index) a3: u32, a4: S3, @location(4) a5: vec2<f16>, @location(10) a6: i32, @location(6) a7: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView104 = texture57.createView({label: '\u88f1\u{1f695}\u055c\ue942'});
+let externalTexture30 = device1.importExternalTexture({label: '\u343b\u{1fbf6}\u{1f94f}\u4c3e\u0825\uc558\u576c', source: videoFrame6});
+try {
+device1.queue.writeBuffer(buffer25, 2128, new DataView(new ArrayBuffer(6574)), 2578);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(564), /* required buffer size: 564 */
+{offset: 564, bytesPerRow: 970}, {width: 391, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline69 = device1.createComputePipeline({
+  label: '\ufbc6\u0a6e\uaecb\ue51a',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline70 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout14,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+  },
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint'}, undefined],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'invert'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 3842051305,
+    stencilWriteMask: 750511486,
+    depthBiasClamp: 355.21997220923845,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 116, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 228, shaderLocation: 1},
+          {format: 'sint32', offset: 200, shaderLocation: 6},
+          {format: 'uint32x3', offset: 140, shaderLocation: 9},
+          {format: 'uint32x4', offset: 316, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 2064,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 188, shaderLocation: 3},
+          {format: 'sint8x4', offset: 36, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 246, shaderLocation: 19},
+          {format: 'sint32x2', offset: 68, shaderLocation: 5},
+          {format: 'uint16x4', offset: 256, shaderLocation: 15},
+          {format: 'sint8x2', offset: 284, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 76, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 434, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 708, shaderLocation: 0},
+          {format: 'sint32x3', offset: 1148, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 6768,
+        attributes: [
+          {format: 'snorm16x2', offset: 3880, shaderLocation: 14},
+          {format: 'float32x2', offset: 2472, shaderLocation: 10},
+          {format: 'uint32x3', offset: 4572, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 2572, shaderLocation: 2},
+          {format: 'uint32x3', offset: 2176, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let video7 = await videoWithData();
+let imageBitmap7 = await createImageBitmap(img2);
+let bindGroupLayout22 = device0.createBindGroupLayout({entries: []});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup12, new Uint32Array(6791), 4636, 0);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(97, 4, 4, 3);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(446815133);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 66736);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer5, 'uint16', 92324, 6399);
+} catch {}
+let img12 = await imageWithData(61, 178, '#1a86baf2', '#e357c315');
+try {
+window.someLabel = externalTexture30.label;
+} catch {}
+let bindGroup22 = device1.createBindGroup({
+  label: '\u{1f80d}\u{1f878}\u{1f93b}\u4f72\u0fb7\uc079\ub9e4\u7aac\uc69a\u7a7b',
+  layout: bindGroupLayout21,
+  entries: [],
+});
+let texture60 = device1.createTexture({
+  size: {width: 4563},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+try {
+computePassEncoder44.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup21, new Uint32Array(4060), 556, 0);
+} catch {}
+try {
+buffer30.destroy();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer2), /* required buffer size: 817 */
+{offset: 817}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline71 = await device1.createComputePipelineAsync({
+  label: '\u{1f8d7}\u0613\u026c\u0143\u9384\u{1fda1}\u0ded\u6b1d\u{1fcb4}\u07bd',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let canvas9 = document.createElement('canvas');
+let textureView105 = texture49.createView({});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(6449, undefined, 0, 1914500395);
+} catch {}
+let pipeline72 = device1.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint'}, {format: 'r16uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, undefined],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero'},
+    stencilReadMask: 3299675420,
+    depthBias: 0,
+    depthBiasSlopeScale: 487.5967387263265,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1988,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 1508, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 220, shaderLocation: 15},
+          {format: 'float32', offset: 492, shaderLocation: 14},
+          {format: 'uint32x3', offset: 1312, shaderLocation: 9},
+          {format: 'sint32', offset: 168, shaderLocation: 13},
+          {format: 'sint8x2', offset: 410, shaderLocation: 8},
+          {format: 'sint8x2', offset: 196, shaderLocation: 11},
+          {format: 'float32x4', offset: 1636, shaderLocation: 6},
+          {format: 'uint32x4', offset: 340, shaderLocation: 7},
+          {format: 'uint32x3', offset: 60, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 160, shaderLocation: 19},
+          {format: 'sint8x2', offset: 228, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 404,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x4', offset: 76, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 1232,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 52, shaderLocation: 16}],
+      },
+      {
+        arrayStride: 4104,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 312, shaderLocation: 3},
+          {format: 'uint32x2', offset: 4056, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 36, shaderLocation: 2},
+          {format: 'sint32x3', offset: 8, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 3016, shaderLocation: 5},
+          {format: 'float32x4', offset: 940, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let commandEncoder82 = device1.createCommandEncoder({label: '\u76af\u{1fea3}\u0677\u0a8b\ua6e1\u824c\u0720'});
+let textureView106 = texture60.createView({label: '\u74d8\udcb5\u0bb5\u{1fd8f}\u{1fb9b}\uac93\u1f4d'});
+let renderBundle46 = renderBundleEncoder33.finish();
+try {
+computePassEncoder46.setPipeline(pipeline57);
+} catch {}
+try {
+commandEncoder82.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 116, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 15046 widthInBlocks: 7523 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25700 */
+  offset: 25700,
+  rowsPerImage: 188,
+  buffer: buffer30,
+}, {width: 7523, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder82.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer19]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 8024, new BigUint64Array(3901), 2420, 236);
+} catch {}
+let pipeline73 = await device1.createRenderPipelineAsync({
+  label: '\u{1f7e1}\ud524',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint'}, {format: 'r16uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: 0}, undefined],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'replace'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 2047625291,
+    depthBias: -2101507810,
+    depthBiasSlopeScale: 66.88767561722736,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 20, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 18},
+          {format: 'uint16x4', offset: 20, shaderLocation: 9},
+          {format: 'sint32x2', offset: 12, shaderLocation: 14},
+          {format: 'uint16x2', offset: 12, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 10, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 6},
+          {format: 'uint16x4', offset: 0, shaderLocation: 17},
+          {format: 'float32x2', offset: 0, shaderLocation: 7},
+          {format: 'uint16x2', offset: 8, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 4124,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 600, shaderLocation: 5},
+          {format: 'sint8x4', offset: 2312, shaderLocation: 13},
+          {format: 'sint32', offset: 488, shaderLocation: 15},
+          {format: 'sint8x2', offset: 684, shaderLocation: 16},
+          {format: 'sint32x4', offset: 1096, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 884, shaderLocation: 11},
+          {format: 'float16x4', offset: 980, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 300, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 1612, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 3024,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 2340, shaderLocation: 19}],
+      },
+    ],
+  },
+});
+canvas9.width = 88;
+let textureView107 = texture37.createView({});
+let computePassEncoder47 = commandEncoder77.beginComputePass({label: '\u{1f91e}\u015a\u518f\u1353\u48ef\u{1fc3e}\u{1f9fd}\u9ee4\uea08\u0980'});
+let sampler43 = device0.createSampler({
+  label: '\u0dd7\ufeb1\u{1f935}\u04e8\u{1ffc2}\u{1f601}\u042c\u0b21\u00a1\u07f2',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.26,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder2.dispatchWorkgroups(3, 3, 3);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer19, 9044);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer19, 'uint32', 101640, 2340);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, buffer4, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 84, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 862 */
+{offset: 862}, {width: 318, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 61, y: 374 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video2.height = 90;
+let commandEncoder83 = device1.createCommandEncoder({label: '\u0fb1\u{1fe66}\u{1fa8e}\u3fcd\ua2e5'});
+let computePassEncoder48 = commandEncoder83.beginComputePass({label: '\u405c\udbf1\u9810\ua307\u0c58\uffbd\u3aad\ue17b\u59e1\u{1fbc8}\u{1f723}'});
+try {
+commandEncoder82.copyBufferToTexture({
+  /* bytesInLastRow: 332 widthInBlocks: 166 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 13920 */
+  offset: 13920,
+  buffer: buffer28,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 166, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 449, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 14509 */
+{offset: 165}, {width: 7172, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView108 = texture41.createView({
+  label: '\u{1fa68}\u62b7\u005b\uaae3\u0917\u0412',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint', 'r32float', 'r8sint', 'r16float', 'rg8unorm', 'r32float', 'r16sint'],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder16.draw(665530817, 759987062);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(1011833876);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 1,
+  origin: {x: 8, y: 8, z: 120},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture7,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u02eb');
+} catch {}
+try {
+device0.queue.submit([commandBuffer21, commandBuffer18]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 481 */
+{offset: 481}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView109 = texture23.createView({label: '\u6c5d\ua450\u7c64\u05c7\u{1f708}\u9485', baseMipLevel: 3});
+let computePassEncoder49 = commandEncoder78.beginComputePass({});
+try {
+renderPassEncoder3.beginOcclusionQuery(193);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 321.6, g: 415.2, b: 867.6, a: -522.4, });
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup14, new Uint32Array(6971), 1580, 0);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer19, 0, 71722);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 70, y: 43 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = canvas9.getContext('webgpu');
+video7.width = 273;
+gc();
+let shaderModule6 = device1.createShaderModule({
+  label: '\ue1b1\u8a4d',
+  code: `@group(2) @binding(2110)
+var<storage, read_write> local2: array<u32>;
+@group(2) @binding(4274)
+var<storage, read_write> function3: array<u32>;
+@group(2) @binding(366)
+var<storage, read_write> global7: array<u32>;
+@group(0) @binding(2110)
+var<storage, read_write> field4: array<u32>;
+@group(1) @binding(2110)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(366)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @location(16) f0: vec2<f16>,
+  @location(9) f1: vec3<f16>,
+  @location(64) f2: vec3<f32>,
+  @location(66) f3: vec3<f16>,
+  @location(10) f4: f32,
+  @location(89) f5: vec4<i32>,
+  @location(103) f6: vec3<u32>,
+  @location(47) f7: vec4<f16>,
+  @location(43) f8: f32,
+  @location(71) f9: vec3<u32>,
+  @location(50) f10: i32,
+  @builtin(front_facing) f11: bool,
+  @location(73) f12: vec4<f32>,
+  @location(20) f13: vec2<f16>,
+  @location(101) f14: vec3<f16>,
+  @location(13) f15: i32,
+  @location(91) f16: vec3<f16>,
+  @location(97) f17: f16,
+  @location(49) f18: vec3<f16>,
+  @location(31) f19: f32,
+  @location(99) f20: vec2<f16>,
+  @location(74) f21: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec2<i32>,
+  @location(2) f3: vec4<u32>,
+  @location(5) f4: vec4<i32>,
+  @location(4) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(88) a0: vec2<i32>, @location(68) a1: vec2<i32>, @location(51) a2: vec3<f16>, @location(8) a3: vec3<u32>, @builtin(sample_index) a4: u32, @location(29) a5: vec3<u32>, @builtin(position) a6: vec4<f32>, @location(98) a7: f32, @location(2) a8: vec4<u32>, @location(70) a9: vec2<u32>, @builtin(sample_mask) a10: u32, a11: S6, @location(26) a12: f16, @location(45) a13: u32, @location(87) a14: vec2<f16>, @location(53) a15: f16, @location(94) a16: vec3<f16>, @location(23) a17: u32, @location(59) a18: u32, @location(79) a19: vec2<f32>, @location(76) a20: vec3<u32>, @location(107) a21: vec4<f32>, @location(105) a22: vec4<f32>, @location(14) a23: vec4<i32>, @location(52) a24: vec2<u32>, @location(6) a25: vec3<f16>, @location(4) a26: vec2<i32>, @location(27) a27: vec4<u32>, @location(57) a28: f16, @location(78) a29: vec2<f32>, @location(35) a30: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(0) f0: vec2<f16>,
+  @location(7) f1: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(91) f108: vec3<f16>,
+  @location(78) f109: vec2<f32>,
+  @location(103) f110: vec3<u32>,
+  @location(107) f111: vec4<f32>,
+  @location(55) f112: vec4<u32>,
+  @location(14) f113: vec4<i32>,
+  @location(23) f114: u32,
+  @location(53) f115: f16,
+  @location(35) f116: vec3<f16>,
+  @location(88) f117: vec2<i32>,
+  @location(48) f118: vec2<u32>,
+  @location(43) f119: f32,
+  @location(45) f120: u32,
+  @location(97) f121: f16,
+  @location(87) f122: vec2<f16>,
+  @location(2) f123: vec4<u32>,
+  @location(99) f124: vec2<f16>,
+  @location(44) f125: vec2<u32>,
+  @location(94) f126: vec3<f16>,
+  @location(42) f127: f32,
+  @location(98) f128: f32,
+  @location(29) f129: vec3<u32>,
+  @location(47) f130: vec4<f16>,
+  @location(16) f131: vec2<f16>,
+  @location(57) f132: f16,
+  @location(66) f133: vec3<f16>,
+  @location(68) f134: vec2<i32>,
+  @location(20) f135: vec2<f16>,
+  @location(79) f136: vec2<f32>,
+  @location(89) f137: vec4<i32>,
+  @location(76) f138: vec3<u32>,
+  @location(64) f139: vec3<f32>,
+  @location(50) f140: i32,
+  @location(74) f141: i32,
+  @location(9) f142: vec3<f16>,
+  @location(10) f143: f32,
+  @location(26) f144: f16,
+  @location(105) f145: vec4<f32>,
+  @location(52) f146: vec2<u32>,
+  @location(13) f147: i32,
+  @location(73) f148: vec4<f32>,
+  @location(8) f149: vec3<u32>,
+  @location(71) f150: vec3<u32>,
+  @location(49) f151: vec3<f16>,
+  @location(51) f152: vec3<f16>,
+  @location(27) f153: vec4<u32>,
+  @location(6) f154: vec3<f16>,
+  @location(70) f155: vec2<u32>,
+  @location(31) f156: f32,
+  @location(59) f157: u32,
+  @builtin(position) f158: vec4<f32>,
+  @location(101) f159: vec3<f16>,
+  @location(4) f160: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: u32, @location(12) a1: f32, @location(13) a2: vec3<f32>, @location(15) a3: vec3<f32>, @location(16) a4: vec3<f32>, @location(17) a5: vec4<f32>, @location(19) a6: vec2<u32>, @location(14) a7: vec4<f32>, @location(3) a8: vec4<i32>, @location(4) a9: vec2<i32>, @location(10) a10: vec2<u32>, @location(8) a11: vec3<u32>, @location(18) a12: f32, @location(2) a13: u32, @location(1) a14: u32, a15: S5, @location(5) a16: vec2<u32>, @location(9) a17: vec3<u32>, @location(6) a18: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder50 = commandEncoder82.beginComputePass({label: '\u{1f627}\u{1ff94}\u98cb\u91da'});
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 2852, new DataView(new ArrayBuffer(1481)), 129, 184);
+} catch {}
+let textureView110 = texture58.createView({
+  label: '\ub32b\u013f\u0d87\u0d5f\u0e47\u06ab\uf2ed\u{1fe51}\ube21\u02ff',
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({
+  label: '\u0fbb\u09d1\u06d1\ud00c\ua4e7\u0be6\u0d10\u7d7c\u00e8\u{1f6b3}\u6155',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture31 = device1.importExternalTexture({
+  label: '\u1445\ub487\u0b15\u{1fbff}\u0608\u{1fe53}\uc750\u0c3a\u4717\u0c69',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup21, new Uint32Array(4770), 1993, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup22, new Uint32Array(9868), 5025, 0);
+} catch {}
+let commandEncoder84 = device1.createCommandEncoder({label: '\u379e\u9cff\u21c3\u131a'});
+let externalTexture32 = device1.importExternalTexture({label: '\ue178\uede7\u{1fb6d}\u2397\uddba\ucd3d\ucb1f', source: videoFrame1});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup21, new Uint32Array(7610), 2063, 0);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 3902, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 461, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer30, 559712, 824);
+dissociateBuffer(device1, buffer30);
+} catch {}
+let buffer31 = device1.createBuffer({
+  label: '\u02ef\u0022',
+  size: 28663,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let commandEncoder85 = device1.createCommandEncoder();
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+});
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 6217, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 73, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 207, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder85.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let renderBundleEncoder39 = device1.createRenderBundleEncoder({
+  label: '\u0122\u390b\u{1f7e5}\u{1f6f8}\u0b25\u{1f9c9}',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  stencilReadOnly: true,
+});
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15516 */
+  offset: 15516,
+  buffer: buffer28,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 3268, new Float32Array(12123), 3723, 380);
+} catch {}
+let videoFrame9 = new VideoFrame(img5, {timestamp: 0});
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\ub035\u7013\ue458\u088d\ue688',
+  entries: [
+    {
+      binding: 211,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 994,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let querySet35 = device0.createQuerySet({
+  label: '\u8122\u0a8a\u04c7\u266e\u06b4\u71b2\u9729\uce7b\u{1fbd0}\u02c7\u09b1',
+  type: 'occlusion',
+  count: 1246,
+});
+let externalTexture33 = device0.importExternalTexture({
+  label: '\ub29f\u{1f700}\u5fea\uc1bc\u5c74\u26b0\u01b2\u{1fab6}',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup2, new Uint32Array(5460), 4240, 0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(5.540, 0.1946, 0.9338, 0.1635, 0.7908, 0.9027);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer19, 67260);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer5, 'uint16', 8264, 91303);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline29);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 31, y: 1 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img13 = await imageWithData(156, 34, '#52a61bc8', '#465bef7b');
+let video8 = await videoWithData();
+let bindGroupLayout24 = device1.createBindGroupLayout({label: '\u8c1e\u0030\uc761\u0cfb', entries: []});
+let commandEncoder86 = device1.createCommandEncoder({label: '\u091f\ud5a1\u0bee\u2f7b'});
+let textureView111 = texture60.createView({label: '\u{1fc0d}\u0ae7\u764c\u{1fada}\u{1fb28}\u53d8'});
+let renderBundle47 = renderBundleEncoder32.finish({label: '\uabad\u9d4a\u0dd3\ub8c8\ua9c8\u360e\ued19\u{1f755}\uc254\u03c9\ub89b'});
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer28, 2548, buffer25, 7412, 3796);
+dissociateBuffer(device1, buffer28);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 408 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38980 */
+  offset: 38980,
+  rowsPerImage: 59,
+  buffer: buffer28,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 102, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1888, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 206, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 9936, new BigUint64Array(63343), 41442, 692);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline74 = await device1.createRenderPipelineAsync({
+  label: '\uad2a\u09b4\ufdaf\u0469\u{1fdee}\u5676\u0373\u0921\u0abd\u02d0\u0179',
+  layout: pipelineLayout17,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'always', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 1106478684,
+    stencilWriteMask: 2458450878,
+    depthBias: -705489760,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32x4', offset: 4720, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 180, shaderLocation: 2},
+          {format: 'float32x4', offset: 172, shaderLocation: 12},
+          {format: 'uint32x4', offset: 1836, shaderLocation: 1},
+          {format: 'float16x4', offset: 4172, shaderLocation: 6},
+          {format: 'uint8x4', offset: 688, shaderLocation: 17},
+          {format: 'sint16x4', offset: 2016, shaderLocation: 16},
+          {format: 'sint16x4', offset: 1184, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 1152, shaderLocation: 11},
+          {format: 'uint32x2', offset: 6760, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 444, shaderLocation: 0},
+          {format: 'uint32x3', offset: 2808, shaderLocation: 19},
+          {format: 'float32x4', offset: 2728, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 2404, shaderLocation: 3},
+          {format: 'sint32', offset: 1472, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 1136,
+        attributes: [
+          {format: 'sint16x2', offset: 12, shaderLocation: 14},
+          {format: 'sint16x4', offset: 248, shaderLocation: 10},
+          {format: 'sint32x3', offset: 144, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 2408,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 260, shaderLocation: 4},
+          {format: 'float32x3', offset: 188, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let video9 = await videoWithData();
+let commandEncoder87 = device0.createCommandEncoder({label: '\u0327\u{1f65b}\u495f'});
+let texture61 = device0.createTexture({
+  label: '\u80ba\u6061\u533b\u0dca',
+  size: {width: 960, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-5x4-unorm-srgb'],
+});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(1985);
+} catch {}
+try {
+renderPassEncoder9.setViewport(1.667, 0.2423, 1.856, 0.3543, 0.9072, 0.9674);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup10, new Uint32Array(5030), 1660, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer14, 'uint32', 123608);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 14, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+canvas5.height = 186;
+let promise9 = adapter1.requestAdapterInfo();
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  label: '\u068f\u{1f7e8}\u{1f679}\udc99\u07f8\u5f30\u0ee7\u22d3',
+  entries: [
+    {binding: 147, visibility: 0, sampler: { type: 'comparison' }},
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 723424, hasDynamicOffset: false },
+    },
+    {
+      binding: 916,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder88 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder11.beginComputePass({label: '\u8060\u07d2\u0bee\ue7cc\u0841\u{1fdd9}\u6491\u28bd'});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer5, 3644);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 88 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9528 */
+  offset: 4232,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 108, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 88, height: 21, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 120, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer16, 469880, 2984);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 489 */
+{offset: 489}, {width: 72, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise9;
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter();
+let computePassEncoder52 = commandEncoder87.beginComputePass({label: '\u097e\ub6f8\u94ff\u87f7\u0d6d\u60c0\ua596\u21ea\u{1f960}\u0fd2'});
+let externalTexture34 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder9.dispatchWorkgroups(5, 1, 5);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(1280);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer19, 'uint16', 54504, 47660);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer4, 353892, 123086);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer1, 132848, 4720);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline75 = device0.createComputePipeline({
+  label: '\u{1fe5d}\u01b9\u0c94\u47ae\u050d\u6dc5\u0e9e\u{1fa8e}\ub356\u0ccd\u6e26',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline76 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {mask: 0xc876716f},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 1233204778,
+    stencilWriteMask: 1068015589,
+    depthBias: -1409194,
+    depthBiasSlopeScale: 785.9544058316569,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 620,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 80, shaderLocation: 11},
+          {format: 'sint16x4', offset: 144, shaderLocation: 15},
+          {format: 'sint8x2', offset: 18, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 60, shaderLocation: 10},
+          {format: 'float32x3', offset: 16, shaderLocation: 9},
+          {format: 'sint32x4', offset: 84, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 428,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 12, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 0},
+          {format: 'uint32x2', offset: 4, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 236, attributes: [{format: 'uint32x3', offset: 36, shaderLocation: 12}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let img14 = await imageWithData(171, 225, '#ffe69353', '#21d8b237');
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  label: '\u6dd9\u0afe\u0f1c\u09e5',
+  entries: [
+    {binding: 234, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true }},
+    {binding: 584, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder89 = device0.createCommandEncoder();
+let textureView112 = texture1.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 1});
+let computePassEncoder53 = commandEncoder88.beginComputePass({label: '\u0d07\u51d3\u{1f724}\ue48b\u0fdf\u6922\u0905\u{1fe6a}\u0621'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u0c48\u0460\ubd41\uc1b6\u8350',
+  colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle48 = renderBundleEncoder23.finish();
+try {
+computePassEncoder40.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer19, 21364);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(7, buffer29, 0);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 1086 widthInBlocks: 543 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5568 */
+  offset: 5568,
+  bytesPerRow: 1280,
+  buffer: buffer8,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 34, y: 38, z: 0},
+  aspect: 'all',
+}, {width: 543, height: 15, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 23184, new BigUint64Array(25083), 7182, 112);
+} catch {}
+let promise10 = device0.createRenderPipelineAsync({
+  label: '\u98a2\u26cd\u{1f8ac}\u0a78\u6f16\ude71\ub7cf\u1cfd\u3257\u0e3c\u{1fde3}',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0xeffab088},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 2336674362,
+    stencilWriteMask: 962561475,
+    depthBiasSlopeScale: 533.286304014883,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder90 = device1.createCommandEncoder({label: '\uf14b\u5fb4\u{1f9cb}\uec4e\u9d53'});
+let computePassEncoder54 = commandEncoder90.beginComputePass({label: '\u0b88\u{1f841}\u03b9\u0746\u3be4\uc309\ub094\u75d0\u05ed'});
+let sampler44 = device1.createSampler({
+  label: '\u{1fac3}\u6ef7\u{1f91a}\ucb3d\u{1f89a}\u0b20\ufc85\u871a\u3169\u21ec\u{1fbd6}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.49,
+  lodMaxClamp: 75.45,
+  compare: 'greater',
+});
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder50.pushDebugGroup('\u60a2');
+} catch {}
+let pipeline77 = await device1.createComputePipelineAsync({layout: pipelineLayout17, compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}}});
+let pipeline78 = device1.createRenderPipeline({
+  label: '\u{1feb9}\u01e7\ueeab\u{1fdf7}\u00e5\ue66e\u064a\uccb3\u{1fab9}\u72d5',
+  layout: pipelineLayout17,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2380,
+        attributes: [
+          {format: 'uint32x2', offset: 96, shaderLocation: 7},
+          {format: 'uint32x2', offset: 432, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 104, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 680,
+        attributes: [
+          {format: 'uint8x2', offset: 42, shaderLocation: 11},
+          {format: 'uint32x3', offset: 52, shaderLocation: 10},
+          {format: 'uint32', offset: 20, shaderLocation: 9},
+          {format: 'uint8x4', offset: 76, shaderLocation: 6},
+          {format: 'float32x2', offset: 12, shaderLocation: 18},
+          {format: 'float32', offset: 116, shaderLocation: 13},
+          {format: 'uint8x4', offset: 332, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 78, shaderLocation: 14},
+          {format: 'uint16x2', offset: 16, shaderLocation: 5},
+          {format: 'uint32', offset: 84, shaderLocation: 1},
+          {format: 'uint16x4', offset: 88, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 120, shaderLocation: 15},
+          {format: 'float32x2', offset: 204, shaderLocation: 17},
+          {format: 'sint32x4', offset: 140, shaderLocation: 4},
+          {format: 'sint8x4', offset: 52, shaderLocation: 3},
+          {format: 'float16x4', offset: 76, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 368, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder91 = device1.createCommandEncoder({label: '\u0d3c\u05d1\u{1f7eb}\u0105\ua6cf\u08bf\u4cf7\u02e0\u{1fb90}'});
+let textureView113 = texture54.createView({
+  label: '\u007d\u06b2\u80af\u09d5\u0272\u072d\u0512',
+  dimension: '2d',
+  baseMipLevel: 6,
+  mipLevelCount: 3,
+  baseArrayLayer: 292,
+});
+let computePassEncoder55 = commandEncoder91.beginComputePass({label: '\u{1fbbe}\u{1f902}\ub8d3\ub9c7\ua974\u085e\u{1fcb6}\uf57f\u239a\u02ee\u6a44'});
+let renderBundle49 = renderBundleEncoder39.finish({label: '\u{1fe12}\u{1ffc1}\u0550\u8d4b\u0723\u0073\u9770\u410c\u03fb'});
+let sampler45 = device1.createSampler({
+  label: '\u2a71\u{1fbde}\ub646\uce5c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 52.86,
+  lodMaxClamp: 79.15,
+});
+try {
+renderBundleEncoder38.setVertexBuffer(2852, undefined, 1450581866);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 556 widthInBlocks: 278 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2940 */
+  offset: 2940,
+  buffer: buffer30,
+}, {width: 278, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 4439, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 73, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 124, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let textureView114 = texture47.createView({label: '\u69dc\uf284\u05c1\u8f36\uc2f9\ua132\u0941\uf419', baseMipLevel: 6, mipLevelCount: 1});
+let renderBundleEncoder41 = device1.createRenderBundleEncoder({
+  label: '\u6f59\u0b2b\u32f8\u88b1\u{1f9ff}\u8421\u0b26\u{1faa6}\ud5a1\uf7bf',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  sampleCount: 1,
+});
+let renderBundle50 = renderBundleEncoder41.finish({label: '\u0420\u0c74\u9ba3\u{1f695}\u8bb4\u{1f713}\u{1fb4d}\u52a0\ua34f'});
+try {
+computePassEncoder44.setPipeline(pipeline57);
+} catch {}
+canvas3.width = 622;
+let commandEncoder92 = device1.createCommandEncoder({label: '\u0a35\u{1f716}\u0f42\uacdc\u0fe7\u056d\u00a5'});
+let texture62 = device1.createTexture({
+  label: '\uca71\u31b0\u7b24\u{1f87e}\u0623\u5069\ufd1b\u0e4d\u7a2f\u006d',
+  size: {width: 1140, height: 1, depthOrArrayLayers: 36},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView115 = texture62.createView({label: '\u19ea\udf90\u0112\u21a4', format: 'r32uint'});
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 14170 widthInBlocks: 7085 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 66506 */
+  offset: 52336,
+  buffer: buffer28,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 435, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7085, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer31, 22852, 1960);
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 1112, new DataView(new ArrayBuffer(49664)), 6116, 724);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer1), /* required buffer size: 757 */
+{offset: 757}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer32 = device1.createBuffer({
+  label: '\u{1f7d1}\u{1f6c7}\uc1a6\u07fe\u075f',
+  size: 72501,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder93 = device1.createCommandEncoder({label: '\ub638\u4362\u21a0\uf748'});
+let commandBuffer23 = commandEncoder93.finish({label: '\u3be7\u0cfa'});
+let texture63 = device1.createTexture({
+  label: '\u0562\ufd32',
+  size: [240],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let computePassEncoder56 = commandEncoder85.beginComputePass({});
+let renderBundle51 = renderBundleEncoder41.finish({label: '\u{1f66b}\u0ad5\u0995\u0039\u4673\uc968\u9611\u{1fded}'});
+let sampler46 = device1.createSampler({
+  label: '\u0361\uf729',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.22,
+  lodMaxClamp: 55.27,
+});
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 129, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7234 widthInBlocks: 3617 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 340 */
+  offset: 340,
+  buffer: buffer30,
+}, {width: 3617, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+let bindGroup23 = device1.createBindGroup({label: '\ub976\u2490\u6eb3\u0b52\u3935', layout: bindGroupLayout19, entries: []});
+let commandEncoder94 = device1.createCommandEncoder({label: '\u{1f6a2}\u0b38\u5bdd\u09b6\u7e2d\u5c5d\u46e0\u{1fe20}'});
+let querySet36 = device1.createQuerySet({label: '\u0f57\u3511\u5b67\u0b18\ufb05\u6846\u{1f711}', type: 'occlusion', count: 985});
+let textureView116 = texture58.createView({label: '\u34bf\ub1fc\u5a8b\uc169', baseArrayLayer: 0});
+let computePassEncoder57 = commandEncoder84.beginComputePass({label: '\u344d\u1b84\uf4bd\u04f8\u{1ff38}\u{1f878}\uf4a6'});
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'r8unorm', 'rgba8unorm-srgb', 'rgba16uint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 1122, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4484 widthInBlocks: 2242 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25656 */
+  offset: 21172,
+  buffer: buffer31,
+}, {width: 2242, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer31, 10736, 15112);
+dissociateBuffer(device1, buffer31);
+} catch {}
+let img15 = await imageWithData(23, 94, '#f1ac5774', '#ebf719f7');
+let commandEncoder95 = device0.createCommandEncoder();
+let commandBuffer24 = commandEncoder95.finish({label: '\u{1fca9}\u0c1a\uf912\u09e5'});
+let renderBundle52 = renderBundleEncoder12.finish({label: '\ubb8e\u{1f841}\u{1f670}\u0761\ub091\ud9d8\uf0be\u09ee'});
+try {
+renderPassEncoder13.setBlendConstant({ r: 172.9, g: 771.8, b: -111.5, a: -281.9, });
+} catch {}
+try {
+renderPassEncoder15.setViewport(52.86, 4.460, 54.96, 3.179, 0.8510, 0.8544);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer5, 'uint32', 87716, 38927);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(5, buffer9, 0, 689058);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet0, 1116, 325, buffer5, 38912);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 52488, new Float32Array(47177), 45559);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer3), /* required buffer size: 333 */
+{offset: 333}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup24 = device0.createBindGroup({layout: bindGroupLayout12, entries: []});
+let commandEncoder96 = device0.createCommandEncoder();
+let externalTexture35 = device0.importExternalTexture({label: '\u6d3e\u6fa8', source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2271);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(10966623, 620780574);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer14, 'uint32');
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer0), /* required buffer size: 61742 */
+{offset: 382, bytesPerRow: 236, rowsPerImage: 260}, {width: 0, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline79 = device0.createComputePipeline({
+  label: '\u4a11\u1a22\u1c85\u0106\u7586\u254a',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline80 = device0.createRenderPipeline({
+  label: '\uff5f\u852d\u{1fb0c}\u{1fbcf}\u01f8\u9a62\u{1f8b0}\uef31\u008f\u{1fc00}\u4385',
+  layout: pipelineLayout11,
+  fragment: {module: shaderModule1, entryPoint: 'fragment0', targets: [{format: 'rgb10a2uint', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'keep'},
+    stencilWriteMask: 1309197379,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 307.8225562739712,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 60, shaderLocation: 0},
+          {format: 'sint8x4', offset: 80, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 12, shaderLocation: 3}],
+      },
+      {
+        arrayStride: 384,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x2', offset: 4, shaderLocation: 12},
+          {format: 'uint32x3', offset: 92, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 132, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 160, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 756,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 268, shaderLocation: 9},
+          {format: 'uint16x4', offset: 60, shaderLocation: 8},
+          {format: 'sint16x4', offset: 264, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+try {
+externalTexture27.label = '\u{1f68c}\ue50b\u{1f7e2}\ucbf6\u8cc5\uabdc';
+} catch {}
+let texture64 = device1.createTexture({
+  label: '\u{1f7b1}\u03ce\u0b04',
+  size: [960, 160, 1331],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView117 = texture62.createView({label: '\u07e2\uc0a2\u0683\u62d1\ueb23', baseMipLevel: 1});
+try {
+commandEncoder86.copyBufferToBuffer(buffer32, 51544, buffer30, 259344, 14248);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 3005, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 388, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer25, 6916);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let pipeline81 = device1.createComputePipeline({layout: pipelineLayout17, compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}}});
+let adapter3 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let textureView118 = texture58.createView({format: 'bgra8unorm', mipLevelCount: 1});
+let renderBundleEncoder43 = device1.createRenderBundleEncoder({
+  label: '\u8ddd\ubbc8\u{1fbd7}',
+  colorFormats: ['r16sint', 'r8unorm', 'rgba8unorm-srgb', 'rgba16uint', 'r16uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let externalTexture36 = device1.importExternalTexture({
+  label: '\u{1fd46}\uf9de\u90e9\u{1f884}\u087e\u0a32\u09f9\u{1fff8}',
+  source: videoFrame9,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+  /* bytesInLastRow: 650 widthInBlocks: 325 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 24706 */
+  offset: 24056,
+  buffer: buffer32,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 325, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 487, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 89, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer31, 8868, 8792);
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+computePassEncoder50.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 2704, new DataView(new ArrayBuffer(47591)), 46748, 356);
+} catch {}
+let pipeline82 = device1.createRenderPipeline({
+  label: '\u{1f924}\u987d',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, undefined],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 1868, shaderLocation: 9},
+          {format: 'float32', offset: 1264, shaderLocation: 19},
+          {format: 'uint16x2', offset: 372, shaderLocation: 17},
+          {format: 'sint16x4', offset: 408, shaderLocation: 11},
+          {format: 'sint16x4', offset: 1208, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 1144,
+        attributes: [
+          {format: 'uint32x3', offset: 92, shaderLocation: 10},
+          {format: 'float32x4', offset: 24, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 252, shaderLocation: 5},
+          {format: 'sint32x4', offset: 96, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 192, shaderLocation: 15},
+          {format: 'sint8x2', offset: 64, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 308, shaderLocation: 1},
+          {format: 'sint16x4', offset: 156, shaderLocation: 8},
+          {format: 'uint8x2', offset: 332, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 204, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 1068,
+        attributes: [
+          {format: 'sint8x2', offset: 906, shaderLocation: 13},
+          {format: 'float32x3', offset: 280, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 412, shaderLocation: 4}],
+      },
+      {arrayStride: 696, attributes: [{format: 'snorm8x4', offset: 44, shaderLocation: 6}]},
+      {arrayStride: 0, attributes: [{format: 'sint8x4', offset: 1660, shaderLocation: 0}]},
+    ],
+  },
+});
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  label: '\u03a2\u7c92',
+  entries: [
+    {
+      binding: 426,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {binding: 226, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 963,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder97 = device0.createCommandEncoder({label: '\u01da\u7d5a\u7e5e'});
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -674.0, g: 679.3, b: -604.1, a: 620.9, });
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(1172086727, 884803227, 673822025, 782633398, 964156666);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker('\u{1fb48}');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let querySet37 = device0.createQuerySet({label: '\u38f2\u0641\u0b26\u36d5\u54cf', type: 'occlusion', count: 1575});
+let commandBuffer25 = commandEncoder97.finish({label: '\u{1febd}\u3e64\u5bad\ue834\u{1f8b1}\u023d\ubbcc'});
+let textureView119 = texture27.createView({label: '\u0757\u6e81\u9db0\u{1f80b}\u0fa6\u56ca\u50a8', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundle53 = renderBundleEncoder14.finish({label: '\u4a3a\u820b\u{1fcf5}\u8e9b\u{1f859}\u{1fa35}\u9f03\u4e24\u52cd'});
+let sampler47 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 67.14,
+  lodMaxClamp: 81.70,
+  compare: 'less',
+});
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(1673);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -752.8, g: 337.4, b: 786.6, a: 829.1, });
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(4089);
+} catch {}
+try {
+renderBundleEncoder9.draw(666901301, 851275735, 413401255, 540888385);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(252989036, 389820736);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer14, 'uint32', 67120, 78803);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet20, 326, 406, buffer27, 153856);
+} catch {}
+let pipeline83 = await device0.createComputePipelineAsync({
+  label: '\u{1fb37}\ubcdd\ubac3\u{1fb8c}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline84 = await promise10;
+let offscreenCanvas13 = new OffscreenCanvas(813, 464);
+let shaderModule7 = device1.createShaderModule({
+  label: '\u12ab\u0d95\u6917',
+  code: `@group(1) @binding(2110)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(4274)
+var<storage, read_write> parameter7: array<u32>;
+@group(0) @binding(366)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(2110)
+var<storage, read_write> parameter8: array<u32>;
+@group(1) @binding(366)
+var<storage, read_write> function5: array<u32>;
+@group(1) @binding(4274)
+var<storage, read_write> type2: array<u32>;
+@group(2) @binding(4274)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(front_facing) f1: bool,
+  @location(24) f2: f16,
+  @location(72) f3: f32,
+  @location(10) f4: vec2<u32>,
+  @builtin(sample_mask) f5: u32,
+  @location(20) f6: u32,
+  @location(76) f7: vec3<f16>,
+  @location(44) f8: vec4<i32>,
+  @location(78) f9: u32,
+  @location(59) f10: f16,
+  @location(27) f11: vec4<f32>,
+  @location(77) f12: f32,
+  @location(71) f13: vec3<u32>,
+  @location(29) f14: vec4<f32>,
+  @location(53) f15: vec2<f16>,
+  @location(83) f16: vec4<f32>,
+  @location(97) f17: u32,
+  @location(21) f18: vec4<f32>,
+  @location(96) f19: i32,
+  @location(87) f20: vec4<f16>,
+  @location(65) f21: f16,
+  @location(26) f22: vec4<f16>,
+  @location(69) f23: vec2<f16>,
+  @location(28) f24: vec2<i32>,
+  @location(18) f25: vec3<f16>,
+  @location(84) f26: f16,
+  @location(45) f27: u32,
+  @location(68) f28: vec3<u32>,
+  @location(40) f29: f16,
+  @location(98) f30: vec3<u32>,
+  @location(56) f31: vec2<u32>,
+  @location(32) f32: vec4<f32>,
+  @location(19) f33: vec3<f32>,
+  @location(23) f34: vec4<f16>,
+  @location(46) f35: vec4<i32>,
+  @location(4) f36: vec3<i32>,
+  @location(39) f37: f16,
+  @location(57) f38: u32,
+  @location(58) f39: vec4<u32>,
+  @location(16) f40: vec2<f16>,
+  @location(48) f41: f32,
+  @location(75) f42: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(5) f0: i32,
+  @builtin(sample_mask) f1: u32,
+  @location(4) f2: u32,
+  @location(2) f3: u32,
+  @location(0) f4: vec4<f32>,
+  @location(1) f5: vec4<u32>,
+  @location(3) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(106) a1: vec4<f16>, @location(1) a2: f32, a3: S8, @location(35) a4: f16, @location(82) a5: u32, @location(9) a6: u32, @location(103) a7: vec2<f16>, @location(99) a8: vec3<u32>, @location(15) a9: vec3<u32>, @location(89) a10: f16, @location(14) a11: vec2<f16>, @location(11) a12: vec2<f16>, @location(31) a13: vec2<f32>, @location(67) a14: f32, @location(79) a15: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(5) f0: vec3<i32>,
+  @builtin(vertex_index) f1: u32,
+  @location(3) f2: vec4<f16>,
+  @location(19) f3: vec3<i32>,
+  @location(9) f4: f32,
+  @location(1) f5: vec4<f32>,
+  @location(13) f6: u32,
+  @location(2) f7: vec4<i32>,
+  @location(16) f8: f32,
+  @location(15) f9: vec4<u32>,
+  @location(12) f10: vec2<f32>,
+  @location(10) f11: vec3<i32>,
+  @location(6) f12: vec2<u32>,
+  @location(14) f13: i32,
+  @location(7) f14: vec4<u32>,
+  @location(0) f15: vec3<u32>,
+  @location(17) f16: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(1) f161: f32,
+  @location(9) f162: u32,
+  @location(53) f163: vec2<f16>,
+  @location(67) f164: f32,
+  @location(56) f165: vec2<u32>,
+  @location(39) f166: f16,
+  @location(29) f167: vec4<f32>,
+  @location(46) f168: vec4<i32>,
+  @location(16) f169: vec2<f16>,
+  @location(59) f170: f16,
+  @location(68) f171: vec3<u32>,
+  @location(75) f172: vec4<f16>,
+  @location(40) f173: f16,
+  @location(97) f174: u32,
+  @location(69) f175: vec2<f16>,
+  @location(57) f176: u32,
+  @location(82) f177: u32,
+  @location(87) f178: vec4<f16>,
+  @location(106) f179: vec4<f16>,
+  @location(79) f180: vec2<f32>,
+  @location(98) f181: vec3<u32>,
+  @location(15) f182: vec3<u32>,
+  @location(83) f183: vec4<f32>,
+  @location(45) f184: u32,
+  @location(76) f185: vec3<f16>,
+  @location(14) f186: vec2<f16>,
+  @location(20) f187: u32,
+  @location(58) f188: vec4<u32>,
+  @location(99) f189: vec3<u32>,
+  @location(35) f190: f16,
+  @location(31) f191: vec2<f32>,
+  @location(11) f192: vec2<f16>,
+  @location(48) f193: f32,
+  @location(32) f194: vec4<f32>,
+  @location(23) f195: vec4<f16>,
+  @builtin(position) f196: vec4<f32>,
+  @location(26) f197: vec4<f16>,
+  @location(27) f198: vec4<f32>,
+  @location(24) f199: f16,
+  @location(78) f200: u32,
+  @location(72) f201: f32,
+  @location(10) f202: vec2<u32>,
+  @location(28) f203: vec2<i32>,
+  @location(44) f204: vec4<i32>,
+  @location(89) f205: f16,
+  @location(96) f206: i32,
+  @location(84) f207: f16,
+  @location(77) f208: f32,
+  @location(18) f209: vec3<f16>,
+  @location(19) f210: vec3<f32>,
+  @location(4) f211: vec3<i32>,
+  @location(21) f212: vec4<f32>,
+  @location(71) f213: vec3<u32>,
+  @location(103) f214: vec2<f16>,
+  @location(65) f215: f16
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, a1: S7, @location(18) a2: f32, @location(11) a3: vec3<u32>, @location(8) a4: vec4<i32>, @location(4) a5: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\uab8f\u0c60',
+  entries: [{binding: 1030, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let commandEncoder98 = device1.createCommandEncoder({});
+try {
+computePassEncoder57.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer28, 49060, buffer30, 114240, 932);
+dissociateBuffer(device1, buffer28);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 1224, new BigUint64Array(16665), 8489, 156);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline85 = device1.createComputePipeline({
+  label: '\u0373\u564a\u{1fd90}\u72e6\u{1feac}\ube7c\u4eca\u{1f7a4}\u092d',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext12 = offscreenCanvas13.getContext('webgpu');
+try {
+adapter0.label = '\u0a10\u0405\u{1fc18}\u0c2d';
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 476,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 279, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+  ],
+});
+let texture65 = device0.createTexture({
+  label: '\u00c2\u9b0c\u425d\u{1f945}\ue239\u38a7\u0821\u096f\u6b9e',
+  size: [225],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let sampler48 = device0.createSampler({
+  label: '\u0a1e\ufb87\u0860\u6245',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.42,
+  lodMaxClamp: 40.28,
+  compare: 'never',
+});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(3556);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer29, 466856, 18284);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer19, 25456);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer5, 17348);
+} catch {}
+try {
+commandEncoder56.insertDebugMarker('\u{1f7e9}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 25108, new BigUint64Array(10349), 49);
+} catch {}
+let pipeline86 = await device0.createRenderPipelineAsync({
+  label: '\ue5e9\u2559\u54b4\u{1fd86}\u{1ff60}',
+  layout: pipelineLayout8,
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'never', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 4289316674,
+    stencilWriteMask: 2734949819,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 92, shaderLocation: 11},
+          {format: 'sint16x2', offset: 12, shaderLocation: 5},
+          {format: 'uint8x2', offset: 8, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 16, shaderLocation: 6},
+          {format: 'sint8x2', offset: 0, shaderLocation: 1},
+          {format: 'uint16x4', offset: 36, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 12},
+          {format: 'sint8x4', offset: 8, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 44, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 620,
+        attributes: [
+          {format: 'sint16x2', offset: 80, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 72, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 1004,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 84, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+let imageData9 = new ImageData(92, 132);
+let commandEncoder99 = device1.createCommandEncoder({label: '\u{1f841}\uebe1'});
+let computePassEncoder58 = commandEncoder99.beginComputePass({});
+try {
+device1.queue.submit([commandBuffer23]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1039, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 752 */
+{offset: 752}, {width: 4573, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise11 = device1.createRenderPipelineAsync({
+  label: '\u5b08\u3624\u81c7\ued9b\u5041\u01be\u3c0a',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint'}, {format: 'r32uint'}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, undefined],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-wrap',
+    },
+    stencilReadMask: 3320947026,
+    stencilWriteMask: 3402122062,
+    depthBiasSlopeScale: 399.42493432811256,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3876,
+        attributes: [
+          {format: 'uint32x2', offset: 160, shaderLocation: 11},
+          {format: 'float32x3', offset: 600, shaderLocation: 14},
+          {format: 'uint32', offset: 400, shaderLocation: 2},
+          {format: 'float16x4', offset: 352, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 32, shaderLocation: 17},
+          {format: 'uint8x2', offset: 476, shaderLocation: 8},
+          {format: 'uint32', offset: 232, shaderLocation: 19},
+          {format: 'float32x2', offset: 1148, shaderLocation: 13},
+          {format: 'uint32x3', offset: 424, shaderLocation: 7},
+          {format: 'uint32', offset: 852, shaderLocation: 6},
+          {format: 'uint16x2', offset: 652, shaderLocation: 10},
+          {format: 'sint32x4', offset: 1448, shaderLocation: 4},
+          {format: 'float16x2', offset: 480, shaderLocation: 12},
+          {format: 'float32x2', offset: 748, shaderLocation: 0},
+          {format: 'float32', offset: 428, shaderLocation: 18},
+          {format: 'uint8x2', offset: 960, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1444,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x4', offset: 176, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 460, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 1212,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 924, shaderLocation: 1},
+          {format: 'sint32', offset: 132, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let imageData10 = new ImageData(40, 16);
+let commandEncoder100 = device0.createCommandEncoder({});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u2393\u2635\u08e3\ua441\u6367\u{1f68a}\u0439\uc6c5\u{1fe90}',
+  colorFormats: ['rgba16uint', 'rg32sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle54 = renderBundleEncoder21.finish();
+let sampler49 = device0.createSampler({
+  label: '\ud68e\uc7b8\u{1f657}\ubead',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 84.53,
+  lodMaxClamp: 94.01,
+});
+try {
+renderPassEncoder9.setBlendConstant({ r: 505.4, g: -812.0, b: 98.79, a: 630.0, });
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder13.setViewport(6.978, 0.5938, 0.01184, 0.1809, 0.9736, 0.9811);
+} catch {}
+try {
+renderBundleEncoder9.draw(713972117);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 59380, new Float32Array(12176), 8633);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture66 = device1.createTexture({
+  label: '\u71e6\u26aa\u027b\u2dd5',
+  size: [9126, 1, 15],
+  mipLevelCount: 13,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({
+  label: '\uaeec\u118a\u097b',
+  colorFormats: ['r16sint', 'r8unorm', 'rgba8unorm-srgb', 'rgba16uint', 'r16uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle55 = renderBundleEncoder45.finish({label: '\u85bd\u0365\u930d\u{1ffbd}\u0517\u4016'});
+let sampler50 = device1.createSampler({
+  label: '\u{1f79b}\u32ac\u5c2d\u367d\uefa2\u0373\u{1fabf}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.89,
+  lodMaxClamp: 65.04,
+});
+try {
+computePassEncoder58.setPipeline(pipeline64);
+} catch {}
+try {
+commandEncoder98.copyBufferToBuffer(buffer32, 52340, buffer25, 1884, 556);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let texture67 = device1.createTexture({
+  label: '\u{1f696}\u058e\u16e8\u8acf\u048e\u06f6\u{1ff49}',
+  size: [480],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView120 = texture63.createView({label: '\u37a2\ud6c7\u{1ff66}\u06e2\u0440\u{1ffd4}\u{1ff1f}\ue858\ue9f0', dimension: '1d'});
+let renderBundle56 = renderBundleEncoder45.finish({label: '\u0f63\u0416\u0196\u9803\u{1faa1}\u05b6\u0363'});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup22, new Uint32Array(6288), 2349, 0);
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer31, 17148, 9688);
+dissociateBuffer(device1, buffer31);
+} catch {}
+let videoFrame10 = new VideoFrame(img3, {timestamp: 0});
+let promise12 = adapter2.requestAdapterInfo();
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 418,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 429, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let textureView121 = texture43.createView({baseMipLevel: 4, mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder20 = commandEncoder89.beginRenderPass({
+  label: '\u72bf\u6ec1\ue414\u8b61',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView76, stencilLoadOp: 'clear', stencilStoreOp: 'store', stencilReadOnly: false},
+  maxDrawCount: 151778077,
+});
+let renderBundle57 = renderBundleEncoder13.finish({label: '\u{1fffb}\u55a4\u57c7\u9acd\u9083\u0c71\ubf1f\u4092'});
+try {
+computePassEncoder6.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(96, 0, 7, 6);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer19, 41632);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet31, 2679, 71, buffer13, 92672);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline87 = device0.createRenderPipeline({
+  label: '\u643a\uee21\u0da2\u3c5c\u{1ff04}\uc465\u1331',
+  layout: pipelineLayout11,
+  multisample: {mask: 0x4b6c8cbc},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 1163691173,
+    stencilWriteMask: 1873454555,
+    depthBias: -59469814,
+    depthBiasSlopeScale: 478.1869855229245,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+offscreenCanvas7.width = 1664;
+let bindGroup25 = device1.createBindGroup({label: '\u741e\u{1f867}\u088e\u297e\u5b34', layout: bindGroupLayout24, entries: []});
+let texture68 = device1.createTexture({
+  size: {width: 4563},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView122 = texture67.createView({label: '\u0690\u9929\u5f69\u5be2\uf832\ua36b\u7f98\u{1fd25}\u8cfc'});
+let computePassEncoder59 = commandEncoder83.beginComputePass();
+let sampler51 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 81.56,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 815 */
+{offset: 555, rowsPerImage: 194}, {width: 65, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise13 = device1.queue.onSubmittedWorkDone();
+let pipelineLayout18 = device0.createPipelineLayout({label: '\u{1f844}\u09d2\ubbbf\uf967\u0873', bindGroupLayouts: [bindGroupLayout5, bindGroupLayout4]});
+try {
+renderPassEncoder9.setStencilReference(3235);
+} catch {}
+try {
+renderPassEncoder14.setViewport(3.185, 3.474, 15.99, 4.515, 0.8981, 0.9900);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline50);
+} catch {}
+let arrayBuffer7 = buffer2.getMappedRange(12504, 29068);
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 437 */
+{offset: 437, rowsPerImage: 213}, {width: 226, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video10 = await videoWithData();
+let querySet38 = device1.createQuerySet({label: '\u7d6a\u{1f7fe}\u2c6d\u0436\u2e40\uc16e', type: 'occlusion', count: 2945});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer28, 26528, buffer25, 9060, 6040);
+dissociateBuffer(device1, buffer28);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let imageBitmap8 = await createImageBitmap(videoFrame10);
+let commandEncoder101 = device1.createCommandEncoder();
+let querySet39 = device1.createQuerySet({
+  label: '\u0c49\u{1f9c2}\u{1f639}\u{1fb8d}\ub98b\ud45e\ud519\u4a94\u{1f8b4}\ue0fc\u1537',
+  type: 'occlusion',
+  count: 3887,
+});
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer32, 29096, buffer25, 5980, 5140);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 684 widthInBlocks: 171 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32668 */
+  offset: 32668,
+  bytesPerRow: 768,
+  buffer: buffer28,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 455, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 171, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 587 */
+{offset: 587, bytesPerRow: 1033, rowsPerImage: 14}, {width: 459, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video11 = await videoWithData();
+let querySet40 = device1.createQuerySet({label: '\u{1fefd}\u{1fe3a}\u307d\u09b6\u2092\u{1f6e9}\u9b01\u0a90', type: 'occlusion', count: 2238});
+let textureView123 = texture49.createView({baseMipLevel: 0});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({
+  label: '\ud95e\u0810\u00ba\u{1fbe0}\u05c3\u0394\uc890\u04c9',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  stencilReadOnly: true,
+});
+let renderBundle58 = renderBundleEncoder42.finish({});
+try {
+computePassEncoder44.setPipeline(pipeline59);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer32, 8104, buffer25, 11552, 4364);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder98.copyTextureToBuffer({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 412 widthInBlocks: 206 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17162 */
+  offset: 16750,
+  buffer: buffer25,
+}, {width: 206, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 812, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 206, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline88 = await promise11;
+try {
+computePassEncoder12.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint16', 75134);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 1120);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 20308);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer0);
+dissociateBuffer(device1, buffer0);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet35, 775, 2, buffer9, 414720);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 685 */
+{offset: 521}, {width: 164, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder102 = device1.createCommandEncoder({label: '\u{1f723}\u8c6e\u3729'});
+let computePassEncoder60 = commandEncoder102.beginComputePass();
+let renderBundleEncoder47 = device1.createRenderBundleEncoder({
+  label: '\u0604\u05e9\u0df7\uf32e\u4c29\uddad\u0714\u4aa3\u06da\u{1f6a6}\u078b',
+  colorFormats: ['r16sint', 'r8unorm', 'rgba8unorm-srgb', 'rgba16uint', 'r16uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let sampler52 = device1.createSampler({
+  label: '\u8d17\u0117\ue23a\u8e04',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.53,
+  lodMaxClamp: 28.23,
+  maxAnisotropy: 13,
+});
+let externalTexture37 = device1.importExternalTexture({label: '\u751a\u10ba\uc0e6\u{1ffab}\ue944\u0321', source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(3, bindGroup21, new Uint32Array(4905), 3882, 0);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer32, 66048, buffer31, 3096, 1892);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 598, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 2427, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2413, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({
+  label: '\ua54b\ud6dd\u{1ffa8}\u3c25\u3389\u1f03\u233c\u1394\u0a66',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout5, bindGroupLayout17],
+});
+let textureView124 = texture5.createView({aspect: 'stencil-only', baseArrayLayer: 105, arrayLayerCount: 37});
+try {
+computePassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer14, 'uint16', 165794);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(596746144, 23306732);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexedIndirect(buffer5, 14304);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer19, 22768);
+} catch {}
+try {
+  await buffer21.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer18, 64684, buffer14, 94420, 11532);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 52, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder100.resolveQuerySet(querySet7, 408, 1391, buffer19, 32768);
+} catch {}
+let pipeline89 = await device0.createComputePipelineAsync({
+  label: '\u7c41\u6b13\u{1fd24}\u5f0f\u0044\u00a1\u{1fded}\u7be7\u0847\u0f32',
+  layout: 'auto',
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline90 = await device0.createRenderPipelineAsync({
+  label: '\uf4c3\ua099\u3342\uc899',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 2351251109,
+    depthBias: 1324843033,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 284,
+        attributes: [
+          {format: 'sint32x2', offset: 152, shaderLocation: 6},
+          {format: 'sint16x4', offset: 16, shaderLocation: 15},
+          {format: 'sint16x4', offset: 64, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 0},
+          {format: 'uint16x2', offset: 0, shaderLocation: 8},
+          {format: 'float32', offset: 64, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 40, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 532,
+        attributes: [
+          {format: 'uint32x2', offset: 92, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 168, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 196, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw'},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let buffer33 = device0.createBuffer({
+  label: '\u{1f90e}\u7854\u{1f991}',
+  size: 296842,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 1229});
+let texture69 = device0.createTexture({
+  label: '\u3dec\u{1f680}\ua1aa\u09ba\u3780\u08ff',
+  size: [480],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView125 = texture40.createView({label: '\uc9c9\u662f\u{1fa4d}\u{1f8a9}\u46e5\u95ce\uc6b7\u0f00', mipLevelCount: 1});
+let computePassEncoder61 = commandEncoder36.beginComputePass();
+let externalTexture38 = device0.importExternalTexture({label: '\u06f3\u6969', source: videoFrame6, colorSpace: 'srgb'});
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 559.7, g: -404.9, b: 955.2, a: 642.2, });
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(1, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer19);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer19, 19456);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer17, 'uint32');
+} catch {}
+document.body.prepend(canvas3);
+let commandEncoder103 = device1.createCommandEncoder({});
+let texture70 = device1.createTexture({
+  size: {width: 2281, height: 1, depthOrArrayLayers: 829},
+  mipLevelCount: 12,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8sint'],
+});
+let renderBundle59 = renderBundleEncoder46.finish({label: '\u0879\u{1fc97}'});
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25138 */
+  offset: 25138,
+  buffer: buffer31,
+}, {width: 15, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer31);
+} catch {}
+let promise14 = device1.createRenderPipelineAsync({
+  label: '\u0ee0\u{1fef4}\u87ec\u{1feb5}\u0f48\u0274\u0632\ue9c7',
+  layout: pipelineLayout14,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', passOp: 'zero'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilWriteMask: 3831365913,
+    depthBiasClamp: 695.986958168784,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1516,
+        attributes: [
+          {format: 'float32x4', offset: 216, shaderLocation: 18},
+          {format: 'float32x3', offset: 500, shaderLocation: 13},
+          {format: 'uint32', offset: 788, shaderLocation: 11},
+          {format: 'uint8x4', offset: 996, shaderLocation: 9},
+          {format: 'uint32x2', offset: 48, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'snorm16x4', offset: 8, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 0},
+          {format: 'uint16x4', offset: 12, shaderLocation: 7},
+          {format: 'uint32x2', offset: 40, shaderLocation: 2},
+          {format: 'sint8x4', offset: 8, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 15},
+          {format: 'uint8x4', offset: 56, shaderLocation: 1},
+          {format: 'uint32x2', offset: 108, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 38, shaderLocation: 14},
+          {format: 'uint16x2', offset: 24, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 420,
+        attributes: [
+          {format: 'uint32x3', offset: 80, shaderLocation: 10},
+          {format: 'sint8x4', offset: 32, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint32x3', offset: 5148, shaderLocation: 6}]},
+      {
+        arrayStride: 1176,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 24, shaderLocation: 17}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', unclippedDepth: true},
+});
+canvas0.width = 1643;
+let video12 = await videoWithData();
+let imageBitmap9 = await createImageBitmap(video12);
+let commandEncoder104 = device0.createCommandEncoder({label: '\u69a3\u{1f6e3}\udb43\u46b7\ue57c\u0241\u{1f734}\u{1fe95}'});
+let commandBuffer26 = commandEncoder11.finish({});
+let textureView126 = texture37.createView({label: '\u0b49\u0bf1\u05ee\uffe3\u6c70\u00d2\u095a\ud518\ua0fa'});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(755);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint32', 130408);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer19, 54148);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 108 widthInBlocks: 108 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 179152 */
+  offset: 27748,
+  bytesPerRow: 256,
+  rowsPerImage: 195,
+  buffer: buffer9,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, {width: 108, height: 7, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder100.resolveQuerySet(querySet5, 1897, 260, buffer13, 32512);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 49056, new Int16Array(33639), 12135);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 949 */
+{offset: 949, bytesPerRow: 950}, {width: 228, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder105 = device1.createCommandEncoder({});
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup22, new Uint32Array(7113), 6602, 0);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(7598, undefined, 2085354909);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+commandEncoder98.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 784 widthInBlocks: 392 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25570 */
+  offset: 25570,
+  buffer: buffer31,
+}, {width: 392, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+commandEncoder105.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 174, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+} catch {}
+let pipeline91 = await device1.createRenderPipelineAsync({
+  label: '\ud45a\u1110\u7dc4\u{1fbcb}\u9194\u48e6\ub2fd\u01f4\u{1ff49}\u{1feec}',
+  layout: pipelineLayout15,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint'}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'never', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 856903250,
+    stencilWriteMask: 2716745004,
+    depthBias: 1371709826,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 44, shaderLocation: 3},
+          {format: 'float32x3', offset: 132, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 232, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 288, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1120,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 76, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 760, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 244, shaderLocation: 17},
+          {format: 'uint32', offset: 188, shaderLocation: 11},
+          {format: 'float16x2', offset: 136, shaderLocation: 18},
+          {format: 'float16x2', offset: 240, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 428, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 1132,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 64, shaderLocation: 2},
+          {format: 'uint16x2', offset: 136, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 392,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 26, shaderLocation: 5},
+          {format: 'uint32', offset: 48, shaderLocation: 19},
+          {format: 'uint32', offset: 264, shaderLocation: 6},
+          {format: 'uint32x2', offset: 124, shaderLocation: 7},
+          {format: 'uint8x2', offset: 64, shaderLocation: 9},
+          {format: 'sint8x2', offset: 78, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 2416, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 1576, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let shaderModule8 = device1.createShaderModule({
+  label: '\u{1fec0}\u2da3\u{1fcab}\ue627\u629b\u513b\ud2ae\u089b\u3b13\u09c8',
+  code: `@group(0) @binding(2110)
+var<storage, read_write> parameter9: array<u32>;
+@group(2) @binding(366)
+var<storage, read_write> local5: array<u32>;
+@group(1) @binding(2110)
+var<storage, read_write> field5: array<u32>;
+@group(0) @binding(366)
+var<storage, read_write> local6: array<u32>;
+@group(2) @binding(4274)
+var<storage, read_write> parameter10: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(76) f0: vec3<f16>,
+  @location(104) f1: vec3<u32>,
+  @location(38) f2: f16,
+  @location(32) f3: i32
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec3<u32>,
+  @location(0) f1: vec2<i32>,
+  @location(3) f2: vec4<u32>,
+  @location(6) f3: vec2<f32>,
+  @location(2) f4: vec4<f32>,
+  @location(1) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(63) a0: i32, @builtin(sample_index) a1: u32, @location(41) a2: i32, @location(19) a3: u32, a4: S10, @location(85) a5: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(14) f0: vec4<f32>,
+  @location(15) f1: vec2<f16>,
+  @location(17) f2: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(38) f216: f16,
+  @location(41) f217: i32,
+  @location(32) f218: i32,
+  @location(63) f219: i32,
+  @builtin(position) f220: vec4<f32>,
+  @location(76) f221: vec3<f16>,
+  @location(19) f222: u32,
+  @location(85) f223: u32,
+  @location(104) f224: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec3<i32>, @location(8) a1: vec4<f32>, @location(1) a2: i32, a3: S9, @location(2) a4: vec2<f32>, @location(5) a5: vec3<i32>, @location(6) a6: u32, @location(9) a7: vec3<i32>, @location(7) a8: vec3<i32>, @location(19) a9: vec3<u32>, @location(11) a10: vec2<f16>, @location(16) a11: vec3<f16>, @location(0) a12: vec3<f16>, @location(12) a13: vec2<f16>, @location(18) a14: vec3<i32>, @location(13) a15: vec2<u32>, @location(10) a16: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let textureView127 = texture64.createView({label: '\u0da8\ua33c\uae29\u6e5e\u{1f9af}', aspect: 'all'});
+let sampler53 = device1.createSampler({
+  label: '\u{1f8c6}\u433d\u0797\u0d1e\ub686\u01a5\ud099\u{1f640}\u0b7b\uece8',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.63,
+  lodMaxClamp: 94.29,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder59.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder54.end();
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({label: '\uaa5b\u408d\uda35\u{1fb0a}\ubfe3\ue478\u{1f9f7}\u44c2\u4af6\u{1fd6d}\u068e'});
+let querySet42 = device0.createQuerySet({
+  label: '\u{1fa3a}\u{1f62f}\u1d67\u{1fb17}\u14ad\ua67e\u0cbf\u010f\u025a\u022a\uc475',
+  type: 'occlusion',
+  count: 3824,
+});
+let textureView128 = texture2.createView({
+  label: '\u7c0a\u0b31\u0e56\u390b\uea2a\u0071\u0a4f\u0b86\ub537\u{1fc7f}\ud577',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 78,
+  arrayLayerCount: 16,
+});
+let renderBundle60 = renderBundleEncoder5.finish({label: '\u099f\u{1fb0e}\u812f\ua61c\u{1fe7a}\u0908\u7a74\u0185\u{1fb39}\u036d'});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup16, new Uint32Array(9688), 9238, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(1204277438, 912137196, 594790087, 1216514460);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer5, 3396);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let bindGroup26 = device0.createBindGroup({label: '\u{1fe16}\uc751\u023d\u2d36\ub67c', layout: bindGroupLayout16, entries: []});
+let commandEncoder107 = device0.createCommandEncoder({label: '\u03c1\u1f1c\u12e3\u{1f758}\u1f12\u9c8f\uf1e1'});
+let commandBuffer27 = commandEncoder104.finish({label: '\u00e0\u{1fe03}\u{1f674}\u0e65\u4d56\u35c5\ub17b\u{1fa0b}\u5562\ub084\u7e4a'});
+try {
+renderPassEncoder10.beginOcclusionQuery(982);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setViewport(5.039, 0.5767, 1.136, 0.1450, 0.1330, 0.2311);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer5, 'uint16', 65170);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(158578633, 876981522, 747241845);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer19, 4336);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer19, 53180, 38839);
+} catch {}
+let arrayBuffer8 = buffer7.getMappedRange(90768, 21236);
+try {
+commandEncoder107.copyBufferToBuffer(buffer9, 124412, buffer15, 194932, 7296);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 528 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6672 */
+  offset: 6672,
+  buffer: buffer8,
+}, {
+  texture: texture61,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 165, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let commandEncoder108 = device0.createCommandEncoder();
+let textureView129 = texture38.createView({label: '\ue607\u9d76', dimension: '3d', baseMipLevel: 1, mipLevelCount: 5});
+let externalTexture39 = device0.importExternalTexture({source: video9, colorSpace: 'display-p3'});
+try {
+renderPassEncoder11.beginOcclusionQuery(2758);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup5, new Uint32Array(4397), 342, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(260090583, 552223061, 503211753, 1046116488);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer5, 33552);
+} catch {}
+try {
+renderBundleEncoder4.drawIndirect(buffer5, 10580);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer4, 269916, 143048);
+} catch {}
+let pipeline92 = device0.createComputePipeline({
+  label: '\ud6d0\u053f\u3a53\u02c5\u01be\ub9fd\u0dd8',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas14 = new OffscreenCanvas(803, 189);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView130 = texture59.createView({label: '\u03f0\u680b\u873a\u90ec\u{1fa12}\u4b3b', arrayLayerCount: 1});
+let renderBundle61 = renderBundleEncoder45.finish({label: '\u{1f6d6}\u0392\u{1fd8a}\u02f8\u0569\u08e3'});
+try {
+  await promise12;
+} catch {}
+document.body.prepend(canvas8);
+let img16 = await imageWithData(92, 93, '#06bb4d17', '#c9d0c719');
+let commandEncoder109 = device1.createCommandEncoder();
+let querySet43 = device1.createQuerySet({label: '\u{1f9c7}\u{1f7b8}\uea8a\u30e2\u{1ffe2}', type: 'occlusion', count: 2754});
+let texture71 = device1.createTexture({
+  size: {width: 672, height: 1, depthOrArrayLayers: 1185},
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let textureView131 = texture57.createView({label: '\u6bf8\uf580\u02ac', format: 'r32uint'});
+let sampler54 = device1.createSampler({
+  label: '\u8af4\u0ae1\u5091\u{1f732}\u0ec9\u37dd\udfdd',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.44,
+  lodMaxClamp: 73.49,
+  compare: 'greater-equal',
+});
+try {
+commandEncoder103.clearBuffer(buffer31, 6996, 10396);
+dissociateBuffer(device1, buffer31);
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(242, 346);
+let pipelineLayout20 = device0.createPipelineLayout({label: '\u0b5c\u7a5f', bindGroupLayouts: [bindGroupLayout29]});
+let textureView132 = texture8.createView({
+  label: '\u2ed8\u1f8b\u{1f9c3}\uf9d4',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 185,
+});
+let computePassEncoder62 = commandEncoder106.beginComputePass({label: '\u{1f957}\uf3b5\u009e\u098d'});
+let renderBundle62 = renderBundleEncoder17.finish({});
+let sampler55 = device0.createSampler({
+  label: '\u{1faa5}\ufbd2\u0ec0\u819d\u0bce\u8760\ud3fd\ub57d',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.03,
+  lodMaxClamp: 56.29,
+});
+try {
+renderPassEncoder16.setIndexBuffer(buffer14, 'uint32', 57124, 61062);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer5, 40272);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(2, buffer19, 0, 72327);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 960, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer13, 105596, 1584);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet2, 1705, 764, buffer5, 53760);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 86, y: 141 },
+  flipY: false,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder63 = commandEncoder92.beginComputePass({});
+let sampler56 = device1.createSampler({
+  label: '\u{1f7aa}\u0844\uf066\u0b63\u05e9\u{1fd1a}\ue49b\u8502',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 91.54,
+  lodMaxClamp: 91.79,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder60.setPipeline(pipeline71);
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer32, 45416, buffer31, 21156, 5388);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 5500, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 110, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline93 = await device1.createComputePipelineAsync({
+  label: '\u{1fb76}\u48ab',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup27 = device1.createBindGroup({label: '\uc78d\u6049\u{1fc40}\u{1fe1d}\u{1f6b1}\u{1fdcc}', layout: bindGroupLayout24, entries: []});
+let texture72 = device1.createTexture({
+  label: '\uece0\u702d\ud483\u{1f674}\u6fbe',
+  size: [672, 1, 641],
+  mipLevelCount: 10,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 46570 */
+  offset: 46570,
+  rowsPerImage: 253,
+  buffer: buffer28,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 170, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 800 widthInBlocks: 400 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17162 */
+  offset: 16362,
+  buffer: buffer31,
+}, {width: 400, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 21380, new BigUint64Array(16723), 6808, 132);
+} catch {}
+let bindGroupLayout31 = pipeline85.getBindGroupLayout(1);
+let bindGroup28 = device1.createBindGroup({label: '\u7853\u3112\u1f2f', layout: bindGroupLayout24, entries: []});
+let commandEncoder110 = device1.createCommandEncoder({label: '\u30a4\u905a\u0d1e\udf4d\u00a0\u{1f63d}\ue5d3'});
+let renderBundleEncoder48 = device1.createRenderBundleEncoder({
+  label: '\ub1a5\u{1f839}',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+});
+let externalTexture40 = device1.importExternalTexture({label: '\u{1fc6e}\u00c5\uce02\u0217\u4a7e', source: videoFrame6, colorSpace: 'display-p3'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup23, []);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(2, bindGroup28, new Uint32Array(3785), 1346, 0);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer32, 3628, buffer25, 12956, 3684);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 243, y: 4, z: 72},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1376 widthInBlocks: 344 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 175640 */
+  offset: 2232,
+  bytesPerRow: 1536,
+  buffer: buffer30,
+}, {width: 344, height: 113, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 104, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer3), /* required buffer size: 404 */
+{offset: 316}, {width: 44, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline94 = await device1.createComputePipelineAsync({
+  label: '\u0899\u3ada',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas10 = document.createElement('canvas');
+let img17 = await imageWithData(290, 239, '#ca5cb091', '#38177945');
+let buffer34 = device0.createBuffer({size: 41701, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView133 = texture19.createView({label: '\ua09b\ud798\u{1f661}\u027f\u9801\u736d', baseMipLevel: 5, arrayLayerCount: 1});
+let sampler57 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.38,
+  lodMaxClamp: 52.36,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder31.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle9, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(3858);
+} catch {}
+try {
+renderPassEncoder3.setViewport(6.808, 0.04398, 0.08131, 0.03383, 0.1803, 0.2477);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder26.draw(332387917, 1220485647, 541673422, 926599113);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img9,
+  origin: { x: 33, y: 93 },
+  flipY: true,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline95 = device0.createRenderPipeline({
+  label: '\ud4ea\ubfa1\ude35\u{1ffa9}\u0f29\u08be\ub891',
+  layout: pipelineLayout13,
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 2785403720,
+    stencilWriteMask: 3136748876,
+    depthBiasClamp: 358.5256812020284,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 88, shaderLocation: 11},
+          {format: 'sint16x2', offset: 40, shaderLocation: 0},
+          {format: 'float32x4', offset: 132, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 814, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 700,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 60, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 268,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 80, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 28, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 148, shaderLocation: 2},
+          {format: 'uint8x2', offset: 266, shaderLocation: 14},
+          {format: 'uint32x2', offset: 148, shaderLocation: 10},
+          {format: 'sint16x4', offset: 60, shaderLocation: 3},
+          {format: 'sint32x3', offset: 100, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 664, attributes: []},
+      {arrayStride: 236, attributes: [{format: 'sint16x2', offset: 4, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let bindGroupLayout32 = pipeline8.getBindGroupLayout(0);
+let querySet44 = device0.createQuerySet({label: '\u0ffd\u5715\u83a5\ud723\u0ba0\u015f\uae3d\uf6a6\u078b', type: 'occlusion', count: 2052});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({colorFormats: ['r16sint', 'rgba8unorm-srgb', 'r8uint', 'rg16uint', 'rg8unorm'], sampleCount: 1});
+try {
+renderPassEncoder2.executeBundles([renderBundle11, renderBundle9, renderBundle5, renderBundle4, renderBundle22, renderBundle6, renderBundle6, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 751.9, g: -611.2, b: 319.5, a: 264.7, });
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(2641);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer9, 0, 579283);
+} catch {}
+try {
+renderBundleEncoder26.draw(824262146, 11143077, 701565844, 1209122766);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(602295271, 832164792);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer5, 26432);
+} catch {}
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 20984 */
+  offset: 20984,
+  buffer: buffer9,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'stencil-only',
+}, {width: 112, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup29 = device1.createBindGroup({
+  label: '\u67e4\ucc69\u9737\u8021\u0048\u{1fee4}\ufc03\u0b3e\u0445\u6b1d',
+  layout: bindGroupLayout19,
+  entries: [],
+});
+let pipelineLayout21 = device1.createPipelineLayout({label: '\u{1f703}\u05a8', bindGroupLayouts: [bindGroupLayout31, bindGroupLayout28]});
+let commandEncoder111 = device1.createCommandEncoder({label: '\uc88d\u0a48\u06b6\u7e3a\u0d79\u07bd'});
+let textureView134 = texture72.createView({baseMipLevel: 1, mipLevelCount: 9, baseArrayLayer: 69, arrayLayerCount: 446});
+let renderBundle63 = renderBundleEncoder38.finish({});
+try {
+commandEncoder94.copyBufferToBuffer(buffer28, 18888, buffer30, 250812, 27656);
+dissociateBuffer(device1, buffer28);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 25396, new BigUint64Array(23949), 1961, 0);
+} catch {}
+document.body.prepend(video5);
+let bindGroup30 = device0.createBindGroup({
+  label: '\u{1fef9}\ub184\u3865\u{1fe47}\u4613\u00a0\u{1f97b}\u00b3\u0669\u7120\u6a1c',
+  layout: bindGroupLayout12,
+  entries: [],
+});
+let texture73 = gpuCanvasContext11.getCurrentTexture();
+let sampler58 = device0.createSampler({
+  label: '\u9fe9\u{1f6c6}\u121e',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 9.471,
+  lodMaxClamp: 24.50,
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint16', 151056, 16363);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer19, 92548, 4006);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(276569450, 491313307, 803484700);
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(buffer11, 14636, buffer12, 144360, 7004);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer0, 258896);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let textureView135 = texture7.createView({
+  label: '\u3e13\u0d54\u{1f6fc}\u0c86\u05e1\u87b0\u3dd5\ua7d9',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({
+  label: '\u{1f6d9}\u7946\u0564\u424d\u52db\u3cd9',
+  colorFormats: ['rg16uint', 'rgb10a2unorm', 'rgb10a2uint'],
+});
+let renderBundle64 = renderBundleEncoder10.finish({label: '\u3dfb\u{1ff2e}\u{1fcc3}\u96f1\u{1f743}\ud037\u{1fdab}\u83fd\u{1ffb4}\u0063\ubead'});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder11.setViewport(10.18, 1.237, 37.04, 5.026, 0.2468, 0.7511);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(941771565, 748080037);
+} catch {}
+try {
+commandEncoder107.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 109, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 476 widthInBlocks: 119 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28808 */
+  offset: 13484,
+  bytesPerRow: 512,
+  buffer: buffer20,
+}, {width: 119, height: 30, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet35, 16, 313, buffer13, 87808);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 4528, new Float32Array(64696), 59758);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 2, y: 3 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas15.getContext('webgpu');
+let commandEncoder112 = device0.createCommandEncoder({});
+let textureView136 = texture28.createView({
+  label: '\ua41c\uc677\u0933\u{1f713}\u0760\u0a28\u{1f65d}\u{1f9bb}\ud233\ud589\udee7',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle65 = renderBundleEncoder49.finish({});
+try {
+computePassEncoder9.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(3686);
+} catch {}
+try {
+renderPassEncoder16.setViewport(79.50, 2.114, 4.500, 2.141, 0.02487, 0.1746);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer17, 'uint32', 177588);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer4, 0, 489607);
+} catch {}
+let commandBuffer28 = commandEncoder109.finish({label: '\u80f7\u07a3\u{1f6e2}\u{1fc47}'});
+let textureView137 = texture59.createView({baseMipLevel: 0});
+let renderBundle66 = renderBundleEncoder47.finish({label: '\u0abf\u0563\u9b0a\u0f38\u0ba1\u{1fd29}\u400b\ued36'});
+try {
+renderBundleEncoder43.setVertexBuffer(2675, undefined, 3188133961, 295041950);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 2745, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3757, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 4292, new DataView(new ArrayBuffer(22680)), 19477, 1480);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 125},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer3), /* required buffer size: 30222613 */
+{offset: 117, bytesPerRow: 827, rowsPerImage: 64}, {width: 76, height: 1, depthOrArrayLayers: 572});
+} catch {}
+let pipeline96 = await device1.createComputePipelineAsync({
+  label: '\u0c54\u6863\u7278\u{1fbfa}',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder113 = device0.createCommandEncoder({label: '\ucb23\udbc1\u49b9\u0466\uc83d\ub23f\ufaf7\u969a\ufd1f\u{1f7ce}\u{1fed8}'});
+let textureView138 = texture69.createView({label: '\udcd1\u{1f8fc}\u044c\u0753\u0fbb\uf7b9\u0764\u0a33\ud43c', baseArrayLayer: 0});
+let computePassEncoder64 = commandEncoder108.beginComputePass({});
+let sampler59 = device0.createSampler({
+  label: '\u9c41\u{1f97e}\u6f68',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 62.37,
+  lodMaxClamp: 91.10,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup7, new Uint32Array(6176), 324, 0);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder10.setViewport(43.85, 5.432, 58.74, 0.7437, 0.7906, 0.9596);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup9, new Uint32Array(2082), 1279, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(765045434, 391767555, 1180351782, 95944462, 431287293);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer19, 8368);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer19, 'uint32', 85268);
+} catch {}
+try {
+commandEncoder113.resolveQuerySet(querySet12, 483, 2159, buffer19, 46080);
+} catch {}
+try {
+commandEncoder56.insertDebugMarker('\u3281');
+} catch {}
+let gpuCanvasContext14 = canvas10.getContext('webgpu');
+try {
+  await promise13;
+} catch {}
+gc();
+let offscreenCanvas16 = new OffscreenCanvas(650, 855);
+let commandEncoder114 = device1.createCommandEncoder({label: '\uf2a3\ua0b7\u6b97\ufc3e'});
+let commandBuffer29 = commandEncoder105.finish({label: '\ud007\u0c83\ua7a4\ue504'});
+let computePassEncoder65 = commandEncoder90.beginComputePass();
+try {
+renderBundleEncoder48.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+buffer32.destroy();
+} catch {}
+try {
+commandEncoder114.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1291, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5580 widthInBlocks: 2790 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 13004 */
+  offset: 13004,
+  buffer: buffer25,
+}, {width: 2790, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(707), /* required buffer size: 707 */
+{offset: 707, rowsPerImage: 227}, {width: 422, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline97 = device1.createRenderPipeline({
+  label: '\u110d\u49a1\u0bb8\ud93a',
+  layout: pipelineLayout14,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, undefined],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 6768,
+        attributes: [
+          {format: 'uint32x2', offset: 1028, shaderLocation: 11},
+          {format: 'sint32x3', offset: 632, shaderLocation: 14},
+          {format: 'sint32', offset: 524, shaderLocation: 4},
+          {format: 'float32x2', offset: 564, shaderLocation: 16},
+          {format: 'uint32x2', offset: 1120, shaderLocation: 13},
+          {format: 'sint32x2', offset: 1540, shaderLocation: 19},
+          {format: 'sint32x3', offset: 568, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 288,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 40, shaderLocation: 10},
+          {format: 'uint32x4', offset: 48, shaderLocation: 0},
+          {format: 'uint16x4', offset: 12, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 2156,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 72, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 544, shaderLocation: 18},
+          {format: 'sint8x4', offset: 24, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 432, shaderLocation: 3},
+          {format: 'uint8x4', offset: 128, shaderLocation: 7},
+          {format: 'uint16x2', offset: 1364, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 1328, shaderLocation: 17},
+          {format: 'sint16x4', offset: 172, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 1564, attributes: [{format: 'float32x3', offset: 848, shaderLocation: 12}]},
+      {arrayStride: 1620, stepMode: 'instance', attributes: []},
+      {arrayStride: 564, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5256,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 548, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', unclippedDepth: true},
+});
+let texture74 = device1.createTexture({
+  size: [480, 80, 665],
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16sint', 'r16sint', 'r16sint'],
+});
+let textureView139 = texture71.createView({
+  label: '\u0921\u{1fdf6}\u{1fb68}\u00e0\u{1fe5e}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 75,
+  arrayLayerCount: 141,
+});
+let sampler60 = device1.createSampler({
+  label: '\u092d\uf290\u{1fec3}\u4173\u066e\u{1f9c4}\u0b69\u{1fe25}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.44,
+  compare: 'greater-equal',
+  maxAnisotropy: 17,
+});
+let externalTexture41 = device1.importExternalTexture({source: videoFrame7});
+try {
+renderBundleEncoder48.setVertexBuffer(7522, undefined, 0, 542901214);
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 3162, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 197, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline98 = device1.createComputePipeline({
+  label: '\uc0ed\u8fcc\u4c47\u02b6',
+  layout: 'auto',
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+let imageBitmap10 = await createImageBitmap(video5);
+let bindGroupLayout33 = device0.createBindGroupLayout({label: '\ue2a2\ue345', entries: []});
+let renderBundle67 = renderBundleEncoder4.finish({label: '\ud78b\u0e8f\u09de\u{1f988}'});
+try {
+computePassEncoder14.dispatchWorkgroups(4);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup0, new Uint32Array(7902), 7513, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer14, 'uint16');
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer4, 0, 448733);
+} catch {}
+try {
+commandEncoder100.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 15, y: 1, z: 27},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer20);
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: img11,
+  origin: { x: 6, y: 39 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline99 = await device0.createRenderPipelineAsync({
+  label: '\u9982\uca98\u8735\u{1f9cb}\u19c5\u0e02\u3b84\u{1ff07}',
+  layout: pipelineLayout4,
+  multisample: {mask: 0xb51743ad},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'replace', passOp: 'zero'},
+    stencilWriteMask: 2080978913,
+    depthBiasSlopeScale: 927.8940762826078,
+    depthBiasClamp: 699.899355454676,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let shaderModule9 = device1.createShaderModule({
+  label: '\u0d3c\u6157\u073b\u09a5\u{1f9fe}\u{1fa6b}\u1940\u0fcf',
+  code: `@group(1) @binding(2110)
+var<storage, read_write> parameter11: array<u32>;
+@group(0) @binding(366)
+var<storage, read_write> function7: array<u32>;
+@group(0) @binding(4274)
+var<storage, read_write> type3: array<u32>;
+@group(2) @binding(2110)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(4274)
+var<storage, read_write> global9: array<u32>;
+@group(2) @binding(366)
+var<storage, read_write> function8: array<u32>;
+@group(1) @binding(366)
+var<storage, read_write> field6: array<u32>;
+
+@compute @workgroup_size(3, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(4) f2: u32,
+  @location(0) f3: vec3<i32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(2) f0: vec2<f32>,
+  @builtin(instance_index) f1: u32,
+  @location(19) f2: vec3<f32>,
+  @location(7) f3: vec4<i32>,
+  @location(10) f4: vec3<i32>,
+  @location(9) f5: vec4<f32>,
+  @location(11) f6: vec2<u32>,
+  @location(6) f7: vec2<f32>,
+  @location(3) f8: vec4<i32>,
+  @location(5) f9: vec3<i32>,
+  @builtin(vertex_index) f10: u32,
+  @location(1) f11: vec4<f32>,
+  @location(16) f12: vec3<f32>,
+  @location(17) f13: vec2<u32>,
+  @location(0) f14: f16,
+  @location(4) f15: f16,
+  @location(15) f16: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<f16>, @location(18) a1: vec3<u32>, a2: S11, @location(12) a3: vec3<u32>, @location(8) a4: vec2<f16>, @location(14) a5: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder115 = device1.createCommandEncoder({label: '\u7924\u{1fd59}\u01e6\u7549\u6057\ud22f\u0621'});
+let texture75 = device1.createTexture({
+  label: '\u29bb\u0726\u32b6\u0d2e\uee2c',
+  size: [2281],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8unorm'],
+});
+let textureView140 = texture64.createView({mipLevelCount: 1});
+let renderBundleEncoder51 = device1.createRenderBundleEncoder({
+  label: '\uaaa6\u0832\u0b3c\ua36e\u{1fcde}\u{1f6bc}',
+  colorFormats: ['r16sint', 'r8unorm', 'rgba8unorm-srgb', 'rgba16uint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle68 = renderBundleEncoder37.finish({label: '\u41e9\ua766\ufffd\u5293\u0a1d\u3790\u{1fd9c}\u{1fa18}\u1db9'});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder114.copyTextureToBuffer({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1880 widthInBlocks: 470 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7188 */
+  offset: 7188,
+  buffer: buffer25,
+}, {width: 470, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+computePassEncoder45.pushDebugGroup('\ueef7');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 1820, new Int16Array(474), 399, 0);
+} catch {}
+let computePassEncoder66 = commandEncoder113.beginComputePass({label: '\u{1fae5}\u0e60'});
+let externalTexture42 = device0.importExternalTexture({label: '\u{1f75d}\ufc9e\u{1fd5e}\u{1fd4e}\u0e9b\u0a51', source: video11, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(3, 1, 3, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer19, 0, 66952);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(2, buffer19, 69752, 17018);
+} catch {}
+try {
+commandEncoder107.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2064 */
+  offset: 2064,
+  buffer: buffer19,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer19);
+} catch {}
+document.body.prepend(img14);
+try {
+renderBundleEncoder48.setBindGroup(2, bindGroup27, new Uint32Array(4542), 4431, 0);
+} catch {}
+try {
+commandEncoder111.clearBuffer(buffer31, 2260, 6972);
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+offscreenCanvas16.getContext('2d');
+} catch {}
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  label: '\u{1f6a6}\u0245\u0561\u27df\u7c7d\u0f58\u0afa\ud1b1\u{1fa69}',
+  entries: [
+    {binding: 308, visibility: 0, sampler: { type: 'filtering' }},
+    {binding: 807, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder116 = device1.createCommandEncoder({label: '\uc11c\ufc16\u6d8d\u8ed2\u07d1'});
+let texture76 = device1.createTexture({
+  label: '\u{1f9a1}\u09e6\u0441\u{1fbe9}',
+  size: {width: 672},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+let textureView141 = texture70.createView({
+  label: '\uf8e4\u1278',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 3,
+  baseArrayLayer: 74,
+  arrayLayerCount: 1,
+});
+let computePassEncoder67 = commandEncoder111.beginComputePass({label: '\u{1f939}\u{1f855}\u{1f978}\u9b89'});
+let externalTexture43 = device1.importExternalTexture({label: '\ue5a3\uc48d\u{1f96b}\u1bc6\u0b75\u{1fb3f}\ueb62', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 216, new BigUint64Array(61300), 53454, 704);
+} catch {}
+offscreenCanvas12.height = 1429;
+let textureView142 = texture73.createView({label: '\uc316\u{1fe68}\u{1f9bb}\u0638\u76e4\u4461\ubc11', dimension: '2d-array'});
+try {
+renderPassEncoder11.beginOcclusionQuery(2040);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: -32.68, g: 593.1, b: -995.2, a: -260.3, });
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(1733);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer14, 'uint16', 303232, 228);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer6), /* required buffer size: 1069615 */
+{offset: 348, bytesPerRow: 313, rowsPerImage: 110}, {width: 59, height: 7, depthOrArrayLayers: 32});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+  await promise15;
+} catch {}
+let computePassEncoder68 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder58.setPipeline(pipeline71);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 252, new BigUint64Array(63444), 32979, 20);
+} catch {}
+let pipeline100 = device1.createComputePipeline({
+  label: '\u0cc3\u0f50\ufa7a\u{1f6bb}\u1229\u257d\u{1f838}\ue7c3',
+  layout: 'auto',
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let gpuCanvasContext15 = offscreenCanvas14.getContext('webgpu');
+let pipelineLayout22 = device0.createPipelineLayout({label: '\u0a5f\u941b\ufc50\u448a', bindGroupLayouts: [bindGroupLayout11, bindGroupLayout13]});
+let computePassEncoder69 = commandEncoder56.beginComputePass({label: '\u4d3e\u053d\u1515'});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint', 'rgba8sint', 'rgba8sint'], stencilReadOnly: true});
+let renderBundle69 = renderBundleEncoder40.finish();
+try {
+computePassEncoder30.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(43, 3, 26, 4);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer9, 773968, 7897);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer11, 144456, buffer7, 145164, 42204);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let pipeline101 = device0.createRenderPipeline({
+  label: '\u928f\u2b09\u0223\u{1ff38}\u9dfc\u00ee\u{1ff1a}',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'zero', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 3856223118,
+    depthBiasClamp: -81.65745039040002,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 168,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 4, shaderLocation: 8},
+          {format: 'sint16x2', offset: 0, shaderLocation: 6},
+          {format: 'float16x2', offset: 0, shaderLocation: 0},
+          {format: 'sint32', offset: 36, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 10},
+          {format: 'uint32x3', offset: 16, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 11},
+          {format: 'sint32x2', offset: 64, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 660,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 60, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {},
+});
+let shaderModule10 = device0.createShaderModule({
+  label: '\u39cc\u{1ff06}\u846e\u{1fd9e}\u0ea6',
+  code: `@group(1) @binding(900)
+var<storage, read_write> n3: array<u32>;
+@group(0) @binding(111)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(768)
+var<storage, read_write> local7: array<u32>;
+@group(0) @binding(278)
+var<storage, read_write> n5: array<u32>;
+@group(1) @binding(141)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec4<u32>,
+  @location(1) f1: vec2<i32>,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(11) f0: vec2<f16>,
+  @location(5) f1: vec4<f16>,
+  @location(2) f2: vec4<i32>,
+  @location(15) f3: i32,
+  @location(6) f4: vec2<f16>,
+  @location(3) f5: i32,
+  @location(1) f6: vec4<f32>,
+  @location(9) f7: f32,
+  @builtin(instance_index) f8: u32,
+  @location(13) f9: vec4<f16>,
+  @location(0) f10: vec2<u32>
+}
+struct VertexOutput0 {
+  @builtin(position) f225: vec4<f32>,
+  @location(12) f226: f32,
+  @location(4) f227: vec3<f32>,
+  @location(9) f228: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: u32, @location(7) a1: vec4<u32>, @location(10) a2: vec4<i32>, @location(14) a3: vec4<f16>, @builtin(vertex_index) a4: u32, a5: S12, @location(12) a6: u32, @location(4) a7: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 1629});
+let textureView143 = texture8.createView({
+  label: '\ufacc\u047e\u09fb\u0559\u{1fd4a}',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 177,
+  arrayLayerCount: 23,
+});
+let computePassEncoder70 = commandEncoder100.beginComputePass();
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\u8bd1\u9654\u8820\uef4a\u02af\u{1f82e}\u{1ffd6}\u{1fecb}\u73a9\u2c4d\u2b58',
+  colorFormats: ['rg32uint', 'rgba8sint', 'rgba8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer5, 31044);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer19, 37512);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(0, buffer19, 0);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 125, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'stencil-only',
+}, arrayBuffer2, /* required buffer size: 5084072 */
+{offset: 746, bytesPerRow: 346, rowsPerImage: 249}, {width: 240, height: 1, depthOrArrayLayers: 60});
+} catch {}
+let pipeline102 = device0.createRenderPipeline({
+  label: '\udb72\u8838\u82e7\u833c\u{1fdaf}\u0e1b\u{1f8e6}\u103e\ub352',
+  layout: pipelineLayout6,
+  multisample: {mask: 0x45493d78},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgb10a2unorm'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'never', failOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 350615728,
+    depthBiasClamp: 507.18136255606817,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder117 = device1.createCommandEncoder();
+let renderBundleEncoder54 = device1.createRenderBundleEncoder({
+  label: '\u09eb\ub1ad\u4bea\u{1fbc8}\u025d\u0530\u0b59',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle70 = renderBundleEncoder39.finish({label: '\u{1f7ad}\u0f9d\u66bc\u0c83\u940a\u{1f944}\u2b69\u06b4\u0f0b\uc1e4'});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup22, new Uint32Array(4953), 1884, 0);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline81);
+} catch {}
+try {
+commandEncoder115.clearBuffer(buffer25, 12756);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let bindGroupLayout35 = device1.createBindGroupLayout({entries: []});
+let commandEncoder118 = device1.createCommandEncoder();
+let textureView144 = texture68.createView({label: '\u948d\u0900\udf92\u{1f9dc}\u{1f874}'});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+renderBundleEncoder51.insertDebugMarker('\u{1f785}');
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(729, 914);
+try {
+offscreenCanvas17.getContext('bitmaprenderer');
+} catch {}
+let bindGroup31 = device1.createBindGroup({
+  label: '\u2a33\u70c5\u{1f74f}',
+  layout: bindGroupLayout34,
+  entries: [{binding: 807, resource: externalTexture40}, {binding: 308, resource: sampler37}],
+});
+let querySet46 = device1.createQuerySet({type: 'occlusion', count: 2550});
+let sampler61 = device1.createSampler({
+  label: '\u14d3\ub597\u0941\u77eb\u{1fe56}\u809c\u{1fed4}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.755,
+  lodMaxClamp: 23.84,
+  compare: 'never',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+commandEncoder115.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 6,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 143578 */
+  offset: 10458,
+  bytesPerRow: 256,
+  rowsPerImage: 130,
+  buffer: buffer30,
+}, {width: 12, height: 0, depthOrArrayLayers: 5});
+dissociateBuffer(device1, buffer30);
+} catch {}
+let pipeline103 = await device1.createComputePipelineAsync({layout: pipelineLayout21, compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}}});
+let pipeline104 = await promise14;
+let commandEncoder119 = device0.createCommandEncoder({label: '\u5862\uda0f'});
+let texture77 = device0.createTexture({
+  label: '\u7204\u{1fd93}\u0520\u0acd',
+  size: [960],
+  sampleCount: 12,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let computePassEncoder71 = commandEncoder112.beginComputePass({});
+try {
+computePassEncoder14.dispatchWorkgroups(3);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(56, 1, 40, 1);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7712, undefined, 0, 1542488474);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 45724);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer26, 65220, buffer12, 58908, 59168);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14008 */
+  offset: 14000,
+  bytesPerRow: 256,
+  buffer: buffer9,
+}, {
+  texture: texture43,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer34, 13044, 14256);
+dissociateBuffer(device0, buffer34);
+} catch {}
+try {
+device0.queue.submit([commandBuffer26, commandBuffer27]);
+} catch {}
+let pipeline105 = device0.createComputePipeline({
+  label: '\ufd92\u0188\u0249\u{1ff55}\uaff9\u9704\u0c86\u03d6\u4f9b\u0de6\u08b2',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video6);
+let pipelineLayout23 = device0.createPipelineLayout({
+  label: '\u02bf\u542e\u651a\u902e\u4c82\ufcf9\u06ab\u86f9',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout25],
+});
+let buffer35 = device0.createBuffer({
+  label: '\u685d\u3cba',
+  size: 10470,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let querySet47 = device0.createQuerySet({label: '\u0af7\u0db8\u0c9c\u{1fc96}\u{1f687}\uc3a8', type: 'occlusion', count: 2459});
+let textureView145 = texture27.createView({label: '\u00cb\u{1fe5b}\ud951\u9226', mipLevelCount: 1});
+let sampler62 = device0.createSampler({
+  label: '\uc218\u072c\udb9a\u{1fb85}\u000f\u03e8\ue4c4\u7a09\u1d4a',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 89.34,
+  lodMaxClamp: 90.52,
+  maxAnisotropy: 1,
+});
+let externalTexture44 = device0.importExternalTexture({label: '\u6563\u05f6\u0999\u0f6f\u90ae', source: video5, colorSpace: 'srgb'});
+try {
+renderPassEncoder16.setBlendConstant({ r: 733.6, g: 286.2, b: 195.5, a: 6.205, });
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer19, 0, 59563);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer22, 49780, buffer6, 747064, 2016);
+dissociateBuffer(device0, buffer22);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer5), /* required buffer size: 367 */
+{offset: 367}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(12, 789);
+let video13 = await videoWithData();
+let querySet48 = device1.createQuerySet({
+  label: '\u0665\u1eb8\u0bbd\u0fde\u6a22\u2c01\u9a46\u99d4\u0a73\u9f63\u099c',
+  type: 'occlusion',
+  count: 2344,
+});
+let texture78 = device1.createTexture({
+  label: '\u0da7\u791d\u{1fd1e}\u{1fed6}\u0db0\u{1f87f}',
+  size: [120],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder55 = device1.createRenderBundleEncoder({
+  label: '\u6b66\u0694\u{1fe69}\uf03f\u5d3d\u05bf\u{1fc0a}\u8f6e\u017f\u{1fe5b}\u0e9d',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder68.setBindGroup(1, bindGroup29, new Uint32Array(128), 2, 0);
+} catch {}
+let promise16 = device1.queue.onSubmittedWorkDone();
+let pipeline106 = await device1.createComputePipelineAsync({
+  label: '\u{1f7f4}\u6236\u0143\u8f26\u06f7\uec76\u8e66\u073f\uca67\u5660',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline107 = await device1.createRenderPipelineAsync({
+  label: '\u9eec\u7a55\u05cd\u4c75\u0df6',
+  layout: pipelineLayout21,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm'}, {format: 'rgba16uint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg8sint'}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1032,
+        attributes: [
+          {format: 'float32x3', offset: 112, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 124, shaderLocation: 0},
+          {format: 'uint8x2', offset: 202, shaderLocation: 19},
+          {format: 'uint32x3', offset: 220, shaderLocation: 17},
+          {format: 'uint16x2', offset: 68, shaderLocation: 8},
+          {format: 'sint16x4', offset: 8, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 124, shaderLocation: 18},
+          {format: 'sint32x4', offset: 140, shaderLocation: 14},
+          {format: 'uint16x2', offset: 544, shaderLocation: 9},
+          {format: 'float32', offset: 308, shaderLocation: 7},
+          {format: 'sint16x2', offset: 196, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 836, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 104,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 16, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 12, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 1788, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 868,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 588, shaderLocation: 11},
+          {format: 'sint8x4', offset: 84, shaderLocation: 5},
+          {format: 'sint32', offset: 288, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 6412,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 288, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 1556,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 1392, shaderLocation: 3}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 1264, shaderLocation: 16}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder120 = device0.createCommandEncoder({label: '\u{1f9e8}\u915e'});
+let texture79 = device0.createTexture({
+  label: '\u0a0d\u6d30\u167a\u02de\uc656\u5440',
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder25.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup11, new Uint32Array(5314), 1621, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 34.96, g: -739.3, b: 164.2, a: -671.7, });
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 400628 */
+  offset: 9732,
+  bytesPerRow: 256,
+  rowsPerImage: 46,
+  buffer: buffer3,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 125, y: 2, z: 58},
+  aspect: 'all',
+}, {width: 120, height: 9, depthOrArrayLayers: 34});
+dissociateBuffer(device0, buffer3);
+} catch {}
+gc();
+let commandEncoder121 = device1.createCommandEncoder({label: '\u0d99\u6d24\u43f0'});
+let textureView146 = texture54.createView({
+  label: '\uc1a3\u0ae8\ub8bf\u04e7\u85f5\u{1f7f6}\u669f\u0124\uf603',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 204,
+});
+let sampler63 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.97,
+  lodMaxClamp: 99.07,
+});
+try {
+renderBundleEncoder35.setVertexBuffer(7023, undefined, 0, 2470552571);
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16968 */
+  offset: 16968,
+  buffer: buffer32,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 273, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 78 */
+{offset: 78, rowsPerImage: 278}, {width: 362, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline108 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout14,
+  multisample: {mask: 0xa007c330},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}, {format: 'r8unorm'}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba16uint'}, {format: 'r16uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 3471058040,
+    depthBiasClamp: 314.15837271052567,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x2', offset: 4972, shaderLocation: 18},
+          {format: 'float16x2', offset: 1388, shaderLocation: 1},
+          {format: 'uint16x4', offset: 1808, shaderLocation: 11},
+          {format: 'uint16x4', offset: 984, shaderLocation: 12},
+          {format: 'sint16x2', offset: 836, shaderLocation: 5},
+          {format: 'uint8x2', offset: 708, shaderLocation: 17},
+          {format: 'sint32x4', offset: 780, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 384, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 560, shaderLocation: 19},
+          {format: 'float16x2', offset: 1920, shaderLocation: 0},
+          {format: 'sint8x2', offset: 270, shaderLocation: 7},
+          {format: 'uint16x4', offset: 268, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 2764, shaderLocation: 16},
+          {format: 'sint32x2', offset: 6120, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 352, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 696,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 180, shaderLocation: 2},
+          {format: 'sint16x2', offset: 80, shaderLocation: 10},
+          {format: 'float32x4', offset: 36, shaderLocation: 13},
+          {format: 'float16x2', offset: 320, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 460, attributes: []},
+      {
+        arrayStride: 416,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 208, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+let commandBuffer30 = commandEncoder103.finish({label: '\u0ebf\u964f\u4f6f\u0893\u3efd\ua2e0\u1bc4'});
+let computePassEncoder72 = commandEncoder94.beginComputePass({});
+let externalTexture45 = device1.importExternalTexture({label: '\u0662\ue1ef\u0a17', source: videoFrame4});
+let promise17 = buffer31.mapAsync(GPUMapMode.READ, 3144, 19692);
+let shaderModule11 = device0.createShaderModule({
+  label: '\u0f1b\u3c4e\u09d0\u5969\u{1fa2b}\u0312\u0655\ud8b0\u{1f979}',
+  code: `@group(1) @binding(493)
+var<storage, read_write> parameter12: array<u32>;
+@group(0) @binding(141)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(900)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(4, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(12) f0: vec2<i32>,
+  @location(13) f1: vec4<f16>,
+  @location(6) f2: vec2<f32>,
+  @location(1) f3: vec4<i32>,
+  @location(7) f4: vec4<u32>,
+  @location(4) f5: f16,
+  @location(3) f6: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(4) f2: f32,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec2<f32>, a1: S13, @location(2) a2: vec3<u32>, @builtin(sample_index) a3: u32, @location(0) a4: vec3<f32>, @location(5) a5: vec2<f32>, @location(9) a6: i32, @location(14) a7: vec3<u32>, @location(8) a8: f32, @location(11) a9: vec4<f16>, @builtin(front_facing) a10: bool, @builtin(position) a11: vec4<f32>, @builtin(sample_mask) a12: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f229: vec4<f16>,
+  @location(3) f230: vec4<u32>,
+  @location(5) f231: vec2<f32>,
+  @location(4) f232: f16,
+  @location(6) f233: vec2<f32>,
+  @location(12) f234: vec2<i32>,
+  @location(11) f235: vec4<f16>,
+  @location(8) f236: f32,
+  @location(7) f237: vec4<u32>,
+  @location(9) f238: i32,
+  @location(10) f239: vec2<f32>,
+  @location(14) f240: vec3<u32>,
+  @location(0) f241: vec3<f32>,
+  @location(1) f242: vec4<i32>,
+  @location(2) f243: vec3<u32>,
+  @builtin(position) f244: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<u32>, @location(1) a1: f16, @location(9) a2: vec4<i32>, @location(14) a3: vec4<i32>, @location(6) a4: vec2<u32>, @location(7) a5: vec3<i32>, @location(12) a6: f32, @location(5) a7: vec3<u32>, @location(13) a8: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder122 = device0.createCommandEncoder({label: '\u02e5\u{1fce5}'});
+let textureView147 = texture39.createView({label: '\u0f52\ue8d6\u46ff', dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 104});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup24, new Uint32Array(2159), 371, 0);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -442.7, g: -537.8, b: 486.9, a: -276.1, });
+} catch {}
+try {
+renderPassEncoder9.setViewport(1.181, 0.7792, 5.004, 0.09182, 0.1330, 0.1985);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint32', 46652, 31146);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer26, 187772, buffer16, 453756, 480);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer25]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  label: '\u0073\u75a6\u{1fe89}\u{1f866}\u{1fa3b}\u0406\u9189\uba98\u{1fbe3}\u71ad',
+  code: `@group(1) @binding(493)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(2) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(11) f0: f16,
+  @location(15) f1: vec4<i32>,
+  @location(0) f2: vec3<u32>,
+  @location(6) f3: vec4<f16>,
+  @location(13) f4: vec4<i32>,
+  @location(14) f5: vec2<f32>,
+  @location(9) f6: vec4<f32>,
+  @location(7) f7: u32,
+  @location(2) f8: vec3<u32>,
+  @location(4) f9: vec3<f32>,
+  @builtin(instance_index) f10: u32
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec3<u32>, @location(1) a1: f16, @location(5) a2: vec3<u32>, @location(8) a3: vec2<u32>, @location(10) a4: vec4<u32>, @location(12) a5: vec3<i32>, a6: S14, @builtin(vertex_index) a7: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let texture80 = device0.createTexture({
+  label: '\u{1fa6b}\ue3fb\uf5c9\u0a86\ud94e\u{1f99d}\u0bf9\u0e68\u{1faf3}',
+  size: [960, 4, 68],
+  mipLevelCount: 9,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(678);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer14, 'uint16', 4498);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer19, 11744, 19697);
+} catch {}
+try {
+commandEncoder107.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 3,
+  origin: {x: 1, y: 4, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7208 */
+  offset: 7208,
+  bytesPerRow: 256,
+  buffer: buffer24,
+}, {width: 59, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline109 = device0.createRenderPipeline({
+  label: '\u580f\u05d3\u4971\u{1fb82}\u{1f77d}\ud3ef\u0aed',
+  layout: pipelineLayout12,
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 2845224250,
+    depthBiasSlopeScale: 287.65693684560483,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 660,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 16, shaderLocation: 5},
+          {format: 'float32', offset: 204, shaderLocation: 6},
+          {format: 'uint16x2', offset: 160, shaderLocation: 8},
+          {format: 'uint16x4', offset: 380, shaderLocation: 2},
+          {format: 'sint32x2', offset: 128, shaderLocation: 13},
+          {format: 'uint32', offset: 260, shaderLocation: 7},
+          {format: 'uint32', offset: 44, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 348, shaderLocation: 1},
+          {format: 'sint8x2', offset: 34, shaderLocation: 12},
+          {format: 'float32x2', offset: 40, shaderLocation: 9},
+          {format: 'uint32x4', offset: 72, shaderLocation: 10},
+          {format: 'uint32x4', offset: 72, shaderLocation: 0},
+          {format: 'sint16x4', offset: 88, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 140, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 52, attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 4}]},
+      {arrayStride: 212, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 208, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let gpuCanvasContext16 = offscreenCanvas18.getContext('webgpu');
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet49 = device1.createQuerySet({
+  label: '\u742b\u{1fb60}\uec65\u9d0d\ub73f\u057b\ua51a\uf0f2\u0681\u{1fe4b}',
+  type: 'occlusion',
+  count: 1591,
+});
+let textureView148 = texture57.createView({label: '\u0ab0\u0a99\uc3c4\u{1f618}\u0a06\uded6\u6553\ub6c9\u0fa5\u03dd\uf10f'});
+let sampler64 = device1.createSampler({
+  label: '\u96c7\ub0e9\u006b\u2d8e\uad9a\u5792\u9bed\u0bf9',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.67,
+  lodMaxClamp: 82.06,
+  maxAnisotropy: 6,
+});
+try {
+device1.queue.writeBuffer(buffer25, 2352, new Int16Array(5710));
+} catch {}
+let pipeline110 = await device1.createComputePipelineAsync({
+  label: '\uab16\u0bcd\u0af5\ud08e\uf38c\u0548\u650a',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup27, new Uint32Array(6131), 502, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline96);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(0, bindGroup25);
+} catch {}
+let textureView149 = texture62.createView({label: '\u0740\ue8a9\ub962\u49e1\u4ffe\u{1f990}', mipLevelCount: 1});
+let computePassEncoder73 = commandEncoder98.beginComputePass({label: '\u{1fbb7}\u29e5\u0b9d\u0dba\uacc6\uef9f\u{1f9ee}\u03bf'});
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({
+  label: '\u1fa1\u9a49',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline77);
+} catch {}
+try {
+commandEncoder114.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5242 */
+  offset: 5242,
+  rowsPerImage: 193,
+  buffer: buffer32,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 87, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 128, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroup32 = device1.createBindGroup({
+  label: '\u8cf8\u01dc',
+  layout: bindGroupLayout28,
+  entries: [{binding: 1030, resource: externalTexture30}],
+});
+let sampler65 = device1.createSampler({
+  label: '\u281b\u0d91\uf902\u0f63\u{1f81f}\u{1fa4b}\u0e37\ub83f\u{1f997}\u017a',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.40,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder44.setPipeline(pipeline98);
+} catch {}
+try {
+commandEncoder116.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5752 */
+  offset: 5752,
+  bytesPerRow: 0,
+  rowsPerImage: 177,
+  buffer: buffer32,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 83},
+  aspect: 'all',
+}, {width: 0, height: 28, depthOrArrayLayers: 250});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 334, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3940 widthInBlocks: 1970 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 29878 */
+  offset: 25938,
+  rowsPerImage: 15,
+  buffer: buffer30,
+}, {width: 1970, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 5656, new Int16Array(41171), 3330, 1324);
+} catch {}
+try {
+  await promise16;
+} catch {}
+video3.width = 158;
+let bindGroup33 = device1.createBindGroup({
+  label: '\u{1f706}\u8ed7\u3e8e\ucc1d\u5672\uea54\ube38\u{1f890}\u{1fda1}\u0838',
+  layout: bindGroupLayout21,
+  entries: [],
+});
+let commandBuffer31 = commandEncoder117.finish({label: '\u0e2f\u031c\u34f6\u079d\u7843'});
+let textureView150 = texture70.createView({label: '\u0776\u7501', baseMipLevel: 6, mipLevelCount: 2, baseArrayLayer: 725, arrayLayerCount: 73});
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({
+  label: '\u113b\u01e3\u{1fb53}\u{1f9a9}\ucbc4\u0613',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture46 = device1.importExternalTexture({label: '\u047f\udc4f\ud64e\u1c7f\u05eb\u{1fb53}\u0c83', source: video9, colorSpace: 'srgb'});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+commandEncoder121.copyBufferToTexture({
+  /* bytesInLastRow: 4652 widthInBlocks: 1163 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18532 */
+  offset: 18532,
+  bytesPerRow: 4864,
+  buffer: buffer32,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 87, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1163, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder118.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+device1.queue.submit([commandBuffer28]);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+  await promise17;
+} catch {}
+video4.width = 26;
+let bindGroupLayout36 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 257,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup34 = device1.createBindGroup({layout: bindGroupLayout19, entries: []});
+let commandEncoder123 = device1.createCommandEncoder({label: '\ufd88\u7d71'});
+let textureView151 = texture74.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 189, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 406 widthInBlocks: 203 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 27686 */
+  offset: 27686,
+  bytesPerRow: 512,
+  buffer: buffer30,
+}, {width: 203, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder118.insertDebugMarker('\u{1fab3}');
+} catch {}
+video2.width = 177;
+gc();
+let renderBundle71 = renderBundleEncoder28.finish();
+try {
+computePassEncoder40.setBindGroup(0, bindGroup18, new Uint32Array(757), 166, 0);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroupsIndirect(buffer5, 126336);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup24, new Uint32Array(8905), 2727, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1976);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle18, renderBundle0, renderBundle5, renderBundle7, renderBundle4, renderBundle1, renderBundle53, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(102.3, 4.717, 4.502, 0.8831, 0.2117, 0.2810);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(894896652);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer5, 64276);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer17, 'uint32', 174048, 2301);
+} catch {}
+let arrayBuffer9 = buffer2.getMappedRange(656, 424);
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 1700 widthInBlocks: 850 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25012 */
+  offset: 25012,
+  bytesPerRow: 1792,
+  buffer: buffer9,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 24, z: 0},
+  aspect: 'all',
+}, {width: 850, height: 31, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 49124, new Float32Array(40290));
+} catch {}
+let pipeline111 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout18,
+  multisample: {mask: 0xe588c23e},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg32sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'increment-wrap',
+    },
+    stencilReadMask: 2090820203,
+    stencilWriteMask: 1580419299,
+    depthBias: 1744215923,
+    depthBiasClamp: 443.5280141489154,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 24,
+        attributes: [
+          {format: 'sint32x3', offset: 0, shaderLocation: 15},
+          {format: 'float32', offset: 4, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 14},
+          {format: 'float32', offset: 0, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 6},
+          {format: 'float32x4', offset: 0, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 396,
+        attributes: [
+          {format: 'uint32x4', offset: 96, shaderLocation: 8},
+          {format: 'uint32', offset: 32, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 11},
+          {format: 'sint16x4', offset: 12, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 282, shaderLocation: 5},
+          {format: 'sint16x2', offset: 4, shaderLocation: 10},
+          {format: 'uint32x2', offset: 156, shaderLocation: 4},
+          {format: 'uint8x2', offset: 164, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 892,
+        attributes: [
+          {format: 'sint16x2', offset: 36, shaderLocation: 2},
+          {format: 'uint8x2', offset: 52, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let video14 = await videoWithData();
+let commandBuffer32 = commandEncoder107.finish({label: '\u6391\u0897\u60cb\u5a70'});
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u{1f7d4}\u5942\uaf70\u{1fd0c}\u41e0\u69a1\u{1fa58}\ubb78\u24a8\u1d04',
+  colorFormats: ['rg32float', 'rg11b10ufloat', 'r32float', 'r16uint', 'rgba8sint', 'r8unorm', 'rg8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler66 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 64.44,
+  compare: 'equal',
+});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(85, 8, 12, 0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(6.004, 0.8590, 0.3415, 0.02797, 0.4794, 0.7792);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder30.draw(1080012662, 1104956919, 628916188, 749861148);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(3, buffer9, 0, 458276);
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 128, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet17, 328, 717, buffer19, 46592);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 76, y: 49 },
+  flipY: false,
+}, {
+  texture: texture56,
+  mipLevel: 2,
+  origin: {x: 141, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let texture81 = device1.createTexture({
+  label: '\u0700\u0371\u9142\uaa5c\u7b1e\u5843\u{1f6c1}\u0912\u{1f83f}',
+  size: [672, 1, 35],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView152 = texture62.createView({label: '\u0718\u3cfa\u{1ff74}\ubbf5', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({
+  label: '\u789c\u235e',
+  colorFormats: ['bgra8unorm', 'rgba16uint', 'r16uint', 'rg8sint', 'r32uint', 'r32sint', undefined],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup29, new Uint32Array(2416), 147, 0);
+} catch {}
+let promise18 = device1.popErrorScope();
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 2522, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 278 widthInBlocks: 139 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 19450 */
+  offset: 19450,
+  rowsPerImage: 253,
+  buffer: buffer30,
+}, {width: 139, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer31, 23988, 1120);
+dissociateBuffer(device1, buffer31);
+} catch {}
+let pipeline112 = await device1.createRenderPipelineAsync({
+  label: '\u4f9f\ubbf9\uc95f\u1d21\u05fc\u{1fb30}\u0196\u{1f976}\uf9e5',
+  layout: pipelineLayout17,
+  multisample: {mask: 0xefca5f2e},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rgba16uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', failOp: 'replace', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'always', failOp: 'zero', depthFailOp: 'replace', passOp: 'replace'},
+    stencilReadMask: 769423843,
+    stencilWriteMask: 3589606420,
+    depthBiasSlopeScale: 743.8910776239874,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1124, attributes: []},
+      {
+        arrayStride: 5896,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 2684, shaderLocation: 0},
+          {format: 'sint32x4', offset: 2812, shaderLocation: 10},
+          {format: 'float32x4', offset: 4168, shaderLocation: 16},
+          {format: 'uint16x4', offset: 152, shaderLocation: 14},
+          {format: 'float16x4', offset: 4448, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 128, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 148, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 2596, shaderLocation: 1},
+          {format: 'uint32', offset: 1540, shaderLocation: 18},
+          {format: 'sint8x2', offset: 122, shaderLocation: 3},
+          {format: 'float16x4', offset: 836, shaderLocation: 4},
+          {format: 'float32x3', offset: 328, shaderLocation: 19},
+          {format: 'sint16x4', offset: 3524, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 664, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 732,
+        attributes: [
+          {format: 'sint32x3', offset: 88, shaderLocation: 7},
+          {format: 'uint8x2', offset: 154, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 2584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 128, shaderLocation: 8},
+          {format: 'uint32', offset: 2272, shaderLocation: 11},
+          {format: 'uint32x2', offset: 1024, shaderLocation: 12},
+          {format: 'sint32x4', offset: 68, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'none', unclippedDepth: true},
+});
+let buffer36 = device0.createBuffer({
+  label: '\u0edc\u{1ff4f}\u7262',
+  size: 68068,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder124 = device0.createCommandEncoder();
+let texture82 = device0.createTexture({
+  size: [451, 32, 1],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let renderPassEncoder21 = commandEncoder119.beginRenderPass({
+  label: '\u7caf\u0067\ua645\ua0a6\u02a1\u0619\u0a8c\ube95',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView15,
+    depthClearValue: -4.272253404387493,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 489610130,
+});
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 19072);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(7, buffer9, 0, 245652);
+} catch {}
+try {
+commandEncoder120.copyBufferToBuffer(buffer26, 49532, buffer33, 42856, 83748);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer33);
+} catch {}
+try {
+commandEncoder120.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 96032 */
+  offset: 96032,
+  buffer: buffer24,
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 502, y: 0, z: 51},
+  aspect: 'all',
+},
+{width: 112, height: 1, depthOrArrayLayers: 13});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 12260, new Float32Array(50427), 7813, 2068);
+} catch {}
+let commandBuffer33 = commandEncoder124.finish({label: '\u0519\u03c1\u{1fd79}'});
+let sampler67 = device0.createSampler({
+  label: '\u{1f82c}\u0c0c\u{1fab1}\u0c0d\u07ba\ucaf8\ufda0\u4e80\u0e68',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.49,
+  lodMaxClamp: 64.16,
+});
+let externalTexture47 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder2.dispatchWorkgroups(2, 2, 2);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: 205.1, g: 664.4, b: -513.5, a: -946.9, });
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer5, 40384);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet45, 41, 814, buffer5, 6912);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let renderBundleEncoder60 = device0.createRenderBundleEncoder({
+  label: '\u{1facc}\u4c04\u53a1\ue2cc\u0b75',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(26, 7, 7, 0);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(2326);
+} catch {}
+try {
+renderPassEncoder19.setViewport(43.53, 6.071, 12.92, 1.070, 0.1681, 0.4266);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer17, 'uint32', 22044, 151403);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer19, 21884);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline50);
+} catch {}
+let promise19 = buffer11.mapAsync(GPUMapMode.WRITE, 64136, 116668);
+try {
+commandEncoder122.copyBufferToBuffer(buffer22, 30748, buffer16, 435964, 12732);
+dissociateBuffer(device0, buffer22);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 46, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet2, 1178, 523, buffer9, 181760);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 3992, new BigUint64Array(52075), 16053, 1908);
+} catch {}
+let pipeline113 = await device0.createRenderPipelineAsync({
+  label: '\u49d5\u000a\u1802\u035c\u93ea\u{1f77d}\u5a8e\u{1fa92}\u02ad\u93d0',
+  layout: pipelineLayout22,
+  multisample: {mask: 0x7972c21c},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16uint'}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilReadMask: 2763955720,
+    stencilWriteMask: 2849111723,
+    depthBias: 1989317669,
+    depthBiasClamp: 230.35592378782923,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 416, attributes: [{format: 'sint16x4', offset: 16, shaderLocation: 3}]},
+      {
+        arrayStride: 408,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 12, shaderLocation: 1},
+          {format: 'uint8x4', offset: 8, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 5},
+          {format: 'sint8x2', offset: 122, shaderLocation: 2},
+          {format: 'sint32', offset: 56, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 152, shaderLocation: 11},
+          {format: 'uint16x4', offset: 24, shaderLocation: 7},
+          {format: 'uint32x2', offset: 48, shaderLocation: 4},
+          {format: 'uint8x2', offset: 28, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 32, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 20, shaderLocation: 6},
+          {format: 'float32', offset: 248, shaderLocation: 9},
+          {format: 'sint32', offset: 72, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 152,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x2', offset: 48, shaderLocation: 13},
+          {format: 'uint32', offset: 0, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+try {
+  await promise19;
+} catch {}
+let imageBitmap11 = await createImageBitmap(imageData6);
+let videoFrame11 = new VideoFrame(videoFrame0, {timestamp: 0});
+let textureView153 = texture68.createView({label: '\uc9f4\u{1f8d4}\u04c2\u{1fd5a}\u{1f608}', dimension: '1d', baseMipLevel: 0});
+try {
+buffer32.destroy();
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1543, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3862 widthInBlocks: 1931 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 76512 */
+  offset: 76512,
+  buffer: buffer30,
+}, {width: 1931, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.submit([commandBuffer29, commandBuffer31]);
+} catch {}
+let texture83 = device1.createTexture({
+  label: '\u50e1\u25a9\uc156\u1510\u7e63\u{1fbc0}',
+  size: [5376],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let externalTexture48 = device1.importExternalTexture({
+  label: '\u{1f7a6}\ucbd6\u{1f896}\u2291\u{1f6f4}\u0d5f\u3c21\u0da4',
+  source: video6,
+  colorSpace: 'display-p3',
+});
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let sampler68 = device1.createSampler({
+  label: '\u{1ffa2}\u86e8\u{1f661}\ua6fe\u844e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 65.69,
+  compare: 'greater-equal',
+});
+try {
+querySet40.destroy();
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer32, 21828, buffer30, 224984, 38516);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder114.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 70092 */
+  offset: 34876,
+  bytesPerRow: 256,
+  rowsPerImage: 137,
+  buffer: buffer30,
+}, {width: 36, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer31, 18968, new Int16Array(18224), 17760, 60);
+} catch {}
+let pipeline114 = device1.createComputePipeline({
+  label: '\u0fc7\uaa69\u{1f7df}\ucb2a\u{1fdad}\u7aac\u{1f9d2}\u87c4\u28ac\u74ef',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  label: '\u327c\u73f0\u1873\u{1f7c1}\u0bd2\u67cc',
+  entries: [
+    {binding: 441, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 992,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup35 = device0.createBindGroup({label: '\u004e\u1d7b', layout: bindGroupLayout17, entries: []});
+let buffer37 = device0.createBuffer({label: '\ufff8\u18bc', size: 55358, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView154 = texture31.createView({
+  label: '\u0313\uad28\u8a63\u9830',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 89,
+  arrayLayerCount: 129,
+});
+let externalTexture49 = device0.importExternalTexture({label: '\u{1fae0}\u2738\u4ff2', source: videoFrame2});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+computePassEncoder41.dispatchWorkgroupsIndirect(buffer5, 16180);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 854.5, g: -463.3, b: -596.3, a: -872.5, });
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(1145519142, 856192104, 43342700);
+} catch {}
+try {
+commandEncoder120.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 67864 */
+  offset: 67864,
+  bytesPerRow: 256,
+  buffer: buffer8,
+}, {
+  texture: texture43,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 11, y: 3, z: 44},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet13, 464, 282, buffer5, 83712);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: img14,
+  origin: { x: 23, y: 15 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 28},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 20, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let querySet50 = device1.createQuerySet({type: 'occlusion', count: 3314});
+let texture84 = device1.createTexture({
+  label: '\u656b\u04b4\ue44e',
+  size: {width: 5376},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+try {
+computePassEncoder60.setPipeline(pipeline94);
+} catch {}
+try {
+computePassEncoder45.popDebugGroup();
+} catch {}
+try {
+computePassEncoder67.insertDebugMarker('\u0deb');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 2,
+  origin: {x: 21, y: 0, z: 341},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer3), /* required buffer size: 480 */
+{offset: 480, bytesPerRow: 534, rowsPerImage: 0}, {width: 38, height: 0, depthOrArrayLayers: 653});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let computePassEncoder74 = commandEncoder120.beginComputePass({label: '\u0d2f\uf63c\u221b\ub74d\uad55'});
+try {
+renderPassEncoder9.setBlendConstant({ r: -747.7, g: -337.6, b: -143.1, a: -211.9, });
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(100, 1, 1, 3);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(759);
+} catch {}
+try {
+renderPassEncoder9.setViewport(3.703, 0.3577, 0.5122, 0.01047, 0.4546, 0.9544);
+} catch {}
+try {
+renderBundleEncoder30.draw(223852943, 5359463, 102118856, 208949558);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer5, 6360);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer19, 'uint32', 104364, 150);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer15);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 2276, new BigUint64Array(1213));
+} catch {}
+let device2 = await adapter2.requestDevice({
+  label: '\ufbd0\u6a1b\u{1f9df}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 48,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 38351,
+    maxStorageTexturesPerShaderStage: 24,
+    maxStorageBuffersPerShaderStage: 29,
+    maxDynamicStorageBuffersPerPipelineLayout: 65413,
+    maxDynamicUniformBuffersPerPipelineLayout: 45273,
+    maxBindingsPerBindGroup: 7607,
+    maxTextureArrayLayers: 2017,
+    maxTextureDimension1D: 14389,
+    maxTextureDimension2D: 11778,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 5331137,
+    maxUniformBuffersPerShaderStage: 35,
+    maxSampledTexturesPerShaderStage: 44,
+    maxInterStageShaderVariables: 121,
+    maxInterStageShaderComponents: 96,
+  },
+});
+let video15 = await videoWithData();
+let imageData11 = new ImageData(252, 240);
+let buffer38 = device1.createBuffer({label: '\u0bf8\uf364\u02ba', size: 578284, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandBuffer34 = commandEncoder110.finish();
+let sampler69 = device1.createSampler({
+  label: '\u{1fc98}\u03a7\u2e45\u055d\u54fc\uc431\u979e\u4d35\u{1fcf6}\u{1f8c3}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 67.00,
+  lodMaxClamp: 77.31,
+});
+try {
+commandEncoder115.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 338, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(56)), /* required buffer size: 32 */
+{offset: 32, rowsPerImage: 204}, {width: 5369, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas11 = document.createElement('canvas');
+let promise20 = adapter2.requestAdapterInfo();
+try {
+canvas11.getContext('bitmaprenderer');
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise20;
+} catch {}
+gc();
+let querySet51 = device2.createQuerySet({label: '\u{1ff88}\uaabd\u{1f7d9}\ua682\u03b2\u5d7d', type: 'occlusion', count: 3856});
+let renderBundleEncoder61 = device2.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler70 = device2.createSampler({
+  label: '\u{1fea3}\u{1fddb}\ua0d5\u0a31\u007e\u5573\u2fcf\u0a1e\ub4ce\u001a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.53,
+  lodMaxClamp: 93.30,
+});
+let externalTexture50 = device2.importExternalTexture({source: video13, colorSpace: 'srgb'});
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData12 = new ImageData(240, 168);
+let bindGroupLayout38 = device2.createBindGroupLayout({label: '\u057d\u{1fb23}\uf269\u027e\u0076', entries: []});
+let texture85 = device2.createTexture({
+  label: '\uc0f8\u0d46\u{1fe74}\u021f',
+  size: {width: 2840, height: 1, depthOrArrayLayers: 616},
+  mipLevelCount: 9,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView155 = texture85.createView({
+  label: '\ub939\uf41c\u871a\u1577\uca96\u656d\u0ae1\u{1fc7b}\u9220',
+  mipLevelCount: 3,
+  baseArrayLayer: 434,
+  arrayLayerCount: 93,
+});
+let texture86 = device2.createTexture({
+  label: '\uc634\u02b6\u{1ff36}\u8e88\uea22\ud2b8\u{1f60c}\uf9af\u5172\uc574',
+  size: [1420, 1, 6],
+  mipLevelCount: 5,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let textureView156 = texture85.createView({
+  label: '\u0d58\u0cee\u{1ffef}\u689f\u{1fd5f}\u9804\u0620',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 71,
+  arrayLayerCount: 383,
+});
+let promise21 = device2.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+gc();
+let bindGroupLayout39 = device1.createBindGroupLayout({
+  label: '\u3059\ud25f\u{1f6dd}\ub507\u05a2\u0c5d\ud755\uf807',
+  entries: [
+    {
+      binding: 4044,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 645,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 1914,
+      visibility: 0,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let renderBundle72 = renderBundleEncoder46.finish({label: '\u58c1\u093b\u67fe\u0797\u5e00\u0d3e'});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup33, new Uint32Array(3331), 2909, 0);
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.READ, 0, 21384);
+} catch {}
+try {
+commandEncoder115.copyBufferToBuffer(buffer32, 60084, buffer31, 24052, 1592);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 508, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 17791 */
+{offset: 431}, {width: 4340, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline115 = device1.createComputePipeline({
+  label: '\u4876\u0f4a\u{1fbfd}\udad6\uaaf2\u1f53\ubfae\u{1f7f1}\u257b',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule8, entryPoint: 'compute0'},
+});
+try {
+device1.destroy();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+video7.height = 150;
+let imageBitmap12 = await createImageBitmap(imageBitmap5);
+let texture87 = device2.createTexture({
+  label: '\u{1f757}\u0ee4\u0592\u{1faf9}\u056a',
+  size: [1420, 1, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView157 = texture87.createView({label: '\uee4b\ue9b0', aspect: 'all', baseMipLevel: 2});
+let renderBundle73 = renderBundleEncoder61.finish({label: '\u0635\ub3af\u7c8c\u00d2\ubd2b'});
+try {
+device2.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 774 */
+{offset: 774}, {width: 1180, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView158 = texture87.createView({
+  label: '\u{1fde5}\u03aa\u{1fa0f}\u8af4\u09a8\u{1fd6a}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  baseArrayLayer: 0,
+});
+let renderBundle74 = renderBundleEncoder61.finish({label: '\uc4b3\ube13\ud011\u{1fff1}\u73e9\u0869\u0d2c\u0668\u0445'});
+let texture88 = gpuCanvasContext14.getCurrentTexture();
+let textureView159 = texture86.createView({label: '\u6474\u249f\u08a5\u2cf7', dimension: '2d', mipLevelCount: 2, baseArrayLayer: 5});
+let imageBitmap13 = await createImageBitmap(img5);
+let buffer39 = device0.createBuffer({
+  label: '\u02f9\u{1f73c}\ub1e6\u8fc2\u0ded\u5e7b\u065e',
+  size: 94842,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder125 = device0.createCommandEncoder();
+let querySet52 = device0.createQuerySet({label: '\ube62\u0269\u024a\u{1fe09}\u05b9\u031c\u24e1', type: 'occlusion', count: 3256});
+try {
+computePassEncoder14.dispatchWorkgroups(4, 4, 4);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline92);
+} catch {}
+try {
+renderPassEncoder18.setViewport(60.24, 0.6500, 15.39, 0.4188, 0.1756, 0.8987);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer19, 10564);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 2464, new BigUint64Array(25431), 5225, 2012);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(56)), /* required buffer size: 760 */
+{offset: 760}, {width: 91, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 283, y: 184 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise22 = device0.createComputePipelineAsync({
+  label: '\u071d\u0501\u{1f9a9}\ub696\u2458\u{1f862}\ueb22\u{1fb4a}\u815a\u2abe',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let pipeline116 = device0.createRenderPipeline({
+  label: '\ufdb0\ufa06\u{1fd55}\u58e6\u{1fe92}\u5911\u8681\ua163\u260a',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 3619982103,
+    stencilWriteMask: 141684522,
+    depthBiasSlopeScale: 449.36807110061534,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise21;
+} catch {}
+let imageData13 = new ImageData(256, 88);
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.47,
+  lodMaxClamp: 80.96,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder6.dispatchWorkgroups(5, 5, 1);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(1, 1, 6, 0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer39, 0);
+} catch {}
+try {
+renderBundleEncoder50.draw(35043032, 1050055920);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(370375805, 1037067914, 1223038179, 752155407);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer19, 3364);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer11, 54324, buffer0, 155128, 55564);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder4.clearBuffer(buffer34, 17512, 19348);
+dissociateBuffer(device0, buffer34);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 28304, new BigUint64Array(18173), 3943, 5056);
+} catch {}
+let sampler72 = device2.createSampler({
+  label: '\u089b\u0995\ufb63\u0d4f\uf420\u1b16\u08dd\u23d8\u95e0',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.87,
+  lodMaxClamp: 90.17,
+  compare: 'never',
+  maxAnisotropy: 17,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 1690356 */
+{offset: 476, bytesPerRow: 10180, rowsPerImage: 166}, {width: 619, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+computePassEncoder35.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1005);
+} catch {}
+try {
+renderBundleEncoder26.draw(795598170);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(576490839, 1077109032, 427168767, -704461766, 439052758);
+} catch {}
+try {
+renderBundleEncoder50.drawIndirect(buffer5, 27856);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(48)), /* required buffer size: 827 */
+{offset: 827}, {width: 431, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise23 = device0.createRenderPipelineAsync({
+  label: '\u00d7\uaae1',
+  layout: pipelineLayout2,
+  multisample: {mask: 0x881ee13d},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint'}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 20, shaderLocation: 1},
+          {format: 'sint16x4', offset: 4, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 12},
+          {format: 'sint32x2', offset: 16, shaderLocation: 9},
+          {format: 'uint16x2', offset: 0, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 496, attributes: []},
+      {
+        arrayStride: 232,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x4', offset: 16, shaderLocation: 15}],
+      },
+      {arrayStride: 1444, attributes: [{format: 'sint32x3', offset: 548, shaderLocation: 7}]},
+      {
+        arrayStride: 392,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 64, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 360,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 16, shaderLocation: 5}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let querySet53 = device0.createQuerySet({label: '\u2f96\u{1fa24}\ud2cc\u7093\u{1fa26}\u0226\u39fc\u8443', type: 'occlusion', count: 147});
+let textureView160 = texture24.createView({label: '\u{1f824}\u01b2\u046c'});
+let renderBundle75 = renderBundleEncoder17.finish();
+let sampler73 = device0.createSampler({
+  label: '\u{1f83d}\u{1fe7a}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 51.63,
+  lodMaxClamp: 63.06,
+});
+let externalTexture51 = device0.importExternalTexture({label: '\u8111\u{1fe5a}\u{1fb50}\u7422\u{1fe4f}', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder20.setScissorRect(108, 2, 4, 0);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(2608);
+} catch {}
+let arrayBuffer10 = buffer16.getMappedRange(0, 120752);
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 132 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 83188 */
+  offset: 24688,
+  bytesPerRow: 256,
+  rowsPerImage: 12,
+  buffer: buffer18,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 15},
+  aspect: 'all',
+}, {width: 33, height: 1, depthOrArrayLayers: 20});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9396 */
+  offset: 9396,
+  buffer: buffer37,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer37);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet0, 1475, 3, buffer39, 29696);
+} catch {}
+try {
+device0.queue.submit([commandBuffer32, commandBuffer22]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 151},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(1199893), /* required buffer size: 1199893 */
+{offset: 37, bytesPerRow: 256, rowsPerImage: 142}, {width: 240, height: 1, depthOrArrayLayers: 34});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise24 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2306223430,
+    stencilWriteMask: 2670862887,
+    depthBias: -1920464907,
+    depthBiasClamp: 240.48896769351705,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+let externalTexture52 = device2.importExternalTexture({label: '\u{1ff5b}\u0eac\u6a13\u0da4\u0bbc', source: video6, colorSpace: 'srgb'});
+let img18 = await imageWithData(219, 149, '#7121dabb', '#5ea3f21e');
+let video16 = await videoWithData();
+let bindGroup36 = device2.createBindGroup({label: '\u0555\u0b61', layout: bindGroupLayout38, entries: []});
+let buffer40 = device2.createBuffer({
+  label: '\ubded\u01dd\u{1f749}\u7fa8\u{1f74a}\u{1f941}',
+  size: 127239,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 14, y: 20 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet54 = device0.createQuerySet({
+  label: '\u051a\u6209\u{1fdb6}\u0396\u6995\u{1f8e2}\u{1fab3}\u0987\u0e3e\u1bf1',
+  type: 'occlusion',
+  count: 3428,
+});
+let texture89 = device0.createTexture({
+  label: '\u{1f65f}\u5ac2\u69b6\u087f\u0d5f\u0791\u05eb\u1fbe\ua328',
+  size: {width: 120, height: 1, depthOrArrayLayers: 26},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup14, new Uint32Array(3870), 2156, 0);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer19, 6384);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer19, 18816);
+} catch {}
+let pipeline117 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x44558d18},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 2002538564,
+    depthBiasSlopeScale: 665.5956009909213,
+    depthBiasClamp: 795.9237633736831,
+  },
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+document.body.prepend(video8);
+let commandEncoder126 = device0.createCommandEncoder();
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer29, 493204, 23230);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(300906068, 24714414, 814842907, -1140404092);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer5, 2240);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer5, 13952);
+} catch {}
+let arrayBuffer11 = buffer16.getMappedRange(241416, 8168);
+try {
+commandEncoder8.resolveQuerySet(querySet5, 480, 93, buffer39, 4352);
+} catch {}
+let pipeline118 = await promise24;
+let commandEncoder127 = device0.createCommandEncoder();
+let querySet55 = device0.createQuerySet({
+  label: '\u721c\u9955\u7bc6\u5095\u37e1\u05a9\u0c21\u{1fe5a}\u0810\u{1f614}',
+  type: 'occlusion',
+  count: 1547,
+});
+let externalTexture53 = device0.importExternalTexture({label: '\ud542\u5edc', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(0, bindGroup5, new Uint32Array(7981), 6762, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle9, renderBundle3, renderBundle43]);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(237406739, 426750965, 1105962152, 51656332, 73487490);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer5, 2396);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer17, 'uint16', 120570, 34882);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(7, buffer9);
+} catch {}
+try {
+commandEncoder126.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23892 */
+  offset: 23892,
+  buffer: buffer0,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture41,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer11), /* required buffer size: 545 */
+{offset: 545, bytesPerRow: 104}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video17 = await videoWithData();
+try {
+computePassEncoder16.setBindGroup(0, bindGroup2, new Uint32Array(9043), 3687, 0);
+} catch {}
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(30);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(546206118, 370288980, 1078354668, -186650881, 541379624);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({label: '\ub6cf\u{1fce2}'});
+let querySet56 = device0.createQuerySet({label: '\u40d2\u{1fd1a}\u{1f9a5}\u400e\u07e1', type: 'occlusion', count: 1031});
+let textureView161 = texture14.createView({label: '\u8777\u9fe3\u025b\u{1f7ed}\uf702\ue2b1\u{1fa0d}\ubad3\u{1f623}\u{1fef6}'});
+let renderBundle76 = renderBundleEncoder49.finish({});
+try {
+computePassEncoder35.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(101, 4, 7, 4);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 3924);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer24, 848);
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 10148, new BigUint64Array(61852), 11957, 580);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer9), /* required buffer size: 318 */
+{offset: 318}, {width: 99, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout24 = device0.createPipelineLayout({
+  label: '\ue981\u0363\u8db6\ue0b0\uaca3\u03b3',
+  bindGroupLayouts: [bindGroupLayout23, bindGroupLayout8, bindGroupLayout2, bindGroupLayout26],
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+let texture90 = device0.createTexture({
+  label: '\u0c81\u{1fb0b}\u{1f605}\u0c21\u09ec\u{1fd20}\u8629\u{1fc19}\u9758',
+  size: {width: 960},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let renderBundle77 = renderBundleEncoder60.finish({label: '\u{1f799}\uf072\u{1fd52}\u52d7\uf907\u{1fddf}\u2e03'});
+try {
+computePassEncoder52.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle53, renderBundle2, renderBundle1, renderBundle16, renderBundle8, renderBundle1, renderBundle18, renderBundle9, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder11.setViewport(77.71, 2.467, 16.37, 2.941, 0.2621, 0.5542);
+} catch {}
+try {
+renderBundleEncoder30.draw(982366954, 14919433, 209973128, 808580359);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer19, 79684);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(6, buffer29, 0, 500143);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 102 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 121828 */
+  offset: 6014,
+  bytesPerRow: 256,
+  rowsPerImage: 44,
+  buffer: buffer8,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 268, y: 1, z: 19},
+  aspect: 'all',
+}, {width: 51, height: 13, depthOrArrayLayers: 11});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 4,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21444 */
+  offset: 19828,
+  bytesPerRow: 512,
+  rowsPerImage: 258,
+  buffer: buffer14,
+}, {width: 20, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder4.clearBuffer(buffer20);
+dissociateBuffer(device0, buffer20);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 4828, new DataView(new ArrayBuffer(38515)), 4160, 6904);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 41, y: 2, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let pipelineLayout25 = device2.createPipelineLayout({
+  label: '\u{1ff20}\uf891\u219e\u7b1a\u0686\u7e3b\u6c67\u0857\u{1fe1f}',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout38, bindGroupLayout38],
+});
+let sampler74 = device2.createSampler({
+  label: '\u99b4\u09a2\u0d38\u7fa7\u065f\u6e24\u3460\u21b7\u8bca\u{1fadf}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 66.88,
+  lodMaxClamp: 67.13,
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let pipelineLayout26 = device0.createPipelineLayout({
+  label: '\ud711\u6ca7\u673c',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout6, bindGroupLayout11],
+});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\u799a\uae93\ub325\u18bf\u600b\u52c7\u{1f78f}',
+  colorFormats: ['rg32uint', 'rgba8sint', 'rgba8sint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder53.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup4, new Uint32Array(1010), 84, 0);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer19, 36576);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer5, 6444);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 192, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 72, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 26932, new Int16Array(5386), 142, 1756);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap14 = await createImageBitmap(imageBitmap7);
+let buffer41 = device2.createBuffer({size: 214961, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 12832, new DataView(new ArrayBuffer(10195)), 4948, 1688);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let texture91 = device0.createTexture({
+  size: {width: 903, height: 64, depthOrArrayLayers: 360},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg11b10ufloat', 'rg11b10ufloat'],
+});
+let sampler75 = device0.createSampler({
+  label: '\u97ce\u{1ff92}\u1279\u069a\u{1f7da}\ud6e0\u{1ffd1}\u0a4a\u92fd\u{1f64d}\udbb7',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 81.72,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder52.dispatchWorkgroups(2, 4, 3);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 3376, new Int16Array(29382), 11818, 84);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let commandEncoder130 = device2.createCommandEncoder({});
+let querySet57 = device2.createQuerySet({label: '\u0654\u{1fc81}\u7685', type: 'occlusion', count: 1549});
+let texture92 = device2.createTexture({
+  label: '\u{1f6e8}\ue7fc\u06f0\u9867\uefeb',
+  size: {width: 2840},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let textureView162 = texture87.createView({label: '\uac26\u0b4b', baseMipLevel: 2});
+let renderBundle78 = renderBundleEncoder61.finish({label: '\uda79\ucfeb\u084b\udd0e\ue076\u0e13\u{1f7b5}\uc7c7\u5200\uacce'});
+try {
+commandEncoder130.clearBuffer(buffer41, 95572, 85244);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 263 */
+{offset: 263, bytesPerRow: 45}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas13,
+  origin: { x: 322, y: 4 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas5);
+try {
+querySet51.label = '\u161c\u06f8\ue9a9\u0040\uca8b\u02ea\u{1fca2}\u52b4';
+} catch {}
+let bindGroup37 = device2.createBindGroup({
+  label: '\u4da4\u0713\u0603\ubd9f\u0fa8\u590b\u0a1b\u623e\u475a',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let commandEncoder131 = device2.createCommandEncoder({});
+let renderBundle79 = renderBundleEncoder61.finish({label: '\u5ef8\uc9bc\u08af\uc12e'});
+let canvas12 = document.createElement('canvas');
+let shaderModule13 = device1.createShaderModule({
+  label: '\u0c5e\u0c50\u{1fed1}\u{1fc7e}\u48c3\u03a8\ucd72\u0b15\u{1ffcb}',
+  code: `@group(1) @binding(2110)
+var<storage, read_write> n7: array<u32>;
+@group(2) @binding(2110)
+var<storage, read_write> n8: array<u32>;
+@group(1) @binding(4274)
+var<storage, read_write> parameter13: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(4) f1: vec4<u32>,
+  @location(1) f2: vec2<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(1) f0: vec4<f32>,
+  @location(11) f1: vec4<u32>,
+  @location(10) f2: f32,
+  @location(18) f3: vec3<f32>,
+  @builtin(vertex_index) f4: u32,
+  @location(12) f5: f32,
+  @builtin(instance_index) f6: u32,
+  @location(5) f7: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec3<i32>, @location(6) a1: vec4<f32>, @location(8) a2: vec2<f32>, @location(17) a3: u32, @location(15) a4: u32, @location(19) a5: vec2<i32>, a6: S15, @location(14) a7: vec4<i32>, @location(3) a8: vec4<i32>, @location(7) a9: vec4<i32>, @location(9) a10: vec4<i32>, @location(4) a11: vec3<f16>, @location(13) a12: f16, @location(0) a13: vec2<u32>, @location(2) a14: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup38 = device1.createBindGroup({
+  label: '\u45b0\uafb4\ue157\u22b1\u{1face}\u6c97\u{1f959}\ua8ee\u1049\u7d8d\u0a30',
+  layout: bindGroupLayout21,
+  entries: [],
+});
+let commandEncoder132 = device1.createCommandEncoder({label: '\u0158\ufac9\u{1ff21}\ub1aa\u0a36\u028a'});
+let querySet58 = device1.createQuerySet({
+  label: '\u1e14\u00c6\u0c01\u{1fc9a}\u9f47\u{1fe99}\uf51f\u021f\u0eeb\ue225',
+  type: 'occlusion',
+  count: 1476,
+});
+let textureView163 = texture59.createView({baseArrayLayer: 0});
+let computePassEncoder75 = commandEncoder132.beginComputePass({label: '\u53e7\u7c62\u{1fbce}\u00a8\u0f1d\u0e0b\u{1fd25}\u{1f7c1}\u6108'});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup22, new Uint32Array(8852), 2690, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+commandEncoder115.copyBufferToBuffer(buffer28, 3356, buffer38, 83092, 26756);
+dissociateBuffer(device1, buffer28);
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 202 widthInBlocks: 101 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 94 */
+  offset: 94,
+  bytesPerRow: 512,
+  buffer: buffer30,
+}, {width: 101, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 32 */
+{offset: 32}, {width: 101, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline119 = device1.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xf6330001},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rgba16uint', writeMask: 0}, {format: 'r16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 996, attributes: [{format: 'sint16x2', offset: 348, shaderLocation: 10}]},
+      {
+        arrayStride: 72,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 4, shaderLocation: 8},
+          {format: 'uint16x4', offset: 0, shaderLocation: 14},
+          {format: 'sint8x2', offset: 22, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 568,
+        attributes: [
+          {format: 'sint32x2', offset: 560, shaderLocation: 3},
+          {format: 'sint32', offset: 160, shaderLocation: 5},
+          {format: 'sint16x2', offset: 232, shaderLocation: 15},
+          {format: 'uint16x4', offset: 44, shaderLocation: 17},
+          {format: 'uint32x4', offset: 124, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 2},
+          {format: 'float32x3', offset: 76, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 4},
+          {format: 'uint16x4', offset: 64, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 792,
+        attributes: [
+          {format: 'uint32x4', offset: 488, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 30, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 284, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 38, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 296,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 40, shaderLocation: 6}],
+      },
+      {arrayStride: 6768, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 2580, attributes: [{format: 'float16x2', offset: 192, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup39 = device2.createBindGroup({
+  label: '\u1d1e\ub05a\u{1fa39}\ua30b\u{1f615}\u267f\ub375\u098b',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let computePassEncoder76 = commandEncoder131.beginComputePass({label: '\u6456\ud0e3\u5509\u4190\u3605\u{1f8cc}\u0da1\u8514\u006f\u00fe'});
+try {
+computePassEncoder76.setBindGroup(5, bindGroup36);
+} catch {}
+try {
+commandEncoder130.clearBuffer(buffer41, 181684, 12080);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 39856, new Float32Array(63666), 4110, 484);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder133 = device2.createCommandEncoder({label: '\ua676\u{1f837}\ubd2c\uf47c\u60e2\u1f9f\u0dda'});
+let commandBuffer35 = commandEncoder130.finish({label: '\u4842\uf7d5\ufa74\uf73e\u69a6\u{1ff9a}\uf332\u89b7\u0514\ub12e'});
+let computePassEncoder77 = commandEncoder133.beginComputePass({});
+document.body.prepend(canvas11);
+try {
+canvas12.getContext('2d');
+} catch {}
+let texture93 = device2.createTexture({label: '\u9f89\u0d81\uef74', size: [5680, 1, 1], mipLevelCount: 12, format: 'rgba32sint', usage: 0});
+let externalTexture54 = device2.importExternalTexture({label: '\u700e\u{1f608}\u8dfc\ubeeb\u{1fa8e}\u11c9', source: videoFrame8, colorSpace: 'display-p3'});
+try {
+device2.queue.writeBuffer(buffer41, 58272, new BigUint64Array(45815), 12528, 6256);
+} catch {}
+let commandEncoder134 = device2.createCommandEncoder({label: '\u0085\ub2ea\u05d9\ub429\u3023\u0778\u038c'});
+let renderBundle80 = renderBundleEncoder61.finish({label: '\u377b\uc999'});
+try {
+commandEncoder134.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6992 widthInBlocks: 437 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 28240 */
+  offset: 28240,
+  buffer: buffer41,
+}, {width: 437, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer41);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 371, y: 1111 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise25 = adapter2.requestAdapterInfo();
+let bindGroup40 = device2.createBindGroup({
+  label: '\u0587\u0078\ue832\u078b\ua5bf\u28f8\ub34c\u692c\u2323\u8af5\u6567',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let pipelineLayout27 = device2.createPipelineLayout({
+  label: '\ud1d6\u1ef4\u{1f929}',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout38, bindGroupLayout38, bindGroupLayout38, bindGroupLayout38, bindGroupLayout38],
+});
+let textureView164 = texture93.createView({
+  label: '\u{1fea3}\u2a7b\uacd4\u06b0\u{1f680}\u36f3\u{1fdb5}\u111c\udbcd\u0138',
+  dimension: '2d-array',
+  baseMipLevel: 8,
+  mipLevelCount: 1,
+});
+let computePassEncoder78 = commandEncoder134.beginComputePass({label: '\u076c\u073c'});
+try {
+buffer41.destroy();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet59 = device2.createQuerySet({
+  label: '\u{1ffc9}\u0c17\u0e3b\u{1ffd1}\u6ebd\u{1fff6}\uc943\u0d54\u0f0d',
+  type: 'occlusion',
+  count: 1577,
+});
+let sampler76 = device2.createSampler({
+  label: '\u0de7\u0b76\u8aca\u0dc7\u77f4',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.67,
+  lodMaxClamp: 96.35,
+  maxAnisotropy: 18,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 80, y: 3 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let bindGroup41 = device2.createBindGroup({
+  label: '\u{1fece}\u50f4\u642a\u739c\u07ab\u0026\u27dc\ue331\u{1fb24}\u5c18\u0b6f',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let commandEncoder135 = device2.createCommandEncoder({});
+let commandBuffer36 = commandEncoder135.finish({});
+let sampler77 = device2.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.22,
+  lodMaxClamp: 91.17,
+  compare: 'never',
+  maxAnisotropy: 17,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(347), /* required buffer size: 347 */
+{offset: 347, rowsPerImage: 235}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 214, y: 0 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video18 = await videoWithData();
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+video3.width = 231;
+try {
+window.someLabel = device2.queue.label;
+} catch {}
+let bindGroupLayout40 = device2.createBindGroupLayout({
+  label: '\uc840\u9a33\u0bac\uf3cb\u9be7\u0199\u{1faa5}\u0355\u6808\uf3a8\u9a26',
+  entries: [
+    {
+      binding: 6763,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 3322,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup39);
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(897, 44);
+let imageData14 = new ImageData(120, 40);
+let bindGroup42 = device2.createBindGroup({layout: bindGroupLayout38, entries: []});
+let commandEncoder136 = device2.createCommandEncoder({label: '\u0bba\ud773\u2c5b\u0b1a\u{1f69d}\u{1f6d4}\u0df7\u5a1a\u0165\u0229\u9d0c'});
+let texture94 = device2.createTexture({
+  label: '\u4184\u4f1a\u47ac\uc0be\ufc32\u06fd\u74bb\ua7ec',
+  size: {width: 5680},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle81 = renderBundleEncoder61.finish({label: '\u4b06\u{1f94b}'});
+try {
+commandEncoder136.copyBufferToBuffer(buffer40, 124752, buffer41, 189736, 532);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 37},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(32)), /* required buffer size: 1007336 */
+{offset: 317, bytesPerRow: 2869, rowsPerImage: 39}, {width: 1314, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 59, y: 2 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder137 = device2.createCommandEncoder({label: '\u02e9\u7e37\u0d2e\u{1ff89}\u02ad\u0627\uf1a8\u{1ff79}\u0d6c'});
+let computePassEncoder79 = commandEncoder136.beginComputePass({label: '\u867c\u{1f703}\u{1ffbd}\u{1f6b9}\ud60d\u0124'});
+try {
+computePassEncoder79.end();
+} catch {}
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 91, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas19.getContext('webgpu');
+let img19 = await imageWithData(137, 209, '#97c362ea', '#3116bf7c');
+let imageData15 = new ImageData(64, 96);
+try {
+window.someLabel = externalTexture40.label;
+} catch {}
+try {
+adapter0.label = '\u32ff\u9168\ub39f\u08a1\udda0\uf0d5\u0fbf\ua427';
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({});
+let texture95 = gpuCanvasContext14.getCurrentTexture();
+let renderBundle82 = renderBundleEncoder61.finish();
+let sampler78 = device2.createSampler({
+  label: '\u{1f913}\uba81\u0c17\u07d0',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.49,
+  lodMaxClamp: 66.90,
+});
+try {
+commandEncoder136.clearBuffer(buffer41, 181156, 5072);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageData13);
+let pipelineLayout28 = device2.createPipelineLayout({
+  label: '\u0354\u{1fcf7}\ud0de\u00b9\udf85\ucdb5\u{1f730}',
+  bindGroupLayouts: [bindGroupLayout40, bindGroupLayout38, bindGroupLayout38],
+});
+let commandEncoder138 = device2.createCommandEncoder();
+let texture96 = device2.createTexture({
+  label: '\u0c91\u0543\u8ab3\ucc1b\u{1fe01}\u{1fc39}\u0b36\u{1fd2e}\u{1f8b3}\u3659',
+  size: [1420],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView165 = texture95.createView({label: '\ucff2\u7358\u0e95\u{1fa62}\u{1fe89}\u1568\u4d6b\uad84\uda09'});
+let sampler79 = device2.createSampler({
+  label: '\u48b1\u6f30\ua6dc\u2415\u551e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.91,
+  lodMaxClamp: 38.94,
+  maxAnisotropy: 17,
+});
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 458, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 51, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView166 = texture18.createView({label: '\ua4d1\u6255\ue2a5\u0c89\uf269\u0d1c\u0dfa\u{1f9d2}\u{1ff28}\uf655\u02b8', baseMipLevel: 1});
+let renderBundle83 = renderBundleEncoder12.finish({label: '\u404c\u0140\u032c\u929e\u4665\u14fc\uab61\u0132\u5f8e\u9f69'});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup6, new Uint32Array(5396), 69, 0);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -285.0, g: -852.1, b: 753.0, a: -262.2, });
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer17, 'uint16', 163440, 8445);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer19, 17916);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 68 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 41264 */
+  offset: 4844,
+  bytesPerRow: 256,
+  rowsPerImage: 141,
+  buffer: buffer3,
+}, {
+  texture: texture23,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 2, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7036 */
+  offset: 7036,
+  buffer: buffer15,
+}, {width: 112, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 60840, new Float32Array(31280), 24371);
+} catch {}
+let pipeline120 = await promise22;
+let canvas13 = document.createElement('canvas');
+let bindGroup43 = device2.createBindGroup({label: '\u87c8\u4c26\u0a0e\u022c\uc441\ud6b3\u1901\u813d', layout: bindGroupLayout38, entries: []});
+let commandEncoder139 = device2.createCommandEncoder({label: '\ub234\u09fd\u0734\u05b0\u{1f7f2}\u01ca\u0eb5\u599d\u1b1d\u{1f7ed}\uff22'});
+let textureView167 = texture93.createView({
+  label: '\u{1f9dd}\u0e96\ud9a8\u{1f955}\u290e\u0700\u{1f7d6}\u111a\u0776\u4d05\uebdd',
+  baseMipLevel: 11,
+});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup41, new Uint32Array(1007), 672, 0);
+} catch {}
+try {
+commandEncoder136.copyBufferToBuffer(buffer40, 99448, buffer41, 11148, 15772);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 409},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 2,
+  origin: {x: 132, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext18 = canvas13.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+video0.height = 286;
+try {
+  await promise25;
+} catch {}
+let bindGroup44 = device2.createBindGroup({
+  label: '\u0e0f\u3aea\u0d52\u6bf6\u0769\ud0be\u119d\u{1f808}\u5118',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let querySet60 = device2.createQuerySet({type: 'occlusion', count: 2569});
+let textureView168 = texture96.createView({});
+let computePassEncoder80 = commandEncoder137.beginComputePass();
+let sampler80 = device2.createSampler({
+  label: '\u{1f9e4}\u{1f962}\u{1ff1d}\uda88\u1a25\u0051\u0d2d',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.10,
+  lodMaxClamp: 97.34,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup44, new Uint32Array(4550), 808, 0);
+} catch {}
+try {
+  await buffer40.mapAsync(GPUMapMode.WRITE, 83528, 32256);
+} catch {}
+try {
+commandEncoder136.clearBuffer(buffer41, 99244, 17380);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 997 */
+{offset: 989, bytesPerRow: 158}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap16 = await createImageBitmap(videoFrame7);
+let texture97 = device2.createTexture({
+  label: '\u60f3\u{1f9df}\u05bd\ud417',
+  size: [1420],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16sint', 'r16sint', 'r16sint'],
+});
+let textureView169 = texture85.createView({
+  label: '\u7406\u004d\u021c\ua08c',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 213,
+  arrayLayerCount: 363,
+});
+let computePassEncoder81 = commandEncoder139.beginComputePass({label: '\ud2d9\ud024\u52ff\u0a0d\u3c12\u4543'});
+let renderBundle84 = renderBundleEncoder61.finish({label: '\u126c\u8da7\uf057\ucad9\u{1f67e}\u{1fc98}\uef8b\u0493'});
+let externalTexture55 = device2.importExternalTexture({source: video5, colorSpace: 'srgb'});
+let img20 = await imageWithData(114, 297, '#e76ea569', '#de217a46');
+let imageData16 = new ImageData(236, 76);
+try {
+window.someLabel = externalTexture54.label;
+} catch {}
+let commandEncoder140 = device2.createCommandEncoder({label: '\u996f\uecb9\u6063\u{1fd52}\ue3cc\u{1f858}\udb55'});
+let texture98 = device2.createTexture({
+  size: {width: 710, height: 1, depthOrArrayLayers: 1174},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView170 = texture86.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2});
+let renderBundle85 = renderBundleEncoder61.finish({label: '\u3439\u53b8\u{1f7a0}\u{1f734}\u2e3e\u{1f90f}\ufb77\u{1f77a}\u1b04\u759c'});
+try {
+commandEncoder140.copyBufferToBuffer(buffer40, 95544, buffer41, 8520, 13180);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+let img21 = await imageWithData(140, 200, '#88f97370', '#daf475eb');
+let bindGroupLayout41 = device2.createBindGroupLayout({entries: []});
+let textureView171 = texture98.createView({baseMipLevel: 7});
+let computePassEncoder82 = commandEncoder140.beginComputePass({label: '\u5957\u0491\u4799\u69ec\u34de\u01ae\u0457\ucfc4'});
+let renderBundleEncoder64 = device2.createRenderBundleEncoder({
+  label: '\ub3ac\u9273',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler81 = device2.createSampler({
+  label: '\u240b\u0744\u1ff5\u3a66\u39f6\u9a6a\udb4c\u5593\u0ac9\u32d7\u1896',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 37.28,
+  lodMaxClamp: 64.35,
+});
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(2, bindGroup41, new Uint32Array(262), 73, 0);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img13,
+  origin: { x: 6, y: 0 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas14 = document.createElement('canvas');
+let video19 = await videoWithData();
+let commandEncoder141 = device2.createCommandEncoder({label: '\u{1ffca}\ub1e4\u55d0\u08c8\u{1fbc7}\uf45e\u16ed\u1d53\u{1f9aa}\uf7e5\ueea0'});
+let commandBuffer37 = commandEncoder141.finish({});
+let renderBundleEncoder65 = device2.createRenderBundleEncoder({
+  label: '\u0aab\u0d24\ubfeb\uccc8\udc22',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let externalTexture56 = device2.importExternalTexture({source: video12, colorSpace: 'display-p3'});
+try {
+commandEncoder134.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 12, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 848 widthInBlocks: 53 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 11504 */
+  offset: 11504,
+  buffer: buffer41,
+}, {width: 53, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 530, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer3), /* required buffer size: 705 */
+{offset: 705}, {width: 1925, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise26 = device2.queue.onSubmittedWorkDone();
+let querySet61 = device2.createQuerySet({label: '\u1000\u0e12', type: 'occlusion', count: 3288});
+let textureView172 = texture85.createView({label: '\u2b27\u19de\udcfe', dimension: '2d', baseMipLevel: 7, mipLevelCount: 1, baseArrayLayer: 16});
+try {
+renderBundleEncoder64.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder138.clearBuffer(buffer41, 18488, 162968);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+adapter1.label = '\u0f91\uccb4';
+} catch {}
+let pipelineLayout29 = device2.createPipelineLayout({label: '\u1df6\u50df\u9f00\u8f43\u{1fd6a}\ub817', bindGroupLayouts: []});
+let commandEncoder142 = device2.createCommandEncoder();
+let texture99 = device2.createTexture({
+  label: '\u8314\u0b11\u02ad\u{1fedb}\u{1f773}\u395f',
+  size: {width: 5680},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView173 = texture88.createView({label: '\ud869\ufa46\u{1f7c5}', mipLevelCount: 1});
+let renderBundleEncoder66 = device2.createRenderBundleEncoder({
+  label: '\u{1ffb7}\uc1c3\uce49',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder66.setBindGroup(1, bindGroup40, new Uint32Array(1595), 1319, 0);
+} catch {}
+try {
+commandEncoder136.copyBufferToBuffer(buffer40, 33080, buffer41, 61876, 21348);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder138.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2248 widthInBlocks: 1124 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 53494 */
+  offset: 53494,
+  buffer: buffer41,
+}, {width: 1124, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder142.copyTextureToTexture({
+  texture: texture98,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 34},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 2211, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 148, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder142.insertDebugMarker('\u{1fb6b}');
+} catch {}
+try {
+renderBundleEncoder66.insertDebugMarker('\u0772');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(412), /* required buffer size: 412 */
+{offset: 412}, {width: 2440, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer42 = device2.createBuffer({
+  label: '\u0d4c\u84bb\u{1fa26}\uf317\u0667\u9457\u{1f775}',
+  size: 420940,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let querySet62 = device2.createQuerySet({label: '\u19e8\u0fa5\u{1fb07}\u4a1e\u0d79\uf876\uc168\u{1f9bf}', type: 'occlusion', count: 2934});
+let textureView174 = texture86.createView({
+  label: '\u2c8c\uad3e\uaa9b\u{1f910}\uefc0\u5481\ucb5a\uc6e7',
+  dimension: '2d',
+  format: 'rgba32sint',
+  baseMipLevel: 3,
+});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup43, new Uint32Array(4034), 3056, 0);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(1025, undefined, 2667590930, 300348529);
+} catch {}
+let arrayBuffer12 = buffer42.getMappedRange();
+try {
+commandEncoder134.copyBufferToBuffer(buffer40, 66432, buffer41, 53924, 32712);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1438, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 207, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 407, y: 150 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let device3 = await adapter4.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 34348,
+    maxStorageTexturesPerShaderStage: 30,
+    maxStorageBuffersPerShaderStage: 44,
+    maxDynamicStorageBuffersPerPipelineLayout: 8901,
+    maxDynamicUniformBuffersPerPipelineLayout: 6851,
+    maxBindingsPerBindGroup: 6542,
+    maxTextureArrayLayers: 352,
+    maxTextureDimension1D: 10505,
+    maxTextureDimension2D: 15940,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 207242568,
+    maxUniformBuffersPerShaderStage: 16,
+    maxSampledTexturesPerShaderStage: 42,
+    maxInterStageShaderVariables: 23,
+    maxInterStageShaderComponents: 104,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let video20 = await videoWithData();
+let commandEncoder143 = device3.createCommandEncoder({label: '\ube9b\u0354'});
+let querySet63 = device3.createQuerySet({label: '\udc5c\u{1fdf6}\u05dd', type: 'occlusion', count: 75});
+try {
+device3.destroy();
+} catch {}
+canvas9.width = 332;
+let canvas15 = document.createElement('canvas');
+let renderBundleEncoder67 = device2.createRenderBundleEncoder({colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'], sampleCount: 4});
+try {
+commandEncoder142.copyBufferToBuffer(buffer40, 50608, buffer41, 214464, 424);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext19 = canvas14.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+let adapter5 = await navigator.gpu.requestAdapter({});
+let gpuCanvasContext20 = canvas15.getContext('webgpu');
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  label: '\u0485\u040a\u0e24\u7f59\u1196\u0daa\u4bda\u0918',
+  entries: [
+    {binding: 1461, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 6110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let querySet64 = device3.createQuerySet({
+  label: '\u{1fbfb}\u{1f885}\ufbb5\u2764\uca66\u8965\u{1fae9}\u73d6\u0658\u04c5\u{1fc04}',
+  type: 'occlusion',
+  count: 178,
+});
+let commandBuffer38 = commandEncoder143.finish({});
+let promise27 = adapter4.requestAdapterInfo();
+document.body.prepend(video12);
+try {
+  await promise27;
+} catch {}
+let commandEncoder144 = device2.createCommandEncoder();
+let renderBundle86 = renderBundleEncoder61.finish({label: '\u0eeb\uaae2'});
+try {
+renderBundleEncoder64.setBindGroup(0, bindGroup40, new Uint32Array(3028), 820, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+gc();
+let video21 = await videoWithData();
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(342, 973);
+let bindGroupLayout43 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2141,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture100 = device2.createTexture({
+  label: '\u0989\u7419',
+  size: [1420, 1, 215],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView175 = texture88.createView({label: '\u0e66\u{1fe5a}\u{1fe20}'});
+let renderBundle87 = renderBundleEncoder61.finish({label: '\u{1fa17}\ue1c6\u07a0\ufe67\udefc'});
+let sampler82 = device2.createSampler({
+  label: '\u7df7\u50af\u00ae\u8c4b\u896a\u0f14\u{1fdc7}\u{1f789}\u0328\u0943\u86e0',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 12.11,
+  lodMaxClamp: 70.53,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+device2.queue.submit([commandBuffer36, commandBuffer35]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas0.height = 992;
+let canvas16 = document.createElement('canvas');
+let imageData17 = new ImageData(104, 100);
+let commandEncoder145 = device2.createCommandEncoder({});
+let texture101 = device2.createTexture({
+  label: '\u{1f8b5}\u{1ff5b}',
+  size: {width: 1420, height: 1, depthOrArrayLayers: 1297},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let externalTexture57 = device2.importExternalTexture({label: '\u04b6\u{1ff75}\ua872', source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder77.setBindGroup(4, bindGroup43);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 5954248 */
+{offset: 996, bytesPerRow: 558, rowsPerImage: 127}, {width: 254, height: 1, depthOrArrayLayers: 85});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 52, y: 4 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap17 = await createImageBitmap(video16);
+let commandEncoder146 = device2.createCommandEncoder({label: '\ude89\uf08b'});
+let commandBuffer39 = commandEncoder142.finish({label: '\u01e1\u120c'});
+let textureView176 = texture100.createView({baseMipLevel: 3});
+let renderBundle88 = renderBundleEncoder61.finish({label: '\uf711\uf959\ud8de\u{1fea3}'});
+let sampler83 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 8.386,
+  lodMaxClamp: 60.33,
+});
+try {
+commandEncoder144.copyBufferToBuffer(buffer40, 90740, buffer41, 134616, 2156);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap12,
+  origin: { x: 211, y: 24 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup45 = device2.createBindGroup({label: '\u{1f7be}\u0e0b', layout: bindGroupLayout38, entries: []});
+let buffer43 = device2.createBuffer({size: 475811, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder147 = device2.createCommandEncoder({label: '\u0dc0\uc0aa\ubcc5\u2fde\u0d9e\u0644'});
+let querySet65 = device2.createQuerySet({label: '\u7b25\u0daa\u{1f734}', type: 'occlusion', count: 3840});
+let textureView177 = texture85.createView({
+  label: '\u{1f71e}\u4ec6\u{1f891}\ud698\u03f7',
+  mipLevelCount: 4,
+  baseArrayLayer: 424,
+  arrayLayerCount: 75,
+});
+let computePassEncoder83 = commandEncoder144.beginComputePass({label: '\u0fc5\ucf51\u0d18\u0939\u0e83\u0741\ua302\u0760\u0cfa\u0ec6'});
+let renderBundleEncoder68 = device2.createRenderBundleEncoder({
+  label: '\ub001\u8538\u{1fe4b}\u{1f7e3}\u{1ff66}\u87a4\u2c17\u80a9\u{1fd72}\u8f10',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+});
+let renderBundle89 = renderBundleEncoder65.finish({label: '\u{1fcd1}\u60a7'});
+let externalTexture58 = device2.importExternalTexture({
+  label: '\ufa8a\u0164\u0a83\u423a\u0bb2\u0e75\u46ff\u{1f869}\ubd5d',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder147.clearBuffer(buffer41, 115100, 19672);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+offscreenCanvas20.getContext('bitmaprenderer');
+} catch {}
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+commandEncoder134.clearBuffer(buffer41, 64492, 61836);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.submit([commandBuffer37]);
+} catch {}
+let promise28 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise26;
+} catch {}
+document.body.prepend(video6);
+video5.height = 159;
+gc();
+let promise29 = navigator.gpu.requestAdapter({});
+video10.height = 175;
+try {
+canvas16.getContext('webgpu');
+} catch {}
+gc();
+let canvas17 = document.createElement('canvas');
+try {
+commandBuffer14.label = '\u{1fdff}\u37b3\u877b\u0aac\u218d\u{1f8af}\u0186';
+} catch {}
+try {
+adapter5.label = '\u01a0\u064a\ud450';
+} catch {}
+try {
+  await promise28;
+} catch {}
+gc();
+let img22 = await imageWithData(219, 236, '#60fd2117', '#f9f9279d');
+let img23 = await imageWithData(295, 127, '#5fab4fcc', '#fc9724e3');
+let externalTexture59 = device2.importExternalTexture({
+  label: '\u{1fc7c}\u0996\ue1b8\u{1fcb4}\u{1f759}\ubd98\u{1f8cb}\u0b60\u01d8\u0d62\u0046',
+  source: video15,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(0, buffer43);
+} catch {}
+try {
+computePassEncoder80.pushDebugGroup('\u{1f7c7}');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 71, y: 1 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas18 = document.createElement('canvas');
+let offscreenCanvas21 = new OffscreenCanvas(886, 339);
+let gpuCanvasContext21 = canvas17.getContext('webgpu');
+let img24 = await imageWithData(155, 135, '#ddf3d4db', '#ee828aa8');
+let bindGroup46 = device2.createBindGroup({
+  label: '\ude24\uefc9\u0d43\u1a64\u616c\ub47c\ua53b\u2a69\u3c36\u0bc9',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let textureView178 = texture96.createView({label: '\u6d44\u{1fce2}\u46a4\u9103\u0b43\u{1fb7f}\uc360\ud08a\u0b59'});
+let computePassEncoder84 = commandEncoder136.beginComputePass({label: '\u4e0e\ub58f\ubd8e\u{1f718}\uddae\u{1fcdf}\u82cd\u{1f719}\ud9b1'});
+try {
+renderBundleEncoder66.setVertexBuffer(10, buffer43, 0, 168367);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 53248 */
+  offset: 53248,
+  buffer: buffer40,
+}, {
+  texture: texture87,
+  mipLevel: 2,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 128, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+commandEncoder145.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 486, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 936 widthInBlocks: 468 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 54462 */
+  offset: 53526,
+  buffer: buffer41,
+}, {width: 468, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 3,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 413358 */
+{offset: 42, bytesPerRow: 1602, rowsPerImage: 86}, {width: 85, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let videoFrame12 = new VideoFrame(canvas10, {timestamp: 0});
+try {
+offscreenCanvas21.getContext('webgpu');
+} catch {}
+try {
+canvas18.getContext('bitmaprenderer');
+} catch {}
+gc();
+let computePassEncoder85 = commandEncoder145.beginComputePass({label: '\ue06c\ud2a7'});
+let sampler84 = device2.createSampler({addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 9.508, lodMaxClamp: 74.23});
+try {
+renderBundleEncoder64.setBindGroup(4, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(1138, undefined, 0, 2677173428);
+} catch {}
+try {
+renderBundleEncoder67.insertDebugMarker('\u{1fe0f}');
+} catch {}
+let promise30 = device2.queue.onSubmittedWorkDone();
+let querySet66 = device2.createQuerySet({label: '\u0620\ud763\u{1f7ed}\u6193\u0c23\u32a5', type: 'occlusion', count: 1290});
+let texture102 = device2.createTexture({
+  size: [312, 6, 492],
+  mipLevelCount: 7,
+  format: 'astc-8x6-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x6-unorm-srgb'],
+});
+let sampler85 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 52.72,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder67.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(2, buffer43, 192444, 178655);
+} catch {}
+try {
+commandEncoder147.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 704, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 904 widthInBlocks: 452 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 28398 */
+  offset: 28398,
+  buffer: buffer41,
+}, {width: 452, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder146.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 301},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 29},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 52});
+} catch {}
+try {
+commandEncoder146.clearBuffer(buffer41, 39756, 125660);
+dissociateBuffer(device2, buffer41);
+} catch {}
+video9.width = 4;
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet67 = device2.createQuerySet({label: '\u991f\ue20b\ubab9\u{1fb8a}\u{1ffd0}\u031e\u41ac\u0c87', type: 'occlusion', count: 1578});
+let renderBundleEncoder69 = device2.createRenderBundleEncoder({
+  label: '\ub9b3\u0416\u0ed8\u{1fa4e}\u86c9\u07c6\u0890',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+querySet65.destroy();
+} catch {}
+try {
+commandEncoder146.copyBufferToBuffer(buffer40, 35476, buffer41, 22388, 81012);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder146.copyTextureToBuffer({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 2320, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4756 widthInBlocks: 2378 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 100000 */
+  offset: 100000,
+  rowsPerImage: 180,
+  buffer: buffer41,
+}, {width: 2378, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer41);
+} catch {}
+let promise31 = device2.queue.onSubmittedWorkDone();
+let bindGroup47 = device2.createBindGroup({layout: bindGroupLayout41, entries: []});
+let buffer44 = device2.createBuffer({size: 253053, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder148 = device2.createCommandEncoder({label: '\u{1fe7f}\ua5e6\u62dd\u0b52\u0b2e\u081a\uf61d\u{1fbfc}\u{1fbde}\uf095\ua0f9'});
+let querySet68 = device2.createQuerySet({label: '\ua654\ue57d\u{1fa08}\u0aa4\u887d\u0a4d\u0e5a\u6b5a\u{1fa24}', type: 'occlusion', count: 540});
+try {
+renderBundleEncoder66.setVertexBuffer(6, buffer43, 412388);
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1604, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 490, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder146.resolveQuerySet(querySet59, 1340, 147, buffer43, 364800);
+} catch {}
+try {
+renderBundleEncoder67.pushDebugGroup('\ub1c7');
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 20, y: 120 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas8.height = 64;
+let commandEncoder149 = device2.createCommandEncoder();
+let querySet69 = device2.createQuerySet({label: '\u84e4\u0992\u6596\u0417\u0d82', type: 'occlusion', count: 644});
+let texture103 = device2.createTexture({
+  label: '\ucc9b\u{1f7f0}\u{1f70b}\u9679\u753e',
+  size: {width: 5680},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+let textureView179 = texture102.createView({format: 'astc-8x6-unorm-srgb', baseMipLevel: 2, baseArrayLayer: 369, arrayLayerCount: 91});
+let renderBundle90 = renderBundleEncoder64.finish({label: '\u{1fa92}\u6065\u0ab9\u4203\u9586\u0dfb\uf74d\u8237\u0616'});
+let sampler86 = device2.createSampler({
+  label: '\u763b\uca7e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.15,
+});
+let externalTexture60 = device2.importExternalTexture({source: video11, colorSpace: 'display-p3'});
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 6356 widthInBlocks: 1589 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1140 */
+  offset: 1140,
+  bytesPerRow: 6400,
+  buffer: buffer40,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 174, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1589, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+commandEncoder149.insertDebugMarker('\uee3e');
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 51712, new Float32Array(65417), 49175, 3200);
+} catch {}
+let textureView180 = texture87.createView({label: '\u{1ffbc}\ufbd2\u{1fe68}\u{1f8c8}\u1f79', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 51012, new Float32Array(1257), 337, 48);
+} catch {}
+let commandEncoder150 = device2.createCommandEncoder({label: '\ub5f9\u{1fd4f}\uee78\u5778\u{1fdab}'});
+let textureView181 = texture88.createView({label: '\u{1f74b}\u9ef6\u1e33\u{1fcf8}', dimension: '2d-array', mipLevelCount: 1});
+let sampler87 = device2.createSampler({
+  label: '\u3834\udb8d\u7fb6\u67f3\u3eff\u044f',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.04,
+  compare: 'equal',
+});
+let externalTexture61 = device2.importExternalTexture({
+  label: '\u{1fdb4}\u0526\u0ba5\ueff0\ua85a\u2c51\u{1ffbe}\ub169\u{1fe19}\u3ee7',
+  source: videoFrame5,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(8, buffer43, 0, 25337);
+} catch {}
+try {
+commandEncoder148.copyBufferToBuffer(buffer40, 13388, buffer41, 99756, 72696);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder149.copyTextureToBuffer({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 11166 widthInBlocks: 5583 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3118 */
+  offset: 3118,
+  bytesPerRow: 11520,
+  buffer: buffer44,
+}, {width: 5583, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 179620, new Int16Array(50119), 2724, 296);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 2,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer3), /* required buffer size: 833 */
+{offset: 833}, {width: 213, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 734, y: 109 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let bindGroup48 = device0.createBindGroup({label: '\u18c8\u{1fc4d}\u0d12', layout: bindGroupLayout9, entries: []});
+let commandEncoder151 = device0.createCommandEncoder({label: '\u0631\u1271\u050e\u019c\u{1f9c3}\u9170\u04e1\u0888\u31b3\u0dd2'});
+let querySet70 = device0.createQuerySet({label: '\u{1fffa}\u0bd4\uef8c\u0d69\u{1fcf9}\u0330\uc995\u9fcd', type: 'occlusion', count: 3525});
+let commandBuffer40 = commandEncoder128.finish({});
+let computePassEncoder86 = commandEncoder151.beginComputePass();
+try {
+computePassEncoder66.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(1484);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -827.9, g: 310.1, b: -163.5, a: 754.6, });
+} catch {}
+try {
+renderPassEncoder20.setViewport(21.20, 2.062, 77.60, 1.402, 0.5919, 0.6897);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer4, 187712, 10012);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 20032);
+} catch {}
+try {
+commandEncoder122.resolveQuerySet(querySet15, 661, 139, buffer27, 99072);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 90}
+*/
+{
+  source: video7,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise30;
+} catch {}
+let canvas19 = document.createElement('canvas');
+let videoFrame13 = new VideoFrame(imageBitmap0, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let promise32 = adapter5.requestDevice({
+  defaultQueue: {label: '\u44c9\u{1f7da}\u019c\u8383\u03c7\u{1f972}\u{1fc61}\u{1ff9c}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let video22 = await videoWithData();
+let textureView182 = texture100.createView({
+  label: '\u{1fe13}\u4200\u{1f9d2}\u4928\u{1fe56}\u{1f947}\ub5df\ue360\u76c5\u969e\uf33e',
+  baseMipLevel: 6,
+});
+let sampler88 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 38.92,
+  lodMaxClamp: 84.11,
+  compare: 'greater-equal',
+});
+try {
+renderBundleEncoder67.setBindGroup(3, bindGroup39, []);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(6, bindGroup42, new Uint32Array(3472), 706, 0);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(3, buffer43, 303072);
+} catch {}
+try {
+commandEncoder150.clearBuffer(buffer44, 56028, 101684);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img19,
+  origin: { x: 6, y: 37 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise31;
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let canvas20 = document.createElement('canvas');
+let imageBitmap18 = await createImageBitmap(videoFrame4);
+try {
+adapter0.label = '\ua705\u{1f952}\u0d42\u{1f7c9}\ud20c\u{1fa45}\u{1f67c}\u0fa4\uda45\u0404\ufec9';
+} catch {}
+let img25 = await imageWithData(255, 70, '#3bf8e9dd', '#88eea99d');
+let imageBitmap19 = await createImageBitmap(video21);
+let promise33 = adapter2.requestAdapterInfo();
+try {
+canvas19.getContext('webgpu');
+} catch {}
+let imageBitmap20 = await createImageBitmap(imageBitmap7);
+let imageData18 = new ImageData(88, 52);
+let texture104 = device2.createTexture({
+  label: '\u02e5\u{1fb8c}\u0e4a\uf503\u04b1\u5ab0\u09fd\u014e\u8007\u092e\ub722',
+  size: {width: 710, height: 1, depthOrArrayLayers: 163},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView183 = texture103.createView({label: '\ud0a2\uf8b9\u039e'});
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 495, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder138.clearBuffer(buffer41, 173516, 29136);
+dissociateBuffer(device2, buffer41);
+} catch {}
+document.body.prepend(video12);
+canvas8.width = 642;
+let videoFrame14 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+try {
+canvas20.getContext('2d');
+} catch {}
+let videoFrame15 = videoFrame3.clone();
+let canvas21 = document.createElement('canvas');
+let img26 = await imageWithData(196, 187, '#207db559', '#4a0d3b6d');
+let shaderModule14 = device2.createShaderModule({
+  code: `@group(0) @binding(6763)
+var<storage, read_write> n9: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(1) f1: vec3<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(4) f3: vec4<i32>,
+  @location(2) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(9) f0: vec3<i32>,
+  @location(3) f1: vec4<f16>,
+  @location(0) f2: vec2<f16>,
+  @location(10) f3: f16,
+  @location(13) f4: u32,
+  @location(17) f5: vec4<f16>,
+  @location(2) f6: vec3<u32>,
+  @location(8) f7: vec2<i32>,
+  @location(12) f8: f16,
+  @location(7) f9: vec2<u32>,
+  @location(16) f10: vec2<f16>,
+  @location(14) f11: u32,
+  @location(6) f12: f16,
+  @location(11) f13: vec4<f32>,
+  @location(5) f14: f16,
+  @location(15) f15: f16,
+  @builtin(instance_index) f16: u32
+}
+
+@vertex
+fn vertex0(@location(1) a0: i32, @location(4) a1: vec4<f16>, @builtin(vertex_index) a2: u32, a3: S16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup49 = device2.createBindGroup({
+  label: '\u{1fe3a}\u{1fc4e}\u{1f7c5}\u{1fb4c}\u0c5d\u9a27\u07db\u1a54\uea1c\u0338\u704d',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let commandEncoder152 = device2.createCommandEncoder({label: '\u6474\ufc5b\uf101\ua85d\ub3db'});
+let textureView184 = texture93.createView({
+  label: '\ued09\ud413\u68f0\u01cf\u288c',
+  dimension: '2d-array',
+  baseMipLevel: 7,
+  mipLevelCount: 3,
+  arrayLayerCount: 1,
+});
+let computePassEncoder87 = commandEncoder150.beginComputePass({label: '\u0df6\u{1f675}\u149d\uc757\ua9f7\u3155\u0084\ue11b\ue79c\u0e12'});
+let renderBundle91 = renderBundleEncoder64.finish({});
+let externalTexture62 = device2.importExternalTexture({label: '\u0e55\u{1fffc}\u871d\u71c7\u0870\u088c\ud9e4', source: video21, colorSpace: 'srgb'});
+try {
+renderBundleEncoder68.setBindGroup(6, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(10, buffer43, 0, 32124);
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer40, 43556, buffer44, 159696, 14868);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder148.clearBuffer(buffer41, 144500, 26372);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 17604, new BigUint64Array(55239), 48250, 1400);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer7), /* required buffer size: 1074 */
+{offset: 172}, {width: 451, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext22 = canvas21.getContext('webgpu');
+video14.width = 184;
+try {
+  await promise33;
+} catch {}
+gc();
+canvas20.height = 68;
+let video23 = await videoWithData();
+let commandEncoder153 = device2.createCommandEncoder({label: '\ufe00\u{1f64e}\u3fea\u{1fb42}\ua5a8\u06aa\u{1fe77}\u0586'});
+let textureView185 = texture93.createView({label: '\u26e4\ub033\u9214', baseMipLevel: 4, mipLevelCount: 2});
+let computePassEncoder88 = commandEncoder146.beginComputePass({label: '\ueab2\u{1fd28}\uc862\ue0f7\u{1fc62}\u9ac4\u{1fbdc}'});
+try {
+commandEncoder149.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 62378 */
+  offset: 62378,
+  buffer: buffer41,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet59, 1321, 30, buffer42, 121088);
+} catch {}
+let textureView186 = texture45.createView({label: '\u{1f73d}\u7d8c\u44ed\u405c\u0a78\ua17e\u7d21\u0b71\u04e4', baseMipLevel: 3, mipLevelCount: 1});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer19, 'uint16', 5846, 48779);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer19, 0, 29722);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer5, 30260);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer19, 0, 20760);
+} catch {}
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2316 */
+  offset: 2316,
+  buffer: buffer35,
+}, {
+  texture: texture41,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer35);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 25, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 123, height: 12, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 3720, new Float32Array(18444), 16645, 308);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 127, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(0)), /* required buffer size: 465 */
+{offset: 465, bytesPerRow: 370}, {width: 75, height: 26, depthOrArrayLayers: 0});
+} catch {}
+let pipeline121 = device0.createComputePipeline({layout: pipelineLayout24, compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}}});
+let pipeline122 = device0.createRenderPipeline({
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0x6bb75f50},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1748,
+        attributes: [
+          {format: 'uint16x2', offset: 72, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 924, shaderLocation: 1},
+          {format: 'uint8x4', offset: 440, shaderLocation: 5},
+          {format: 'uint32x3', offset: 136, shaderLocation: 13},
+          {format: 'uint32x2', offset: 344, shaderLocation: 15},
+          {format: 'sint16x4', offset: 200, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 52, shaderLocation: 12},
+          {format: 'sint32x2', offset: 132, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 0, shaderLocation: 7}],
+      },
+    ],
+  },
+});
+document.body.prepend(img18);
+gc();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let querySet71 = device2.createQuerySet({type: 'occlusion', count: 2726});
+let textureView187 = texture103.createView({label: '\u00ac\u0a38\ucb91', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 80960 */
+  offset: 80960,
+  buffer: buffer44,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+let pipeline123 = device2.createRenderPipeline({
+  label: '\uad80\u{1f947}\ua679\u3327\u0a4c\u0ede\u00f4\u8563\u{1fff3}\ue889',
+  layout: pipelineLayout27,
+  multisample: {count: 4, mask: 0xe14401f3},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.RED}, undefined, {format: 'r16uint', writeMask: 0}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilReadMask: 3412762497,
+    stencilWriteMask: 3120605332,
+    depthBias: 768537999,
+    depthBiasSlopeScale: 426.7869903519992,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2952,
+        attributes: [
+          {format: 'unorm8x2', offset: 114, shaderLocation: 6},
+          {format: 'float16x4', offset: 224, shaderLocation: 12},
+          {format: 'uint32x3', offset: 744, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x4', offset: 684, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 520, shaderLocation: 0},
+          {format: 'sint8x2', offset: 5414, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 12692, shaderLocation: 10},
+          {format: 'uint8x2', offset: 4604, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 9908, shaderLocation: 11},
+          {format: 'uint32x2', offset: 1312, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 1924, shaderLocation: 3},
+          {format: 'uint32x4', offset: 6400, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 3124, shaderLocation: 16},
+          {format: 'sint32', offset: 6904, shaderLocation: 8},
+          {format: 'float32x2', offset: 15068, shaderLocation: 4},
+          {format: 'float16x4', offset: 12016, shaderLocation: 5},
+          {format: 'float32x2', offset: 3564, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 13436, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+});
+let imageBitmap21 = await createImageBitmap(imageData8);
+let canvas22 = document.createElement('canvas');
+let offscreenCanvas22 = new OffscreenCanvas(52, 61);
+let video24 = await videoWithData();
+let texture105 = device2.createTexture({
+  label: '\u0fbe\u11aa\u{1fcb6}\u0a99\u6536',
+  size: [1420, 1, 1],
+  mipLevelCount: 7,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+let externalTexture63 = device2.importExternalTexture({source: video13, colorSpace: 'srgb'});
+try {
+renderBundleEncoder68.setVertexBuffer(9, buffer43, 0, 81663);
+} catch {}
+gc();
+let gpuCanvasContext23 = offscreenCanvas22.getContext('webgpu');
+offscreenCanvas20.width = 96;
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  label: '\u085d\u6b8c\u4a3a\u346d\u98b0\u553b\ued8e\u7294\u1b40',
+  layout: bindGroupLayout12,
+  entries: [],
+});
+let renderBundle92 = renderBundleEncoder1.finish({label: '\u0954\u0f8f\u0adc\ub14d\u{1f62b}\uc618\u9f14\u02a7'});
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle24, renderBundle5, renderBundle6, renderBundle18, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(1.213, 0.9651, 1.722, 0.03221, 0.2164, 0.3654);
+} catch {}
+try {
+commandEncoder129.resolveQuerySet(querySet15, 362, 375, buffer9, 220672);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 21701152 */
+{offset: 928, bytesPerRow: 324, rowsPerImage: 299}, {width: 240, height: 0, depthOrArrayLayers: 225});
+} catch {}
+let pipeline124 = device0.createRenderPipeline({
+  label: '\u0a73\u643b\u0ede\u0461\u{1fc98}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', failOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 578752284,
+    stencilWriteMask: 1755310443,
+    depthBiasSlopeScale: 978.6606165477788,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 28,
+        attributes: [
+          {format: 'float16x4', offset: 4, shaderLocation: 14},
+          {format: 'sint32x4', offset: 4, shaderLocation: 3},
+          {format: 'uint32x3', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 1172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 132, shaderLocation: 8},
+          {format: 'float32x2', offset: 112, shaderLocation: 9},
+          {format: 'sint32x3', offset: 292, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 13},
+          {format: 'uint16x2', offset: 356, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 168, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 456,
+        attributes: [
+          {format: 'sint32x2', offset: 228, shaderLocation: 2},
+          {format: 'sint16x2', offset: 40, shaderLocation: 10},
+          {format: 'float32x2', offset: 0, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 1684,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 212, shaderLocation: 7},
+          {format: 'uint8x4', offset: 916, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 1090, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 196,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 32, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+let imageBitmap22 = await createImageBitmap(canvas17);
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let querySet72 = device2.createQuerySet({type: 'occlusion', count: 3913});
+let texture106 = device2.createTexture({
+  label: '\u{1fe7d}\u8892\ucabf\udc0d\u7778\u016e',
+  size: [1420, 1, 47],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint'],
+});
+let renderBundle93 = renderBundleEncoder68.finish({label: '\u87b9\ucd5c\uec21\u00fa\u{1fae8}\u2779\u83d7\u0c1d\u51b0'});
+let externalTexture64 = device2.importExternalTexture({
+  label: '\u07f4\uc2b1\u202c\uf673\u{1f993}\u5592\u02b5\u0269\u5aec\ua84e',
+  source: videoFrame14,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+commandEncoder148.copyBufferToBuffer(buffer40, 122580, buffer44, 192196, 884);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder152.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 1116, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 3,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise34 = device2.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture107 = device2.createTexture({
+  label: '\uebcf\u0d76\u0e39\u9711\uefe0\u{1fbe8}\uaa1f\u1e3b\u4339\u7c4a\ue473',
+  size: [8444, 4, 925],
+  format: 'etc2-rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['etc2-rgba8unorm', 'etc2-rgba8unorm', 'etc2-rgba8unorm-srgb'],
+});
+try {
+renderBundleEncoder67.setBindGroup(6, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(5, buffer43, 0, 423598);
+} catch {}
+try {
+commandEncoder152.copyBufferToBuffer(buffer44, 170924, buffer41, 128436, 32976);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 72240, new Int16Array(47688), 44365, 12);
+} catch {}
+try {
+canvas22.getContext('2d');
+} catch {}
+let pipelineLayout30 = device2.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout41, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout41],
+});
+let textureView188 = texture92.createView({aspect: 'all', baseMipLevel: 0});
+let externalTexture65 = device2.importExternalTexture({label: '\ue6b1\u0844', source: videoFrame11, colorSpace: 'srgb'});
+let promise35 = buffer40.mapAsync(GPUMapMode.WRITE, 0, 87740);
+try {
+commandEncoder134.copyBufferToBuffer(buffer44, 234440, buffer41, 85772, 4208);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder134.resolveQuerySet(querySet59, 1119, 392, buffer42, 204800);
+} catch {}
+try {
+computePassEncoder80.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 15140, new BigUint64Array(8318), 5689, 680);
+} catch {}
+let promise36 = device2.queue.onSubmittedWorkDone();
+let imageBitmap23 = await createImageBitmap(canvas22);
+let img27 = await imageWithData(229, 117, '#7e003b0f', '#67dbbf6a');
+gc();
+let imageData19 = new ImageData(136, 4);
+try {
+externalTexture43.label = '\u872d\u2da4\u{1fcd8}\u0dcd\uc584\u03b1\u{1f90f}\u8671\u{1fd99}\u{1fb93}';
+} catch {}
+let img28 = await imageWithData(75, 39, '#c0b97395', '#3aa45fdf');
+let imageData20 = new ImageData(116, 216);
+let textureView189 = texture71.createView({label: '\u0d31\u{1fd87}\uf716\u09e4', baseMipLevel: 1, arrayLayerCount: 482});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(0, bindGroup25, new Uint32Array(9714), 5382, 0);
+} catch {}
+try {
+  await promise34;
+} catch {}
+try {
+window.someLabel = texture49.label;
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+document.body.prepend(canvas11);
+let imageBitmap24 = await createImageBitmap(img1);
+let promise37 = adapter0.requestAdapterInfo();
+try {
+adapter4.label = '\u768e\ud8ef\u{1fa09}\u8944\u{1ffe1}';
+} catch {}
+try {
+  await promise36;
+} catch {}
+let bindGroup51 = device2.createBindGroup({
+  label: '\u31f6\u{1f8f0}\u{1fd85}\u0535\u{1f8d8}\uaa9c\u44b9\u0b03\u{1fb61}\u{1fbac}\ub385',
+  layout: bindGroupLayout41,
+  entries: [],
+});
+let computePassEncoder89 = commandEncoder152.beginComputePass({label: '\u0cd2\u16b4\uf5ee\ue591\u{1f6c8}\u1a00\u0957\u0458\u2225'});
+try {
+commandEncoder148.resolveQuerySet(querySet57, 1464, 22, buffer43, 401664);
+} catch {}
+try {
+renderBundleEncoder67.popDebugGroup();
+} catch {}
+let promise38 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 13, y: 12 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline125 = device2.createComputePipeline({
+  label: '\u0d2e\u{1fb01}\u1f04\u0d8e\u0911\u9160',
+  layout: pipelineLayout27,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let buffer45 = device2.createBuffer({size: 19971, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture108 = device2.createTexture({
+  label: '\u0a03\u0fbd\u{1fc3c}',
+  size: [710, 1, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let texture109 = gpuCanvasContext2.getCurrentTexture();
+let textureView190 = texture108.createView({label: '\u{1fc4a}\u0d8c\u096e\u895b\u{1fd2e}', baseMipLevel: 0});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup40, new Uint32Array(5515), 2808, 0);
+} catch {}
+try {
+commandEncoder149.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 3,
+  origin: {x: 28, y: 0, z: 112},
+  aspect: 'all',
+},
+{
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 829, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 210, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder153.resolveQuerySet(querySet67, 282, 1146, buffer45, 8192);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 380, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 119 */
+{offset: 119, rowsPerImage: 113}, {width: 587, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img23,
+  origin: { x: 15, y: 6 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img29 = await imageWithData(276, 300, '#26890548', '#b707e0fb');
+let videoFrame16 = new VideoFrame(imageBitmap10, {timestamp: 0});
+let querySet73 = device0.createQuerySet({label: '\u{1fa2c}\u63d6\u{1f7b4}\u0502\ud245\udc75\u5a96\u86c6', type: 'occlusion', count: 3955});
+let textureView191 = texture9.createView({label: '\u7763\u750c\u26cd', aspect: 'stencil-only', baseMipLevel: 3, mipLevelCount: 2});
+let computePassEncoder90 = commandEncoder129.beginComputePass();
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup14, new Uint32Array(3577), 1814, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(4.318, 0.7492, 1.165, 0.2056, 0.2398, 0.3013);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer4, 220768, 237682);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer5, 3080);
+} catch {}
+try {
+commandEncoder126.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet55, 693, 474, buffer5, 74496);
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 143, y: 5 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video25 = await videoWithData();
+try {
+  await promise35;
+} catch {}
+gc();
+let bindGroupLayout44 = device2.createBindGroupLayout({entries: [{binding: 358, visibility: 0, externalTexture: {}}]});
+let commandEncoder154 = device2.createCommandEncoder({label: '\ud734\u929d\ub021\u9155\uae00\u5e89\u013b\u0856\u4958'});
+try {
+computePassEncoder82.setBindGroup(4, bindGroup41, new Uint32Array(5912), 3640, 0);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 1,
+  origin: {x: 139, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+commandEncoder147.clearBuffer(buffer44, 170784, 8800);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 2, y: 4 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline126 = device2.createComputePipeline({layout: pipelineLayout25, compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}}});
+let canvas23 = document.createElement('canvas');
+let shaderModule15 = device0.createShaderModule({
+  label: '\u{1ff82}\u{1ff5b}\uf101\u{1fa9a}\u{1ffd8}\u{1f6ed}\u{1f7bc}\u05d5\u{1fc71}\ub4af',
+  code: `@group(1) @binding(569)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(141)
+var<storage, read_write> local10: array<u32>;
+@group(1) @binding(141)
+var<storage, read_write> global10: array<u32>;
+@group(0) @binding(569)
+var<storage, read_write> global11: array<u32>;
+
+@compute @workgroup_size(6, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @location(8) f0: vec4<u32>,
+  @builtin(position) f1: vec4<f32>,
+  @builtin(sample_index) f2: u32,
+  @builtin(sample_mask) f3: u32,
+  @builtin(front_facing) f4: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(5) f1: vec2<f32>,
+  @location(7) f2: f32,
+  @location(3) f3: vec4<u32>,
+  @location(1) f4: vec3<f32>,
+  @location(4) f5: vec4<i32>,
+  @location(6) f6: vec3<u32>,
+  @location(2) f7: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: f16, @location(13) a1: vec2<u32>, a2: S17) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f245: vec4<f32>,
+  @location(13) f246: vec2<u32>,
+  @location(8) f247: vec4<u32>,
+  @location(14) f248: f16
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f16>, @location(2) a1: f16, @location(14) a2: vec3<i32>, @location(8) a3: vec2<i32>, @builtin(instance_index) a4: u32, @location(13) a5: vec4<f32>, @location(7) a6: vec4<f32>, @location(15) a7: f32, @location(9) a8: vec4<f16>, @location(0) a9: vec4<u32>, @location(4) a10: vec4<i32>, @location(6) a11: vec4<f16>, @location(11) a12: vec3<f32>, @location(1) a13: vec3<f32>, @location(12) a14: vec3<f16>, @location(3) a15: vec2<i32>, @location(5) a16: i32, @builtin(vertex_index) a17: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 96, resource: sampler3},
+    {binding: 250, resource: sampler17},
+    {binding: 63, resource: externalTexture22},
+  ],
+});
+let textureView192 = texture9.createView({label: '\u08d5\uee12', dimension: '2d-array', baseMipLevel: 5, mipLevelCount: 1});
+try {
+renderPassEncoder20.setStencilReference(32);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder62.setVertexBuffer(5, buffer9, 166708, 319214);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer11, 62348, buffer36, 65740, 1236);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 39 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 604011 */
+  offset: 13892,
+  bytesPerRow: 256,
+  rowsPerImage: 192,
+  buffer: buffer9,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 39, height: 2, depthOrArrayLayers: 13});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder45.copyTextureToBuffer({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 52656 */
+  offset: 52656,
+  bytesPerRow: 0,
+  buffer: buffer19,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder4.clearBuffer(buffer24, 81924);
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'stencil-only',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 54473 */
+{offset: 363, bytesPerRow: 65, rowsPerImage: 208}, {width: 30, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 903, height: 64, depthOrArrayLayers: 1}
+*/
+{
+  source: img12,
+  origin: { x: 7, y: 5 },
+  flipY: false,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 26, y: 40, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 10, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let pipeline127 = await device0.createComputePipelineAsync({
+  label: '\u2c3f\u{1fd77}\u0214\ua1c5\ud7e2\u0b7d\u07fc\u04f8\u{1fc7d}',
+  layout: pipelineLayout26,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline128 = device0.createRenderPipeline({
+  label: '\u0f59\u2754\u5654',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: 0}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 4186514883,
+    stencilWriteMask: 1017182537,
+    depthBias: -441426437,
+    depthBiasSlopeScale: 268.30721986381525,
+    depthBiasClamp: 178.03604735107575,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 664,
+        attributes: [
+          {format: 'sint8x2', offset: 198, shaderLocation: 2},
+          {format: 'float16x2', offset: 244, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 156, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 9},
+          {format: 'sint32', offset: 12, shaderLocation: 15},
+          {format: 'uint32x2', offset: 44, shaderLocation: 0},
+          {format: 'uint32x2', offset: 124, shaderLocation: 7},
+          {format: 'uint16x4', offset: 48, shaderLocation: 12},
+          {format: 'float32', offset: 64, shaderLocation: 1},
+          {format: 'sint32x2', offset: 116, shaderLocation: 3},
+          {format: 'uint32x2', offset: 220, shaderLocation: 8},
+          {format: 'float16x2', offset: 40, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 134, shaderLocation: 11},
+          {format: 'sint8x2', offset: 80, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 148, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 932,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 292, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+document.body.prepend(video0);
+gc();
+offscreenCanvas15.width = 260;
+let bindGroupLayout45 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2710,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 1876,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let textureView193 = texture101.createView({label: '\u080e\u04e0\u0d73\ub2fd', baseMipLevel: 7, mipLevelCount: 1});
+let sampler89 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.46,
+  lodMaxClamp: 67.12,
+  maxAnisotropy: 5,
+});
+let externalTexture66 = device2.importExternalTexture({label: '\u4acd\u071f', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder81.setBindGroup(4, bindGroup45);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13416 */
+  offset: 13408,
+  buffer: buffer44,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let gpuCanvasContext24 = canvas23.getContext('webgpu');
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let imageBitmap25 = await createImageBitmap(video10);
+let buffer46 = device2.createBuffer({label: '\u{1f7d8}\u00b1', size: 89871, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+buffer41.destroy();
+} catch {}
+try {
+commandEncoder154.copyBufferToBuffer(buffer40, 63956, buffer45, 8936, 1808);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+renderBundleEncoder67.insertDebugMarker('\uc032');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline129 = await device2.createRenderPipelineAsync({
+  label: '\u9f14\u7fc3\u0253',
+  layout: pipelineLayout28,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilWriteMask: 1355562359,
+    depthBiasClamp: 261.94241537762076,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 12872, shaderLocation: 0},
+          {format: 'uint32', offset: 18552, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 672, shaderLocation: 3},
+          {format: 'float32x4', offset: 9200, shaderLocation: 6},
+          {format: 'float32x4', offset: 2260, shaderLocation: 15},
+          {format: 'sint32x2', offset: 9764, shaderLocation: 8},
+          {format: 'uint16x4', offset: 2476, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 3400,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x4', offset: 1280, shaderLocation: 2},
+          {format: 'sint8x4', offset: 904, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 1080, shaderLocation: 12},
+          {format: 'float32x2', offset: 1144, shaderLocation: 4},
+          {format: 'uint32x3', offset: 272, shaderLocation: 7},
+          {format: 'float16x2', offset: 480, shaderLocation: 5},
+          {format: 'float16x2', offset: 156, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 3112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 2220, shaderLocation: 16},
+          {format: 'float32x3', offset: 1844, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 412, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 4104, stepMode: 'instance', attributes: []},
+      {arrayStride: 30008, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 13220, attributes: []},
+      {arrayStride: 9000, stepMode: 'instance', attributes: []},
+      {arrayStride: 2664, attributes: [{format: 'sint32', offset: 320, shaderLocation: 1}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let querySet74 = device2.createQuerySet({label: '\u{1febd}\u20e2\ue7fb\u{1f8c8}', type: 'occlusion', count: 1328});
+let texture110 = device2.createTexture({
+  label: '\u0778\ude8e\u0a21\u045b\ubbff\u{1fe5f}\u{1fad5}\u{1f645}\u9f0c\uc519\u{1fb10}',
+  size: [710, 1, 80],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView194 = texture104.createView({
+  label: '\u3c57\u58fa\uffef\u4d9e\u491f\ue671\ue2d4',
+  dimension: '3d',
+  mipLevelCount: 4,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let computePassEncoder91 = commandEncoder149.beginComputePass({label: '\u0a6e\u9910\u0938'});
+try {
+renderBundleEncoder67.setBindGroup(3, bindGroup46, new Uint32Array(7077), 1255, 0);
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer40, 3576, buffer45, 15952, 1188);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 72 */
+  offset: 72,
+  rowsPerImage: 212,
+  buffer: buffer44,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder138.copyTextureToBuffer({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20288 */
+  offset: 20288,
+  bytesPerRow: 256,
+  buffer: buffer41,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder153.clearBuffer(buffer45, 744, 5848);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let device4 = await adapter3.requestDevice({
+  label: '\ud973\uc006\u{1fccc}\udc74\u0d1e\uddf4\u0913\u6d59',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 53,
+    maxVertexAttributes: 28,
+    maxVertexBufferArrayStride: 4662,
+    maxStorageTexturesPerShaderStage: 30,
+    maxStorageBuffersPerShaderStage: 18,
+    maxDynamicStorageBuffersPerPipelineLayout: 11339,
+    maxDynamicUniformBuffersPerPipelineLayout: 40943,
+    maxBindingsPerBindGroup: 7762,
+    maxTextureArrayLayers: 426,
+    maxTextureDimension1D: 12696,
+    maxTextureDimension2D: 11591,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 194653194,
+    maxSampledTexturesPerShaderStage: 26,
+    maxInterStageShaderVariables: 64,
+    maxInterStageShaderComponents: 118,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+try {
+renderBundle84.label = '\u0d90\u0beb\u{1f985}\u0db9\u51b0\u2ba5';
+} catch {}
+let bindGroupLayout46 = device2.createBindGroupLayout({
+  label: '\u02df\u3a33\u{1f636}',
+  entries: [
+    {
+      binding: 3578,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 985407, hasDynamicOffset: true },
+    },
+    {binding: 1776, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let texture111 = device2.createTexture({
+  label: '\u{1fae9}\u{1f950}\u2b20\u{1fd46}\ub2e5\u042c\u2815\u{1f906}\ufec9\u{1ffd9}\u157e',
+  size: {width: 1420, height: 1, depthOrArrayLayers: 239},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView195 = texture98.createView({label: '\uccaa\u07fe\u35dd\u3cda\u0faf\ua94f\u3baa\u0c0a', baseMipLevel: 3, mipLevelCount: 5});
+try {
+computePassEncoder76.setPipeline(pipeline125);
+} catch {}
+try {
+commandEncoder134.copyBufferToBuffer(buffer40, 124820, buffer45, 18948, 212);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 108536, new Int16Array(58584), 55913, 140);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 335, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(72)), /* required buffer size: 663 */
+{offset: 663, bytesPerRow: 256, rowsPerImage: 170}, {width: 103, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video15,
+  origin: { x: 5, y: 3 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline130 = device2.createComputePipeline({
+  label: '\u052f\ub52f\u{1f860}\u{1fdbc}\uc30f\u4038\u1c37\uc5ce\ubbc0\u532a',
+  layout: pipelineLayout30,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let pipeline131 = await device2.createRenderPipelineAsync({
+  label: '\u{1fef8}\u{1fff8}\u09e5\u4166\u{1f967}\u{1fad3}\u055a\u0299\u{1fedc}\u05ce',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: 0}, {format: 'r16sint', writeMask: 0}, undefined, {format: 'r16uint'}, {
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15264,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 1380, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 576, shaderLocation: 17},
+          {format: 'float16x2', offset: 6708, shaderLocation: 3},
+          {format: 'uint16x4', offset: 1028, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 6552, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 4620, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 916, shaderLocation: 4},
+          {format: 'uint32x2', offset: 1408, shaderLocation: 2},
+          {format: 'float32x2', offset: 5440, shaderLocation: 16},
+          {format: 'uint32x2', offset: 1392, shaderLocation: 7},
+          {format: 'sint32x4', offset: 104, shaderLocation: 9},
+          {format: 'uint32x4', offset: 1764, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 4500, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 18876,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 1372, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 18868, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 26356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 1440, shaderLocation: 6},
+          {format: 'sint16x4', offset: 10872, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 2072, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front'},
+});
+gc();
+document.body.prepend(canvas2);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+  await promise39;
+} catch {}
+let imageData21 = new ImageData(112, 164);
+let buffer47 = device4.createBuffer({label: '\u0087\u08ee', size: 10909, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder92 = commandEncoder134.beginComputePass({label: '\u3b3f\uaffe\ub834\u{1f924}\u{1fb9c}'});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup45, new Uint32Array(3765), 1475, 0);
+} catch {}
+document.body.prepend(canvas9);
+let textureView196 = texture111.createView({baseMipLevel: 5});
+let externalTexture67 = device2.importExternalTexture({
+  label: '\u6138\u93dd\u755c\u864d\u0aa8\uda1f\uecb5\u747f\u877c',
+  source: videoFrame11,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder89.end();
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline125);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline131);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer44, 180672, buffer45, 3936, 13360);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder153.copyTextureToTexture({
+  texture: texture111,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 1,
+  origin: {x: 371, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 93, height: 1, depthOrArrayLayers: 13});
+} catch {}
+try {
+commandEncoder154.clearBuffer(buffer41, 113052, 10416);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas8,
+  origin: { x: 140, y: 131 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline132 = device2.createRenderPipeline({
+  label: '\u8c29\ua5e4\u{1ffb2}\u{1fc7e}\u0a9d\u58c4\udcfa\uec65',
+  layout: pipelineLayout29,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm'}, {format: 'r16sint', writeMask: 0}, undefined, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10540,
+        attributes: [
+          {format: 'unorm16x2', offset: 1684, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 1896, shaderLocation: 5},
+          {format: 'float16x2', offset: 8144, shaderLocation: 17},
+          {format: 'uint32', offset: 320, shaderLocation: 2},
+          {format: 'sint16x2', offset: 360, shaderLocation: 9},
+          {format: 'uint32x4', offset: 3188, shaderLocation: 7},
+          {format: 'sint8x4', offset: 208, shaderLocation: 8},
+          {format: 'sint32x4', offset: 4696, shaderLocation: 1},
+          {format: 'float16x2', offset: 3308, shaderLocation: 12},
+          {format: 'uint32x4', offset: 3380, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 824, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 646, shaderLocation: 6},
+          {format: 'float32', offset: 6992, shaderLocation: 10},
+          {format: 'float32x2', offset: 1784, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 7748, shaderLocation: 0},
+          {format: 'uint32', offset: 2932, shaderLocation: 14},
+          {format: 'float16x2', offset: 1652, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 12320,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 7770, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+let video26 = await videoWithData();
+let imageBitmap26 = await createImageBitmap(offscreenCanvas16);
+let canvas24 = document.createElement('canvas');
+try {
+canvas24.getContext('bitmaprenderer');
+} catch {}
+let textureView197 = texture105.createView({label: '\uc8a3\u0212\ua21f', aspect: 'all', baseMipLevel: 5, mipLevelCount: 1});
+try {
+renderBundleEncoder66.setPipeline(pipeline132);
+} catch {}
+try {
+commandEncoder148.clearBuffer(buffer44, 242804, 2660);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let commandEncoder155 = device4.createCommandEncoder({});
+let querySet75 = device4.createQuerySet({label: '\u3fc8\u9006\u9c96\u5624', type: 'occlusion', count: 3331});
+let externalTexture68 = device4.importExternalTexture({source: videoFrame8, colorSpace: 'srgb'});
+try {
+commandEncoder155.clearBuffer(buffer47, 9076, 1772);
+dissociateBuffer(device4, buffer47);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let imageData22 = new ImageData(244, 240);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let commandEncoder156 = device2.createCommandEncoder({});
+let textureView198 = texture100.createView({baseMipLevel: 7});
+try {
+renderBundleEncoder67.setVertexBuffer(7, buffer43, 0, 278501);
+} catch {}
+try {
+commandEncoder152.copyTextureToBuffer({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5668 */
+  offset: 5668,
+  bytesPerRow: 256,
+  buffer: buffer44,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(1024, 635);
+try {
+adapter3.label = '\ub0f3\u{1fc58}\uc950';
+} catch {}
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let textureView199 = texture94.createView({label: '\ue18e\u13e7\u0e8d'});
+let renderBundle94 = renderBundleEncoder64.finish({label: '\u{1f877}\u57f3\u{1fc51}\u{1fe62}\u7754\u1c4b\u07e4\udc76'});
+let externalTexture69 = device2.importExternalTexture({
+  label: '\u{1f7ce}\u{1fefe}\u{1f668}\u{1f7ef}\u974d\ua8e8\ud804\ue590',
+  source: video15,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder85.setPipeline(pipeline125);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(9, buffer43, 458776, 2471);
+} catch {}
+try {
+commandEncoder153.pushDebugGroup('\u75e6');
+} catch {}
+let pipeline133 = await device2.createRenderPipelineAsync({
+  label: '\ub70f\uc9e4\u0a15\u83e6\u00a9\u{1fe22}\u0b60\u0875\u7862\u1114\u{1f64c}',
+  layout: pipelineLayout25,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r16sint', writeMask: 0}, undefined, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rgba32sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 2550201444,
+    stencilWriteMask: 4011483122,
+    depthBias: 1606119089,
+    depthBiasSlopeScale: 821.664379272154,
+    depthBiasClamp: 961.5701206403223,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4832,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 4060, shaderLocation: 2},
+          {format: 'float32', offset: 480, shaderLocation: 15},
+          {format: 'uint8x2', offset: 1150, shaderLocation: 7},
+          {format: 'float32', offset: 2104, shaderLocation: 11},
+          {format: 'float16x2', offset: 552, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 252, shaderLocation: 4},
+          {format: 'float16x2', offset: 120, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 1960, shaderLocation: 3},
+          {format: 'sint32x4', offset: 1364, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 2924, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 1948, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'snorm16x2', offset: 5540, shaderLocation: 12}]},
+      {
+        arrayStride: 5660,
+        attributes: [
+          {format: 'sint16x4', offset: 24, shaderLocation: 9},
+          {format: 'sint32x3', offset: 304, shaderLocation: 8},
+          {format: 'uint8x4', offset: 344, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 6880, attributes: []},
+      {
+        arrayStride: 6044,
+        attributes: [
+          {format: 'uint32x2', offset: 720, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 632, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 13964,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x2', offset: 22, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front'},
+});
+let querySet76 = device2.createQuerySet({label: '\u{1f7fd}\u{1facf}\u06d9\ube19\u0ad3\u{1fe3c}\u0472', type: 'occlusion', count: 3772});
+let texture112 = device2.createTexture({
+  label: '\u6eb4\u065f\ucbe7\u{1fd73}\ue430\u{1fd22}\udd53\u2cb8\ud905\ub921\ufa5d',
+  size: {width: 710},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint'],
+});
+let renderBundle95 = renderBundleEncoder64.finish({label: '\uc150\u3f05\u3df7\udf1d\u0a3e\u0b86\u1c4d'});
+let sampler90 = device2.createSampler({
+  label: '\u07a2\u5079\u66d2',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 89.59,
+  lodMaxClamp: 96.26,
+});
+let externalTexture70 = device2.importExternalTexture({
+  label: '\u6176\u2493\u4fb2\u88fc\u3033\u{1fa30}\u8db5\u0ea4\u0ec0\u{1f63c}\u1aa0',
+  source: video5,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder66.setPipeline(pipeline131);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(8688, undefined, 0, 791844580);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer44, 36840, 82784);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 9808, new BigUint64Array(48561), 6858, 1584);
+} catch {}
+let pipeline134 = await device2.createComputePipelineAsync({
+  label: '\ufea0\u{1fd64}\uadec\ueb2e',
+  layout: pipelineLayout28,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+gc();
+let offscreenCanvas24 = new OffscreenCanvas(217, 107);
+let imageBitmap27 = await createImageBitmap(imageBitmap19);
+let externalTexture71 = device4.importExternalTexture({source: videoFrame14});
+try {
+buffer47.destroy();
+} catch {}
+document.body.prepend(video6);
+let canvas25 = document.createElement('canvas');
+try {
+canvas25.getContext('webgl');
+} catch {}
+let commandEncoder157 = device4.createCommandEncoder({label: '\uf0b4\u650e'});
+let promise40 = device4.queue.onSubmittedWorkDone();
+let videoFrame17 = new VideoFrame(canvas21, {timestamp: 0});
+let commandEncoder158 = device2.createCommandEncoder({label: '\u0efe\u{1fd02}'});
+let texture113 = device2.createTexture({
+  label: '\uea46\u0c9f\u33a3\u7a01\ueea3\u057f\ufb86\ub4f6',
+  size: {width: 1420},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let textureView200 = texture101.createView({label: '\u02ff\u7565\u6369\ud4c1', baseMipLevel: 7, mipLevelCount: 1});
+let renderBundleEncoder70 = device2.createRenderBundleEncoder({
+  label: '\u{1fd4d}\u061f\u0513\ucd2a',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle96 = renderBundleEncoder70.finish({label: '\u08c7\uf662'});
+try {
+renderBundleEncoder66.setBindGroup(1, bindGroup41, new Uint32Array(3413), 2030, 0);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline132);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 25, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img30 = await imageWithData(77, 51, '#e0e483bd', '#796d9a81');
+let texture114 = device2.createTexture({
+  size: [1420, 1, 1],
+  mipLevelCount: 9,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder93 = commandEncoder158.beginComputePass({label: '\u0b80\u{1fae5}\u0f40\ubfea\ua317\u0f63\u0cc9\u014f\u0a7b\u3e27'});
+try {
+computePassEncoder76.setPipeline(pipeline126);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer39]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 634 */
+{offset: 634}, {width: 605, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise38;
+} catch {}
+let shaderModule16 = device2.createShaderModule({
+  code: `@group(0) @binding(6763)
+var<storage, read_write> global12: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<i32>,
+  @location(0) f1: vec4<f32>,
+  @location(1) f2: vec2<i32>,
+  @location(3) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(10) f0: vec3<f32>,
+  @location(12) f1: vec3<f32>,
+  @location(13) f2: vec2<u32>,
+  @location(14) f3: vec2<f16>,
+  @location(0) f4: f32,
+  @location(6) f5: vec2<f16>,
+  @location(11) f6: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec4<u32>, a1: S18, @builtin(vertex_index) a2: u32, @location(7) a3: vec4<u32>, @location(3) a4: f32, @builtin(instance_index) a5: u32, @location(5) a6: vec4<i32>, @location(16) a7: i32, @location(2) a8: vec4<f16>, @location(8) a9: vec3<u32>, @location(4) a10: vec4<f32>, @location(1) a11: vec2<u32>, @location(9) a12: f16, @location(15) a13: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout47 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 94,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup53 = device2.createBindGroup({label: '\u{1fb57}\u2fd5\udddd\u381a\u0fd5\uefb5\u09a9', layout: bindGroupLayout41, entries: []});
+let commandEncoder159 = device2.createCommandEncoder({});
+let renderBundle97 = renderBundleEncoder70.finish({label: '\uda98\u9999\u0687\u{1fa56}'});
+try {
+computePassEncoder88.setBindGroup(2, bindGroup45, []);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(0, bindGroup49);
+} catch {}
+let promise41 = device2.popErrorScope();
+try {
+commandEncoder153.copyBufferToBuffer(buffer44, 103472, buffer45, 19964, 0);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder152.resolveQuerySet(querySet68, 159, 250, buffer43, 214528);
+} catch {}
+try {
+commandEncoder153.popDebugGroup();
+} catch {}
+try {
+  await promise40;
+} catch {}
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let commandEncoder160 = device4.createCommandEncoder({label: '\u7f09\u7f80\u1fe5\u{1ff94}\udc04'});
+let computePassEncoder94 = commandEncoder157.beginComputePass({label: '\ua11b\u1754'});
+let renderBundleEncoder71 = device4.createRenderBundleEncoder({
+  label: '\u05ca\u0aad\u687f\u0bba\u{1f912}\ude26',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  depthReadOnly: true,
+});
+try {
+  await device4.popErrorScope();
+} catch {}
+video13.width = 244;
+let offscreenCanvas25 = new OffscreenCanvas(661, 32);
+let offscreenCanvas26 = new OffscreenCanvas(757, 372);
+let imageBitmap28 = await createImageBitmap(video15);
+try {
+offscreenCanvas25.getContext('2d');
+} catch {}
+let shaderModule17 = device2.createShaderModule({
+  label: '\u79a6\u075f\u0642\u7cbf\u0ccf\u7feb',
+  code: `@group(3) @binding(2141)
+var<storage, read_write> parameter14: array<u32>;
+@group(1) @binding(2141)
+var<storage, read_write> field9: array<u32>;
+@group(4) @binding(2141)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @location(39) f0: f16,
+  @location(59) f1: vec3<f16>,
+  @location(28) f2: f16,
+  @location(66) f3: vec3<f16>,
+  @location(119) f4: vec4<i32>,
+  @location(26) f5: vec2<f16>,
+  @location(110) f6: vec2<f32>,
+  @location(12) f7: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: vec4<i32>,
+  @location(3) f2: u32,
+  @location(1) f3: i32
+}
+
+@fragment
+fn fragment0(@location(88) a0: f16, @location(94) a1: u32, @location(89) a2: u32, @location(80) a3: vec3<f16>, @location(113) a4: f32, @location(105) a5: f16, @location(34) a6: vec3<i32>, a7: S19, @builtin(sample_index) a8: u32, @location(36) a9: u32, @location(54) a10: i32, @location(20) a11: vec3<u32>, @location(70) a12: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(80) f249: vec3<f16>,
+  @location(44) f250: vec2<f32>,
+  @location(54) f251: i32,
+  @location(28) f252: f16,
+  @location(59) f253: vec3<f16>,
+  @location(89) f254: u32,
+  @location(119) f255: vec4<i32>,
+  @location(105) f256: f16,
+  @location(20) f257: vec3<u32>,
+  @location(94) f258: u32,
+  @builtin(position) f259: vec4<f32>,
+  @location(12) f260: vec3<f16>,
+  @location(88) f261: f16,
+  @location(111) f262: vec4<f32>,
+  @location(36) f263: u32,
+  @location(113) f264: f32,
+  @location(70) f265: vec4<f32>,
+  @location(34) f266: vec3<i32>,
+  @location(39) f267: f16,
+  @location(66) f268: vec3<f16>,
+  @location(110) f269: vec2<f32>,
+  @location(118) f270: vec4<f32>,
+  @location(26) f271: vec2<f16>,
+  @location(75) f272: i32,
+  @location(10) f273: f32
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<u32>, @location(1) a1: vec2<f32>, @location(10) a2: vec3<i32>, @location(11) a3: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup54 = device2.createBindGroup({label: '\ubf71\u8604\u01d2', layout: bindGroupLayout41, entries: []});
+let commandEncoder161 = device2.createCommandEncoder({label: '\u0bf2\u9d9f\u{1fd17}'});
+try {
+computePassEncoder83.end();
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline131);
+} catch {}
+try {
+commandEncoder156.copyBufferToTexture({
+  /* bytesInLastRow: 13712 widthInBlocks: 857 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2736 */
+  offset: 2736,
+  rowsPerImage: 287,
+  buffer: buffer44,
+}, {
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 352, y: 0, z: 205},
+  aspect: 'all',
+}, {width: 3428, height: 4, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 4178, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16598), /* required buffer size: 16598 */
+{offset: 534, bytesPerRow: 16272}, {width: 1004, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas20,
+  origin: { x: 35, y: 4 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline135 = device2.createRenderPipeline({
+  label: '\uc23c\ud4ab\u05c2',
+  layout: pipelineLayout28,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined, {format: 'r16uint'}, {
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'always', failOp: 'keep', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilWriteMask: 2895382600,
+    depthBias: -832561424,
+    depthBiasClamp: 905.1675280981772,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2464,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 168, shaderLocation: 2},
+          {format: 'sint16x4', offset: 256, shaderLocation: 9},
+          {format: 'uint32x2', offset: 80, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1696,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 104, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 44, shaderLocation: 11},
+          {format: 'float16x4', offset: 764, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 88, shaderLocation: 5},
+          {format: 'float32', offset: 948, shaderLocation: 6},
+          {format: 'uint32x4', offset: 28, shaderLocation: 14},
+          {format: 'sint32x3', offset: 584, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 56, shaderLocation: 10},
+          {format: 'float32x2', offset: 1248, shaderLocation: 0},
+          {format: 'float16x2', offset: 188, shaderLocation: 15},
+          {format: 'uint32x4', offset: 1456, shaderLocation: 13},
+          {format: 'sint16x2', offset: 36, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 760, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 5140, attributes: [{format: 'snorm16x2', offset: 332, shaderLocation: 4}]},
+      {arrayStride: 776, attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 16}]},
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let imageData23 = new ImageData(96, 76);
+document.body.prepend(video10);
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+let texture115 = device2.createTexture({
+  size: {width: 1420, height: 1, depthOrArrayLayers: 128},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder87.setBindGroup(5, bindGroup44);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline134);
+} catch {}
+try {
+renderBundleEncoder66.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder66.setPipeline(pipeline132);
+} catch {}
+try {
+commandEncoder159.copyBufferToTexture({
+  /* bytesInLastRow: 71376 widthInBlocks: 4461 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 39792 */
+  offset: 39792,
+  bytesPerRow: 71424,
+  buffer: buffer44,
+}, {
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 734, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4461, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder147.copyTextureToBuffer({
+  texture: texture98,
+  mipLevel: 5,
+  origin: {x: 5, y: 0, z: 15},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3388 */
+  offset: 3388,
+  bytesPerRow: 256,
+  buffer: buffer45,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1136, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture106,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 7},
+  aspect: 'all',
+},
+{width: 452, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(255, 704);
+try {
+window.someLabel = commandEncoder34.label;
+} catch {}
+try {
+  await promise41;
+} catch {}
+canvas9.width = 2626;
+let promise42 = navigator.gpu.requestAdapter({});
+let buffer48 = device0.createBuffer({label: '\uc956\u06dd\u5b88\u06e9', size: 667755, usage: GPUBufferUsage.INDEX});
+let commandEncoder162 = device0.createCommandEncoder({});
+let textureView201 = texture11.createView({label: '\u{1f759}\u1b67\u0015', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 6});
+let renderBundleEncoder72 = device0.createRenderBundleEncoder({
+  label: '\u{1f807}\u{1ff3e}\u28d7\u7702\ud868\u6996\u0fb2',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+let renderBundle98 = renderBundleEncoder5.finish({label: '\u78b8\uf110\u0232\u7c1e\u95d3\u22cb\u9828\ue3cb\u5053\u{1fe77}'});
+let sampler91 = device0.createSampler({
+  label: '\u00c6\ua095\u0bc3\u8bee\uc56f\u00cd\u{1fd4c}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.70,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup18, new Uint32Array(8626), 6747, 0);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(571);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer14, 'uint16');
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer29, 0);
+} catch {}
+try {
+renderBundleEncoder26.draw(312981561, 781460945, 1209012211, 841739493);
+} catch {}
+try {
+renderBundleEncoder29.drawIndirect(buffer19, 1128);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet15, 292, 216, buffer27, 137984);
+} catch {}
+let gpuCanvasContext25 = offscreenCanvas27.getContext('webgpu');
+try {
+renderBundleEncoder67.setPipeline(pipeline131);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 576, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture111,
+  mipLevel: 3,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 115, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder138.clearBuffer(buffer45, 9896, 2848);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer45, 4216, new Float32Array(6800), 4804, 180);
+} catch {}
+let pipeline136 = device2.createComputePipeline({
+  label: '\u6211\u0f53',
+  layout: pipelineLayout28,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let commandBuffer41 = commandEncoder160.finish({label: '\u8497\ua293\uca5b\ue83b\ub804\u08ff\u{1fa07}\u{1fae4}'});
+let texture116 = device4.createTexture({
+  size: {width: 240, height: 768, depthOrArrayLayers: 26},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView202 = texture116.createView({label: '\u52e7\u3099\u0c77', format: 'r16float', baseArrayLayer: 0});
+let renderBundleEncoder73 = device4.createRenderBundleEncoder({
+  label: '\uf1de\u0c15\u0142\u7398\u06b2\ud996\u{1fba0}\u11d3\u0efd',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+});
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 60, height: 192, depthOrArrayLayers: 6}
+*/
+{
+  source: offscreenCanvas16,
+  origin: { x: 45, y: 645 },
+  flipY: false,
+}, {
+  texture: texture116,
+  mipLevel: 2,
+  origin: {x: 14, y: 48, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 21, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+videoFrame11.close();
+} catch {}
+let commandEncoder163 = device4.createCommandEncoder({label: '\u0a6c\u7eb4\ub8d2\udfec\u{1f646}\u06a9\uf8ab\u0efd\u{1ffc5}'});
+let querySet77 = device4.createQuerySet({type: 'occlusion', count: 1281});
+let renderBundleEncoder74 = device4.createRenderBundleEncoder({
+  label: '\u0b0c\uac10\u{1f72f}\u1d3d\u4f3c\ucc0b',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+buffer47.unmap();
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 30, height: 96, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap15,
+  origin: { x: 33, y: 20 },
+  flipY: true,
+}, {
+  texture: texture116,
+  mipLevel: 3,
+  origin: {x: 1, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 43, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap29 = await createImageBitmap(img7);
+gc();
+let canvas26 = document.createElement('canvas');
+let offscreenCanvas28 = new OffscreenCanvas(404, 541);
+let img31 = await imageWithData(177, 208, '#f6b3bf03', '#95e92e21');
+let commandEncoder164 = device2.createCommandEncoder({});
+let textureView203 = texture96.createView({label: '\u{1ffaa}\u{1faa0}\u45a3\u{1fd2e}\u0fba\u4e92\u2b52\u8438\u801e'});
+try {
+renderBundleEncoder66.setVertexBuffer(1, buffer46, 30028);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 200, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 952, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 400, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder154.clearBuffer(buffer45, 10168, 1960);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+renderBundleEncoder66.insertDebugMarker('\u3c0c');
+} catch {}
+let pipeline137 = await device2.createRenderPipelineAsync({
+  label: '\u0cb2\u{1fb72}\uc2f1\u0065\u3c62\u0d3b',
+  layout: pipelineLayout30,
+  multisample: {count: 4, mask: 0x59279a33},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, undefined, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5068,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 1028, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 1468, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 124, shaderLocation: 0},
+          {format: 'sint32', offset: 912, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 1564, shaderLocation: 9},
+          {format: 'float16x2', offset: 1468, shaderLocation: 2},
+          {format: 'uint32x4', offset: 64, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 2576, shaderLocation: 4},
+          {format: 'uint32x2', offset: 2180, shaderLocation: 13},
+          {format: 'uint32x4', offset: 3880, shaderLocation: 8},
+          {format: 'sint32x4', offset: 2768, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 1464, shaderLocation: 15},
+          {format: 'sint32x2', offset: 2340, shaderLocation: 16},
+          {format: 'float32x3', offset: 3528, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 756, shaderLocation: 12},
+          {format: 'uint32x2', offset: 536, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 16, shaderLocation: 6}],
+      },
+      {arrayStride: 372, attributes: []},
+      {arrayStride: 2960, attributes: [{format: 'unorm8x4', offset: 744, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let imageBitmap30 = await createImageBitmap(offscreenCanvas27);
+let imageData24 = new ImageData(56, 152);
+let textureView204 = texture116.createView({label: '\u{1fcc3}\ub0cf\ue5c6\u{1fe76}\u732c\u0976\u008f\u0706\u3918\u0028\u{1fe76}'});
+let renderBundleEncoder75 = device4.createRenderBundleEncoder({
+  label: '\u9811\u3cf9\u3fcc\uabd4\u08ce\u{1fc47}\u0f9d\u066b\u45af\u02fa',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle99 = renderBundleEncoder74.finish({label: '\ud991\u{1f715}'});
+let sampler92 = device4.createSampler({
+  label: '\u1e7c\u7ed7\u0606\uda63\u4c6e\u00fb\u03b1\ufca3',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  compare: 'equal',
+});
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 7, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 84, y: 19 },
+  flipY: false,
+}, {
+  texture: texture116,
+  mipLevel: 5,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas28.getContext('webgpu');
+let shaderModule18 = device2.createShaderModule({
+  label: '\u04ff\uc34f\u4bb2',
+  code: `@group(1) @binding(2141)
+var<storage, read_write> local11: array<u32>;
+@group(2) @binding(2141)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(2141)
+var<storage, read_write> local12: array<u32>;
+@group(4) @binding(2141)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+  @location(48) f0: vec2<f32>,
+  @location(93) f1: f16,
+  @builtin(position) f2: vec4<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(26) f4: vec2<i32>,
+  @location(95) f5: vec4<f16>,
+  @builtin(front_facing) f6: bool,
+  @location(47) f7: u32,
+  @location(64) f8: vec3<f16>,
+  @location(10) f9: vec2<i32>,
+  @location(82) f10: i32,
+  @location(91) f11: u32,
+  @location(104) f12: vec2<i32>,
+  @location(90) f13: vec2<i32>,
+  @location(30) f14: vec3<f32>,
+  @location(80) f15: vec2<i32>,
+  @location(63) f16: vec2<f32>,
+  @location(40) f17: f16,
+  @location(33) f18: vec2<f16>,
+  @location(44) f19: vec2<i32>,
+  @location(107) f20: vec3<f16>,
+  @location(14) f21: vec2<i32>,
+  @location(117) f22: vec4<f32>,
+  @location(31) f23: u32,
+  @location(43) f24: vec3<f32>,
+  @location(25) f25: vec2<f32>,
+  @location(29) f26: u32,
+  @location(97) f27: vec3<i32>,
+  @location(18) f28: vec4<u32>,
+  @location(106) f29: f32,
+  @location(62) f30: i32,
+  @location(115) f31: vec3<u32>,
+  @location(72) f32: u32,
+  @location(120) f33: vec4<i32>,
+  @location(51) f34: vec3<f32>,
+  @location(105) f35: vec4<u32>,
+  @location(71) f36: u32,
+  @location(96) f37: vec4<u32>,
+  @location(109) f38: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: u32,
+  @location(0) f1: vec4<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(4) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(66) a0: vec4<f32>, @location(85) a1: vec2<f32>, @location(88) a2: vec2<u32>, @builtin(sample_index) a3: u32, @location(67) a4: vec3<f32>, @location(19) a5: f16, @location(79) a6: vec4<u32>, a7: S21) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(0) f0: vec4<i32>,
+  @location(5) f1: i32,
+  @location(2) f2: vec3<u32>,
+  @location(1) f3: vec4<f32>,
+  @builtin(vertex_index) f4: u32,
+  @location(17) f5: vec4<f32>,
+  @location(8) f6: vec2<u32>,
+  @location(15) f7: vec2<i32>,
+  @location(12) f8: vec2<i32>,
+  @location(7) f9: vec4<i32>,
+  @location(6) f10: vec4<f32>,
+  @location(16) f11: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(120) f274: vec4<i32>,
+  @location(90) f275: vec2<i32>,
+  @location(44) f276: vec2<i32>,
+  @location(80) f277: vec2<i32>,
+  @location(72) f278: u32,
+  @location(64) f279: vec3<f16>,
+  @location(47) f280: u32,
+  @location(96) f281: vec4<u32>,
+  @location(79) f282: vec4<u32>,
+  @location(117) f283: vec4<f32>,
+  @location(29) f284: u32,
+  @location(51) f285: vec3<f32>,
+  @location(18) f286: vec4<u32>,
+  @location(67) f287: vec3<f32>,
+  @location(31) f288: u32,
+  @location(40) f289: f16,
+  @builtin(position) f290: vec4<f32>,
+  @location(71) f291: u32,
+  @location(109) f292: vec2<f32>,
+  @location(19) f293: f16,
+  @location(62) f294: i32,
+  @location(43) f295: vec3<f32>,
+  @location(107) f296: vec3<f16>,
+  @location(93) f297: f16,
+  @location(105) f298: vec4<u32>,
+  @location(82) f299: i32,
+  @location(104) f300: vec2<i32>,
+  @location(106) f301: f32,
+  @location(91) f302: u32,
+  @location(25) f303: vec2<f32>,
+  @location(10) f304: vec2<i32>,
+  @location(66) f305: vec4<f32>,
+  @location(88) f306: vec2<u32>,
+  @location(30) f307: vec3<f32>,
+  @location(115) f308: vec3<u32>,
+  @location(85) f309: vec2<f32>,
+  @location(26) f310: vec2<i32>,
+  @location(95) f311: vec4<f16>,
+  @location(63) f312: vec2<f32>,
+  @location(48) f313: vec2<f32>,
+  @location(14) f314: vec2<i32>,
+  @location(97) f315: vec3<i32>,
+  @location(33) f316: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<f16>, @location(11) a1: f16, @location(3) a2: vec3<i32>, a3: S20, @location(9) a4: vec4<i32>, @location(4) a5: vec4<u32>, @location(13) a6: vec3<u32>, @location(14) a7: u32, @builtin(instance_index) a8: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder165 = device2.createCommandEncoder({label: '\u2de2\u591a\u0bd9'});
+let texture117 = device2.createTexture({
+  size: [710, 1, 1248],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let renderBundle100 = renderBundleEncoder64.finish();
+let externalTexture72 = device2.importExternalTexture({label: '\u03d1\u5c15\u96ef', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder88.setPipeline(pipeline136);
+} catch {}
+try {
+commandEncoder153.copyTextureToBuffer({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 1203, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 868 widthInBlocks: 217 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 79408 */
+  offset: 79408,
+  bytesPerRow: 1280,
+  rowsPerImage: 213,
+  buffer: buffer44,
+}, {width: 217, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+let video27 = await videoWithData();
+let bindGroupLayout48 = device4.createBindGroupLayout({label: '\uc2bb\u5de8', entries: []});
+let texture118 = device4.createTexture({
+  label: '\u{1fad5}\u3465\ud3c4\u051d\u8fb7\u0b80\u65d3',
+  size: {width: 60, height: 192, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let computePassEncoder95 = commandEncoder163.beginComputePass({label: '\u8d20\uc344\u7cae\u0a2d\u1465\u69d9\u{1f8b9}\u0094\ube4f\u{1fa37}'});
+let renderBundleEncoder76 = device4.createRenderBundleEncoder({
+  label: '\uf2d7\u589d',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  stencilReadOnly: true,
+});
+try {
+commandEncoder155.clearBuffer(buffer47, 9636, 1148);
+dissociateBuffer(device4, buffer47);
+} catch {}
+let gpuCanvasContext27 = canvas26.getContext('webgpu');
+let bindGroupLayout49 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2496,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder166 = device4.createCommandEncoder({});
+let querySet78 = device4.createQuerySet({label: '\ud419\ub1a2\u{1fd37}\ue8e0\u9f2c\u1c12\u92e7\u9165\u237a', type: 'occlusion', count: 2619});
+let computePassEncoder96 = commandEncoder166.beginComputePass({label: '\u082e\u2e1c\u56b2'});
+let sampler93 = device4.createSampler({
+  label: '\u{1f7fc}\u076e',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 24.32,
+  maxAnisotropy: 1,
+});
+let externalTexture73 = device4.importExternalTexture({label: '\u0a65\u47a8\u8cda\u{1f60b}', source: videoFrame4});
+try {
+commandEncoder155.copyTextureToTexture({
+  texture: texture118,
+  mipLevel: 1,
+  origin: {x: 0, y: 42, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture118,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 19, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas14.height = 2032;
+let commandBuffer42 = commandEncoder138.finish({label: '\u09be\ub8b4\u1691\ub0df'});
+let textureView205 = texture106.createView({mipLevelCount: 2, arrayLayerCount: 1});
+let computePassEncoder97 = commandEncoder153.beginComputePass({label: '\u32b9\u0e61\u{1f88d}\u{1f62a}\u329a'});
+let renderBundle101 = renderBundleEncoder65.finish({label: '\u{1f64c}\u03cf\u0277\u{1fe59}'});
+let sampler94 = device2.createSampler({
+  label: '\u44c1\u{1ff38}\u83fa\uaa6a\u1ee6\u431d\uf12a\u9f7d\u30bc',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.15,
+  lodMaxClamp: 99.21,
+});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup37, new Uint32Array(8627), 8444, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline130);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline131);
+} catch {}
+try {
+commandEncoder154.copyBufferToBuffer(buffer44, 60900, buffer41, 188952, 4100);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder154.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2192 widthInBlocks: 137 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 59728 */
+  offset: 57536,
+  bytesPerRow: 2304,
+  buffer: buffer41,
+}, {width: 137, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer45, 19724, 116);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer9), /* required buffer size: 2581496 */
+{offset: 472, bytesPerRow: 2456, rowsPerImage: 210}, {width: 139, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline138 = device2.createRenderPipeline({
+  label: '\u{1ff73}\u4aef\uc1c3',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17772,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 13320, shaderLocation: 3},
+          {format: 'uint8x4', offset: 1132, shaderLocation: 7},
+          {format: 'uint32x4', offset: 3972, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 7360, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 4664, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 5428, shaderLocation: 0},
+          {format: 'float32x2', offset: 812, shaderLocation: 16},
+          {format: 'float16x4', offset: 1184, shaderLocation: 12},
+          {format: 'uint16x4', offset: 1776, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 5528, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 230, shaderLocation: 15},
+          {format: 'sint32x4', offset: 3388, shaderLocation: 8},
+          {format: 'uint16x2', offset: 1132, shaderLocation: 14},
+          {format: 'sint32x3', offset: 408, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 7196,
+        attributes: [
+          {format: 'snorm16x2', offset: 1156, shaderLocation: 5},
+          {format: 'sint8x2', offset: 5134, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 2280, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 52, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+gc();
+let canvas27 = document.createElement('canvas');
+let bindGroup55 = device4.createBindGroup({layout: bindGroupLayout48, entries: []});
+let textureView206 = texture118.createView({
+  label: '\u{1fcba}\uf61a\u{1fb9d}',
+  dimension: '2d-array',
+  format: 'r8sint',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+let computePassEncoder98 = commandEncoder155.beginComputePass({label: '\ud1ca\u2742\u4ee1\u{1fb9e}\ue2c4\uc26e'});
+let sampler95 = device4.createSampler({
+  label: '\u0f4d\u442c\u0f8a\u0446\u08ec\u196e\uc2bd\ud939\u{1faa2}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.00,
+  lodMaxClamp: 97.60,
+  compare: 'greater',
+  maxAnisotropy: 5,
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame18 = new VideoFrame(video3, {timestamp: 0});
+let canvas28 = document.createElement('canvas');
+let buffer49 = device4.createBuffer({
+  label: '\u6d08\ucd96\u0eec\u2641\u769b\u0821\u366a',
+  size: 144576,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder167 = device4.createCommandEncoder({label: '\uff09\u7e83\u52ec'});
+let querySet79 = device4.createQuerySet({
+  label: '\uf077\ua1fd\u1d8b\ueccf\u{1f994}\u001a\u0560\u5e57\u0c24\u{1f7da}',
+  type: 'occlusion',
+  count: 3074,
+});
+let img32 = await imageWithData(249, 286, '#5dda1bf0', '#aca1a856');
+let bindGroup56 = device4.createBindGroup({
+  label: '\u0fb2\u00b0\ue5ec\u0b22\u798b\ub5a0\uae52',
+  layout: bindGroupLayout49,
+  entries: [{binding: 2496, resource: sampler93}],
+});
+let texture119 = device4.createTexture({
+  label: '\ua725\u0677\u0046\u0179\u010e\uefd6',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let computePassEncoder99 = commandEncoder167.beginComputePass({label: '\u0a2a\u711e\ud6a1\ua170'});
+let sampler96 = device4.createSampler({
+  label: '\u1919\u20b9\u7322\u096a\u97b9\uc3de\u0e96\u0252',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.506,
+  lodMaxClamp: 90.81,
+  maxAnisotropy: 3,
+});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let videoFrame19 = new VideoFrame(imageBitmap17, {timestamp: 0});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+video9.height = 278;
+let canvas29 = document.createElement('canvas');
+let texture120 = device4.createTexture({
+  label: '\u{1fbe9}\u02dc\u0262\u{1fcb4}\ucde2',
+  size: [192],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle102 = renderBundleEncoder74.finish({label: '\u37ea\u87c3\u{1f765}\u{1f7d6}\u0721'});
+let sampler97 = device4.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 31.70,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder71.setBindGroup(4, bindGroup55, new Uint32Array(4026), 2298, 0);
+} catch {}
+let gpuCanvasContext28 = canvas27.getContext('webgpu');
+canvas25.width = 193;
+gc();
+let bindGroup57 = device4.createBindGroup({
+  label: '\u{1f7f5}\uc6d3\u93d6\u788a\u14a0',
+  layout: bindGroupLayout49,
+  entries: [{binding: 2496, resource: sampler93}],
+});
+let pipelineLayout31 = device4.createPipelineLayout({
+  label: '\u087d\u{1fc7a}\u6ef4\u48c0\u04c5\u798e\u{1f65e}\u{1fe6e}',
+  bindGroupLayouts: [bindGroupLayout48, bindGroupLayout49],
+});
+let commandEncoder168 = device4.createCommandEncoder({label: '\udda9\u02db\u0d7e\u0791\u10bc\u0c8a\u{1fd51}'});
+let renderBundle103 = renderBundleEncoder74.finish({label: '\u0e39\u069e\u958c\ub924\u5064\udb10\ub234\u3441\ud34b'});
+let sampler98 = device4.createSampler({
+  label: '\u0e3a\u0a81\u{1fe2a}\u{1fd2a}\u5184',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 50.36,
+});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(3, bindGroup55, new Uint32Array(8986), 1326, 0);
+} catch {}
+try {
+commandEncoder168.resolveQuerySet(querySet75, 3198, 26, buffer49, 94976);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 3,
+  origin: {x: 15, y: 2, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 46095 */
+{offset: 83, bytesPerRow: 96, rowsPerImage: 214}, {width: 14, height: 52, depthOrArrayLayers: 3});
+} catch {}
+let shaderModule19 = device4.createShaderModule({
+  label: '\ucc5f\u{1ffd5}\u8c79\uabfb',
+  code: `@group(1) @binding(2496)
+var<storage, read_write> parameter16: array<u32>;
+
+@compute @workgroup_size(3, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+  @location(39) f0: vec2<i32>,
+  @location(1) f1: vec3<f16>,
+  @location(4) f2: vec3<f16>,
+  @location(6) f3: i32,
+  @location(54) f4: vec3<f32>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: vec2<i32>,
+  @location(2) f5: vec4<f32>,
+  @location(5) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(a0: S23, @location(16) a1: vec4<f32>, @location(0) a2: f16, @location(40) a3: vec4<u32>, @location(36) a4: f16, @location(63) a5: vec2<f16>, @location(48) a6: vec3<u32>, @location(17) a7: vec3<u32>, @builtin(sample_index) a8: u32, @builtin(position) a9: vec4<f32>, @builtin(front_facing) a10: bool, @builtin(sample_mask) a11: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S22 {
+  @location(18) f0: vec2<f32>,
+  @location(17) f1: vec3<u32>,
+  @location(7) f2: vec2<u32>
+}
+struct VertexOutput0 {
+  @builtin(position) f317: vec4<f32>,
+  @location(54) f318: vec3<f32>,
+  @location(40) f319: vec4<u32>,
+  @location(39) f320: vec2<i32>,
+  @location(6) f321: i32,
+  @location(17) f322: vec3<u32>,
+  @location(16) f323: vec4<f32>,
+  @location(36) f324: f16,
+  @location(48) f325: vec3<u32>,
+  @location(63) f326: vec2<f16>,
+  @location(1) f327: vec3<f16>,
+  @location(0) f328: f16,
+  @location(4) f329: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec2<f16>, @location(5) a1: vec4<f32>, @builtin(instance_index) a2: u32, @location(22) a3: vec3<u32>, @location(6) a4: vec2<i32>, @location(11) a5: u32, @location(24) a6: vec4<i32>, @location(8) a7: f16, @location(19) a8: vec2<f32>, @location(13) a9: vec2<f32>, a10: S22, @location(21) a11: vec3<i32>, @location(20) a12: vec2<i32>, @location(9) a13: vec4<f32>, @location(25) a14: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle104 = renderBundleEncoder73.finish({label: '\u2fca\u{1f6ed}\u371e\u4621\u0bec\u0d16\u{1fd96}\u2d95\u0860\u96b6\u42f3'});
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture118,
+  mipLevel: 1,
+  origin: {x: 0, y: 19, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture118,
+  mipLevel: 1,
+  origin: {x: 5, y: 25, z: 0},
+  aspect: 'all',
+},
+{width: 25, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let img33 = await imageWithData(243, 120, '#8c3a018d', '#cac37592');
+try {
+canvas28.getContext('webgl');
+} catch {}
+let gpuCanvasContext29 = canvas29.getContext('webgpu');
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let textureView207 = texture116.createView({baseMipLevel: 3});
+let computePassEncoder100 = commandEncoder168.beginComputePass({});
+try {
+renderBundleEncoder75.setBindGroup(0, bindGroup55, new Uint32Array(9206), 2395, 0);
+} catch {}
+let querySet80 = device4.createQuerySet({label: '\u7a2c\u1ff0\u{1f7cf}\u07b0\u3b59\u{1fd22}', type: 'occlusion', count: 172});
+let texture121 = device4.createTexture({
+  label: '\ufc98\u2dc5\u{1f8d4}\u{1f6d7}\u0b3e\u{1f868}\u{1fd57}\u{1ff91}\u{1fecc}\u{1f949}\ued36',
+  size: {width: 48, height: 40, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView208 = texture116.createView({baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder77 = device4.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle105 = renderBundleEncoder71.finish({label: '\u6e91\u{1fe8c}\u{1ffb1}\u{1f722}\u0567\u6f2e\ud61a\ucc0d\u{1f784}'});
+let sampler99 = device4.createSampler({
+  label: '\u{1fd13}\u{1f720}\uc8ed',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.10,
+  maxAnisotropy: 14,
+});
+let externalTexture74 = device4.importExternalTexture({label: '\u03cf\u0941\u0137\ued1d\u2363\u6ae0\u41b0\u{1f7a6}', source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder94.setBindGroup(2, bindGroup55, new Uint32Array(1529), 86, 0);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(5650, undefined, 3390803631);
+} catch {}
+let pipeline139 = device4.createComputePipeline({
+  label: '\u9f13\ucbb1\ub365\u2329\u6fbb',
+  layout: pipelineLayout31,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas4.height = 309;
+let commandEncoder169 = device2.createCommandEncoder({});
+let textureView209 = texture115.createView({label: '\uc0c6\u013e', baseMipLevel: 3, mipLevelCount: 6});
+let computePassEncoder101 = commandEncoder164.beginComputePass();
+let renderBundleEncoder78 = device2.createRenderBundleEncoder({
+  label: '\u{1f936}\u{1fcdd}\u1d62\u0bab\u83b7\u0c8c',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline130);
+} catch {}
+try {
+commandEncoder154.copyBufferToBuffer(buffer44, 50456, buffer45, 17908, 368);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer44, 181776, 3640);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 326 */
+{offset: 326}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule20 = device4.createShaderModule({
+  label: '\u2b68\u9e2f\u679e\u22b7\u0863',
+  code: `@group(1) @binding(2496)
+var<storage, read_write> field10: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @location(42) f0: vec2<f32>,
+  @location(34) f1: vec4<f32>,
+  @builtin(sample_index) f2: u32,
+  @location(53) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec4<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(3) f4: vec4<f32>,
+  @location(5) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec3<f32>, @location(45) a1: vec3<f16>, @location(30) a2: vec4<i32>, @builtin(front_facing) a3: bool, @location(37) a4: vec4<f32>, @location(28) a5: vec3<f32>, a6: S24, @location(63) a7: vec3<u32>, @location(43) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(63) f330: vec3<u32>,
+  @location(46) f331: vec4<f32>,
+  @location(45) f332: vec3<f16>,
+  @location(32) f333: vec2<f16>,
+  @location(22) f334: f16,
+  @location(28) f335: vec3<f32>,
+  @location(49) f336: vec4<u32>,
+  @location(8) f337: vec3<i32>,
+  @location(53) f338: vec4<f32>,
+  @location(43) f339: u32,
+  @location(37) f340: vec4<f32>,
+  @builtin(position) f341: vec4<f32>,
+  @location(30) f342: vec4<i32>,
+  @location(16) f343: vec4<f16>,
+  @location(42) f344: vec2<f32>,
+  @location(34) f345: vec4<f32>,
+  @location(52) f346: i32,
+  @location(9) f347: vec3<f32>,
+  @location(55) f348: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<u32>, @location(23) a1: vec4<i32>, @location(0) a2: vec4<i32>, @location(15) a3: vec2<i32>, @location(3) a4: vec3<u32>, @location(9) a5: vec4<f32>, @location(19) a6: f16, @builtin(instance_index) a7: u32, @location(2) a8: vec4<u32>, @location(14) a9: vec4<u32>, @builtin(vertex_index) a10: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup58 = device4.createBindGroup({
+  label: '\ud024\u9586\u0992',
+  layout: bindGroupLayout49,
+  entries: [{binding: 2496, resource: sampler93}],
+});
+let externalTexture75 = device4.importExternalTexture({label: '\u00eb\u4b41\u432b\u1556\u738e', source: video24, colorSpace: 'display-p3'});
+let pipeline140 = await device4.createRenderPipelineAsync({
+  label: '\u3878\u84fb\u0bb9\u{1fa1c}\u{1f931}\ue2be\u05f7\u0e52',
+  layout: pipelineLayout31,
+  multisample: {},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: 0}, {format: 'r16float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+  },
+}, {format: 'r8sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1448,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 196, shaderLocation: 8},
+          {format: 'uint16x4', offset: 56, shaderLocation: 11},
+          {format: 'float16x4', offset: 284, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 292,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 80, shaderLocation: 25},
+          {format: 'float32x4', offset: 68, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 64, shaderLocation: 13},
+          {format: 'float32', offset: 32, shaderLocation: 18},
+          {format: 'sint16x4', offset: 100, shaderLocation: 24},
+          {format: 'float32x3', offset: 140, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32x4', offset: 400, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 2108, shaderLocation: 19},
+          {format: 'uint32x4', offset: 1388, shaderLocation: 7},
+          {format: 'uint16x2', offset: 1096, shaderLocation: 17},
+          {format: 'sint32x2', offset: 1052, shaderLocation: 20},
+        ],
+      },
+      {arrayStride: 1044, attributes: [{format: 'sint32', offset: 156, shaderLocation: 6}]},
+      {arrayStride: 1080, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 496,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 12, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let texture122 = device4.createTexture({
+  label: '\u{1f82a}\u0c23\udc46\u01f5',
+  size: [48],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+try {
+renderBundleEncoder75.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 48, height: 40, depthOrArrayLayers: 16}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 66, y: 2 },
+  flipY: true,
+}, {
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 5, y: 7, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let img34 = await imageWithData(275, 296, '#c785691b', '#0c650020');
+let imageData25 = new ImageData(140, 96);
+let videoFrame20 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let renderBundleEncoder79 = device4.createRenderBundleEncoder({
+  label: '\ub49e\u080b\u647e\u{1fd9b}\ud1f9\u7ee4\u0fa5\uf226',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+});
+let externalTexture76 = device4.importExternalTexture({label: '\u1f9f\uf9cc\u0c58\u07c8', source: video18, colorSpace: 'srgb'});
+try {
+computePassEncoder98.setBindGroup(4, bindGroup58, new Uint32Array(1297), 1155, 0);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline139);
+} catch {}
+document.body.prepend(canvas1);
+try {
+externalTexture27.label = '\u{1f76d}\u7f88\u78be\u{1fed0}\u007c\u0ca1\u{1f64a}\ue106';
+} catch {}
+let bindGroup59 = device4.createBindGroup({layout: bindGroupLayout49, entries: [{binding: 2496, resource: sampler93}]});
+let commandEncoder170 = device4.createCommandEncoder({label: '\u05f4\u0b2b\u4242\u{1f85c}\u18ff\u{1f7d7}\u{1fcdf}\u7f3a\u0050'});
+let textureView210 = texture116.createView({label: '\u{1f730}\u{1f7b6}\u91d4\u03cb', mipLevelCount: 2});
+let renderBundleEncoder80 = device4.createRenderBundleEncoder({
+  label: '\u9abf\u09ed',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder99.setBindGroup(5, bindGroup57, new Uint32Array(681), 319, 0);
+} catch {}
+try {
+renderBundleEncoder75.setBindGroup(4, bindGroup58);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(7748, undefined, 0, 4051764430);
+} catch {}
+let promise43 = device4.createComputePipelineAsync({
+  label: '\u4806\u02b5\ud369\u0a78\ub72d',
+  layout: pipelineLayout31,
+  compute: {module: shaderModule20, entryPoint: 'compute0', constants: {}},
+});
+try {
+device4.destroy();
+} catch {}
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+gc();
+canvas0.height = 247;
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let videoFrame21 = new VideoFrame(offscreenCanvas15, {timestamp: 0});
+let canvas30 = document.createElement('canvas');
+let gpuCanvasContext30 = canvas30.getContext('webgpu');
+gc();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let imageData26 = new ImageData(132, 76);
+let buffer50 = device2.createBuffer({
+  label: '\u045e\u917c\u{1ff04}\u071e\u{1f897}\u0d64\ufc47\u9a85',
+  size: 159699,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder171 = device2.createCommandEncoder();
+let textureView211 = texture110.createView({
+  label: '\u77ae\u0bad\u03c3\u26ff\u5577\u0a53\u{1f93c}\u046b\u7169\u{1f98d}',
+  format: 'rgba32sint',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder81 = device2.createRenderBundleEncoder({
+  label: '\ubf21\uac0f\u{1f7d9}\ucd63\ub1e0\uff43\u422b\u0650\ua8a5',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle106 = renderBundleEncoder78.finish({});
+try {
+computePassEncoder101.end();
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline132);
+} catch {}
+try {
+commandEncoder156.copyBufferToBuffer(buffer40, 95628, buffer41, 93332, 22360);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 1,
+  origin: {x: 124, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 161209 */
+{offset: 937, bytesPerRow: 159, rowsPerImage: 28}, {width: 49, height: 0, depthOrArrayLayers: 37});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 177, y: 21 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture123 = device2.createTexture({
+  label: '\u03dd\u2d7f\u34dc\u962d',
+  size: [710, 1, 68],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView212 = texture100.createView({label: '\u0188\uf50e\u{1f8ed}\u{1f671}\u{1fe6f}\ub0a5', baseMipLevel: 8});
+let renderBundle107 = renderBundleEncoder78.finish({label: '\ucd81\u003d\u7ed0\u{1ff6e}\u8f5d\u0371\u0f56\u4c67'});
+let externalTexture77 = device2.importExternalTexture({source: videoFrame19, colorSpace: 'srgb'});
+try {
+computePassEncoder80.setBindGroup(6, bindGroup53);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline134);
+} catch {}
+try {
+device2.queue.submit([commandBuffer42]);
+} catch {}
+let shaderModule21 = device2.createShaderModule({
+  label: '\u0ac0\u4295\u0cb4\u0a5b\u6e36',
+  code: `@group(0) @binding(3322)
+var<storage, read_write> local13: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec2<u32>,
+  @location(0) f1: vec4<f32>,
+  @location(4) f2: vec4<i32>,
+  @location(1) f3: i32,
+  @location(3) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(95) a0: vec4<f16>, @location(78) a1: f16, @location(52) a2: f32, @location(93) a3: vec4<f32>, @location(9) a4: vec2<u32>, @builtin(position) a5: vec4<f32>, @location(57) a6: vec2<f32>, @location(72) a7: vec4<u32>, @location(86) a8: vec3<i32>, @location(22) a9: vec4<i32>, @location(28) a10: vec2<f32>, @location(12) a11: i32, @location(32) a12: f16, @location(73) a13: vec2<f16>, @location(43) a14: vec2<u32>, @builtin(front_facing) a15: bool, @builtin(sample_mask) a16: u32, @location(11) a17: vec3<f16>, @location(77) a18: f16, @location(119) a19: f16, @builtin(sample_index) a20: u32, @location(99) a21: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(17) f0: vec4<i32>,
+  @builtin(instance_index) f1: u32,
+  @location(2) f2: vec2<f32>,
+  @location(5) f3: u32,
+  @location(8) f4: vec4<i32>,
+  @location(12) f5: i32,
+  @location(4) f6: vec4<f32>,
+  @location(15) f7: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(22) f349: vec4<i32>,
+  @location(66) f350: vec2<f16>,
+  @location(32) f351: f16,
+  @location(95) f352: vec4<f16>,
+  @location(86) f353: vec3<i32>,
+  @location(77) f354: f16,
+  @location(52) f355: f32,
+  @location(9) f356: vec2<u32>,
+  @location(111) f357: vec4<f16>,
+  @location(93) f358: vec4<f32>,
+  @location(41) f359: vec2<u32>,
+  @location(21) f360: vec4<i32>,
+  @location(118) f361: vec4<i32>,
+  @location(46) f362: vec2<f16>,
+  @location(109) f363: vec4<f16>,
+  @location(57) f364: vec2<f32>,
+  @location(72) f365: vec4<u32>,
+  @location(99) f366: vec2<f16>,
+  @location(28) f367: vec2<f32>,
+  @location(43) f368: vec2<u32>,
+  @location(73) f369: vec2<f16>,
+  @location(58) f370: vec2<u32>,
+  @location(76) f371: vec2<f32>,
+  @location(0) f372: vec3<i32>,
+  @location(119) f373: f16,
+  @location(27) f374: vec2<f16>,
+  @location(108) f375: vec4<u32>,
+  @location(78) f376: f16,
+  @builtin(position) f377: vec4<f32>,
+  @location(11) f378: vec3<f16>,
+  @location(12) f379: i32,
+  @location(31) f380: vec4<i32>,
+  @location(107) f381: vec3<f16>,
+  @location(40) f382: f32,
+  @location(19) f383: f32,
+  @location(112) f384: vec3<i32>,
+  @location(101) f385: vec3<f16>,
+  @location(7) f386: vec4<f16>,
+  @location(17) f387: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<u32>, @location(6) a1: vec3<u32>, @location(7) a2: vec2<f16>, @builtin(vertex_index) a3: u32, @location(13) a4: vec3<f32>, a5: S25, @location(0) a6: vec2<i32>, @location(9) a7: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder172 = device2.createCommandEncoder({label: '\u7221\u07bb\ub7cd\uf803'});
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13368 */
+  offset: 13368,
+  buffer: buffer44,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 3728, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video24,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let buffer51 = device2.createBuffer({size: 57103, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder173 = device2.createCommandEncoder({label: '\ub98f\u837c\u{1fa8d}\uc901\u71e0\ud87f\u{1f70d}'});
+let textureView213 = texture86.createView({label: '\uec54\u053e\u7627\ubfbf\u9baa\u0b19\u{1faef}', baseArrayLayer: 3, arrayLayerCount: 1});
+let renderBundleEncoder82 = device2.createRenderBundleEncoder({
+  label: '\u08c2\u06b6\u061e\u{1f84e}',
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder82.setPipeline(pipeline130);
+} catch {}
+try {
+renderBundleEncoder81.setPipeline(pipeline137);
+} catch {}
+try {
+texture114.destroy();
+} catch {}
+try {
+commandEncoder165.clearBuffer(buffer44, 222780, 20204);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let pipeline141 = await device2.createRenderPipelineAsync({
+  label: '\u{1fac8}\uca32\ue4aa\u09da\u7c82\u{1fde3}\u0b4c',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r16sint', writeMask: 0}, undefined, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5296,
+        attributes: [
+          {format: 'sint32x4', offset: 1452, shaderLocation: 12},
+          {format: 'sint16x2', offset: 2452, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 1292, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3048,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 2154, shaderLocation: 10},
+          {format: 'sint32x4', offset: 124, shaderLocation: 7},
+          {format: 'float16x2', offset: 632, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 1480,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1088, shaderLocation: 1},
+          {format: 'sint32x3', offset: 324, shaderLocation: 3},
+          {format: 'sint16x2', offset: 616, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 26588,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 1908, shaderLocation: 16},
+          {format: 'uint8x4', offset: 17556, shaderLocation: 4},
+          {format: 'uint32x4', offset: 14800, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 66, shaderLocation: 11},
+          {format: 'uint32', offset: 5752, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 5786, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 25860,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 6944, shaderLocation: 2},
+          {format: 'uint32x2', offset: 8672, shaderLocation: 8},
+          {format: 'sint16x2', offset: 25856, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 576, stepMode: 'vertex', attributes: []},
+      {arrayStride: 2700, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5640,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 1588, shaderLocation: 9}],
+      },
+    ],
+  },
+});
+let imageBitmap31 = await createImageBitmap(video25);
+let buffer52 = device2.createBuffer({
+  label: '\u2356\u4430\u0c3c\u{1ff5b}\u04b6\u22bd\ud095\u{1f819}\u6304\u{1f800}\uc3b6',
+  size: 186876,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture124 = device2.createTexture({
+  size: [710, 1, 298],
+  mipLevelCount: 8,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let externalTexture78 = device2.importExternalTexture({label: '\u0e29\u{1fef4}', source: videoFrame15, colorSpace: 'srgb'});
+try {
+commandEncoder172.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 3,
+  origin: {x: 37, y: 0, z: 37},
+  aspect: 'all',
+},
+{
+  texture: texture115,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise44;
+} catch {}
+let imageData27 = new ImageData(40, 72);
+try {
+adapter2.label = '\ud953\u23f8\u{1ff53}\u8d00';
+} catch {}
+let commandEncoder174 = device2.createCommandEncoder({});
+let textureView214 = texture113.createView({format: 'bgra8unorm-srgb'});
+let renderBundleEncoder83 = device2.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'r16sint', undefined, 'r16uint', 'rgba32sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder76.setPipeline(pipeline130);
+} catch {}
+try {
+commandEncoder156.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas19,
+  origin: { x: 129, y: 7 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture125 = device2.createTexture({
+  label: '\u66af\u0d23',
+  size: [710, 1, 1285],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let textureView215 = texture125.createView({
+  label: '\u85e0\udd74\ud4b2\u4e3c\u0c67\u0283\u{1f891}\uf617\uec44\u88fe',
+  dimension: '3d',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let sampler100 = device2.createSampler({
+  label: '\u7f2f\u00bb\u8078\uf041\u00e4\u0e4e\uef2f\uba6e\u{1f7e4}\uf5c3\u{1f69e}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 63.53,
+  lodMaxClamp: 83.32,
+});
+let externalTexture79 = device2.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder77.setPipeline(pipeline134);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(6, buffer46);
+} catch {}
+try {
+commandEncoder147.copyBufferToTexture({
+  /* bytesInLastRow: 1146 widthInBlocks: 573 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7308 */
+  offset: 7308,
+  buffer: buffer44,
+}, {
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 573, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder172.copyTextureToBuffer({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6256 */
+  offset: 6256,
+  bytesPerRow: 0,
+  buffer: buffer44,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+let pipeline142 = await device2.createComputePipelineAsync({
+  label: '\u00db\u6c39\u0fa3\u0d10\u716a\u9eb6',
+  layout: pipelineLayout27,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame22 = new VideoFrame(canvas6, {timestamp: 0});
+let video28 = await videoWithData();
+let offscreenCanvas29 = new OffscreenCanvas(462, 884);
+let commandEncoder175 = device2.createCommandEncoder({label: '\u1d3c\u{1fe4e}\u{1fba3}\u0943\u2466\ue14a\u0881\u{1fbad}\u3ccd'});
+let computePassEncoder102 = commandEncoder152.beginComputePass({label: '\u{1f8a7}\u09a6\u{1fe50}\ua224\u39c3\ueb86\u{1f984}'});
+try {
+device2.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer11), /* required buffer size: 822 */
+{offset: 822, rowsPerImage: 269}, {width: 511, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let gpuCanvasContext31 = offscreenCanvas29.getContext('webgpu');
+let offscreenCanvas30 = new OffscreenCanvas(77, 952);
+let gpuCanvasContext32 = offscreenCanvas30.getContext('webgpu');
+let video29 = await videoWithData();
+let bindGroupLayout50 = device2.createBindGroupLayout({
+  label: '\udf4a\u67e9\u08e9\u514e\u0ac4\u7d0c\ub78f\u0e03\u0a10',
+  entries: [
+    {
+      binding: 5931,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 7041, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 4959, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder176 = device2.createCommandEncoder({label: '\u2741\u{1f7ba}\u04a0\u71cb\u09a9\u0092\u093a\u1bf7'});
+let querySet81 = device2.createQuerySet({label: '\u98a9\u0381\u0855\u{1faae}\u{1f94b}\u9b42', type: 'occlusion', count: 3331});
+let textureView216 = texture96.createView({label: '\ucab9\u{1fba1}\u{1fe21}\ua9a8\u{1ff52}\u65ac\ud988'});
+let computePassEncoder103 = commandEncoder175.beginComputePass({label: '\u96bb\u2100\ud619\u{1fb20}\u013e'});
+try {
+renderBundleEncoder81.setVertexBuffer(6, buffer43, 221100, 153784);
+} catch {}
+try {
+commandEncoder159.copyBufferToBuffer(buffer40, 122024, buffer45, 13472, 3952);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture104,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 344, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 83, height: 0, depthOrArrayLayers: 17});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 81, y: 42 },
+  flipY: true,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer53 = device2.createBuffer({
+  label: '\u8f91\u{1ffad}\ucd94\u1cd1\u{1ff9c}\u723d\uf030\u{1f7e3}\u693c',
+  size: 40978,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let textureView217 = texture109.createView({
+  label: '\u{1f8dc}\u0e09\u1ae7',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder84 = device2.createRenderBundleEncoder({
+  label: '\u2234\u{1fc7f}\u4e2e\u{1f849}\u{1fc53}\u046f\uedb1\ub431\uf6a1\u509f',
+  colorFormats: ['rgba8unorm-srgb', 'r16sint', 'r16uint', 'rg32uint', 'r16sint', 'r16uint', 'rg8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder69.setPipeline(pipeline131);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(2, buffer43, 304960, 112053);
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 186 widthInBlocks: 93 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 82924 */
+  offset: 79922,
+  bytesPerRow: 256,
+  rowsPerImage: 1,
+  buffer: buffer44,
+}, {
+  texture: texture111,
+  mipLevel: 3,
+  origin: {x: 15, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 93, height: 1, depthOrArrayLayers: 12});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder159.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2532 widthInBlocks: 1266 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1182 */
+  offset: 1182,
+  rowsPerImage: 65,
+  buffer: buffer45,
+}, {width: 1266, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 99144, new Float32Array(22858), 9629, 1436);
+} catch {}
+let pipeline143 = await device2.createComputePipelineAsync({layout: pipelineLayout27, compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}}});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+adapter1.label = '\u9033\u{1fbe7}\u0a1f\u5e2a\u9f5e\u9b0f\u043b\u2a85\u08c4\u82ed';
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let videoFrame23 = new VideoFrame(video13, {timestamp: 0});
+try {
+window.someLabel = externalTexture62.label;
+} catch {}
+let texture126 = device2.createTexture({
+  label: '\u0d94\u{1fa46}\u{1f84a}\u029d\u5587\u1943',
+  size: [710],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint'],
+});
+let textureView218 = texture110.createView({label: '\u4e06\u0bf4\u{1fe7b}', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 0});
+let externalTexture80 = device2.importExternalTexture({
+  label: '\uf095\u{1f9a2}\ucf1a\u0e2b\ucb40\u0ffa\u{1fd28}\u80a1\ued3c\u3f7c',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder84.setPipeline(pipeline143);
+} catch {}
+try {
+renderBundleEncoder69.setIndexBuffer(buffer53, 'uint16');
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(1, buffer46, 47432, 15346);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer44, 26516, buffer41, 105272, 85000);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture125,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 54},
+  aspect: 'all',
+},
+{
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 243, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 76, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer45, 1380, 17844);
+dissociateBuffer(device2, buffer45);
+} catch {}
+let bindGroup60 = device2.createBindGroup({layout: bindGroupLayout44, entries: [{binding: 358, resource: externalTexture61}]});
+let texture127 = device2.createTexture({
+  label: '\u8edc\u31df',
+  size: [9252, 12, 1958],
+  mipLevelCount: 5,
+  format: 'astc-12x12-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView219 = texture92.createView({label: '\u{1fa43}\uee52', format: 'bgra8unorm-srgb'});
+let renderBundleEncoder85 = device2.createRenderBundleEncoder({
+  label: '\ub2c3\ufb98\u07ef\u134a',
+  colorFormats: ['rgba8unorm-srgb', 'r16sint', 'r16uint', 'rg32uint', 'r16sint', 'r16uint', 'rg8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 37712 */
+  offset: 37704,
+  buffer: buffer44,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder176.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2216 widthInBlocks: 1108 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4710 */
+  offset: 4710,
+  buffer: buffer41,
+}, {width: 1108, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder171.resolveQuerySet(querySet66, 821, 396, buffer42, 64512);
+} catch {}
+let promise45 = device2.createRenderPipelineAsync({
+  layout: pipelineLayout27,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 188,
+        attributes: [
+          {format: 'sint16x4', offset: 48, shaderLocation: 3},
+          {format: 'sint16x2', offset: 172, shaderLocation: 7},
+          {format: 'sint32', offset: 16, shaderLocation: 5},
+          {format: 'sint8x2', offset: 26, shaderLocation: 0},
+          {format: 'float32', offset: 28, shaderLocation: 6},
+          {format: 'uint32x2', offset: 12, shaderLocation: 8},
+          {format: 'uint8x4', offset: 4, shaderLocation: 14},
+          {format: 'sint16x2', offset: 28, shaderLocation: 9},
+          {format: 'sint32', offset: 60, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 38340, shaderLocation: 13},
+          {format: 'float32x3', offset: 10856, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 756,
+        attributes: [
+          {format: 'uint32', offset: 184, shaderLocation: 4},
+          {format: 'uint32x4', offset: 104, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 38348,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 4932, shaderLocation: 12},
+          {format: 'float16x2', offset: 29632, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 96,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 0, shaderLocation: 17},
+          {format: 'float32x4', offset: 0, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 24, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let imageBitmap32 = await createImageBitmap(imageBitmap6);
+let textureView220 = texture87.createView({label: '\u{1ff90}\u040c\ubadd\u0981\u7242\u211d\u4249\ud6da\u6283', baseMipLevel: 1, mipLevelCount: 1});
+try {
+commandEncoder173.copyTextureToTexture({
+  texture: texture104,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 157, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 174, height: 1, depthOrArrayLayers: 34});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img35 = await imageWithData(52, 152, '#22e013f4', '#8eb99fe9');
+let renderBundle108 = renderBundleEncoder84.finish({label: '\u4dd5\u7905\u{1fb34}\u0fcf\uedb9\u08dc\uc772\u{1f9c3}\u{1fe5c}'});
+try {
+renderBundleEncoder66.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderBundleEncoder82.setBindGroup(2, bindGroup43, new Uint32Array(893), 116, 0);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 8,
+  origin: {x: 5, y: 0, z: 270},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 65});
+} catch {}
+try {
+commandEncoder154.clearBuffer(buffer45, 3876, 15548);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 70 */
+{offset: 70}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline144 = await device2.createComputePipelineAsync({
+  label: '\u068a\u5ca4\u0154\u88b1',
+  layout: pipelineLayout29,
+  compute: {module: shaderModule21, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas0);
+let bindGroupLayout51 = pipeline130.getBindGroupLayout(0);
+let buffer54 = device2.createBuffer({
+  size: 316692,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let commandEncoder177 = device2.createCommandEncoder({label: '\u{1f946}\u58cf\ue47c\u8453'});
+let texture128 = gpuCanvasContext0.getCurrentTexture();
+let textureView221 = texture100.createView({label: '\u0893\ucf52\ub63c', baseMipLevel: 1, mipLevelCount: 6});
+let computePassEncoder104 = commandEncoder174.beginComputePass({label: '\u099b\u50d3\u6320\u0e53\uec88\u1adb\u0693\u{1f8a9}'});
+let externalTexture81 = device2.importExternalTexture({label: '\ueaee\u0d1e\u25b8\ub7cf\ud58c\u{1f842}\uaebc', source: videoFrame18});
+try {
+renderBundleEncoder83.setBindGroup(5, bindGroup49);
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer40, 88108, buffer45, 18100, 1840);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder173.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 50096 */
+  offset: 50096,
+  buffer: buffer44,
+}, {
+  texture: texture115,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder147.copyTextureToBuffer({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2804 widthInBlocks: 1402 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9244 */
+  offset: 9244,
+  buffer: buffer44,
+}, {width: 1402, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+let pipeline145 = await promise45;
+document.body.prepend(canvas14);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let bindGroupLayout52 = device3.createBindGroupLayout({
+  label: '\ub986\u{1fa73}\uf270',
+  entries: [
+    {
+      binding: 871,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 3476,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 5095,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout32 = device3.createPipelineLayout({
+  label: '\u476c\u1cbb\u295d\u004b\u2027\u80e2\u{1f7f7}\u8126\ua7d0\u0818\u8199',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout42, bindGroupLayout42, bindGroupLayout52, bindGroupLayout42, bindGroupLayout52],
+});
+let commandEncoder178 = device3.createCommandEncoder({});
+let promise46 = adapter5.requestAdapterInfo();
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let videoFrame24 = new VideoFrame(videoFrame22, {timestamp: 0});
+let adapter6 = await navigator.gpu.requestAdapter({});
+let buffer55 = device0.createBuffer({
+  label: '\u0b2f\u0f88\u05ed\udba5\uc1e3\u00f2\u{1f7ca}\u3f82',
+  size: 21671,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let commandEncoder179 = device0.createCommandEncoder({label: '\u445b\u0e6d\u0854\u4d21\u0261\u9937\u0652\u{1fa03}\u29a1\uce8a\ud7a2'});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup15, new Uint32Array(6882), 1578, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2, renderBundle32, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(38, 0, 61, 4);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 43448, 77326);
+} catch {}
+try {
+renderBundleEncoder30.draw(865768770, 791939872, 744964058, 435918153);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer14, 'uint16', 158290, 26656);
+} catch {}
+try {
+commandEncoder125.copyBufferToBuffer(buffer18, 18800, buffer15, 30400, 856);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline146 = device0.createComputePipeline({
+  label: '\ufe53\u00da\ue57e\u0511\u{1f787}\u6392\u0f76',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+canvas21.height = 336;
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let img36 = await imageWithData(157, 213, '#3214c09c', '#ef84ad7b');
+let querySet82 = device2.createQuerySet({label: '\u6206\ue443\u{1fc61}\u0261', type: 'occlusion', count: 2363});
+let texture129 = device2.createTexture({
+  label: '\ud89c\u{1fd1f}\u57c2\u05a8',
+  size: [5680],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let textureView222 = texture106.createView({dimension: '3d', baseMipLevel: 1, mipLevelCount: 1});
+let externalTexture82 = device2.importExternalTexture({source: video26, colorSpace: 'srgb'});
+try {
+renderBundleEncoder82.setBindGroup(0, bindGroup51, new Uint32Array(6740), 2792, 0);
+} catch {}
+try {
+renderBundleEncoder69.setIndexBuffer(buffer53, 'uint16', 10200, 26512);
+} catch {}
+try {
+commandEncoder173.clearBuffer(buffer41, 173628, 11584);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 7168, new BigUint64Array(25013), 11317, 5160);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer5), /* required buffer size: 722 */
+{offset: 722}, {width: 4506, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let video30 = await videoWithData();
+let imageBitmap33 = await createImageBitmap(videoFrame7);
+offscreenCanvas24.height = 621;
+gc();
+let imageData28 = new ImageData(256, 116);
+offscreenCanvas21.width = 1060;
+let imageData29 = new ImageData(128, 248);
+let buffer56 = device2.createBuffer({size: 363569, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView223 = texture88.createView({label: '\ua09d\u048c\u4820\ub411\u{1f84a}\ubebc\u5fed\u{1f8d0}\u022f'});
+let renderBundle109 = renderBundleEncoder64.finish({label: '\u0918\uc207\u0bf3\ua482\ub5f4'});
+try {
+computePassEncoder103.setPipeline(pipeline126);
+} catch {}
+try {
+commandEncoder161.copyBufferToBuffer(buffer44, 230872, buffer45, 2492, 16956);
+dissociateBuffer(device2, buffer44);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer45, 1724, new Int16Array(65513), 27301, 72);
+} catch {}
+let imageBitmap34 = await createImageBitmap(imageData15);
+let texture130 = device2.createTexture({
+  label: '\u069f\u09b4\udf6a\u18e6\u9d62\ub62d\u0a0d\u3f28\u001a\u3260\u0543',
+  size: {width: 2840},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint'],
+});
+let textureView224 = texture110.createView({
+  label: '\u7300\uc9d9\u0f8a\u{1f9b5}\u{1fe7f}\u0cc0\u{1fb8f}\ue905\u0838\u4052',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+});
+let renderBundle110 = renderBundleEncoder78.finish({label: '\u0acc\u0e2e\u{1f82d}\u{1fd5d}\u1dc2\u56bd'});
+try {
+renderBundleEncoder81.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder83.setIndexBuffer(buffer53, 'uint32');
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(6, buffer56, 0, 158764);
+} catch {}
+let arrayBuffer13 = buffer52.getMappedRange(109520);
+try {
+device2.queue.writeBuffer(buffer45, 0, new BigUint64Array(42452), 33090, 424);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 155684 */
+{offset: 368, bytesPerRow: 301, rowsPerImage: 129}, {width: 11, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 509, y: 141 },
+  flipY: true,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline147 = await device2.createRenderPipelineAsync({
+  label: '\u0dee\uf9b3\ufdf1\u{1fe70}\u0588\u04a6',
+  layout: pipelineLayout27,
+  multisample: {count: 4, mask: 0xffffffff},
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint', writeMask: GPUColorWrite.RED}, undefined, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 33628,
+        attributes: [
+          {format: 'uint8x2', offset: 5782, shaderLocation: 10},
+          {format: 'sint16x4', offset: 1332, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 13098, shaderLocation: 13},
+          {format: 'uint16x4', offset: 512, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 28048, shaderLocation: 4},
+          {format: 'sint32x4', offset: 10832, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 15696, attributes: []},
+      {
+        arrayStride: 812,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 100, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 124, shaderLocation: 2},
+          {format: 'sint8x2', offset: 270, shaderLocation: 8},
+          {format: 'uint8x4', offset: 88, shaderLocation: 5},
+          {format: 'sint32', offset: 44, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 3508, attributes: []},
+      {arrayStride: 0, attributes: [{format: 'sint8x4', offset: 3076, shaderLocation: 15}]},
+      {arrayStride: 3808, attributes: [{format: 'float32x3', offset: 2380, shaderLocation: 9}]},
+    ],
+  },
+});
+let imageBitmap35 = await createImageBitmap(videoFrame4);
+document.body.prepend(video24);
+try {
+externalTexture68.label = '\u9b28\u{1fd8f}\u0ead\u2f8c\ue4b5\u{1f80c}\ua785\ua08d\uab25';
+} catch {}
+let textureView225 = texture74.createView({label: '\u{1f900}\u1333\u1b04\u03b9\u0a26', dimension: '3d', baseMipLevel: 7});
+let sampler101 = device1.createSampler({
+  label: '\u0df1\ub585\u6f31\u40ce\u0762\ueee0\ud61a\u07e2\u0c73\u{1f7f4}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.55,
+  lodMaxClamp: 71.93,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+commandEncoder123.copyBufferToBuffer(buffer32, 46104, buffer25, 848, 16924);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 149, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1324 widthInBlocks: 331 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5908 */
+  offset: 4584,
+  buffer: buffer38,
+}, {width: 331, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer38);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer38, 37640, new Float32Array(27950));
+} catch {}
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+canvas13.width = 54;
+let video31 = await videoWithData();
+let bindGroup61 = device2.createBindGroup({layout: bindGroupLayout44, entries: [{binding: 358, resource: externalTexture66}]});
+let texture131 = device2.createTexture({
+  label: '\u{1fede}\u7864\ub1a3',
+  size: [2840, 1, 1163],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView226 = texture98.createView({label: '\u{1f967}\u0935\ueef0', format: 'r16uint', baseMipLevel: 8});
+let renderBundle111 = renderBundleEncoder67.finish();
+try {
+computePassEncoder82.setPipeline(pipeline125);
+} catch {}
+try {
+commandEncoder148.copyTextureToBuffer({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 87, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4384 widthInBlocks: 1096 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 31380 */
+  offset: 31380,
+  bytesPerRow: 4608,
+  buffer: buffer44,
+}, {width: 1096, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 3,
+  origin: {x: 16, y: 0, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture115,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 99, height: 1, depthOrArrayLayers: 14});
+} catch {}
+try {
+commandEncoder172.clearBuffer(buffer54);
+dissociateBuffer(device2, buffer54);
+} catch {}
+let pipeline148 = await device2.createRenderPipelineAsync({
+  label: '\u{1fa4e}\u0f8e',
+  layout: pipelineLayout29,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, undefined, {format: 'r16uint'}, {format: 'rgba32sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 3695880346,
+    stencilWriteMask: 107067820,
+    depthBiasSlopeScale: 150.2540674188772,
+  },
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6372,
+        attributes: [
+          {format: 'float32', offset: 76, shaderLocation: 17},
+          {format: 'sint32', offset: 136, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 6370, shaderLocation: 16},
+          {format: 'uint32x3', offset: 1752, shaderLocation: 8},
+          {format: 'uint16x2', offset: 400, shaderLocation: 4},
+          {format: 'sint32x2', offset: 1520, shaderLocation: 3},
+          {format: 'uint32x4', offset: 876, shaderLocation: 14},
+          {format: 'sint32', offset: 1012, shaderLocation: 7},
+          {format: 'sint32', offset: 716, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 7596,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 2684, shaderLocation: 12},
+          {format: 'sint32x4', offset: 620, shaderLocation: 5},
+          {format: 'uint8x4', offset: 792, shaderLocation: 2},
+          {format: 'uint16x4', offset: 1672, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 4532, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 19656, attributes: []},
+      {
+        arrayStride: 5088,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 12, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 164, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 3904,
+        attributes: [
+          {format: 'unorm16x4', offset: 2204, shaderLocation: 6},
+          {format: 'sint16x2', offset: 516, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(canvas5);
+offscreenCanvas18.width = 2125;
+let promise47 = adapter1.requestAdapterInfo();
+let bindGroup62 = device2.createBindGroup({label: '\u{1f99e}\u53d0\u9068', layout: bindGroupLayout38, entries: []});
+let commandEncoder180 = device2.createCommandEncoder({label: '\u086f\u098b\u8479\ud4ec\u064a\u66b5'});
+let querySet83 = device2.createQuerySet({label: '\u588c\u4275\u0f50\u{1f8fb}', type: 'occlusion', count: 294});
+let textureView227 = texture107.createView({
+  label: '\ud68c\u3e3f\u04e4\u58ae\u5d6b\uabb7\u516e',
+  format: 'etc2-rgba8unorm',
+  baseMipLevel: 0,
+  baseArrayLayer: 135,
+  arrayLayerCount: 211,
+});
+try {
+commandEncoder171.copyBufferToTexture({
+  /* bytesInLastRow: 10048 widthInBlocks: 2512 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21300 */
+  offset: 21300,
+  buffer: buffer44,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2512, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder144.copyTextureToTexture({
+  texture: texture111,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 250, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 416 */
+{offset: 416, rowsPerImage: 79}, {width: 34, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline149 = device2.createComputePipeline({
+  label: '\u0235\u{1fa08}\u07c1\u942e\u7c0a\uedd8\u07b8\u27d2\u0ecc\uab9f',
+  layout: pipelineLayout30,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let textureView228 = texture85.createView({
+  label: '\u042f\u{1f853}\uae95\u{1fa3a}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 239,
+});
+try {
+renderBundleEncoder81.setIndexBuffer(buffer53, 'uint32', 31288, 4760);
+} catch {}
+try {
+commandEncoder147.copyBufferToTexture({
+  /* bytesInLastRow: 5600 widthInBlocks: 350 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 20848 */
+  offset: 15248,
+  bytesPerRow: 5632,
+  buffer: buffer44,
+}, {
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 3024, y: 0, z: 31},
+  aspect: 'all',
+}, {width: 1400, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer41, 100112, 105684);
+dissociateBuffer(device2, buffer41);
+} catch {}
+let commandEncoder181 = device3.createCommandEncoder({});
+let texture132 = device3.createTexture({
+  label: '\u3af0\u1b46\u081e',
+  size: {width: 960, height: 8, depthOrArrayLayers: 1239},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+  await promise47;
+} catch {}
+let textureView229 = texture92.createView({label: '\u0811\u{1ff7b}', format: 'bgra8unorm-srgb'});
+let pipeline150 = device2.createComputePipeline({
+  label: '\u0d19\ud7cb\u08b8\u02f0\u3244',
+  layout: pipelineLayout27,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+try {
+device2.destroy();
+} catch {}
+try {
+  await promise46;
+} catch {}
+let imageBitmap36 = await createImageBitmap(videoFrame16);
+let bindGroupLayout53 = device3.createBindGroupLayout({label: '\u81e0\u{1f893}\u0ad5\u{1fd86}\uf27a\u07da\ued1c\u5bc1', entries: []});
+let textureView230 = texture132.createView({label: '\udf40\u05ad\ufd8d\u1243\u{1fb2e}\u270c\udd22', dimension: '3d', mipLevelCount: 1});
+let externalTexture83 = device3.importExternalTexture({label: '\u575d\uc32d\uf4fa\u0fe3\u0855\u{1fd00}\uca23\u22ac', source: video8, colorSpace: 'srgb'});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video10);
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+offscreenCanvas28.width = 440;
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas31 = document.createElement('canvas');
+try {
+canvas31.getContext('webgl');
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let computePassEncoder105 = commandEncoder170.beginComputePass();
+let renderBundleEncoder86 = device4.createRenderBundleEncoder({
+  label: '\u029f\u{1f96a}\udd6c',
+  colorFormats: ['rgba8uint', 'rg16sint', 'r8unorm', 'r16float', 'rgb10a2unorm', 'r8sint'],
+  depthReadOnly: true,
+});
+let renderBundle112 = renderBundleEncoder76.finish();
+let sampler102 = device4.createSampler({
+  label: '\ud370\u{1fecc}\u{1f71d}\u{1fb78}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 25.06,
+  lodMaxClamp: 60.30,
+});
+let externalTexture84 = device4.importExternalTexture({label: '\u2cf6\u0965\u{1fd39}\u{1fb70}\u88ab\u81d4', source: videoFrame21, colorSpace: 'srgb'});
+try {
+renderBundleEncoder77.setPipeline(pipeline140);
+} catch {}
+try {
+device4.pushErrorScope('validation');
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 158904 */
+{offset: 672, bytesPerRow: 180, rowsPerImage: 70}, {width: 3, height: 40, depthOrArrayLayers: 13});
+} catch {}
+offscreenCanvas18.width = 19;
+try {
+window.someLabel = externalTexture36.label;
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+canvas8.width = 148;
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+offscreenCanvas8.height = 336;
+let adapter7 = await navigator.gpu.requestAdapter({});
+gc();
+try {
+window.someLabel = externalTexture42.label;
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let imageData30 = new ImageData(132, 208);
+gc();
+let canvas32 = document.createElement('canvas');
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas33 = document.createElement('canvas');
+let offscreenCanvas31 = new OffscreenCanvas(499, 989);
+let querySet84 = device4.createQuerySet({label: '\u0f5d\u{1ff8a}\ubd51\u3452', type: 'occlusion', count: 1312});
+try {
+computePassEncoder98.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline140);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(1301, undefined, 250770881, 1741596625);
+} catch {}
+let gpuCanvasContext33 = canvas33.getContext('webgpu');
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+let canvas34 = document.createElement('canvas');
+let canvas35 = document.createElement('canvas');
+gc();
+let videoFrame25 = new VideoFrame(video24, {timestamp: 0});
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let imageData31 = new ImageData(96, 20);
+document.body.prepend(video31);
+try {
+offscreenCanvas31.getContext('webgl2');
+} catch {}
+document.body.prepend(img18);
+let img37 = await imageWithData(2, 275, '#dc71f29f', '#6954da08');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let canvas36 = document.createElement('canvas');
+document.body.prepend(img21);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+gc();
+let gpuCanvasContext34 = canvas36.getContext('webgpu');
+offscreenCanvas30.height = 864;
+document.body.prepend(img25);
+let gpuCanvasContext35 = canvas35.getContext('webgpu');
+let videoFrame26 = new VideoFrame(video4, {timestamp: 0});
+let offscreenCanvas32 = new OffscreenCanvas(479, 38);
+let gpuCanvasContext36 = canvas34.getContext('webgpu');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+externalTexture71.label = '\u40da\u{1f9cd}\uae93\u{1f930}\u4464\u348f\u017f';
+} catch {}
+let video32 = await videoWithData();
+let gpuCanvasContext37 = canvas32.getContext('webgpu');
+video23.height = 16;
+try {
+offscreenCanvas32.getContext('webgl2');
+} catch {}
+document.body.prepend(canvas14);
+let adapter8 = await navigator.gpu.requestAdapter({});
+let bindGroup63 = device2.createBindGroup({
+  label: '\u0b34\u892d\ude1c\u59d4\ue6f5\u8402\u{1f9d6}\u0c0c\u{1f6ff}\ue0e0',
+  layout: bindGroupLayout45,
+  entries: [
+    {binding: 1876, resource: {buffer: buffer51, offset: 10496, size: 42380}},
+    {binding: 2710, resource: sampler89},
+  ],
+});
+let textureView231 = texture125.createView({baseMipLevel: 3});
+let sampler103 = device2.createSampler({
+  label: '\u0485\uef7a\u2e49',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 52.23,
+});
+try {
+renderBundleEncoder66.setVertexBuffer(2, buffer46);
+} catch {}
+try {
+commandEncoder180.copyTextureToTexture({
+  texture: texture104,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture125,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 41},
+  aspect: 'all',
+},
+{width: 44, height: 0, depthOrArrayLayers: 30});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 80816, new Float32Array(11211), 2053, 52);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 19 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise48 = device2.createRenderPipelineAsync({
+  label: '\u04f8\ue5df\ude19\u0073\uac59\u{1f93b}',
+  layout: pipelineLayout25,
+  multisample: {count: 4, mask: 0x4ba6a6a6},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, undefined, {format: 'r16uint'}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 11572, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x4', offset: 27376, shaderLocation: 9},
+          {format: 'float32x2', offset: 3580, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 7954, shaderLocation: 6},
+          {format: 'sint16x2', offset: 8056, shaderLocation: 1},
+          {format: 'uint32', offset: 6468, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 3756, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 4032, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 7048, shaderLocation: 16},
+          {format: 'uint32x2', offset: 14904, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 13724, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 4718, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 6428, attributes: []},
+      {
+        arrayStride: 6648,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 896, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 204, shaderLocation: 3},
+          {format: 'sint8x4', offset: 752, shaderLocation: 8},
+          {format: 'uint16x4', offset: 60, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 1720, shaderLocation: 5},
+          {format: 'float32', offset: 552, shaderLocation: 4},
+          {format: 'uint8x4', offset: 432, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'none', unclippedDepth: true},
+});
+try {
+pipelineLayout32.label = '\uc4a4\u{1f745}\u{1fdde}\u8497\u0fd6';
+} catch {}
+let videoFrame27 = new VideoFrame(offscreenCanvas31, {timestamp: 0});
+let videoFrame28 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let canvas37 = document.createElement('canvas');
+let gpuCanvasContext38 = canvas37.getContext('webgpu');
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+offscreenCanvas26.width = 690;
+video29.width = 213;
+let imageBitmap37 = await createImageBitmap(videoFrame24);
+canvas37.height = 779;
+gc();
+let canvas38 = document.createElement('canvas');
+let gpuCanvasContext39 = canvas38.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img38 = await imageWithData(106, 50, '#960044dd', '#aba132e1');
+let video33 = await videoWithData();
+let videoFrame29 = new VideoFrame(imageBitmap10, {timestamp: 0});
+let imageBitmap38 = await createImageBitmap(imageBitmap14);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas39 = document.createElement('canvas');
+let videoFrame30 = new VideoFrame(offscreenCanvas28, {timestamp: 0});
+let gpuCanvasContext40 = canvas39.getContext('webgpu');
+document.body.prepend(canvas3);
+let canvas40 = document.createElement('canvas');
+try {
+canvas40.getContext('2d');
+} catch {}
+let imageData32 = new ImageData(80, 108);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let imageData33 = new ImageData(200, 128);
+try {
+adapter5.label = '\u0245\u0c17\uc76a\u058e\u0619\udda9\udc13';
+} catch {}
+let imageBitmap39 = await createImageBitmap(canvas37);
+let imageData34 = new ImageData(100, 116);
+try {
+externalTexture43.label = '\u09e6\u0cce\ub11d';
+} catch {}
+let canvas41 = document.createElement('canvas');
+try {
+window.someLabel = textureView112.label;
+} catch {}
+let imageBitmap40 = await createImageBitmap(canvas34);
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+try {
+canvas41.getContext('bitmaprenderer');
+} catch {}
+let buffer57 = device3.createBuffer({label: '\u0009\u{1fb22}\u{1f873}', size: 363537, usage: GPUBufferUsage.STORAGE});
+let commandEncoder182 = device3.createCommandEncoder({label: '\u{1f860}\u28f4\uf246\ud487'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img25);
+let adapter9 = await promise42;
+let img39 = await imageWithData(85, 10, '#9bae5cb1', '#92f3000b');
+let videoFrame31 = new VideoFrame(videoFrame5, {timestamp: 0});
+let canvas42 = document.createElement('canvas');
+try {
+canvas42.getContext('webgl');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+document.body.prepend(canvas10);
+let imageBitmap41 = await createImageBitmap(canvas16);
+gc();
+let imageBitmap42 = await createImageBitmap(canvas16);
+try {
+window.someLabel = externalTexture83.label;
+} catch {}
+canvas36.width = 4817;
+let img40 = await imageWithData(245, 89, '#a29ac660', '#4bf34f71');
+let video34 = await videoWithData();
+document.body.prepend(canvas22);
+let img41 = await imageWithData(185, 213, '#e8fc2c22', '#9bd5cc52');
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+document.body.prepend(img20);
+gc();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+offscreenCanvas26.height = 281;
+gc();
+try {
+adapter9.label = '\u01a0\u6383\u7705';
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+try {
+window.someLabel = commandBuffer14.label;
+} catch {}
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(743, 381);
+let offscreenCanvas34 = new OffscreenCanvas(893, 158);
+let videoFrame32 = new VideoFrame(imageBitmap25, {timestamp: 0});
+document.body.prepend(video24);
+gc();
+let video35 = await videoWithData();
+canvas33.height = 941;
+let offscreenCanvas35 = new OffscreenCanvas(808, 343);
+try {
+offscreenCanvas34.getContext('bitmaprenderer');
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(608, 1022);
+let videoFrame33 = new VideoFrame(offscreenCanvas28, {timestamp: 0});
+offscreenCanvas33.height = 520;
+document.body.prepend(img33);
+try {
+sampler81.label = '\u6058\u2772\udb4c';
+} catch {}
+try {
+offscreenCanvas36.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let gpuCanvasContext41 = offscreenCanvas33.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let img42 = await imageWithData(206, 127, '#9862bdaa', '#65fe68bf');
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+let bindGroup64 = device3.createBindGroup({label: '\u0b99\u2e05\ua42e\u04da', layout: bindGroupLayout53, entries: []});
+let textureView232 = texture132.createView({
+  label: '\ua2db\u{1f776}\u02da\u{1ffe1}\u0103\u{1f9f5}\u9cb8\u{1feac}\u{1ffe0}\u{1fd5c}',
+  mipLevelCount: 1,
+});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+canvas42.height = 246;
+let bindGroupLayout54 = device2.createBindGroupLayout({
+  label: '\u87d0\u5d70\u006b\u40db\u0e60\ude0c\u0fe9\u62f2\u0e61',
+  entries: [
+    {
+      binding: 5010,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 7451,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder183 = device2.createCommandEncoder();
+let texture133 = device2.createTexture({
+  size: [710, 1, 1],
+  mipLevelCount: 9,
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView233 = texture110.createView({baseMipLevel: 6});
+try {
+renderBundleEncoder81.setPipeline(pipeline147);
+} catch {}
+try {
+commandEncoder148.clearBuffer(buffer54, 118708);
+dissociateBuffer(device2, buffer54);
+} catch {}
+try {
+commandEncoder156.resolveQuerySet(querySet68, 163, 94, buffer45, 512);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer44, 32380, new Float32Array(19339), 7985, 3412);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 30, y: 21 },
+  flipY: false,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline151 = device2.createComputePipeline({
+  label: '\u4c55\u0b7d\u00b5\u0a46\u3955',
+  layout: 'auto',
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let promise49 = adapter1.requestAdapterInfo();
+let video36 = await videoWithData();
+let gpuCanvasContext42 = offscreenCanvas35.getContext('webgpu');
+try {
+  await promise49;
+} catch {}
+let imageBitmap43 = await createImageBitmap(video5);
+let imageData35 = new ImageData(216, 172);
+let offscreenCanvas37 = new OffscreenCanvas(21, 395);
+try {
+offscreenCanvas37.getContext('webgl2');
+} catch {}
+let video37 = await videoWithData();
+try {
+window.someLabel = externalTexture83.label;
+} catch {}
+document.body.prepend(video33);
+let offscreenCanvas38 = new OffscreenCanvas(883, 525);
+let video38 = await videoWithData();
+let adapter10 = await promise29;
+let videoFrame34 = new VideoFrame(videoFrame2, {timestamp: 0});
+let offscreenCanvas39 = new OffscreenCanvas(444, 89);
+let img43 = await imageWithData(284, 131, '#8ec9853d', '#0c9f4b70');
+let gpuCanvasContext43 = offscreenCanvas38.getContext('webgpu');
+let imageBitmap44 = await createImageBitmap(imageBitmap40);
+try {
+  await adapter9.requestAdapterInfo();
+} catch {}
+try {
+externalTexture40.label = '\u0a57\u{1f762}';
+} catch {}
+let imageData36 = new ImageData(156, 240);
+document.body.prepend(img18);
+let gpuCanvasContext44 = offscreenCanvas39.getContext('webgpu');
+let imageBitmap45 = await createImageBitmap(video31);
+let videoFrame35 = new VideoFrame(canvas5, {timestamp: 0});
+let img44 = await imageWithData(88, 242, '#61e27148', '#08f9a676');
+let video39 = await videoWithData();
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+video24.width = 80;
+let canvas43 = document.createElement('canvas');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+canvas43.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img42);
+offscreenCanvas6.height = 1141;
+let img45 = await imageWithData(22, 279, '#75825ffc', '#1939e927');
+video26.height = 21;
+let video40 = await videoWithData();
+let img46 = await imageWithData(215, 85, '#73774462', '#69c454a7');
+let shaderModule22 = device3.createShaderModule({
+  label: '\u{1fbd4}\u0450\u{1fd66}\u{1fc88}\u{1ff42}\u6ad0',
+  code: `@group(3) @binding(5095)
+var<storage, read_write> parameter17: array<u32>;
+@group(0) @binding(6110)
+var<storage, read_write> global13: array<u32>;
+@group(5) @binding(5095)
+var<storage, read_write> parameter18: array<u32>;
+@group(2) @binding(6110)
+var<storage, read_write> type6: array<u32>;
+@group(3) @binding(871)
+var<storage, read_write> parameter19: array<u32>;
+@group(1) @binding(6110)
+var<storage, read_write> type7: array<u32>;
+@group(4) @binding(1461)
+var<storage, read_write> type8: array<u32>;
+@group(2) @binding(1461)
+var<storage, read_write> n10: array<u32>;
+@group(3) @binding(3476)
+var<storage, read_write> field11: array<u32>;
+@group(4) @binding(6110)
+var<storage, read_write> local14: array<u32>;
+@group(0) @binding(1461)
+var<storage, read_write> global14: array<u32>;
+@group(5) @binding(3476)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(8, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(1) f1: vec3<u32>,
+  @location(0) f2: vec4<i32>,
+  @location(2) f3: vec3<f32>,
+  @location(3) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S26 {
+  @location(4) f0: vec3<f32>,
+  @location(5) f1: vec3<f16>,
+  @location(23) f2: vec2<u32>,
+  @builtin(vertex_index) f3: u32,
+  @location(19) f4: vec3<i32>,
+  @location(14) f5: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec3<f32>, @location(21) a1: vec4<u32>, @builtin(instance_index) a2: u32, @location(18) a3: vec4<u32>, @location(2) a4: vec3<u32>, @location(7) a5: u32, @location(20) a6: u32, @location(6) a7: vec4<f32>, a8: S26, @location(10) a9: vec3<i32>, @location(12) a10: vec4<u32>, @location(1) a11: vec3<f16>, @location(17) a12: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup65 = device3.createBindGroup({label: '\uc91b\u3b85\ud7dd\u12eb\u{1fd5b}', layout: bindGroupLayout53, entries: []});
+let textureView234 = texture132.createView({label: '\u00ae\u5b07\u2b48\u649b\u7797'});
+let externalTexture85 = device3.importExternalTexture({label: '\u02ff\u64cb\ua651\u9b61\u272f', source: videoFrame33, colorSpace: 'srgb'});
+let imageBitmap46 = await createImageBitmap(videoFrame27);
+let img47 = await imageWithData(9, 109, '#1c1a84b8', '#c33688cf');
+let video41 = await videoWithData();
+gc();
+gc();
+let canvas44 = document.createElement('canvas');
+let offscreenCanvas40 = new OffscreenCanvas(379, 641);
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+offscreenCanvas10.height = 1133;
+let videoFrame36 = new VideoFrame(img0, {timestamp: 0});
+document.body.prepend(img42);
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext45 = offscreenCanvas40.getContext('webgpu');
+let promise50 = adapter3.requestAdapterInfo();
+canvas23.width = 877;
+try {
+  await promise50;
+} catch {}
+canvas29.width = 2447;
+let offscreenCanvas41 = new OffscreenCanvas(254, 919);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroup66 = device4.createBindGroup({layout: bindGroupLayout49, entries: [{binding: 2496, resource: sampler93}]});
+let buffer58 = device4.createBuffer({
+  label: '\u05bf\u8185\u9dca\u05e3\u7f88\u{1f735}\u{1fc01}\uca01',
+  size: 249184,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder184 = device4.createCommandEncoder({label: '\u5c72\u{1fd57}\u3110'});
+let textureView235 = texture118.createView({label: '\u0f89\u{1f790}\ufc35\u8f25\u0ac8\u708b\u{1fa71}', baseMipLevel: 4});
+let computePassEncoder106 = commandEncoder184.beginComputePass({label: '\u{1fe98}\u02f7\uede4\u0ec6\u{1f927}\u{1fcf7}\u{1f7a0}'});
+let sampler104 = device4.createSampler({minFilter: 'nearest', lodMinClamp: 64.84, lodMaxClamp: 67.82});
+let externalTexture86 = device4.importExternalTexture({label: '\u{1f8fc}\u27a3\u5b65\u{1fb12}', source: videoFrame34, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder77.setBindGroup(6, bindGroup66);
+} catch {}
+try {
+device4.pushErrorScope('internal');
+} catch {}
+let imageData37 = new ImageData(108, 36);
+try {
+offscreenCanvas41.getContext('webgl2');
+} catch {}
+let imageData38 = new ImageData(240, 144);
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+let gpuCanvasContext46 = canvas44.getContext('webgpu');
+gc();
+document.body.prepend(canvas25);
+let img48 = await imageWithData(249, 295, '#e0e22be1', '#71ad4859');
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+document.body.prepend(video30);
+gc();
+let imageBitmap47 = await createImageBitmap(img16);
+try {
+adapter5.label = '\u{1fbca}\u4df9';
+} catch {}
+document.body.prepend(video24);
+let videoFrame37 = new VideoFrame(imageBitmap37, {timestamp: 0});
+let buffer59 = device0.createBuffer({
+  label: '\u{1f6fd}\u{1f864}\uc872\ucf8f',
+  size: 205985,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer43 = commandEncoder126.finish({label: '\ufe5c\u04e9\u9704'});
+let texture134 = device0.createTexture({
+  label: '\uafa4\u0fb3\u6574\u0554\u{1f9d9}\u225a\u05b9\u965c\ufcf6',
+  size: [120],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let externalTexture87 = device0.importExternalTexture({label: '\ufe83\u8470\u84d8\u0fa4\u035b\u442a\u5457\u2f1a\ue2f8', source: video10});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder18.setViewport(96.90, 5.761, 12.78, 0.2997, 0.7572, 0.8314);
+} catch {}
+try {
+renderBundleEncoder30.draw(855177016);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer5, 1128);
+} catch {}
+try {
+commandEncoder127.copyTextureToBuffer({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 33, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3384 widthInBlocks: 423 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24496 */
+  offset: 24496,
+  buffer: buffer19,
+}, {width: 423, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer37, 34332, 14412);
+dissociateBuffer(device0, buffer37);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 225, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas30,
+  origin: { x: 137, y: 1 },
+  flipY: true,
+}, {
+  texture: texture56,
+  mipLevel: 2,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 61, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter({});
+let imageBitmap48 = await createImageBitmap(canvas21);
+let imageBitmap49 = await createImageBitmap(img6);
+document.body.prepend(video13);
+try {
+videoFrame21.close();
+} catch {}
+canvas23.width = 617;
+let video42 = await videoWithData();
+let commandEncoder185 = device4.createCommandEncoder({});
+try {
+commandEncoder185.resolveQuerySet(querySet77, 288, 579, buffer49, 12288);
+} catch {}
+offscreenCanvas24.width = 1429;
+let videoFrame38 = new VideoFrame(imageBitmap38, {timestamp: 0});
+gc();
+canvas7.width = 2284;
+let video43 = await videoWithData();
+let imageData39 = new ImageData(116, 152);
+try {
+adapter5.label = '\ub3d2\u7eb5\uc635\u9565\ua381\u8a50';
+} catch {}
+try {
+gpuCanvasContext41.unconfigure();
+} catch {}
+let promise51 = navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let offscreenCanvas42 = new OffscreenCanvas(732, 238);
+document.body.prepend(video20);
+let videoFrame39 = new VideoFrame(videoFrame32, {timestamp: 0});
+document.body.prepend(img21);
+let gpuCanvasContext47 = offscreenCanvas42.getContext('webgpu');
+document.body.prepend(video28);
+canvas22.width = 472;
+let imageBitmap50 = await createImageBitmap(imageBitmap40);
+video32.height = 150;
+let img49 = await imageWithData(33, 50, '#9919bb68', '#79e6bdcb');
+let offscreenCanvas43 = new OffscreenCanvas(617, 877);
+let video44 = await videoWithData();
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let imageBitmap51 = await createImageBitmap(imageBitmap37);
+let offscreenCanvas44 = new OffscreenCanvas(542, 400);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext48 = offscreenCanvas43.getContext('webgpu');
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+let imageData40 = new ImageData(44, 232);
+let videoFrame40 = new VideoFrame(img8, {timestamp: 0});
+let canvas45 = document.createElement('canvas');
+try {
+pipeline115.label = '\ue625\u62ad\u0484';
+} catch {}
+gc();
+let gpuCanvasContext49 = offscreenCanvas44.getContext('webgpu');
+let texture135 = device2.createTexture({
+  label: '\u064d\u{1f7fe}\u06ba\u{1f854}\u0afb\u23a3\u000f\uf70e',
+  size: {width: 1420},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+try {
+commandEncoder159.copyBufferToBuffer(buffer40, 38576, buffer44, 104572, 76436);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let video45 = await videoWithData();
+let videoFrame41 = new VideoFrame(img47, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(781, 134);
+try {
+texture121.label = '\u08f4\u20d0\u0435';
+} catch {}
+let pipelineLayout33 = device2.createPipelineLayout({label: '\u070b\u1456\u3cd9\u35eb', bindGroupLayouts: [bindGroupLayout51, bindGroupLayout41]});
+let commandEncoder186 = device2.createCommandEncoder({label: '\u355f\u1a95\u943b\ua586\u{1f656}\u8028'});
+let texture136 = device2.createTexture({
+  label: '\u{1fc27}\u{1fbec}\u{1f721}\u08c8',
+  size: {width: 1420, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let textureView236 = texture125.createView({label: '\u47f8\u851c\u{1fdbb}\ua5fe\ud222\u070a\u651f\u0e17\u01fa', baseMipLevel: 2, mipLevelCount: 3});
+let computePassEncoder107 = commandEncoder173.beginComputePass({label: '\u{1f7de}\u{1fcf9}'});
+let renderBundle113 = renderBundleEncoder70.finish({label: '\u9452\u{1fb86}\u05ce\u0141'});
+let externalTexture88 = device2.importExternalTexture({
+  label: '\u{1f75d}\u{1f691}\u{1f6db}\u0f1e\u63bb\u1585\u{1fad1}\u0ae1\uc524\u0e54',
+  source: video34,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder82.setVertexBuffer(0, buffer52);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer52);
+dissociateBuffer(device2, buffer52);
+} catch {}
+let canvas46 = document.createElement('canvas');
+let offscreenCanvas46 = new OffscreenCanvas(831, 270);
+let gpuCanvasContext50 = offscreenCanvas46.getContext('webgpu');
+document.body.prepend(img42);
+offscreenCanvas2.height = 1207;
+document.body.prepend(canvas10);
+let img50 = await imageWithData(98, 73, '#cfa58255', '#ac265bde');
+let imageBitmap52 = await createImageBitmap(imageBitmap24);
+offscreenCanvas11.width = 1580;
+let adapter12 = await navigator.gpu.requestAdapter({});
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let promise52 = adapter12.requestAdapterInfo();
+let renderBundleEncoder87 = device1.createRenderBundleEncoder({
+  label: '\ufa1a\u2649\u8b86\u6380\ua4b5\uab00\u87d4\u0869\uaa83\u{1f95e}',
+  colorFormats: ['rgba8unorm'],
+  sampleCount: 4,
+});
+let sampler105 = device1.createSampler({
+  label: '\uefdb\u8f3a',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.74,
+  lodMaxClamp: 78.73,
+  compare: 'greater',
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder56.setBindGroup(1, bindGroup22);
+} catch {}
+let arrayBuffer14 = buffer31.getMappedRange(384, 11384);
+try {
+  await buffer38.mapAsync(GPUMapMode.READ, 560536, 16972);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 50592 */
+  offset: 50592,
+  buffer: buffer30,
+}, {width: 28, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder102.clearBuffer(buffer25);
+dissociateBuffer(device1, buffer25);
+} catch {}
+let gpuCanvasContext51 = canvas45.getContext('webgpu');
+let canvas47 = document.createElement('canvas');
+try {
+canvas46.getContext('2d');
+} catch {}
+video10.width = 174;
+let imageBitmap53 = await createImageBitmap(offscreenCanvas40);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise52;
+} catch {}
+let img51 = await imageWithData(161, 209, '#0a90e12d', '#b75ca6d5');
+let gpuCanvasContext52 = offscreenCanvas45.getContext('webgpu');
+let img52 = await imageWithData(112, 190, '#5a022dbc', '#d1d27e56');
+let bindGroup67 = device4.createBindGroup({
+  label: '\u0384\u0f4e\u00ad\u6ac3\ucd86\ubddf\u476b\u3b9b\u6410',
+  layout: bindGroupLayout48,
+  entries: [],
+});
+let commandBuffer44 = commandEncoder185.finish({label: '\uf2a1\u64b9\uca5a\uc166\u32b9'});
+let texture137 = device4.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+try {
+renderBundleEncoder77.setPipeline(pipeline140);
+} catch {}
+canvas36.width = 116;
+let offscreenCanvas47 = new OffscreenCanvas(753, 76);
+offscreenCanvas21.height = 1399;
+let imageData41 = new ImageData(228, 192);
+let offscreenCanvas48 = new OffscreenCanvas(262, 1009);
+let imageData42 = new ImageData(236, 72);
+document.body.prepend(img10);
+try {
+offscreenCanvas48.getContext('2d');
+} catch {}
+let gpuCanvasContext53 = offscreenCanvas47.getContext('webgpu');
+document.body.prepend(canvas37);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+canvas37.height = 417;
+let offscreenCanvas49 = new OffscreenCanvas(275, 833);
+let offscreenCanvas50 = new OffscreenCanvas(139, 908);
+try {
+offscreenCanvas49.getContext('webgl');
+} catch {}
+let querySet85 = device2.createQuerySet({label: '\u097c\u9173', type: 'occlusion', count: 0});
+let texture138 = device2.createTexture({
+  label: '\u6303\u304e\u6052\u{1f789}\ue881\u{1f71a}\u43b6\u01aa\u0b5b\u6586',
+  size: {width: 5680},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView237 = texture131.createView({label: '\ud09c\u{1fa41}\ufe69\u07f9\u8589\u55c8', baseArrayLayer: 318, arrayLayerCount: 251});
+try {
+computePassEncoder107.setBindGroup(4, bindGroup54, new Uint32Array(5098), 2738, 0);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(4, bindGroup54, new Uint32Array(1493), 1437, 0);
+} catch {}
+try {
+commandEncoder144.copyTextureToBuffer({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 327, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 24098 */
+  offset: 24098,
+  buffer: buffer41,
+}, {width: 30, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 2919, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder169.clearBuffer(buffer45, 4808, 12828);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+commandEncoder164.resolveQuerySet(querySet67, 431, 1021, buffer50, 148480);
+} catch {}
+let promise53 = device2.queue.onSubmittedWorkDone();
+let pipeline152 = await device2.createComputePipelineAsync({
+  label: '\ufdcb\u300a\u{1fd69}',
+  layout: pipelineLayout29,
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise53;
+} catch {}
+let canvas48 = document.createElement('canvas');
+let buffer60 = device2.createBuffer({
+  label: '\ufd39\u04ba\u0645\ub3bf',
+  size: 79132,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture139 = device2.createTexture({
+  size: {width: 710, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView238 = texture105.createView({dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 1});
+try {
+computePassEncoder84.setPipeline(pipeline130);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 25592 */
+{offset: 778, bytesPerRow: 1306, rowsPerImage: 19}, {width: 69, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let canvas49 = document.createElement('canvas');
+try {
+adapter8.label = '\uc6b5\u0da2\u{1faca}\u0499\ub79f\ub7c8\u0171\u{1facc}\ude31\uec6d';
+} catch {}
+try {
+canvas49.getContext('webgpu');
+} catch {}
+gc();
+gc();
+let canvas50 = document.createElement('canvas');
+try {
+gpuCanvasContext49.unconfigure();
+} catch {}
+try {
+canvas48.getContext('2d');
+} catch {}
+try {
+canvas50.getContext('webgpu');
+} catch {}
+let video46 = await videoWithData();
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -100,7 +100,7 @@ public:
     void setVertexBuffer(uint32_t slot, const Buffer*, uint64_t offset, uint64_t size);
     void setLabel(String&&);
 
-    bool isValid() const { return m_indirectCommandBuffer; }
+    bool isValid() const;
     void replayCommands(RenderPassEncoder&);
 
     static constexpr auto startIndexForFragmentDynamicOffsets = 3;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -639,7 +639,8 @@ void RenderBundleEncoder::endCurrentICB()
     RELEASE_ASSERT(!commandCount || !!m_icbDescriptor.commandTypes);
 
     m_icbDescriptor.maxVertexBufferBindCount = m_device->maxBuffersPlusVertexBuffersForVertexStage() + 1;
-    m_vertexBuffers.grow(m_icbDescriptor.maxVertexBufferBindCount);
+    if (m_vertexBuffers.size() < m_icbDescriptor.maxVertexBufferBindCount)
+        m_vertexBuffers.grow(m_icbDescriptor.maxVertexBufferBindCount);
     if (m_fragmentBuffers.size() < m_icbDescriptor.maxFragmentBufferBindCount)
         m_fragmentBuffers.grow(m_icbDescriptor.maxFragmentBufferBindCount);
     if (m_vertexDynamicOffset && !m_dynamicOffsetsVertexBuffer) {
@@ -730,9 +731,14 @@ Ref<RenderBundle> RenderBundleEncoder::finish(const WGPURenderBundleDescriptor& 
     return renderBundle;
 }
 
+bool RenderBundleEncoder::isValid() const
+{
+    return !!m_icbDescriptor;
+}
+
 void RenderBundleEncoder::replayCommands(RenderPassEncoder& renderPassEncoder)
 {
-    if (!renderPassEncoder.renderCommandEncoder())
+    if (!renderPassEncoder.renderCommandEncoder() || !isValid())
         return;
 
     m_renderPassEncoder = &renderPassEncoder;


### PR DESCRIPTION
#### 21e320d6fce2f9d38872472d1cfb2eddc9acd67d
<pre>
[WebGPU] RenderBundleEncoder::endCurrentICB may assert in ASAN builds on invalid bundle encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=274271">https://bugs.webkit.org/show_bug.cgi?id=274271</a>
&lt;radar://128064942&gt;

Reviewed by Dan Glastonbury.

There is an ASAN assert in Vector::grow(sz) to ensure sz &gt;= the current size,
which will not be true when replaying commands from an invalid RenderBundleEncoder.

But we shouldn&apos;t replay commands from an invalid RenderBundleEncoder in the first place,
so return early if the encoder is invalid.

* LayoutTests/fast/webgpu/fuzz-274271-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274271.html: Added.
* LayoutTests/TestExpectations:
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
(WebGPU::RenderBundleEncoder::isValid const): Deleted.
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::isValid const):
(WebGPU::RenderBundleEncoder::replayCommands):

Canonical link: <a href="https://commits.webkit.org/278997@main">https://commits.webkit.org/278997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0abeda47757be222096b2780fe2556392c94b1d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42478 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/1868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23548 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52037 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26424 "4 new passes 7 flakes") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2320 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1075 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45542 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57063 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51701 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2521 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49108 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29464 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64008 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7638 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28296 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12119 "Passed tests") | 
<!--EWS-Status-Bubble-End-->