### PR TITLE
JSStringGetUTF8CString writes beyond the provided buffer size

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -106,6 +106,16 @@ size_t JSStringGetUTF8CString(JSStringRef string, char* buffer, size_t bufferSiz
         result = WTF::Unicode::convert(string->span16(), target);
     if (result.code == WTF::Unicode::ConversionResultCode::SourceInvalid)
         return 0;
+    char* destination = buffer;
+    bool failed = false;
+    if (string->is8Bit()) {
+        const LChar* source = string->characters8();
+        failed = !convertLatin1ToUTF8(&source, source + string->length(), &destination, destination + bufferSize - 1);
+    } else {
+        const UChar* source = string->characters16();
+        auto result = convertUTF16ToUTF8(&source, source + string->length(), &destination, destination + bufferSize - 1);
+        failed = result != ConversionResult::Success;
+    }
 
     buffer[result.buffer.size()] = '\0';
     return result.buffer.size() + 1;


### PR DESCRIPTION
#### 44cd5f35005e1c2a60d54346c29544007fa7ed29
<pre>
JSStringGetUTF8CString writes beyond the provided buffer size
<a href="https://rdar.apple.com/122388595">rdar://122388595</a>

Reviewed by Yusuke Suzuki.

U8_APPEND only checks the capacity in the non-ascii case,
so we should make sure we always check.

* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convertLatin1ToUTF8):
(WTF::Unicode::convertUTF16ToUTF8):
* Source/WebCore/dom/TextEncoder.cpp:
(WebCore::TextEncoder::encodeInto):

Originally-landed-as: 272448.625@safari-7618-branch (800c12a28dea). rdar://128091153
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44cd5f35005e1c2a60d54346c29544007fa7ed29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51831 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31143 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4195 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55099 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2523 "Hash 44cd5f35 for PR 28674 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37515 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2231 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/55099 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53930 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/37515 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/4195 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/55099 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/37515 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/4195 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45173 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/37515 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/4195 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56690 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51337 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26952 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/2231 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/56690 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28189 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/4195 "Hash 44cd5f35 for PR 28674 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/56690 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29086 "Hash 44cd5f35 for PR 28674 does not build (failure)") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63656 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27926 "Hash 44cd5f35 for PR 28674 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/63656 "Hash 44cd5f35 for PR 28674 does not build (failure)") | 
<!--EWS-Status-Bubble-End-->