### PR TITLE
Sync `form-submission-0` tests from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/FormDataEvent.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/FormDataEvent.window.js
@@ -2,6 +2,7 @@
 
 test(() => {
   let fd = new FormData();
+  assert_throws_js(TypeError, () => { FormDataEvent('', {formData:fd}) }, "Calling FormDataEvent constructor without 'new' must throw");
   assert_throws_js(TypeError, () => { new FormDataEvent() }, '0 arguments');
   assert_throws_js(TypeError, () => { new FormDataEvent('foo') }, '1 argument');
   assert_throws_js(TypeError, () => { new FormDataEvent(fd, fd) }, '2 invalid arguments');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set-expected.txt
@@ -8,6 +8,7 @@
 
 
 
+
   close  button  reset  submit
 
 PASS FormData constructor always produces UTF-8 _charset_ value.
@@ -22,4 +23,5 @@ PASS "formData" IDL attribute should have entries for form-associated elements i
 PASS Entries added to "formData" IDL attribute should be submitted.
 PASS Entries added to the "formdata" IDL attribute shouldn't be newline normalized in the resulting FormData
 PASS The constructed FormData object should not contain an entry for the submit button that was used to submit the form.
+FAIL The constructed FormData object should not contain an entry for the image submit button that was used to submit the form. assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set.html
@@ -158,4 +158,19 @@ test(() => {
   assert_equals(formDataInEvent.get('n1'), 'v1');
   assert_false(formDataInEvent.has('n2'));
 }, 'The constructed FormData object should not contain an entry for the submit button that was used to submit the form.');
+
+test(() => {
+  let form = populateForm('<input name=n1 value=v1><input type=image name=n2>');
+  let formDataInEvent = null;
+  let submitter = form.querySelector('input[type=image]');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    formDataInEvent = new FormData(e.target);
+  });
+
+  submitter.click();
+  assert_equals(formDataInEvent.get('n1'), 'v1');
+  assert_false(formDataInEvent.has('n2.x'));
+  assert_false(formDataInEvent.has('n2.y'));
+}, 'The constructed FormData object should not contain an entry for the image submit button that was used to submit the form.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action-expected.txt
@@ -1,0 +1,14 @@
+
+
+
+
+submit
+
+
+
+PASS default submit action should supersede input onclick submit()
+PASS default submit action should supersede button onclick submit()
+PASS default submit action should supersede form onclick submit()
+PASS default submit action should supersede form onsubmit submit()
+PASS default submit action should supersede form onclick/onsubmit submit()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/targetted-form.js"></script>
+<!--
+  The submit() in event handler should get superseded by the default action
+  submit(), which isn't preventDefaulted. This is per the Form Submission
+  Algorithm [1], step 24, which says that new planned navigations replace old
+  planned navigations.
+  [1] https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm
+-->
+<body>
+<script>
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  submitter.addEventListener('click', () => {
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v4");
+}, 'default submit action should supersede input onclick submit()');
+
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><button>submit</button>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("button");
+  submitter.addEventListener('click', (e) => {
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v4");
+}, 'default submit action should supersede button onclick submit()');
+
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  form.addEventListener('click', () => {
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v4");
+}, 'default submit action should supersede form onclick submit()');
+
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  form.addEventListener('submit', () => {
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v4");
+}, 'default submit action should supersede form onsubmit submit()');
+
+promise_test(async (t) => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  form.addEventListener('click', () => {
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  form.addEventListener('submit', () => {
+    input.value = 'v5';
+    form.submit();
+    input.value = 'v6';
+    form.submit();
+    input.value = 'v7';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v7");
+}, 'default submit action should supersede form onclick/onsubmit submit()');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click-expected.txt
@@ -1,0 +1,10 @@
+
+
+submit
+
+
+
+PASS PreventDefaulting input onclick should allow submit() to succeed
+PASS PreventDefaulting button onclick should allow submit() to succeed
+PASS PreventDefaulting form onclick should allow submit() to succeed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/targetted-form.js"></script>
+<!--
+  The submit() in event handler should *not* get superseded in this case by the
+  default action submit(), because event handler here calls preventDefault().
+-->
+<body>
+<script>
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  submitter.addEventListener('click', (e) => {
+    e.preventDefault();
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v3");
+}, 'PreventDefaulting input onclick should allow submit() to succeed');
+
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><button>submit</button>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("button");
+  submitter.addEventListener('click', (e) => {
+    e.preventDefault();
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v3");
+}, 'PreventDefaulting button onclick should allow submit() to succeed');
+
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  form.addEventListener('click', (e) => {
+    e.preventDefault();
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v3");
+}, 'PreventDefaulting form onclick should allow submit() to succeed');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt
@@ -1,0 +1,7 @@
+
+
+
+
+FAIL PreventDefaulting form onsubmit should allow submit() to succeed assert_equals: expected "v6" but got "v7"
+FAIL PreventDefaulting form onsubmit should allow submit() to succeed and the second submit() which is invalid should not supersede first one assert_equals: expected "v2" but got "v4"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/targetted-form.js"></script>
+<!--
+  The submit() in event handler should *not* get superseded in this case by the
+  default action submit(), because event handler here calls preventDefault().
+-->
+<body>
+<script>
+promise_test(async () => {
+  let form = populateForm('<input name=n1 value=v1><input type=submit>');
+  let iframe = form.previousSibling;
+  let input = form.querySelector("input[name=n1]");
+  let submitter = form.querySelector("input[type=submit]");
+  form.addEventListener('click', () => {
+    input.value = 'v2';
+    form.submit();
+    input.value = 'v3';
+    form.submit();
+    input.value = 'v4';
+  });
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    input.value = 'v5';
+    form.submit();
+    input.value = 'v6';
+    form.submit();
+    input.value = 'v7';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v6");
+}, 'PreventDefaulting form onsubmit should allow submit() to succeed');
+
+promise_test(async () => {
+  let form = populateForm('<input type=submit><input name=n1 value=v1>');
+  let iframe = form.previousSibling;
+  let input = form['n1'];
+  let submitter = form.querySelector('input[type=submit]');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    input.value = 'v2';
+    form.submit();
+
+    input.value = 'v3';
+    form.remove();
+    form.submit();
+    document.body.insertBefore(form, iframe.nextSibling);
+    input.value = 'v4';
+  });
+  submitter.click();
+  await loadPromise(iframe);
+  assert_equals(getParamValue(iframe, "n1"), "v2");
+}, 'PreventDefaulting form onsubmit should allow submit() to succeed and the second submit() which is invalid should not supersede first one');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt
@@ -1,0 +1,75 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+PASS test runTest with submitterType: input, preventDefaultRequestSubmit: true, preventDefaultSubmitButton: false, passSubmitter: true
+PASS test runTest with submitterType: input, preventDefaultRequestSubmit: true, preventDefaultSubmitButton: false, passSubmitter: false
+PASS test runTest with submitterType: input, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: true, passSubmitter: true
+PASS test runTest with submitterType: input, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: true, passSubmitter: false
+PASS test runTest with submitterType: input, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: true
+PASS test runTest with submitterType: input, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: false
+PASS test runTest with submitterType: button, preventDefaultRequestSubmit: true, preventDefaultSubmitButton: false, passSubmitter: true
+PASS test runTest with submitterType: button, preventDefaultRequestSubmit: true, preventDefaultSubmitButton: false, passSubmitter: false
+PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: true, passSubmitter: true
+PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: true, passSubmitter: false
+PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: true
+PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: false
+FAIL test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: false
+FAIL test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: false
+PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: true
+PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: false
+FAIL test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: false
+FAIL test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: false
+PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: true
+PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: false
+FAIL test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: false
+FAIL test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: false
+PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: true
+PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: false
+FAIL test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: false
+FAIL test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: false
+PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: true
+PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help"
+  href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/targetted-form.js"></script>
+
+<!-- The onclick requestSubmit() should get superseded by the default
+     action submit, which isn't preventDefaulted by onclick here.
+     This is per the Form Submission Algorithm [1], which
+     says that new planned navigations replace old planned navigations.
+     [1] https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#planned-navigation
+  -->
+
+<body>
+  <script>
+    function runTest({ submitterType, preventDefaultSubmitButton, preventDefaultRequestSubmit, passSubmitter, testName }) {
+      if (preventDefaultRequestSubmit && preventDefaultSubmitButton) {
+        // In this case, no submit action will take place.
+        return;
+      }
+
+      promise_test(async () => {
+        const form = populateForm(`<input name=n1 value=v1><${submitterType} type=submit name=n2 value=v2>${submitterType == 'button' ? '</button>' : ''}`);
+        const input = form.elements[0];
+        const submitter = form.elements[1];
+        submitter.addEventListener('click', e => {
+          form.addEventListener('submit', e => {
+            submitter.value = 'v3';
+            if (preventDefaultRequestSubmit) {
+              e.preventDefault();
+            }
+          }, { once: true });
+
+          form.requestSubmit(passSubmitter ? submitter : null);
+          input.value = 'v2';
+
+          form.addEventListener('submit', e => {
+            submitter.value = 'v4';
+            if (preventDefaultSubmitButton) {
+              e.preventDefault();
+            }
+          }, { once: true });
+        });
+
+        let formDataInEvent;
+        form.addEventListener('formdata', e => {
+          formDataInEvent = e.formData;
+        });
+
+        submitter.click();
+        assert_equals(formDataInEvent.get('n1'), preventDefaultSubmitButton ? 'v1' : 'v2');
+        if (preventDefaultSubmitButton && !passSubmitter) {
+          assert_false(formDataInEvent.has('n2'));
+        } else {
+          assert_equals(formDataInEvent.get('n2'),
+            preventDefaultSubmitButton && passSubmitter ? 'v3' : 'v4')
+        }
+
+        let iframe = form.previousSibling;
+        await loadPromise(iframe);
+        assert_equals(getParamValue(iframe, 'n1'), preventDefaultSubmitButton ? 'v1' : 'v2');
+        if (preventDefaultSubmitButton && !passSubmitter) {
+          assert_equals(getParamValue(iframe, 'n2'), null);
+        } else {
+          assert_equals(getParamValue(iframe, 'n2'),
+            preventDefaultSubmitButton && passSubmitter ? 'v3' : 'v4');
+        }
+      }, testName);
+    }
+
+    function runTest2({ submitterType, callRequestSubmit, callSubmit, preventDefault, passSubmitter, testName }) {
+      if (!callSubmit && preventDefault) {
+        // Without callSubmit, preventDefault will cause the form to not get
+        // submitted.
+        return;
+      }
+
+      promise_test(async () => {
+        const form = populateForm(`<input name=n1 value=v1><${submitterType} type=submit name=n2 value=v3>${submitterType == 'button' ? '</button>' : ''}`);
+        const input = form.elements[0];
+        const submitter = form.elements[1];
+
+        form.addEventListener('submit', e => {
+          if (callRequestSubmit) {
+            form.requestSubmit(passSubmitter ? submitter : null);
+            input.value = 'v2';
+          }
+          if (callSubmit) {
+            form.submit();
+          }
+          if (preventDefault) {
+            e.preventDefault();
+          }
+        });
+
+        form.requestSubmit(passSubmitter ? submitter : null);
+        let iframe = form.previousSibling;
+        await loadPromise(iframe);
+
+        assert_equals(getParamValue(iframe, 'n1'), callRequestSubmit ? 'v2' : 'v1');
+        if (callSubmit || !passSubmitter) {
+          assert_equals(getParamValue(iframe, 'n2'), null);
+        } else {
+          assert_equals(getParamValue(iframe, 'n2'), 'v3')
+        }
+      }, testName);
+    }
+
+    function callWithArgs(test, argsLeft, args) {
+      if (argsLeft.length == 0) {
+        args.testName = 'test ' + test.name + ' with ' + Object.entries(args).map(([key, value]) => `${key}: ${value}`).join(', ');
+        test(args);
+        return;
+      }
+
+      let [name, values] = argsLeft[0];
+      for (let value of values) {
+        callWithArgs(test, argsLeft.slice(1), { ...args, [name]: value })
+      }
+    }
+
+    let args = {
+      submitterType: ['input', 'button'],
+      preventDefaultRequestSubmit: [true, false],
+      preventDefaultSubmitButton: [true, false],
+      passSubmitter: [true, false],
+    };
+    callWithArgs(runTest, Object.entries(args), {});
+
+    args = {
+      submitterType: ['input', 'button'],
+      callRequestSubmit: [true, false],
+      callSubmit: [true, false],
+      preventDefault: [true, false],
+      passSubmitter: [true, false],
+    };
+    callWithArgs(runTest2, Object.entries(args), {});
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-submission-algorithm.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-submission-algorithm.html
@@ -49,7 +49,7 @@ test(() => {
   assert_equals(counter, 1);
 }, "If form's firing submission events is true, then return; 'invalid' event");
 
-async_test(t => {
+promise_test(async () => {
   let form = populateForm('<input type=submit name=n value=i><button type=submit name=n value=b>');
   let submitter1 = form.querySelector('input[type=submit]');
   let submitter2 = form.querySelector('button[type=submit]');
@@ -60,13 +60,8 @@ async_test(t => {
   };
   submitter1.click();
   // We actually submit the form in order to check which 'click()' submits it.
-  iframe.onload = t.step_func(() => {
-    // The initial about:blank load event can be fired before the form navigation occurs.
-    // See https://github.com/whatwg/html/issues/490 for more information.
-    if(iframe.contentWindow.location.href == "about:blank") { return; }
-    assert_not_equals(iframe.contentWindow.location.search.indexOf('n=i'), -1);
-    t.done();
-  });
+  await loadPromise(iframe);
+  assert_not_equals(iframe.contentWindow.location.search.indexOf('n=i'), -1);
 }, "If form's firing submission events is true, then return; 'submit' event");
 
 promise_test(async () => {
@@ -137,7 +132,7 @@ promise_test(async () => {
   assert_true(event instanceof SubmitEvent);
 }, 'firing an event named submit; form.requestSubmit(submitter)');
 
-async_test(t => {
+promise_test(async () => {
   let form = populateForm('<input name=n1 value=v1>');
   form.onformdata = (e) => { e.target.remove(); };
   let wasLoaded = false;
@@ -145,17 +140,17 @@ async_test(t => {
   // Request to load '/common/dummy.xhtml', and immediately submit the form to
   // the same frame. If the form submission is aborted, the first request
   // will be completed.
-  // This may be complicated by loads of the initial about:blank;
-  // we need to ignore them and only look at a load that isn't about:blank.
-  iframe.onload = t.step_func(() => {
-    if(iframe.contentWindow.location=="about:blank") { return; }
+  iframe.addEventListener("load", () => {
+    // This may be complicated by loads of the initial about:blank;
+    // we need to ignore them and only look at a load that isn't about:blank.
+    if (iframe.contentWindow.location == "about:blank") { return; }
     wasLoaded = true;
-    assert_true(iframe.contentWindow.location.search.indexOf('n1=v1') == -1);
-    t.done();
   });
   iframe.src = '/common/dummy.xhtml';
   assert_false(wasLoaded, 'Make sure the first loading is ongoing.');
   form.submit();
+  await loadPromise(iframe);
+  assert_true(iframe.contentWindow.location.search.indexOf('n1=v1') == -1);
 }, 'Cannot navigate (after constructing the entry list)');
 
 promise_test(async () => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/multipart-formdata.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/multipart-formdata.window-expected.txt
@@ -59,4 +59,6 @@ PASS multipart/form-data: characters not in encoding in name and value (normal f
 PASS multipart/form-data: characters not in encoding in name and value (formdata event)
 PASS multipart/form-data: character not in encoding in filename (normal form)
 PASS multipart/form-data: character not in encoding in filename (formdata event)
+PASS multipart/form-data: lone surrogate in name and value (normal form)
+PASS multipart/form-data: lone surrogate in name and value (formdata event)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/multipart-formdata.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/multipart-formdata.window.js
@@ -344,3 +344,14 @@ formTest({
   },
   description: "character not in encoding in filename",
 });
+
+formTest({
+  name: "\uD800",
+  value: "\uD800",
+  formEncoding: "windows-1252",
+  expected: {
+    name: "&#65533;",
+    value: "&#65533;"
+  },
+  description: "lone surrogate in name and value",
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/resources/form-submission.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/resources/form-submission.py
@@ -1,12 +1,18 @@
-def main(request, response):
-    if request.headers.get(b'Content-Type') == b'application/x-www-form-urlencoded':
-        result = request.body == b'foo=bara'
-    elif request.headers.get(b'Content-Type') == b'text/plain':
-        result = request.body == b'qux=baz\r\n'
-    else:
-        result = request.POST.first(b'foo') == b'bar'
+from urllib.parse import parse_qsl
 
-    result = result and request.url_parts.query == u'query=1'
+def main(request, response):
+    params = dict(parse_qsl(request.url_parts.query))
+    if params.get('query') == '1':
+        if request.headers.get(b'Content-Type') == b'application/x-www-form-urlencoded':
+            result = request.body == b'foo=bara'
+        elif request.headers.get(b'Content-Type') == b'text/plain':
+            result = request.body == b'qux=baz\r\n'
+        else:
+            result = request.POST.first(b'foo') == b'bar'
+    elif params.get('expected_body') is not None:
+        result = request.body == params['expected_body'].encode('UTF-8')
+    else:
+        result = False
 
     return ([(b"Content-Type", b"text/plain")],
             b"OK" if result else b"FAIL")

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/resources/targetted-form.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/resources/targetted-form.js
@@ -22,7 +22,17 @@ function submitPromise(form, iframe) {
 
 function loadPromise(iframe) {
   return new Promise((resolve, reject) => {
-    iframe.onload = resolve;
+    iframe.onload = function() {
+      // The initial about:blank load event can be fired before the form navigation occurs.
+      // See https://github.com/whatwg/html/issues/490 for more information.
+      if (iframe.contentWindow.location == "about:blank") { return; }
+      resolve();
+    };
     iframe.onerror = () => reject(new Error('iframe onerror fired'));
   });
+}
+
+function getParamValue(iframe, paramName) {
+  let params = (new URL(iframe.contentWindow.location)).searchParams;
+  return params.get(paramName);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body-expected.txt
@@ -11,4 +11,6 @@ PASS form submission from input should navigate to url with multipart/form-data
 PASS form submission from input should navigate to url with text/plain
 PASS form submission from submit input should contain submit button value
 PASS form submission from submit button should contain submit button value
+PASS form submission from image input should contain entries for its clicked coordinate
+PASS form submission from image input should only contain entries for the submitter's clicked coordinate when multiple image inputs are present
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body.html
@@ -74,15 +74,30 @@ var simple_tests = [
     enctype: "application/x-www-form-urlencoded",
     submitelement: "<button id=inputsubmit type=\"submit\" name=foo value=bara>Submit</button>",
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
-  }
-,
+  },
   {
     name: "form submission from submit button should contain submit button value",
     input: "<input type=submit name=notclicked value=nope/>",
     enctype: "application/x-www-form-urlencoded",
     submitelement: "<input id=inputsubmit type=\"submit\" name=foo value=bara >",
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
-  }
+  },
+  {
+    name: "form submission from image input should contain entries for its clicked coordinate",
+    input: "<input type=submit name=notclicked value=nope/>",
+    enctype: "application/x-www-form-urlencoded",
+    submitelement: "<input id=inputsubmit type=image name=foo>",
+    submitaction: function(doc) { doc.getElementById("inputsubmit").click(); },
+    expected_body: "foo.x=0&foo.y=0"
+  },
+  {
+    name: "form submission from image input should only contain entries for the submitter's clicked coordinate when multiple image inputs are present",
+    input: "<input type=image name=bar>",
+    enctype: "application/x-www-form-urlencoded",
+    submitelement: "<input id=inputsubmit type=image name=foo>",
+    submitaction: function(doc) { doc.getElementById("inputsubmit").click(); },
+    expected_body: "foo.x=0&foo.y=0"
+  },
 ];
 simple_tests.forEach(function(test_obj) {
   test_obj.test = async_test(test_obj.name);
@@ -92,11 +107,13 @@ function run_simple_test() {
     return;
   }
   var test_obj = simple_tests.pop();
+  var enctype = test_obj.enctype || "application/x-www-form-urlencoded";
+  var query = test_obj.expected_body ? "expected_body=" + encodeURIComponent(test_obj.expected_body) : "query=1";
   var t = test_obj.test;
   var testframe = document.getElementById("testframe");
   var testdocument = testframe.contentWindow.document;
   testdocument.body.innerHTML =
-    "<form id=testform method=post action=\"/html/semantics/forms/form-submission-0/resources/form-submission.py?query=1\" enctype=\"" + test_obj.enctype + "\">" +
+    "<form id=testform method=post action=\"/html/semantics/forms/form-submission-0/resources/form-submission.py?" + query + "\" enctype=\"" + enctype + "\">" +
     test_obj.input +
     test_obj.submitelement +
     "</form>";

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/text-plain.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/text-plain.window-expected.txt
@@ -59,4 +59,6 @@ PASS text/plain: characters not in encoding in name and value (normal form)
 PASS text/plain: characters not in encoding in name and value (formdata event)
 PASS text/plain: character not in encoding in filename (normal form)
 PASS text/plain: character not in encoding in filename (formdata event)
+PASS text/plain: lone surrogate in name and value (normal form)
+PASS text/plain: lone surrogate in name and value (formdata event)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/text-plain.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/text-plain.window.js
@@ -213,3 +213,11 @@ formTest({
   expected: "\xE1=&#128169;\r\n",
   description: "character not in encoding in filename",
 });
+
+formTest({
+  name: "\uD800",
+  value: "\uD800",
+  formEncoding: "windows-1252",
+  expected: "&#65533;=&#65533;\r\n",
+  description: "lone surrogate in name and value",
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/urlencoded2.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/urlencoded2.window-expected.txt
@@ -59,4 +59,6 @@ PASS application/x-www-form-urlencoded: characters not in encoding in name and v
 PASS application/x-www-form-urlencoded: characters not in encoding in name and value (formdata event)
 PASS application/x-www-form-urlencoded: character not in encoding in filename (normal form)
 PASS application/x-www-form-urlencoded: character not in encoding in filename (formdata event)
+PASS application/x-www-form-urlencoded: lone surrogate in name and value (normal form)
+PASS application/x-www-form-urlencoded: lone surrogate in name and value (formdata event)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/urlencoded2.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/urlencoded2.window.js
@@ -213,3 +213,11 @@ formTest({
   expected: "%E1=%26%23128169%3B",
   description: "character not in encoding in filename",
 });
+
+formTest({
+  name: "\uD800",
+  value: "\uD800",
+  formEncoding: "windows-1252",
+  expected: "%26%2365533%3B=%26%2365533%3B",
+  description: "lone surrogate in name and value",
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/w3c-import.log
@@ -23,7 +23,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-data-set-usv.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-2.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-3.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-multiple-targets.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-echo.py


### PR DESCRIPTION
#### 0ed23510b9c68b87e23d7fe0a47e2ca333f70906
<pre>
Sync `form-submission-0` tests from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=274277">https://bugs.webkit.org/show_bug.cgi?id=274277</a>

Reviewed by Tim Nguyen.

This PR syncs WPT tests for `form-submission-0` from upstream:

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3841d9c792cc60e7de4af80cef23060ed9090ea0">https://github.com/web-platform-tests/wpt/commit/3841d9c792cc60e7de4af80cef23060ed9090ea0</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/FormDataEvent.window.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-submission-algorithm.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/multipart-formdata.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/resources/form-submission.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/resources/targetted-form.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/text-plain.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/urlencoded2.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/multipart-formdata.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/text-plain.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/urlencoded2.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-default-action-expected.txt:

Canonical link: <a href="https://commits.webkit.org/278909@main">https://commits.webkit.org/278909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc788be6420febfb8a34212f600e47c86359a9fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2525 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42166 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1971 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49569 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->