### PR TITLE
Fix more media control website conflicts in in-window mode

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -184,7 +184,7 @@ class MediaController
     macOSControlsBackgroundWasClicked()
     {
         // Toggle playback when clicking on the video but not on any controls on macOS.
-        if (this.media.controls)
+        if (this.media.controls || (this.host && this.host.shouldForceControlsDisplay))
             this.togglePlayback();
     }
 
@@ -334,6 +334,9 @@ class MediaController
         this.controls = new ControlsClass;
         this.controls.delegate = this;
 
+        if (this.media.webkitPresentationMode === "in-window")
+            this._stopPropagationOnClickEvents();
+
         if (this.controls.autoHideController && this.shadowRoot.host && this.shadowRoot.host.dataset.autoHideDelay)
             this.controls.autoHideController.autoHideDelay = this.shadowRoot.host.dataset.autoHideDelay;
 
@@ -355,6 +358,16 @@ class MediaController
             this.controls.timeControl.scrubber.disabled = true;
 
         this._updateControlsAvailability();
+    }
+
+    _stopPropagationOnClickEvents()
+    {
+        let clickEvents = ["click", "mousedown", "mouseup", "pointerdown", "pointerup"];
+        for (let clickEvent of clickEvents) {
+            this.controls.element.addEventListener(clickEvent, (event) => {
+                event.stopPropagation();
+            });
+        }
     }
 
     _updateControlsSize()

--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -76,6 +76,7 @@ iframe:fullscreen {
     max-width: 100vw !important;
     max-height: 100vh !important;
     border-radius: 20px !important;
+    pointer-events: auto !important;
 }
 
 *|*:not(:root):-internal-in-window-fullscreen::backdrop {


### PR DESCRIPTION
#### 2a045b512e469a314414021f7de6122db168ff11
<pre>
Fix more media control website conflicts in in-window mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=274274">https://bugs.webkit.org/show_bug.cgi?id=274274</a>
<a href="https://rdar.apple.com/126942381">rdar://126942381</a>

Reviewed by Jer Noble.

Currently on youtube.com, when you drag the media controls in in-window mode, the video
plays/pauses. To fix this, if the video is in in-window mode, we now stop the propagation
of the click or mousedown events past the media controls &lt;div&gt; element.

Additionally, on tv.apple.com, the media controls in in-window mode are unclickable. This
is because the website sets the pointer-events css property of the &lt;video&gt; to none. We now
set this property to auto !important.

Also, the &lt;video&gt; on tv.apple.com does not have the controls attribute, which was causing us
to not toggle playback when the video is clicked due to a current requirement that the controls
attribute is present. This is fixed now by amending this conditional to check if
host.shouldForceControlsDisplay is true.

Although this fix makes the in-window controls on tv.apple.com clickable, the behavior
is still buggy. This is the new behavior with this fix:

If the video is paused when entering in-window mode and playing when exiting to inline,
the controls are no longer functional in inline. You must re-enter in-window, pause,
then exit to inline, to regain functionality.

If the video is playing when entering in-window mode, the in-window controls are not
functional.

I believe this behavior is due to tv.apple.com keeping their own variable tracking
the play/pause state of the video. If this patch lands, I will file a radar tracking
this.

* Source/WebCore/Modules/modern-media-controls/controls/background-click-delegate-notifier.js:
(BackgroundClickDelegateNotifier.prototype.handleEvent):
(BackgroundClickDelegateNotifier):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype.macOSControlsBackgroundWasClicked):
* Source/WebCore/css/fullscreen.css:
(*|*:not(:root):-internal-in-window-fullscreen):

Canonical link: <a href="https://commits.webkit.org/279024@main">https://commits.webkit.org/279024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54dbc49fa17a82d3839d6c5488db9f12eca738ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42511 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1904 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2360 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49903 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49145 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29511 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7658 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->