### PR TITLE
Fix flakey splitText-crash-during-tear-down-renderers-after-slot-change.

### DIFF
--- a/LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change-expected.txt
+++ b/LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change-expected.txt
@@ -1,0 +1,3 @@
+
+This test passes if it does not crash.
+

--- a/LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change.html
+++ b/LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change.html
@@ -12,7 +12,6 @@
     if (window.testRunner)
         testRunner.dumpAsText();
     function f0() {
-        try { x44.outerHTML = "This test passes if it does not crash."; } catch { }
         try { x47.select(); } catch { }
         try { window.onanimationstart = f4; } catch { }
     }
@@ -32,9 +31,8 @@
 </textarea>
 <embed class="class1" part="part1">
 </object>
-<details open="" tabindex="-1">
-    <summary id="x44" itemgroup="AA">
-    </summary>
+<details open>
+    <summary itemgroup="AA" id="summary">This test passes if it does not crash.</summary>
     <dd dir="rtl" class="class0" onclick="f0()">
         <li id="x19" accesskey="A">
         </li>

--- a/LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change.html
+++ b/LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change.html
@@ -1,0 +1,42 @@
+<style>
+    .class1,
+    .class0:dir(rtl),
+    span {
+        scroll;
+        -webkit-animation: keyframes2, keyframes4
+    }
+
+    @keyframes keyframes4 {}
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function f0() {
+        try { x44.outerHTML = "This test passes if it does not crash."; } catch { }
+        try { x47.select(); } catch { }
+        try { window.onanimationstart = f4; } catch { }
+    }
+    function f4() {
+        try { x19.addEventListener("DOMSubtreeModified", f0); } catch { }
+        try { v12 = window.document; } catch { }
+        try { window.find("a"); } catch { }
+        try { x19.type = "a"; } catch { }
+        try { v55 = window.top; } catch { }
+        try { document.designMode = "on"; } catch { }
+        try { v55.find("This test passes if it does not crash"); } catch { }
+        try { v12.execCommand("subscript", false, null); } catch { }
+        try { x47.selectionEnd = 4; } catch { }
+    }
+</script>
+<textarea id="x47" onfocus="f0()" autofocus="" class="class3">
+</textarea>
+<embed class="class1" part="part1">
+</object>
+<details open="" tabindex="-1">
+    <summary id="x44" itemgroup="AA">
+    </summary>
+    <dd dir="rtl" class="class0" onclick="f0()">
+        <li id="x19" accesskey="A">
+        </li>
+    </dd>
+</details>

--- a/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
@@ -52,15 +52,17 @@ void SplitTextNodeContainingElementCommand::doApply()
     if (!parent || !parent->parentElement() || !parent->parentElement()->hasEditableStyle())
         return;
 
+    bool parentRendererIsNoneOrNotInline = false;
     {
         CheckedPtr parentRenderer = parent->renderer();
-        if (!parentRenderer || !parentRenderer->isInline()) {
-            wrapContentsInDummySpan(*parent);
-            RefPtr firstChild = dynamicDowncast<Element>(parent->firstChild());
-            if (!firstChild)
-                return;
-            parent = WTFMove(firstChild);
-        }
+        parentRendererIsNoneOrNotInline = !parentRenderer || !parentRenderer->isInline();
+    }
+    if (parentRendererIsNoneOrNotInline) {
+        wrapContentsInDummySpan(*parent);
+        RefPtr firstChild = parent->firstChild();
+        if (!is<Element>(firstChild))
+            return;
+        parent = downcast<Element>(WTFMove(firstChild));
     }
 
     splitElement(*parent, m_text);


### PR DESCRIPTION
#### 83a9a0ad6917ef3d6002b5123cc42d7dd847a9b6
<pre>
Fix flakey splitText-crash-during-tear-down-renderers-after-slot-change.
<a href="https://rdar.apple.com/125264773">rdar://125264773</a>

Reviewed by Jonathan Bedard.

Fix text difference on some release builds.

* LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change.html:

Originally-landed-as: 272448.780@safari-7618-branch (c57347c1c44f). <a href="https://rdar.apple.com/128088552">rdar://128088552</a>
Canonical link: <a href="https://commits.webkit.org/278898@main">https://commits.webkit.org/278898@main</a>
</pre>
----------------------------------------------------------------------
#### fd2cfc0030266cf4914ed09116b2fbd745662985
<pre>
ASAN_TRAP | WebCore::RenderObject::~RenderObject; WebCore::RenderInline::~RenderInline.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269667">https://bugs.webkit.org/show_bug.cgi?id=269667</a>
<a href="https://rdar.apple.com/122491721">rdar://122491721</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

Reduce the scope of CheckedPtr renderer in `SplitTextNodeContainingElementCommand::doApply`,
as following `splitElement` could destruct renderer.

* LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change-expected.txt: Added.
* LayoutTests/fast/text/splitText-crash-during-tear-down-renderers-after-slot-change.html: Added.
* Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp:
(WebCore::SplitTextNodeContainingElementCommand::doApply):

Originally-landed-as: 272448.580@safari-7618-branch (3dc4ac46465e). <a href="https://rdar.apple.com/128215842">rdar://128215842</a>
Canonical link: <a href="https://commits.webkit.org/278897@main">https://commits.webkit.org/278897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad485690f0593abd03e8052f59ac9f744ce83d67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42160 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23290 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1959 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49567 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44795 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48822 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29076 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7582 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->