### PR TITLE
Use DataRef for SVGPathByteStream::Data

### DIFF
--- a/Source/WebCore/svg/SVGPathSegList.h
+++ b/Source/WebCore/svg/SVGPathSegList.h
@@ -124,10 +124,16 @@ public:
         return { };
     }
 
-    void updateByteStreamData(const SVGPathByteStream::Data& byteStreamData)
+    void updateByteStreamData(DataRef<SVGPathByteStream::Data>&& byteStreamData)
     {
         pathByteStreamWillChange();
-        m_pathByteStream.setData(byteStreamData);
+        m_pathByteStream.setData(WTFMove(byteStreamData));
+    }
+
+    void clearByteStreamData()
+    {
+        pathByteStreamWillChange();
+        m_pathByteStream.clear();
     }
 
     const SVGPathByteStream& existingPathByteStream() const { return m_pathByteStream; }

--- a/Source/WebCore/svg/SVGPathUtilities.cpp
+++ b/Source/WebCore/svg/SVGPathUtilities.cpp
@@ -96,10 +96,14 @@ Path buildPathFromByteStream(const SVGPathByteStream& stream)
     if (stream.isEmpty())
         return { };
 
+    if (auto path = stream.cachedPath())
+        return path.value();
+
     Path path;
     SVGPathBuilder builder(path);
     SVGPathByteStreamSource source(stream);
     SVGPathParser::parse(source, builder);
+    stream.cachePath(path);
     return path;
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2967,7 +2967,7 @@ struct WebCore::LengthSize {
 }
 
 class WebCore::SVGPathByteStream {
-    Vector<unsigned char> data();
+    Vector<unsigned char> bytes();
 }
 
 header: <WebCore/BasicShapes.h>


### PR DESCRIPTION
#### b64d047f66814f52658e363698db26d29314164a
<pre>
Use DataRef for SVGPathByteStream::Data
<a href="https://bugs.webkit.org/show_bug.cgi?id=274276">https://bugs.webkit.org/show_bug.cgi?id=274276</a>
<a href="https://rdar.apple.com/128219580">rdar://128219580</a>

Reviewed by Matthieu Dubet.

We found that our SVG path caching is not enough. We only cache byte stream of SVG path.
But it turned out that creation of Path from that byte stream is super costly. blink is caching this final result,
and we should do the similar thing.

In this patch, we took sophisticated approach: making SVGPathByteStream::Data DataRef, and adding cached Path too inside it.
Then, we can share created Path, and we do not need to create this until we need it. And if we modify stream, then it clones and clears Path.

We extend DataRef to make it usable for HashMap&apos;s value. So now SVGPathElement&apos;s cache is holding DataRef&lt;&gt; instead of a raw Vector.

* Source/WTF/wtf/DataRef.h:
(WTF::DataRef::DataRef):
(WTF::DataRef::isHashTableDeletedValue const):
(WTF::DataRef::isHashTableEmptyValue const):
(WTF::DataRef::hashTableEmptyValue):
(WTF::HashTraits&lt;DataRef&lt;T&gt;&gt;::emptyValue):
(WTF::HashTraits&lt;DataRef&lt;T&gt;&gt;::constructEmptyValue):
(WTF::HashTraits&lt;DataRef&lt;T&gt;&gt;::isEmptyValue):
* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::SVGPathByteStream):
(WebCore::SVGPathByteStream::operator==):
(WebCore::SVGPathByteStream::begin const):
(WebCore::SVGPathByteStream::end const):
(WebCore::SVGPathByteStream::append):
(WebCore::SVGPathByteStream::clear):
(WebCore::SVGPathByteStream::isEmpty const):
(WebCore::SVGPathByteStream::size const):
(WebCore::SVGPathByteStream::shrinkToFit):
(WebCore::SVGPathByteStream::cachedPath const):
(WebCore::SVGPathByteStream::cachePath const):
(WebCore::SVGPathByteStream::bytes const):
(WebCore::SVGPathByteStream::data const):
(WebCore::SVGPathByteStream::setData):
(WebCore::SVGPathByteStream::operator=): Deleted.
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::PathSegListCache::get const):
(WebCore::PathSegListCache::add):
(WebCore::SVGPathElement::attributeChanged):
* Source/WebCore/svg/SVGPathSegList.h:
* Source/WebCore/svg/SVGPathUtilities.cpp:
(WebCore::buildPathFromByteStream):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/278907@main">https://commits.webkit.org/278907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0fd383eb4c033e361ae62754f620dfc50f27fc6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55170 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26102 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2041 "Found 60 new test failures: editing/execCommand/primitive-value-cleanup-minimal.html, editing/execCommand/primitive-value.html, editing/execCommand/print.html, editing/execCommand/query-command-state.html, editing/execCommand/query-command-value-background-color.html, editing/execCommand/query-font-size-with-typing-style.html, editing/execCommand/query-font-size.html, editing/execCommand/query-format-block.html, editing/execCommand/query-text-alignment.html, editing/execCommand/query-text-decoration-with-typing-style.html ... (failure)") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45244 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48055 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51408 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49621 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48876 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29157 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63727 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7586 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27997 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12021 "Passed tests") | 
<!--EWS-Status-Bubble-End-->