### PR TITLE
Prevent selection repaint in the middle of multicolumn flow destruction

### DIFF
--- a/LayoutTests/fast/block/multicolumn-with-outline-auto-expected.txt
+++ b/LayoutTests/fast/block/multicolumn-with-outline-auto-expected.txt
@@ -1,0 +1,2 @@
+HOCUS
+POCUS

--- a/LayoutTests/fast/block/multicolumn-with-outline-auto.html
+++ b/LayoutTests/fast/block/multicolumn-with-outline-auto.html
@@ -1,0 +1,24 @@
+<style>
+ * { rotate: 180deg; outline-style: auto; column-span: all;}
+ *:focus-within { columns: 2; }
+</style>
+<script>
+    function f0() {
+        window.find("POCUS");
+        keygen.replaceWith("HOCUS");
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+</script>
+<keygen id="keygen" onfocusin="f0()" autofocus="" contenteditable="true"/>
+<dir>
+    <div id="div">
+        <label id="label">POCUS</label>
+    </div>
+</dir>


### PR DESCRIPTION
#### 54cc63f44f09698e77d1ff0823d90612f844c59c
<pre>
Prevent selection repaint in the middle of multicolumn flow destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=263180">https://bugs.webkit.org/show_bug.cgi?id=263180</a>
<a href="https://rdar.apple.com/128090627">rdar://128090627</a>

Reviewed by Alan Baradlay.

During multicolumn fragmented flow destruction, spanners are moved back
to their original DOM position in the tree. This is done through calls
to RenderTreeBuilderBlock::Block::detach(RenderBlockFlow&amp;), which also
calls the more general RenderBlock ::detach() method for each spanner.
The former method results in the destruction of the spanner placeholders
and the merging of the necessary multicolumn sets, but this is not done
immediately, so the tree is temporarily inconsistent, before the
RenderBlock detach() method is called.

RenderTreeBuilderBlock::Block::detach(RenderBlock&amp;), however,
might inadvertely end up triggering a repaint of the selection that the
tree is not ready for. I assume that this is an oversight from the possibility
that this method gets called during RenderBlockFlow detachment. This repaint
happens because RenderTreeBuilder::detachFromRenderElement() clears the
selection if the child being detached is to be destroyed. As
WillBeDestroyed::Yes is the default value in the definition of
detachFromRenderElement(), this is assumed to be the case, even when
that&apos;s not what happens during fragmented flow destruction.

The problem with this is that the selection repaint will eventually find itself
needing a consistent tree, and the fact that multicolumn sets are not merged
yet and there are spanners without a placehoder will break assumptions made
in RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded().

Fix this by making it possible for both detach() methods to propagate
WillBeDestroyed, with a default value of WillBeDestroyed::Yes to preserve
current behavior everywhere, but explicitly passing WillBeDestroyed::No
during fragmented flow destruction when detaching spanners, as this is what
is actually happening. This prevents the selection repaint from happening
before the tree is in a consistent state.

* LayoutTests/fast/block/multicolumn-with-outline-auto-expected.txt: Added.
* LayoutTests/fast/block/multicolumn-with-outline-auto.html: Added.

Originally-landed-as: 274097.6@webkit-2024.2-embargoed (00414cbd744c). <a href="https://rdar.apple.com/128090627">rdar://128090627</a>
Canonical link: <a href="https://commits.webkit.org/278918@main">https://commits.webkit.org/278918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a4cd83641964ffc55127096f6c01066203de19a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2572 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2013 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56739 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49598 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48864 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29135 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7592 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->