### PR TITLE
-[MTLCommandBuffer commit] may be called while encoding is still in progress

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2123,6 +2123,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274161.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274271.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274271.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274275.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274275.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274275-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274275-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274275.html
+++ b/LayoutTests/fast/webgpu/fuzz-274275.html
@@ -1,0 +1,20474 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u86bb\u{1fff1}\u5a9e\uf7f1\u0e88\ue14d\u7027',
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 33,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 56959,
+    maxStorageTexturesPerShaderStage: 42,
+    maxStorageBuffersPerShaderStage: 16,
+    maxDynamicStorageBuffersPerPipelineLayout: 6537,
+    maxDynamicUniformBuffersPerPipelineLayout: 53576,
+    maxBindingsPerBindGroup: 9498,
+    maxTextureArrayLayers: 513,
+    maxTextureDimension1D: 10800,
+    maxTextureDimension2D: 8567,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minStorageBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 171695072,
+    maxStorageBufferBindingSize: 263647637,
+    maxUniformBuffersPerShaderStage: 14,
+    maxSampledTexturesPerShaderStage: 38,
+    maxInterStageShaderVariables: 76,
+    maxInterStageShaderComponents: 97,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let texture0 = device0.createTexture({
+  label: '\ufc9a\ub353\u{1fcb7}\u{1fb1e}\u{1fa71}\u03a4\u46f3\u1399\u685a',
+  size: [216],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8snorm'],
+});
+let textureView0 = texture0.createView({aspect: 'all', baseArrayLayer: 0});
+let sampler0 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 3.859,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(561, 775);
+let querySet0 = device0.createQuerySet({label: '\u{1fee5}\u0672\u{1fb50}\u05d4\u6c67\u1897', type: 'occlusion', count: 3365});
+let texture1 = device0.createTexture({
+  label: '\u{1f935}\ub8c9\u5d9c\u{1f97c}\ub89e\u386f\u0a78\u9229',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8uint'],
+});
+let textureView1 = texture0.createView({label: '\u3bfb\u0682\u07d3\u0e1e\u{1fc3c}\u0424\ucc90\u0232', dimension: '1d'});
+let img0 = await imageWithData(284, 237, '#4838b55e', '#2c28243c');
+let textureView2 = texture0.createView({label: '\u5bcd\u{1fd00}\u0922\u0696\ue911\u372b\uc7cc\u2b0e\u18a9\u07dc\u06c9'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'],
+  depthReadOnly: false,
+  stencilReadOnly: false,
+});
+document.body.prepend(img0);
+let texture2 = device0.createTexture({
+  label: '\u{1ffee}\u0f4a\u{1f8e8}\ucf78',
+  size: {width: 96, height: 1, depthOrArrayLayers: 471},
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView3 = texture0.createView({label: '\uefbe\uc01a\u{1fef6}\ubd08\u{1fde2}'});
+let offscreenCanvas1 = new OffscreenCanvas(278, 966);
+try {
+offscreenCanvas0.getContext('2d');
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3234,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 3977,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 2980,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u01a6\u1b91\uf309\u5cf1\u{1f728}\u95c9',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u8165\u{1fcb7}\u5f35\u02ae\u{1f72a}'});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 44},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(16)), /* required buffer size: 610_854 */
+{offset: 6, bytesPerRow: 303, rowsPerImage: 18}, {width: 75, height: 0, depthOrArrayLayers: 113});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 471}
+*/
+{
+  source: img0,
+  origin: { x: 209, y: 39 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 115},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let shaderModule0 = device0.createShaderModule({
+  label: '\u05a8\u0c63\u8f91\udced\u{1f944}\u54dd\u{1fd1f}\u6a29',
+  code: `@group(4) @binding(3234)
+var<storage, read_write> function0: array<u32>;
+@group(3) @binding(2980)
+var<storage, read_write> field0: array<u32>;
+@group(4) @binding(2980)
+var<storage, read_write> type0: array<u32>;
+@group(1) @binding(2980)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(3977)
+var<storage, read_write> type1: array<u32>;
+@group(0) @binding(3977)
+var<storage, read_write> field1: array<u32>;
+@group(3) @binding(3977)
+var<storage, read_write> local0: array<u32>;
+@group(1) @binding(3234)
+var<storage, read_write> local1: array<u32>;
+@group(1) @binding(3977)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(2980)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(3234)
+var<storage, read_write> n0: array<u32>;
+@group(2) @binding(3234)
+var<storage, read_write> n1: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, a3: S1) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(15) f0: vec4<f32>,
+  @location(8) f1: vec4<f32>,
+  @location(16) f2: f16,
+  @location(13) f3: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<i32>, a1: S0, @location(12) a2: u32, @location(20) a3: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let shaderModule1 = device0.createShaderModule({
+  label: '\u0aa1\ueff3\u613f\u64af\u{1f989}\u0e58\u02ca',
+  code: `@group(1) @binding(3234)
+var<storage, read_write> type2: array<u32>;
+@group(3) @binding(3977)
+var<storage, read_write> n2: array<u32>;
+@group(2) @binding(3977)
+var<storage, read_write> local3: array<u32>;
+@group(4) @binding(2980)
+var<storage, read_write> n3: array<u32>;
+@group(1) @binding(3977)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(3977)
+var<storage, read_write> field2: array<u32>;
+@group(0) @binding(2980)
+var<storage, read_write> function1: array<u32>;
+@group(0) @binding(3234)
+var<storage, read_write> type3: array<u32>;
+@group(2) @binding(3234)
+var<storage, read_write> function2: array<u32>;
+@group(3) @binding(2980)
+var<storage, read_write> type4: array<u32>;
+@group(4) @binding(3234)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @builtin(sample_mask) f0: u32,
+  @location(17) f1: vec4<u32>,
+  @location(60) f2: vec3<f16>,
+  @builtin(front_facing) f3: bool,
+  @location(14) f4: vec4<f16>,
+  @builtin(position) f5: vec4<f32>,
+  @location(43) f6: vec2<u32>,
+  @location(10) f7: vec4<i32>,
+  @location(11) f8: vec2<f32>,
+  @builtin(sample_index) f9: u32,
+  @location(13) f10: i32,
+  @location(42) f11: f32,
+  @location(12) f12: vec4<i32>,
+  @location(49) f13: vec3<u32>,
+  @location(9) f14: i32,
+  @location(29) f15: vec3<f32>,
+  @location(2) f16: vec4<f16>,
+  @location(23) f17: vec2<f16>,
+  @location(27) f18: f32,
+  @location(21) f19: i32,
+  @location(31) f20: u32,
+  @location(28) f21: vec4<f16>,
+  @location(20) f22: vec3<u32>,
+  @location(48) f23: i32,
+  @location(25) f24: i32,
+  @location(61) f25: u32,
+  @location(69) f26: f32,
+  @location(74) f27: vec2<u32>,
+  @location(73) f28: vec2<f16>,
+  @location(66) f29: vec2<u32>,
+  @location(36) f30: vec2<f32>,
+  @location(71) f31: i32,
+  @location(64) f32: i32,
+  @location(45) f33: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(19) a0: f32, @location(67) a1: vec4<u32>, @location(37) a2: vec2<f16>, @location(55) a3: vec2<u32>, @location(7) a4: vec4<f16>, @location(35) a5: u32, @location(53) a6: vec3<f16>, @location(68) a7: f16, a8: S3, @location(4) a9: vec4<f32>, @location(15) a10: vec2<f32>, @location(33) a11: vec4<u32>, @location(47) a12: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(20) f0: vec3<f16>,
+  @location(8) f1: f16,
+  @location(18) f2: vec4<i32>,
+  @location(0) f3: vec4<u32>,
+  @location(9) f4: vec3<u32>,
+  @location(3) f5: vec3<u32>,
+  @location(5) f6: vec4<u32>,
+  @location(12) f7: f16,
+  @location(7) f8: f32,
+  @location(11) f9: vec3<i32>,
+  @location(6) f10: vec2<f32>,
+  @location(22) f11: vec2<f16>,
+  @location(2) f12: vec4<i32>,
+  @location(19) f13: vec2<i32>,
+  @location(10) f14: vec4<u32>,
+  @location(17) f15: vec3<f32>,
+  @builtin(vertex_index) f16: u32,
+  @location(15) f17: vec2<i32>,
+  @location(13) f18: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(53) f0: vec3<f16>,
+  @location(49) f1: vec3<u32>,
+  @location(48) f2: i32,
+  @location(19) f3: f32,
+  @location(2) f4: vec4<f16>,
+  @location(9) f5: i32,
+  @location(67) f6: vec4<u32>,
+  @builtin(position) f7: vec4<f32>,
+  @location(60) f8: vec3<f16>,
+  @location(71) f9: i32,
+  @location(36) f10: vec2<f32>,
+  @location(28) f11: vec4<f16>,
+  @location(31) f12: u32,
+  @location(68) f13: f16,
+  @location(4) f14: vec4<f32>,
+  @location(21) f15: i32,
+  @location(14) f16: vec4<f16>,
+  @location(29) f17: vec3<f32>,
+  @location(35) f18: u32,
+  @location(11) f19: vec2<f32>,
+  @location(64) f20: i32,
+  @location(43) f21: vec2<u32>,
+  @location(73) f22: vec2<f16>,
+  @location(47) f23: f16,
+  @location(15) f24: vec2<f32>,
+  @location(17) f25: vec4<u32>,
+  @location(20) f26: vec3<u32>,
+  @location(7) f27: vec4<f16>,
+  @location(45) f28: vec3<f16>,
+  @location(33) f29: vec4<u32>,
+  @location(37) f30: vec2<f16>,
+  @location(42) f31: f32,
+  @location(12) f32: vec4<i32>,
+  @location(25) f33: i32,
+  @location(10) f34: vec4<i32>,
+  @location(27) f35: f32,
+  @location(66) f36: vec2<u32>,
+  @location(74) f37: vec2<u32>,
+  @location(23) f38: vec2<f16>,
+  @location(55) f39: vec2<u32>,
+  @location(13) f40: i32,
+  @location(61) f41: u32,
+  @location(69) f42: f32
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<i32>, a1: S2, @builtin(instance_index) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer0 = commandEncoder0.finish({label: '\u0d14\ub39e\u{1fdc3}'});
+let textureView4 = texture1.createView({
+  label: '\u0a51\u{1ff0f}\u{1feb5}\ud77f\u32c7\u7413\u0d57\u{1f657}\u06b3\u0888\u0fcc',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(72)), /* required buffer size: 787 */
+{offset: 787}, {width: 42, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 1, depthOrArrayLayers: 471}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 66, y: 17 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 32, y: 0, z: 28},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder1 = device0.createCommandEncoder({});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u8f1b\u{1f7ef}'});
+let querySet1 = device0.createQuerySet({label: '\uba1d\u0fa5', type: 'occlusion', count: 3562});
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+gc();
+let canvas0 = document.createElement('canvas');
+let commandEncoder3 = device0.createCommandEncoder();
+let querySet2 = device0.createQuerySet({
+  label: '\u0a2e\u{1f79e}\u{1f688}\u4d28\u758b\u{1f65f}\ufcdd\ud965\u365b',
+  type: 'occlusion',
+  count: 3759,
+});
+let texture3 = device0.createTexture({
+  label: '\u{1f67f}\u{1f79e}\u0f92\u{1f8c6}\u0274\u{1fa6e}\u06ff\u36f5\u0684\uf006\u0967',
+  size: [433],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let querySet3 = device0.createQuerySet({label: '\u9ade\u0770\u422f\u9d1b\u{1f64d}\ua30d', type: 'occlusion', count: 3307});
+let computePassEncoder0 = commandEncoder2.beginComputePass({label: '\u{1f81d}\u0b19'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'], depthReadOnly: true});
+let renderBundle0 = renderBundleEncoder1.finish({label: '\ue57d\u0b41\u50c6\u0b13\u0adc\ubabd\u3855\u{1fa92}\u7c9b\u0fa5\u{1fab8}'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 1_081 */
+{offset: 977}, {width: 26, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData0 = new ImageData(244, 228);
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fda5}\u682a\u035b\u{1fbe9}\u{1f7e6}\uf504\u087d\u3e0e\u{1fdba}'});
+let renderBundle1 = renderBundleEncoder0.finish();
+let pipeline0 = device0.createRenderPipeline({
+  label: '\u6a0e\u69e2\u059a',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+  },
+  writeMask: 0,
+}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilReadMask: 796950807,
+    stencilWriteMask: 4294967295,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3808, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2396,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1128, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 512, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 1044, shaderLocation: 13},
+          {format: 'uint32x4', offset: 416, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x2', offset: 12104, shaderLocation: 8},
+          {format: 'sint32x4', offset: 17312, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 10916, stepMode: 'vertex', attributes: []},
+      {arrayStride: 10428, attributes: []},
+      {arrayStride: 42424, attributes: [{format: 'unorm8x4', offset: 9312, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+let video0 = await videoWithData();
+let querySet4 = device0.createQuerySet({label: '\ubeb8\uf175\u83fa\u039f\ueafe\ue404\u{1fe8d}', type: 'occlusion', count: 3326});
+let commandBuffer1 = commandEncoder2.finish({label: '\u1a55\u0aa5\u550d\u0d3e\u{1fc4f}\u01b5\u2a24\u{1f836}\u{1fa6c}\u2cc5\u{1f888}'});
+let texture4 = device0.createTexture({
+  label: '\uc6a2\u0ff6\u042c\u78a7\ude73\u45ce\u09aa\u0cf5\u3c2f\u1716\ue7c3',
+  size: {width: 216, height: 1, depthOrArrayLayers: 470},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let textureView5 = texture3.createView({label: '\u{1fa3b}\u{1f8f4}\u47c0\u042a\u038b\u67bf\u4e2e', format: 'rgba8unorm-srgb'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0d7f\ud7bf\u053d\ua4e1\u{1fe8b}\u1415\u08ed\u{1fb31}',
+  colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'],
+});
+let renderBundle2 = renderBundleEncoder2.finish({});
+let sampler1 = device0.createSampler({
+  label: '\u9e4b\u346e\u85d8\u{1ffdb}\uf699\u3d55\u{1faf7}\u0d69\ub7ed\u03b0\u{1fd2e}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.650,
+  lodMaxClamp: 77.55,
+  maxAnisotropy: 15,
+});
+let commandEncoder5 = device0.createCommandEncoder();
+video0.width = 212;
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 910});
+let commandBuffer2 = commandEncoder5.finish({label: '\ue11a\u{1f772}'});
+let textureView6 = texture3.createView({label: '\ue0b0\ucff4\udc4a\ude00\uaac0\u1578\u{1fa9f}\u02d2\ud580\u722b\u0e2b'});
+let computePassEncoder1 = commandEncoder4.beginComputePass({});
+let sampler2 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.32,
+  maxAnisotropy: 18,
+});
+let pipeline1 = device0.createComputePipeline({
+  label: '\u0474\u09f0\u{1fc5c}\u{1f7ba}\u0486',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let canvas1 = document.createElement('canvas');
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u84ab\u37f3\u0eb4\u01a0\u29c0\u{1fe63}\uecb6\u09de\u5ec4\u0033'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u{1fb41}\u07fb\u04c3\u{1fcdd}\u86d4\u082d\u798a\u{1fdb7}\ufb16',
+  colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'],
+});
+try {
+computePassEncoder2.pushDebugGroup('\ufc8b');
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker('\u1979');
+} catch {}
+try {
+canvas1.getContext('bitmaprenderer');
+} catch {}
+let renderBundle3 = renderBundleEncoder3.finish({label: '\u690c\u08b0\u0f44'});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u006f\ua491\u{1fd31}\u13f8\u{1fe76}\u0aef\uccca\u86a6\u218b'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u05bf\u{1f933}\u3ec9\u0007\u0b9f\ua22c\u{1fa73}\u0350\u7834\u{1fe9e}\u{1fe11}',
+  colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'],
+  depthReadOnly: true,
+});
+let sampler3 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.40,
+  lodMaxClamp: 85.68,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\u9a3e\uab4c\u0484\u51e4\u1bae\uccb8\u09c8\uf53a', source: video0});
+let pipeline2 = await device0.createRenderPipelineAsync({
+  label: '\u0251\ub265\u9ff1\ufc6f\u94cb',
+  layout: 'auto',
+  multisample: {mask: 0xccd470b7},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 181591094,
+    stencilWriteMask: 275147665,
+    depthBiasSlopeScale: 515.1533727083571,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x4', offset: 20568, shaderLocation: 20},
+          {format: 'float16x4', offset: 14748, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 8756, shaderLocation: 15},
+          {format: 'float32', offset: 4064, shaderLocation: 16},
+          {format: 'uint8x2', offset: 8052, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 864,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 248, shaderLocation: 10},
+          {format: 'float16x4', offset: 0, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float']});
+let renderBundle4 = renderBundleEncoder5.finish();
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 1, depthOrArrayLayers: 471}
+*/
+{
+  source: img0,
+  origin: { x: 22, y: 54 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 184},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap0 = await createImageBitmap(canvas1);
+let bindGroupLayout1 = pipeline1.getBindGroupLayout(3);
+let buffer0 = device0.createBuffer({
+  label: '\u29d9\u{1fa4d}\u37a7\u472a\u01d8\u0ac3\u490c\u5d40',
+  size: 19191,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder7 = device0.createCommandEncoder({});
+let textureView7 = texture0.createView({label: '\u0d15\u8f42\u7ae4\u079e', format: 'rgba8snorm', mipLevelCount: 1});
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 32},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 4_782_813 */
+{offset: 750, bytesPerRow: 213, rowsPerImage: 157}, {width: 44, height: 0, depthOrArrayLayers: 144});
+} catch {}
+gc();
+try {
+externalTexture0.label = '\u04b4\u0ff5\u0e60\u0793';
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u8d97\u7197\u{1fced}\u874d\u0504\ua551\ub1fb\ud870\uad6a\u05f0\u3389'});
+let textureView8 = texture2.createView({
+  label: '\u{1f97a}\u4a21\u51be\u{1f6d2}\u0706\uddbc\u2ab5',
+  baseMipLevel: 1,
+  baseArrayLayer: 354,
+  arrayLayerCount: 8,
+});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 815 */
+{offset: 815}, {width: 335, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView9 = texture2.createView({
+  label: '\u{1f74d}\ua267\u06ac\ufc7b\u{1ff2d}\ue469',
+  baseMipLevel: 1,
+  baseArrayLayer: 140,
+  arrayLayerCount: 52,
+});
+let externalTexture1 = device0.importExternalTexture({label: '\u{1f684}\u{1fe16}\u7a7b\u0a79', source: video0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder4.setVertexBuffer(9547, undefined, 0, 998537541);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(80)), /* required buffer size: 177 */
+{offset: 177}, {width: 324, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let videoFrame0 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let bindGroupLayout2 = pipeline0.getBindGroupLayout(4);
+let commandBuffer3 = commandEncoder7.finish({});
+let textureView10 = texture1.createView({
+  label: '\u{1fb27}\u0ab9\uf368\u5330\u76d3\u{1fb76}\u9fb3\u07b0\uddcd\u2d7a\ue55e',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderBundle5 = renderBundleEncoder0.finish({label: '\ua578\u{1faa3}\u{1f6b5}\u{1fa94}'});
+let externalTexture2 = device0.importExternalTexture({label: '\u489c\u3119\ua8a5\u7285', source: videoFrame0, colorSpace: 'srgb'});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+  label: '\u32a2\u{1f8b0}\u{1ffd9}\ucffd\udc48\u0fdd\u07e7',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+try {
+buffer0.destroy();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout3 = pipeline2.getBindGroupLayout(1);
+let texture5 = device0.createTexture({
+  label: '\u{1f721}\u{1f900}\u9510\u1dfe\u7abd',
+  size: [12, 1, 218],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+});
+let texture6 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle6 = renderBundleEncoder3.finish({});
+try {
+renderBundleEncoder4.setVertexBuffer(8989, undefined, 3068519548, 635219444);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 471}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 128, y: 46 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  label: '\u1aad\ua738',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x4318b691},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'rgba32float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2680,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 168, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 38, shaderLocation: 20},
+          {format: 'float32x2', offset: 1176, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 420, shaderLocation: 15},
+          {format: 'float32x2', offset: 764, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 7124, stepMode: 'instance', attributes: []},
+      {arrayStride: 14312, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3764,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 168, shaderLocation: 8}],
+      },
+      {arrayStride: 3452, attributes: [{format: 'sint16x4', offset: 156, shaderLocation: 10}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1341,
+      visibility: 0,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 1308,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let texture7 = device0.createTexture({
+  label: '\u6814\uff48\u{1f75a}\u05be\u015b\u02fb\u0a9c\u{1fa4b}\u11e6\uad0e\u054d',
+  size: {width: 24, height: 1, depthOrArrayLayers: 199},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({label: '\u0574\u6985\u0608', colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float']});
+let externalTexture3 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 131},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f744}');
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer2, commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 684_243 */
+{offset: 259, bytesPerRow: 197, rowsPerImage: 217}, {width: 0, height: 1, depthOrArrayLayers: 17});
+} catch {}
+gc();
+let offscreenCanvas2 = new OffscreenCanvas(667, 759);
+let imageBitmap1 = await createImageBitmap(imageData0);
+let commandEncoder10 = device0.createCommandEncoder({label: '\u03bc\u06a2\ubc51'});
+let commandBuffer4 = commandEncoder10.finish({label: '\u0ba4\u03cb\u0923\u4b79\u50b7\ud1ff'});
+let textureView11 = texture4.createView({label: '\ua7b3\u{1f8ef}\u5ff9\u{1fe82}\u4b50\ue44d', baseMipLevel: 1, mipLevelCount: 4});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({label: '\u0757\ub95c\u01d6\u3880\u{1feea}\u0c8c\uaec2\u5014\ub78d'});
+let textureView12 = texture6.createView({dimension: '2d-array'});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler4 = device0.createSampler({
+  label: '\u7bc1\u0853\u4e2e\u{1fba1}\u5fdf\uae5e\u7374\u541f\u651e\u06ab',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.31,
+  lodMaxClamp: 89.90,
+  maxAnisotropy: 18,
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let externalTexture4 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+device0.destroy();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas2 = document.createElement('canvas');
+let videoFrame1 = new VideoFrame(imageBitmap1, {timestamp: 0});
+try {
+  await promise0;
+} catch {}
+canvas1.width = 388;
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let adapter1 = await navigator.gpu.requestAdapter();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter();
+document.body.prepend(img0);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+canvas2.width = 316;
+let gpuCanvasContext3 = offscreenCanvas2.getContext('webgpu');
+let imageBitmap3 = await createImageBitmap(videoFrame0);
+offscreenCanvas1.width = 431;
+let img1 = await imageWithData(290, 65, '#6534e088', '#a3561818');
+let videoFrame2 = new VideoFrame(canvas2, {timestamp: 0});
+let img2 = await imageWithData(244, 86, '#6d8051a3', '#218eac66');
+let videoFrame3 = new VideoFrame(imageBitmap2, {timestamp: 0});
+gc();
+offscreenCanvas2.width = 2888;
+let device1 = await adapter1.requestDevice({
+  requiredLimits: {
+    maxBindGroups: 9,
+    maxColorAttachmentBytesPerSample: 44,
+    maxVertexAttributes: 17,
+    maxVertexBufferArrayStride: 16268,
+    maxStorageTexturesPerShaderStage: 30,
+    maxDynamicStorageBuffersPerPipelineLayout: 447,
+    maxDynamicUniformBuffersPerPipelineLayout: 20958,
+    maxBindingsPerBindGroup: 9141,
+    maxTextureArrayLayers: 1431,
+    maxTextureDimension1D: 12743,
+    maxTextureDimension2D: 12032,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 35350053,
+    maxStorageBufferBindingSize: 204535205,
+    maxUniformBuffersPerShaderStage: 19,
+    maxSampledTexturesPerShaderStage: 27,
+    maxInterStageShaderVariables: 108,
+    maxInterStageShaderComponents: 88,
+  },
+});
+let offscreenCanvas3 = new OffscreenCanvas(930, 159);
+let bindGroupLayout5 = device1.createBindGroupLayout({
+  label: '\u{1fb85}\u5e1e\u0d4c',
+  entries: [
+    {
+      binding: 2668,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 7224,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 3641, visibility: 0, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder12 = device1.createCommandEncoder({label: '\u{1f900}\u{1fda7}\u0f60\u{1fe07}\ue6a9\u{1feb9}\u{1f887}\u{1ffe1}\ub668\u0dfe\u003d'});
+let querySet6 = device1.createQuerySet({type: 'occlusion', count: 259});
+let texture8 = device1.createTexture({
+  label: '\u77fc\u09f5\u{1fca2}\u7db5\u1570\u{1ffef}\u1429\uf7e4\u{1f628}\uf74c\u{1fd10}',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1194},
+  mipLevelCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder3 = commandEncoder12.beginComputePass({label: '\u362f\u0deb\u7cd4'});
+let sampler5 = device1.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.74,
+  lodMaxClamp: 92.33,
+  compare: 'always',
+});
+try {
+computePassEncoder3.insertDebugMarker('\ub343');
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageData0);
+let querySet7 = device0.createQuerySet({
+  label: '\u06b2\u94e8\u0e35\u3085\uf448\u0ce7\u{1f6bb}\u0c63\u228e\ua4dc\u0785',
+  type: 'occlusion',
+  count: 2691,
+});
+let computePassEncoder4 = commandEncoder8.beginComputePass();
+let renderBundle7 = renderBundleEncoder1.finish({label: '\u3f2a\u05cf\u0811\u9261\u03a0\u499e\uf3ff\u94be'});
+let pipeline5 = await device0.createRenderPipelineAsync({
+  label: '\u0d47\u{1f67e}\u0c97\u4fa4\u7735\u{1f8c5}\u7ad1\ue8de',
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9472,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 1800, shaderLocation: 0},
+          {format: 'uint8x4', offset: 940, shaderLocation: 9},
+          {format: 'uint32x4', offset: 0, shaderLocation: 10},
+          {format: 'sint32x4', offset: 4080, shaderLocation: 18},
+          {format: 'sint32', offset: 952, shaderLocation: 2},
+          {format: 'float32x4', offset: 64, shaderLocation: 6},
+          {format: 'sint32x2', offset: 2444, shaderLocation: 15},
+          {format: 'uint16x4', offset: 288, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 776, shaderLocation: 8},
+          {format: 'sint16x4', offset: 1196, shaderLocation: 11},
+          {format: 'sint32x2', offset: 1516, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 520, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 2456, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 1898, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 480, shaderLocation: 12},
+          {format: 'sint32x4', offset: 2092, shaderLocation: 19},
+          {format: 'float32x4', offset: 932, shaderLocation: 7},
+          {format: 'uint16x2', offset: 576, shaderLocation: 5},
+          {format: 'float32', offset: 36, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw'},
+});
+let offscreenCanvas4 = new OffscreenCanvas(723, 626);
+let videoFrame4 = new VideoFrame(canvas2, {timestamp: 0});
+let textureView13 = texture8.createView({
+  label: '\u09be\u0fc3\ufe21\u{1fd24}\u116a\u0969\u{1f877}\u0e81\ucbe2\ub089\u3e01',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 188,
+  arrayLayerCount: 907,
+});
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+document.body.prepend(video0);
+let gpuCanvasContext5 = offscreenCanvas4.getContext('webgpu');
+video0.height = 282;
+let imageBitmap5 = await createImageBitmap(imageBitmap3);
+let bindGroupLayout6 = device1.createBindGroupLayout({label: '\ud65e\u002a', entries: []});
+let querySet8 = device1.createQuerySet({label: '\uee03\u77b9\u0468\ub115\u{1ff6d}\u259b\u{1fd17}\u05b0', type: 'occlusion', count: 579});
+let textureView14 = texture8.createView({label: '\u{1ffb9}\u7ecb\u{1f730}', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1073});
+let externalTexture5 = device1.importExternalTexture({label: '\ub1a1\u6baa\u{1fa6e}\u03db\uba24\uaeb1\ubb79\u98ed', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder3.pushDebugGroup('\u0e4e');
+} catch {}
+let promise1 = adapter2.requestAdapterInfo();
+let commandEncoder13 = device0.createCommandEncoder({label: '\u0507\u0be0\u7625\u3b59\uadfb\u6141\u00dd'});
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 22});
+} catch {}
+offscreenCanvas0.height = 1228;
+let pipelineLayout1 = device1.createPipelineLayout({
+  label: '\u{1fa42}\u{1f734}\u049e\uffa4\u{1fa83}\u{1fd50}\u{1fec3}',
+  bindGroupLayouts: [bindGroupLayout5],
+});
+let sampler6 = device1.createSampler({
+  label: '\u8a92\u{1fc73}\u6d60',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.732,
+  maxAnisotropy: 6,
+});
+let externalTexture6 = device1.importExternalTexture({
+  label: '\ud22b\u10ad\u4f6a\u0bce\u9516\u1a73\u004b\u0dc3\uae15',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+let buffer1 = device1.createBuffer({
+  label: '\ua9ca\uf27a\u0bda\u0290\u008f',
+  size: 16868,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder7 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm-srgb', 'rg32float'], stencilReadOnly: true});
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+device1.queue.label = '\u02cc\ua55b\u06b6';
+} catch {}
+let bindGroupLayout7 = device1.createBindGroupLayout({
+  label: '\u{1fa94}\uec8a\u0962\u3c24\u0e94\u2dde\ue713\u{1ff59}\u29e5',
+  entries: [
+    {
+      binding: 3411,
+      visibility: 0,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 8031,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet9 = device1.createQuerySet({label: '\u27b9\ub9cb\uc0d1\u07b5\ue948', type: 'occlusion', count: 1247});
+let sampler7 = device1.createSampler({
+  label: '\u{1fbec}\uf23f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.16,
+  lodMaxClamp: 92.08,
+  maxAnisotropy: 1,
+});
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise1;
+} catch {}
+document.body.prepend(video0);
+let imageData1 = new ImageData(128, 128);
+let videoFrame5 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let shaderModule2 = device1.createShaderModule({
+  label: '\uf67d\u{1f984}\u2749\u0d09',
+  code: `@group(0) @binding(2668)
+var<storage, read_write> type6: array<u32>;
+@group(0) @binding(7224)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(8) f0: vec2<f32>,
+  @location(6) f1: vec3<f32>,
+  @location(0) f2: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<u32>, @location(10) a1: f16, @location(5) a2: vec2<u32>, @location(11) a3: i32, @location(9) a4: f32, @location(15) a5: vec2<f16>, @location(12) a6: vec4<f32>, @location(14) a7: f32, @location(4) a8: vec4<i32>, @location(2) a9: vec2<f16>, a10: S4, @location(13) a11: f32, @location(16) a12: vec2<u32>, @location(1) a13: i32, @location(7) a14: vec2<f16>, @builtin(instance_index) a15: u32, @builtin(vertex_index) a16: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder14 = device1.createCommandEncoder({label: '\u0c7f\u652b'});
+let externalTexture7 = device1.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+let bindGroupLayout8 = device1.createBindGroupLayout({
+  entries: [{binding: 1811, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let textureView15 = texture8.createView({
+  label: '\u0c55\u12d3\u0d0a\u9624\u02b3\u007f\uae5e\u05df\u7602\u{1f681}\u875d',
+  baseMipLevel: 2,
+  baseArrayLayer: 182,
+  arrayLayerCount: 867,
+});
+let bindGroupLayout9 = device1.createBindGroupLayout({label: '\u285c\u4732\u618b\u19ba\u{1fb9d}\ucf6a\u{1fbd5}', entries: []});
+let querySet10 = device1.createQuerySet({type: 'occlusion', count: 637});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandBuffer5 = commandEncoder14.finish({});
+let textureView16 = texture8.createView({
+  label: '\u08f6\u{1f697}\ued35\u036b\u{1fdd2}\u0a0e',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 587,
+});
+let pipeline6 = device1.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let imageBitmap6 = await createImageBitmap(canvas2);
+let pipelineLayout2 = device1.createPipelineLayout({
+  label: '\ub291\u7301\u0e80\u9fc2\u0aa0',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout8, bindGroupLayout5, bindGroupLayout9, bindGroupLayout7, bindGroupLayout7],
+});
+let commandEncoder15 = device1.createCommandEncoder({label: '\u{1f92d}\u6d15\u61cb\ub7ba\u4bad\u{1fc78}\u9cca\u6bba\u{1ffa2}'});
+let imageBitmap7 = await createImageBitmap(imageData0);
+let commandEncoder16 = device1.createCommandEncoder({label: '\u0eba\u6689\u{1f7e5}\u072e\u0b45'});
+let textureView17 = texture8.createView({label: '\u33fd\ue5cf\u{1f6cf}\u2b56\ua180', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 230});
+let canvas3 = document.createElement('canvas');
+canvas3.width = 722;
+gc();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(615, 778);
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let texture9 = device1.createTexture({
+  label: '\ue6c4\u70ac\u{1fd58}',
+  size: [384, 2, 1194],
+  mipLevelCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView18 = texture8.createView({label: '\u0f7d\u01b8', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 749, arrayLayerCount: 436});
+try {
+querySet8.destroy();
+} catch {}
+try {
+adapter0.label = '\uf793\u440a\u64c3\u0c5f\u0b4d\uff9c';
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({label: '\u0e73\u{1f96a}\u8020\u71ad\u6242\u861f\ua3f5'});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1341});
+let textureView19 = texture5.createView({label: '\u0602\u{1f8e4}\u35d2\u{1f77f}\uea8f\u4b29\u3ec0\u0c85\u07bc'});
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+let imageBitmap8 = await createImageBitmap(img1);
+let bindGroup0 = device1.createBindGroup({
+  label: '\u{1fee5}\ufb07\u{1fc2e}',
+  layout: bindGroupLayout8,
+  entries: [{binding: 1811, resource: externalTexture6}],
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0, new Uint32Array(4106), 548, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup0, new Uint32Array(1853), 529, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline7 = await device1.createComputePipelineAsync({
+  label: '\u0c80\ub260\u0390\uf17c\ua15a\u03a5\u02ce\u08b4',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas6 = new OffscreenCanvas(961, 261);
+let video1 = await videoWithData();
+try {
+window.someLabel = sampler2.label;
+} catch {}
+let bindGroup1 = device1.createBindGroup({
+  label: '\u{1fc1f}\ua79a\u86da',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 7224, resource: externalTexture7},
+    {binding: 2668, resource: sampler7},
+    {binding: 3641, resource: sampler7},
+  ],
+});
+let pipelineLayout3 = device1.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout7, bindGroupLayout5, bindGroupLayout9, bindGroupLayout5, bindGroupLayout9],
+});
+let textureView20 = texture9.createView({label: '\u5da5\ucd00\u7b31\u{1f85b}', baseArrayLayer: 34, arrayLayerCount: 662});
+let externalTexture8 = device1.importExternalTexture({
+  label: '\u088f\u06ed\u{1fe87}\u0a2e\u7889\u{1fa78}\u0138\u{1fc81}\u08ba\u{1f7e9}\ub355',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+commandEncoder16.insertDebugMarker('\ua772');
+} catch {}
+canvas3.width = 1500;
+let offscreenCanvas7 = new OffscreenCanvas(636, 789);
+let bindGroupLayout10 = device1.createBindGroupLayout({label: '\u120f\uecb3\u09e2\u55fc\uc24c\u{1f83b}\u{1fdf5}\u9b5b\u09e9', entries: []});
+let buffer2 = device1.createBuffer({
+  label: '\u{1f764}\u0c84\u67d9\u97a9\u6c35\uf642\u3a6f\u{1f63e}\u{1f7a2}\u0f51',
+  size: 115675,
+  usage: GPUBufferUsage.INDEX,
+  mappedAtCreation: false,
+});
+let commandEncoder18 = device1.createCommandEncoder({});
+let textureView21 = texture8.createView({
+  label: '\u{1fe4f}\u3035\uff23\u{1f66f}\uca20\u06ff\u8e09\u{1fdd7}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 1028,
+});
+let externalTexture9 = device1.importExternalTexture({
+  label: '\u8119\u{1feaa}\u0844\u3b17\ue59f\u{1fe98}\u94c1\u054e\u36d2\u0894',
+  source: videoFrame4,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder7.setVertexBuffer(9252, undefined);
+} catch {}
+let imageBitmap9 = await createImageBitmap(offscreenCanvas6);
+let querySet12 = device1.createQuerySet({
+  label: '\u{1f84d}\ueec6\u099a\u{1fd8a}\ua968\u5e21\u8f7e\ua6af\u0c1f\u025b',
+  type: 'occlusion',
+  count: 3984,
+});
+let externalTexture10 = device1.importExternalTexture({label: '\u20b7\u{1fa10}\u0e40', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(7, bindGroup0);
+} catch {}
+let pipeline8 = await device1.createRenderPipelineAsync({
+  label: '\u07c9\u6a11\u5bf6\ue86e\u{1fe36}\ua00c\u{1fefe}\u{1f82c}\u71b9',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 1750476492,
+    stencilWriteMask: 3488108900,
+    depthBiasSlopeScale: 654.6925626936204,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 222, shaderLocation: 14},
+          {format: 'float32x2', offset: 140, shaderLocation: 8},
+          {format: 'float32', offset: 924, shaderLocation: 6},
+          {format: 'sint8x2', offset: 162, shaderLocation: 1},
+          {format: 'float32x3', offset: 0, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 204, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 10},
+          {format: 'float32x4', offset: 332, shaderLocation: 9},
+          {format: 'uint8x2', offset: 92, shaderLocation: 3},
+          {format: 'uint32x2', offset: 12, shaderLocation: 16},
+          {format: 'sint32', offset: 744, shaderLocation: 4},
+          {format: 'float32', offset: 216, shaderLocation: 12},
+          {format: 'uint32x2', offset: 120, shaderLocation: 5},
+          {format: 'float32x3', offset: 120, shaderLocation: 7},
+          {format: 'sint32x4', offset: 208, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 3772, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 5488,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 428, shaderLocation: 15}],
+      },
+      {arrayStride: 1756, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 336, stepMode: 'instance', attributes: []},
+      {arrayStride: 3388, stepMode: 'vertex', attributes: []},
+      {arrayStride: 484, attributes: []},
+      {arrayStride: 1368, attributes: [{format: 'unorm8x4', offset: 20, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+let canvas4 = document.createElement('canvas');
+let video2 = await videoWithData();
+let commandEncoder19 = device0.createCommandEncoder({label: '\u09a3\u5eae\uc9b1\u030b\u{1f723}\u0792\u8644'});
+let textureView22 = texture5.createView({label: '\u{1fdfe}\ubb0e\uf627\u922a', format: 'bgra8unorm'});
+let externalTexture11 = device0.importExternalTexture({
+  label: '\u0056\ua833\u7553\u6ebb\u5be9\u46de\ubbc8\u4814\u{1f888}\u00d4',
+  source: video0,
+  colorSpace: 'srgb',
+});
+let pipeline9 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 1, mask: 0x87d4a830},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    depthBias: 784175485,
+    depthBiasClamp: -19.32046179892764,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 10576,
+        attributes: [
+          {format: 'sint32x3', offset: 908, shaderLocation: 1},
+          {format: 'float32', offset: 7040, shaderLocation: 12},
+          {format: 'uint8x4', offset: 224, shaderLocation: 5},
+          {format: 'sint8x4', offset: 3020, shaderLocation: 19},
+          {format: 'sint8x4', offset: 1516, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 1516, shaderLocation: 13},
+          {format: 'sint32x3', offset: 244, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 39232,
+        attributes: [
+          {format: 'snorm16x4', offset: 24, shaderLocation: 8},
+          {format: 'float32x3', offset: 9208, shaderLocation: 20},
+          {format: 'uint32x4', offset: 11540, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 13154, shaderLocation: 22},
+          {format: 'uint16x2', offset: 5020, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 12768, shaderLocation: 7},
+          {format: 'uint8x2', offset: 4464, shaderLocation: 10},
+          {format: 'float32x2', offset: 6092, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 7408, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 4756,
+        attributes: [
+          {format: 'uint32', offset: 932, shaderLocation: 3},
+          {format: 'sint32x3', offset: 392, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 10896,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x2', offset: 1986, shaderLocation: 17}],
+      },
+      {
+        arrayStride: 2360,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 644, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'back'},
+});
+let texture10 = device1.createTexture({
+  label: '\u3f77\u{1fa18}',
+  size: [48, 1, 110],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler8 = device1.createSampler({
+  label: '\u25a1\uefd9\u{1fbba}\u57ce\u79f1\u{1fd78}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 94.70,
+});
+let externalTexture12 = device1.importExternalTexture({label: '\ucad8\u2df1\u13af\uf1d2\u{1f735}\ufc2b', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 18},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(0)), /* required buffer size: 753 */
+{offset: 753}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData2 = new ImageData(52, 144);
+let bindGroup2 = device1.createBindGroup({label: '\u{1ffc9}\u0822\u{1fcdb}\u0273\u{1fb40}\u0520', layout: bindGroupLayout9, entries: []});
+let commandEncoder20 = device1.createCommandEncoder({label: '\u5bcb\u{1fe15}\ud36b\uf5b8\u{1fc83}\uab80\u60e5\u{1f93f}\u{1fccc}'});
+let textureView23 = texture8.createView({
+  label: '\uc646\u089e\u0fe5',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 313,
+  arrayLayerCount: 514,
+});
+let computePassEncoder5 = commandEncoder20.beginComputePass({label: '\u01e4\u011b\u0df7\u43dd\u05f8'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup2, new Uint32Array(3960), 2045, 0);
+} catch {}
+let pipeline10 = await device1.createComputePipelineAsync({
+  label: '\u6a5b\u{1f8ed}\u{1fdd6}\u{1f61f}\uc0f8\u{1f667}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline11 = device1.createRenderPipeline({
+  label: '\u{1fb9f}\u1627\ucfb4\u091a\uea91\u{1fc01}\u0538',
+  layout: pipelineLayout3,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'always', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 3123087978,
+    stencilWriteMask: 707723078,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 1888, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 1604, shaderLocation: 0},
+          {format: 'sint32x4', offset: 52, shaderLocation: 1},
+          {format: 'float32x2', offset: 696, shaderLocation: 9},
+          {format: 'uint32x3', offset: 32, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 1260, attributes: [{format: 'sint32x2', offset: 24, shaderLocation: 4}]},
+      {
+        arrayStride: 9192,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 812, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 1904, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 1688, shaderLocation: 12},
+          {format: 'float16x4', offset: 1756, shaderLocation: 2},
+          {format: 'uint32x2', offset: 2128, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 7766, shaderLocation: 14},
+          {format: 'float32x2', offset: 1972, shaderLocation: 6},
+          {format: 'float32x3', offset: 752, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 5360, shaderLocation: 15},
+          {format: 'uint16x4', offset: 848, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 2116, attributes: [{format: 'unorm16x4', offset: 256, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder21 = device1.createCommandEncoder({label: '\u9259\u25ee\uaddd'});
+let querySet13 = device1.createQuerySet({label: '\u0117\u79aa\u{1ffd5}', type: 'occlusion', count: 1106});
+let renderBundle8 = renderBundleEncoder7.finish({label: '\u52af\uc632\u08d3\u{1fa29}\u{1fcf4}\u0133\u4926\u45ff\ub189\u{1f7a6}'});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas7.getContext('webgpu');
+document.body.prepend(img0);
+offscreenCanvas0.width = 763;
+let imageData3 = new ImageData(236, 144);
+try {
+canvas3.getContext('webgl2');
+} catch {}
+let bindGroup3 = device1.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 2668, resource: sampler7},
+    {binding: 3641, resource: sampler8},
+    {binding: 7224, resource: externalTexture9},
+  ],
+});
+let textureView24 = texture8.createView({label: '\uf08f\u82a9', baseMipLevel: 2, baseArrayLayer: 677, arrayLayerCount: 156});
+let externalTexture13 = device1.importExternalTexture({
+  label: '\u2927\u{1fbf1}\ud25e\u0b1e\u0dc2\u0dda\uce60\u04bd\uf146\u5805\uf9b9',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+let pipeline12 = await device1.createComputePipelineAsync({
+  label: '\u889c\u{1fc5e}\u9ab5\uf159\u9298\u0394\u{1fbe5}\ue903',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let promise2 = device1.createRenderPipelineAsync({
+  label: '\u{1fb4c}\u{1fa37}\u33ab\u86e1\uf2f9\u0d17\u1af7\u991a\u093a',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32float'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 664,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 144, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 7},
+          {format: 'float32', offset: 84, shaderLocation: 0},
+          {format: 'float16x4', offset: 28, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 20, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 76, shaderLocation: 13},
+          {format: 'uint32x3', offset: 84, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 304, shaderLocation: 8},
+          {format: 'uint32x4', offset: 32, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 3100,
+        attributes: [
+          {format: 'unorm16x4', offset: 612, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 2},
+          {format: 'sint8x2', offset: 334, shaderLocation: 1},
+          {format: 'uint32x2', offset: 672, shaderLocation: 16},
+          {format: 'float32x3', offset: 516, shaderLocation: 14},
+          {format: 'float16x4', offset: 616, shaderLocation: 10},
+          {format: 'float32x2', offset: 8, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 2800, stepMode: 'vertex', attributes: []},
+      {arrayStride: 8160, attributes: []},
+      {
+        arrayStride: 5412,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 900, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let bindGroupLayout11 = device1.createBindGroupLayout({label: '\uf5b9\u{1fb10}\uab9e\u781d\uf771\u18ce', entries: []});
+let commandEncoder22 = device1.createCommandEncoder();
+let querySet14 = device1.createQuerySet({label: '\u0bb8\ubf21\u{1fc4b}\uc743\u9ef3\u2eb3', type: 'occlusion', count: 512});
+let texture11 = device1.createTexture({
+  label: '\u7e86\u{1f803}\u{1f6b8}\u{1fad2}\u{1f8b1}',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1194},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+let externalTexture14 = device1.importExternalTexture({label: '\uf5f2\uc76b\u6ce6', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+let imageData4 = new ImageData(92, 16);
+let bindGroup4 = device1.createBindGroup({
+  label: '\u0be3\uc1d1\u0951\ue1a9\u{1ff5f}\u{1ff1e}\u0518',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 2668, resource: sampler7},
+    {binding: 7224, resource: externalTexture7},
+    {binding: 3641, resource: sampler8},
+  ],
+});
+let textureView25 = texture9.createView({dimension: '2d', baseArrayLayer: 353});
+let renderBundle9 = renderBundleEncoder7.finish({label: '\u0651\ueab2\u9e64'});
+let externalTexture15 = device1.importExternalTexture({label: '\u0024\uc4d8', source: video2, colorSpace: 'srgb'});
+let pipeline13 = device1.createComputePipeline({
+  label: '\uc64a\u{1ff12}\u0740',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+document.body.prepend(canvas0);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout12 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1666,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 5453, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 8153,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 195198036, hasDynamicOffset: true },
+    },
+  ],
+});
+let textureView26 = texture9.createView({label: '\u{1f75a}\ua05e\u001a', dimension: '2d', baseArrayLayer: 750});
+let computePassEncoder6 = commandEncoder15.beginComputePass({label: '\u03f5\uef5b\u{1f9ed}\u0d03\u{1fda0}\ue113\u901e\u71e2\u{1f669}\u0e2a\uf8f2'});
+try {
+computePassEncoder3.setBindGroup(4, bindGroup3, new Uint32Array(4780), 2749, 0);
+} catch {}
+let texture12 = device1.createTexture({
+  label: '\uadaa\u1dbb\u216a\u99e3\u0846\u08e6\u{1f786}\u{1fe14}',
+  size: [96, 1, 1194],
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let sampler9 = device1.createSampler({
+  label: '\u9538\ubc1a\ubcda\u0bf7\u{1fa20}\u13cd\uf23b\u0157\ua012',
+  addressModeU: 'mirror-repeat',
+  lodMinClamp: 7.516,
+  lodMaxClamp: 18.36,
+});
+try {
+computePassEncoder5.setPipeline(pipeline6);
+} catch {}
+let promise3 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise3;
+} catch {}
+let videoFrame6 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let buffer3 = device1.createBuffer({
+  label: '\u{1f9da}\ub9b7\u{1feda}\u9772\u597f\ue53a',
+  size: 70725,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+let commandEncoder23 = device1.createCommandEncoder();
+let textureView27 = texture8.createView({label: '\u9ac6\u0410\ub743\ua2bf', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 134});
+let renderBundleEncoder8 = device1.createRenderBundleEncoder({
+  label: '\u42dc\u05a0\uf7e7\uc54a\u02de\u0694\u060d\u{1fe52}',
+  colorFormats: ['rgba32float', 'rg16uint', 'rg8uint', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+});
+try {
+computePassEncoder6.setPipeline(pipeline12);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 382},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 3_907_632 */
+{offset: 277, bytesPerRow: 207, rowsPerImage: 52}, {width: 23, height: 1, depthOrArrayLayers: 364});
+} catch {}
+let texture13 = device0.createTexture({
+  label: '\u{1fd71}\udfa4\u71c5\u02d2\udab1\u{1f7eb}\u0bce\u{1fd7d}\u{1fcdb}\u0514\u{1f60f}',
+  size: {width: 216},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let textureView28 = texture2.createView({
+  label: '\u{1fa0c}\u0211\u{1fb4d}\u03d5\uee27',
+  baseMipLevel: 1,
+  baseArrayLayer: 198,
+  arrayLayerCount: 77,
+});
+let computePassEncoder7 = commandEncoder6.beginComputePass({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u0a1e\ucc5e\u064f',
+  colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'],
+  depthReadOnly: true,
+});
+let renderBundle10 = renderBundleEncoder9.finish({label: '\u0902\u0060\uff73\u{1fab3}\uf3f4\u{1fd6f}\u0dd3\ud503\u791d'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 471}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 36, y: 22 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync({
+  label: '\ubec6\u{1ff06}\u9c49',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+try {
+computePassEncoder6.setBindGroup(8, bindGroup2, new Uint32Array(3962), 3075, 0);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 320},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 48, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline15 = device1.createComputePipeline({
+  label: '\u59bb\u5e10\u0c07\u651d\u{1fd7b}\u06a0\uebc3',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let querySet15 = device1.createQuerySet({label: '\u0e74\uda3b\u0958\u2154\u0cd7\u0b4a', type: 'occlusion', count: 3929});
+let texture14 = device1.createTexture({
+  label: '\u22da\u6001\u05f9\u6268\u0c9f',
+  size: [384, 2, 1446],
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+});
+let renderBundleEncoder10 = device1.createRenderBundleEncoder({
+  label: '\ue57e\u5577\u028e\ufd44\u8439\ubaf6\u002f\u{1f803}\u23e8\ucb50',
+  colorFormats: ['bgra8unorm-srgb', 'rg32float'],
+  sampleCount: 1,
+});
+let sampler10 = device1.createSampler({
+  label: '\u890c\u{1ffa4}\u024e\u0f14',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.25,
+  compare: 'not-equal',
+  maxAnisotropy: 13,
+});
+try {
+buffer2.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 18040, new DataView(new ArrayBuffer(61249)), 20749, 444);
+} catch {}
+document.body.prepend(img2);
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+let imageData5 = new ImageData(28, 128);
+let img3 = await imageWithData(207, 244, '#1f587569', '#b27a0120');
+let bindGroup5 = device1.createBindGroup({label: '\u{1ffde}\ua152\ud1de\u{1fae4}\ua118\u4625\u0c80', layout: bindGroupLayout9, entries: []});
+try {
+buffer3.unmap();
+} catch {}
+try {
+window.someLabel = querySet5.label;
+} catch {}
+let canvas5 = document.createElement('canvas');
+let commandEncoder24 = device1.createCommandEncoder({});
+let renderBundleEncoder11 = device1.createRenderBundleEncoder({
+  label: '\u4ce6\u{1fd4f}\u0ab4\u108f\udb3b\u0a19\u0f5e\u94a2\u7cf0\u0149',
+  colorFormats: ['bgra8unorm-srgb', 'rg32float'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder3.setBindGroup(6, bindGroup2, new Uint32Array(6659), 4565, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'stencil-only',
+}, new Int8Array(new ArrayBuffer(56)), /* required buffer size: 9_946_906 */
+{offset: 786, bytesPerRow: 92, rowsPerImage: 95}, {width: 48, height: 0, depthOrArrayLayers: 1139});
+} catch {}
+let pipeline16 = await device1.createComputePipelineAsync({
+  label: '\u17c9\ua980\u689b\ufc0e\u29c9\u1b06\u7213\u7632\u532b',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap10 = await createImageBitmap(img2);
+let querySet16 = device0.createQuerySet({label: '\u741f\u{1f6b9}\u0f58\u08f1\u88ad\ue36e\u056c', type: 'occlusion', count: 985});
+let textureView29 = texture3.createView({label: '\u0a08\u{1f8fa}\u7332\u3bef\u1d65\u0eb6\u5169\u0a12'});
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+let bindGroup6 = device1.createBindGroup({
+  label: '\u29a6\ua877\u81a4\u7589',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 2668, resource: sampler9},
+    {binding: 3641, resource: sampler6},
+    {binding: 7224, resource: externalTexture10},
+  ],
+});
+let commandEncoder25 = device1.createCommandEncoder({label: '\u3797\u016a\u33cc\u0cf3\u53e9\u37ea\u3393\u0871\u662c\u{1fe70}'});
+let textureView30 = texture8.createView({
+  label: '\u0bb3\u0b49\ud817\u{1fd14}\u31f2\u73ad\ud437',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 649,
+  arrayLayerCount: 128,
+});
+let computePassEncoder8 = commandEncoder16.beginComputePass({label: '\u06c0\u907a\ua042\u{1fb64}\ud3f0\u{1ffbd}\u0e65\udc7e'});
+let pipeline17 = device1.createComputePipeline({
+  label: '\ud33b\u0363\u13fe',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let canvas6 = document.createElement('canvas');
+let texture15 = device1.createTexture({
+  size: [192, 1, 1194],
+  mipLevelCount: 8,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder9 = commandEncoder23.beginComputePass({label: '\u7308\ue311\udfe3\u1dbb\ud6d2\u002e\u7d06'});
+let externalTexture16 = device1.importExternalTexture({label: '\u003b\u1448\u1a63\u0289', source: video2, colorSpace: 'srgb'});
+try {
+commandEncoder22.clearBuffer(buffer3, 18460, 37752);
+dissociateBuffer(device1, buffer3);
+} catch {}
+let pipeline18 = await promise2;
+let textureView31 = texture8.createView({
+  label: '\uca23\u01d5\u0926\u{1fa74}\u95da\u5653\u0aca\u0313',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 661,
+});
+let renderBundleEncoder12 = device1.createRenderBundleEncoder({label: '\u4bbf\ub156', colorFormats: ['bgra8unorm-srgb', 'rg32float'], stencilReadOnly: true});
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let video3 = await videoWithData();
+try {
+canvas6.getContext('webgl2');
+} catch {}
+let texture16 = device1.createTexture({
+  label: '\u{1fe57}\uf7b9\u06dd\u04a4\u5bda',
+  size: [192, 1, 127],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let textureView32 = texture16.createView({});
+let renderBundle11 = renderBundleEncoder12.finish({label: '\ufb3b\uf4d6\u053d\u5b34\u0a57\u5548\u0839\u03ca\u{1f63a}\u0e2b'});
+try {
+renderBundleEncoder11.setBindGroup(4, bindGroup1, new Uint32Array(6158), 3072, 0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer3, 0, 53372);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 127},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img4 = await imageWithData(251, 289, '#50632081', '#2db9e364');
+let imageData6 = new ImageData(108, 40);
+let commandEncoder26 = device1.createCommandEncoder();
+let renderBundle12 = renderBundleEncoder8.finish();
+try {
+computePassEncoder8.setBindGroup(1, bindGroup4, new Uint32Array(9705), 7504, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, buffer3, 64584, 76);
+} catch {}
+try {
+commandEncoder24.insertDebugMarker('\u{1f8eb}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 18},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(56), /* required buffer size: 58_381_310 */
+{offset: 744, bytesPerRow: 245, rowsPerImage: 212}, {width: 6, height: 1, depthOrArrayLayers: 1125});
+} catch {}
+let pipeline19 = await device1.createRenderPipelineAsync({
+  label: '\u{1f6be}\u826f\u0cf2\u9194\u68e9\u8043\ue87b\ubdd0\u34de\u0417',
+  layout: pipelineLayout1,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilWriteMask: 1421198654,
+    depthBias: 808780834,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2044,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 428, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 436, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 15},
+          {format: 'sint32x4', offset: 128, shaderLocation: 4},
+          {format: 'sint8x2', offset: 14, shaderLocation: 11},
+          {format: 'sint32x2', offset: 120, shaderLocation: 1},
+          {format: 'float32', offset: 172, shaderLocation: 7},
+          {format: 'float32', offset: 124, shaderLocation: 8},
+          {format: 'float16x4', offset: 788, shaderLocation: 0},
+          {format: 'uint8x2', offset: 516, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 532,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 48, shaderLocation: 12},
+          {format: 'uint8x4', offset: 24, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 268, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 4288,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 1652, shaderLocation: 13},
+          {format: 'float32x3', offset: 768, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 812,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 36, shaderLocation: 10}],
+      },
+      {arrayStride: 600, attributes: []},
+      {arrayStride: 1652, stepMode: 'instance', attributes: []},
+      {arrayStride: 212, stepMode: 'instance', attributes: []},
+      {arrayStride: 1400, stepMode: 'instance', attributes: []},
+      {arrayStride: 2892, attributes: [{format: 'uint32x2', offset: 124, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+let canvas7 = document.createElement('canvas');
+try {
+adapter2.label = '\u1d03\u1ad5';
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder();
+let texture17 = device1.createTexture({
+  label: '\u{1f686}\u9f03\u8fde\u03fc\ue3ae\u0fb3\u{1fe73}\ucd7b\u0f62\ua036\u0571',
+  size: [96, 1, 1194],
+  mipLevelCount: 4,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView33 = texture8.createView({label: '\u0324\u13a6', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 428});
+let externalTexture17 = device1.importExternalTexture({label: '\u174e\u3809\u0554', source: video1});
+try {
+renderBundleEncoder10.setVertexBuffer(3, buffer3, 0, 42980);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let bindGroup7 = device1.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 3641, resource: sampler9},
+    {binding: 2668, resource: sampler9},
+    {binding: 7224, resource: externalTexture16},
+  ],
+});
+let renderBundleEncoder13 = device1.createRenderBundleEncoder({
+  label: '\u{1fb4d}\ua931\u{1fd6f}\ud521\u48cb\uad05\uee45\u0404\u014e\u0f09\u0108',
+  colorFormats: ['rgba32float', 'rg16uint', 'rg8uint', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(306), 133, 0);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 146},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 8144, new Int16Array(5370), 1639, 1736);
+} catch {}
+let pipeline20 = await device1.createComputePipelineAsync({
+  label: '\u1715\u0033\u9fba\ufa4d',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let textureView34 = texture14.createView({label: '\u79eb\ua901', format: 'bgra8unorm', baseMipLevel: 8});
+let computePassEncoder10 = commandEncoder26.beginComputePass({label: '\u{1ff84}\uec7f\u9106\ud558\uecff'});
+let externalTexture18 = device1.importExternalTexture({label: '\u0d03\u{1f64a}\u0b1b\u0d9d\u{1f7b9}\ub7bd\u06b2\ua1a9\u015f', source: video2});
+let gpuCanvasContext9 = canvas7.getContext('webgpu');
+try {
+pipeline5.label = '\uf7a1\u{1ff8e}\ub14f\u{1fe03}';
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({});
+let img5 = await imageWithData(59, 291, '#c1b9e992', '#a1b397e6');
+let pipelineLayout4 = device1.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout10, bindGroupLayout9, bindGroupLayout6, bindGroupLayout12, bindGroupLayout5, bindGroupLayout11, bindGroupLayout10],
+});
+let commandEncoder28 = device1.createCommandEncoder({label: '\u095c\ub774\u0435\u6d5d\u77ed\u199b\u14d7\u77c0\u04a5\u943d'});
+let textureView35 = texture10.createView({});
+let sampler11 = device1.createSampler({
+  label: '\u7854\u018f\u0eaa\u9365\u{1fee2}\ufdd1\u{1fcdb}\u00d9\uf344',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.973,
+  lodMaxClamp: 98.07,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer3, 30260, 39911);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 67},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 16824, new BigUint64Array(17142), 12337, 836);
+} catch {}
+let commandEncoder29 = device1.createCommandEncoder();
+let textureView36 = texture17.createView({
+  label: '\u893c\u078d\u0b8a\u035c\u6764\u8695\u{1f773}\u5003\u0dc8\u062b\u085c',
+  dimension: '2d',
+  format: 'rgba32uint',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 718,
+});
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup5);
+} catch {}
+let bindGroupLayout13 = pipeline6.getBindGroupLayout(0);
+let commandEncoder30 = device1.createCommandEncoder();
+let textureView37 = texture8.createView({label: '\ucf70\u4c32\ua395', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 218});
+let externalTexture19 = device1.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setPipeline(pipeline16);
+} catch {}
+let promise4 = device1.queue.onSubmittedWorkDone();
+let pipeline21 = device1.createRenderPipeline({
+  label: '\u049e\u{1fdad}\ua02a\u7d31\u5de8\ua6d1\u0347\u{1fd0d}\u078a',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 2140181051,
+    stencilWriteMask: 2392448956,
+    depthBias: -417536412,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 508, shaderLocation: 16},
+          {format: 'float16x2', offset: 8604, shaderLocation: 9},
+          {format: 'uint8x4', offset: 4640, shaderLocation: 3},
+          {format: 'uint32x3', offset: 96, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 2932, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 3748, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 2258, shaderLocation: 2},
+          {format: 'sint8x4', offset: 8240, shaderLocation: 11},
+          {format: 'sint8x4', offset: 3436, shaderLocation: 4},
+          {format: 'float32', offset: 1128, shaderLocation: 10},
+          {format: 'float16x4', offset: 1356, shaderLocation: 12},
+          {format: 'sint32x4', offset: 1208, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 5470, shaderLocation: 7},
+          {format: 'float16x2', offset: 9768, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 2692, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 5508, attributes: []},
+      {arrayStride: 8988, attributes: []},
+      {arrayStride: 3856, attributes: []},
+      {arrayStride: 56, attributes: []},
+      {arrayStride: 436, attributes: []},
+      {arrayStride: 2704, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 1924,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 240, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(176, 675);
+let videoFrame7 = new VideoFrame(imageBitmap10, {timestamp: 0});
+try {
+canvas8.getContext('webgl');
+} catch {}
+let querySet17 = device1.createQuerySet({label: '\ud5e4\u6922\u{1fc44}\u0ba7\u{1f7f4}\u0aa9\u7f36\u{1fae8}', type: 'occlusion', count: 3303});
+let textureView38 = texture14.createView({label: '\u{1f630}\u{1fdf9}\u0999\u9409\uf975\u0b2e\u0790\ubf0b', dimension: '3d', baseMipLevel: 6});
+try {
+computePassEncoder6.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(8, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer2, 'uint16', 98594, 13125);
+} catch {}
+let promise5 = device1.popErrorScope();
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 65244 */
+  offset: 65240,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture14,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas8.getContext('webgpu');
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let device2 = await adapter2.requestDevice({
+  label: '\uc690\u{1fbff}\u3a9a\u06e0\u0b72\u7e6e\ue06f\u{1fe73}\u1a3d',
+  defaultQueue: {label: '\u098b\u5bb9\u0e89\u3bee\u9b8c\u0d2c'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+gc();
+let textureView39 = texture17.createView({label: '\u4179\u6bd2\u76d7\u6b5d\u0141', mipLevelCount: 3, baseArrayLayer: 199, arrayLayerCount: 138});
+let renderBundle13 = renderBundleEncoder13.finish({label: '\uac9e\u8e2c\u{1fa8c}\u014c\u0f20\u95b0\u0a01\ue8af\u{1fd1c}\u{1fd4e}'});
+try {
+renderBundleEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+querySet14.destroy();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 63}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 156, y: 11 },
+  flipY: true,
+}, {
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 37, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline22 = await device1.createComputePipelineAsync({
+  label: '\u0813\u6bb5\u7280\ue57d\uf19d\u{1fac5}\u4f30\u03ba\u4a56',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img1);
+offscreenCanvas1.height = 2013;
+let commandEncoder31 = device1.createCommandEncoder();
+try {
+commandEncoder30.clearBuffer(buffer3, 32608, 15624);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+video3.height = 74;
+let texture18 = gpuCanvasContext0.getCurrentTexture();
+let textureView40 = texture18.createView({label: '\u050d\u{1ffb0}\u097d', dimension: '2d-array', format: 'rgba8unorm-srgb'});
+let sampler12 = device2.createSampler({
+  label: '\u073e\u0175\ub554\u42e5\u5273\u2a8c\u4714\u8b7b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 59.43,
+  lodMaxClamp: 74.11,
+});
+let externalTexture20 = device2.importExternalTexture({
+  label: '\u012c\u2d03\u7a4a\u{1fa86}\u0621\u050d\u2932\ud62e\u0776\u{1f69a}',
+  source: video3,
+  colorSpace: 'srgb',
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 86, y: 28 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video4 = await videoWithData();
+let querySet18 = device1.createQuerySet({label: '\u0167\u7dfa\u1fd7\u34c2\u0725', type: 'occlusion', count: 95});
+let texture19 = device1.createTexture({
+  size: [48, 1, 1194],
+  mipLevelCount: 4,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let externalTexture21 = device1.importExternalTexture({label: '\u1786\u59f2\u0278\u00ff\u0583\u{1fed8}', source: video3, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder11.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3, 59572, 528);
+dissociateBuffer(device1, buffer3);
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(78, 114);
+let commandEncoder32 = device2.createCommandEncoder();
+let querySet19 = device2.createQuerySet({
+  label: '\u{1fda1}\u{1ff91}\u{1ff42}\u{1f9a7}\u989c\ufea5\u{1fb37}\u046d',
+  type: 'occlusion',
+  count: 2072,
+});
+let commandBuffer6 = commandEncoder32.finish();
+let videoFrame8 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let buffer4 = device2.createBuffer({size: 116000, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture20 = device2.createTexture({
+  label: '\uee11\u{1fc35}\u0a60\u4742\u0319\ucd70\ua6ba',
+  size: [24, 30, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(24)), /* required buffer size: 300 */
+{offset: 300}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas9 = document.createElement('canvas');
+let bindGroupLayout14 = device1.createBindGroupLayout({entries: []});
+let bindGroup8 = device1.createBindGroup({
+  label: '\u6628\u0542\u90a7\u{1fdc3}\u{1f781}\u{1fcc6}\u52e3\u5edd',
+  layout: bindGroupLayout14,
+  entries: [],
+});
+let pipelineLayout5 = device1.createPipelineLayout({label: '\u{1fad6}\u13b1', bindGroupLayouts: [bindGroupLayout10]});
+let renderBundle14 = renderBundleEncoder8.finish({label: '\u0f15\ude40\u489b\u{1fa2f}\ue04e\u0800\u{1ffb6}\u773c'});
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 48},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 6776 */
+  offset: 6764,
+  buffer: buffer3,
+}, {width: 12, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer3);
+} catch {}
+let pipeline23 = await device1.createRenderPipelineAsync({
+  label: '\u063d\u3c5f\u0d39\uf80c',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: 0}, {format: 'rg32float', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 3701415177,
+    stencilWriteMask: 4007753010,
+    depthBias: -492780361,
+    depthBiasSlopeScale: 471.08263750810625,
+    depthBiasClamp: 689.852677380772,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3068,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 1068, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 1008, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 158, shaderLocation: 7},
+          {format: 'float32', offset: 48, shaderLocation: 0},
+          {format: 'sint32x3', offset: 748, shaderLocation: 11},
+          {format: 'uint8x4', offset: 1064, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 200, shaderLocation: 2},
+          {format: 'sint32', offset: 328, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 1380, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 300, shaderLocation: 13},
+          {format: 'float32', offset: 36, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint16x2', offset: 3844, shaderLocation: 1}]},
+      {
+        arrayStride: 864,
+        attributes: [
+          {format: 'uint16x4', offset: 24, shaderLocation: 16},
+          {format: 'float32x2', offset: 220, shaderLocation: 8},
+          {format: 'float32x3', offset: 56, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 554, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 20, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+let imageBitmap11 = await createImageBitmap(offscreenCanvas5);
+let commandEncoder33 = device1.createCommandEncoder({label: '\ue4ab\ub617\u{1fa5c}\ubac4\u056e\uaa46\u{1fdef}\u02d9'});
+let texture21 = device1.createTexture({
+  label: '\u4ce6\ud951\u0d0d\u{1f8c2}',
+  size: {width: 192, height: 1, depthOrArrayLayers: 156},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder11 = commandEncoder18.beginComputePass();
+let externalTexture22 = device1.importExternalTexture({
+  label: '\u{1fa49}\ub46c\u{1fa58}\u06f3\u03af\uc50c\u0f30\ubed0\u97aa\u0c81\ucd04',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder5.setBindGroup(4, bindGroup0, new Uint32Array(5620), 5051, 0);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 61, height: 0, depthOrArrayLayers: 24});
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer3, 68396, 1996);
+dissociateBuffer(device1, buffer3);
+} catch {}
+canvas8.width = 2608;
+gc();
+let textureView41 = texture20.createView({label: '\ud537\u09bf', dimension: '2d-array', mipLevelCount: 1});
+let canvas10 = document.createElement('canvas');
+let commandEncoder34 = device1.createCommandEncoder();
+let texture22 = device1.createTexture({
+  label: '\uf08e\ua5e3\uee6b\u92cf\ud1b5',
+  size: {width: 48, height: 1, depthOrArrayLayers: 1891},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder11.setIndexBuffer(buffer2, 'uint32', 32372, 43815);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer3, 63936, 3656);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 2316, new DataView(new ArrayBuffer(5332)), 3610, 368);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(64)), /* required buffer size: 1_352_367 */
+{offset: 991, bytesPerRow: 292, rowsPerImage: 178}, {width: 0, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let pipeline24 = await device1.createRenderPipelineAsync({
+  label: '\u21ef\u67b8',
+  layout: pipelineLayout1,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2058713154,
+    stencilWriteMask: 3430461308,
+    depthBias: 1731489374,
+    depthBiasSlopeScale: 441.11853086870633,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5236,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 316, shaderLocation: 8},
+          {format: 'float16x4', offset: 1684, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 1080, shaderLocation: 12},
+          {format: 'float16x4', offset: 2324, shaderLocation: 2},
+          {format: 'uint32x2', offset: 392, shaderLocation: 5},
+          {format: 'sint32x4', offset: 168, shaderLocation: 11},
+          {format: 'uint32x2', offset: 144, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 812, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 254, shaderLocation: 10},
+          {format: 'float32x3', offset: 588, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 1904, shaderLocation: 6},
+          {format: 'sint8x2', offset: 1278, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 1000, shaderLocation: 7},
+          {format: 'float16x2', offset: 4148, shaderLocation: 14},
+          {format: 'uint32x3', offset: 920, shaderLocation: 16},
+          {format: 'float32x4', offset: 172, shaderLocation: 9},
+          {format: 'sint32', offset: 908, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw'},
+});
+try {
+canvas9.getContext('webgpu');
+} catch {}
+let imageData7 = new ImageData(200, 224);
+let commandEncoder35 = device1.createCommandEncoder({label: '\u0940\u5370\u03b3\u40cd'});
+let querySet20 = device1.createQuerySet({label: '\u{1f91a}\uc3cb\u0ccd\u0286\u{1f73c}', type: 'occlusion', count: 718});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({
+  label: '\u0fa5\ubb6b\u0c5f',
+  colorFormats: ['rgba32float', 'rg16uint', 'rg8uint', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(9, buffer3, 10176, 7579);
+} catch {}
+offscreenCanvas5.width = 124;
+let videoFrame9 = new VideoFrame(video3, {timestamp: 0});
+let bindGroupLayout15 = device2.createBindGroupLayout({
+  label: '\u3230\ud449\u{1fc03}\u076f\uf9c5\udae1\u0aa1\uec5e\u0b2b\u03bd',
+  entries: [{binding: 938, visibility: 0, sampler: { type: 'non-filtering' }}],
+});
+let bindGroup9 = device2.createBindGroup({
+  label: '\u0ccc\u133e\u7f66\u0141\udba5\u{1f9a0}\u41c0',
+  layout: bindGroupLayout15,
+  entries: [{binding: 938, resource: sampler12}],
+});
+let commandEncoder36 = device2.createCommandEncoder();
+let texture23 = device2.createTexture({
+  label: '\u00c4\ua8d6\u{1ff52}\u3777\u8431\u018f\u0e80\u1c60',
+  size: [24, 30, 82],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture23 = device2.importExternalTexture({label: '\u3137\u763e\ufed6\u0e7b\u87c6\u17b4', source: video0, colorSpace: 'srgb'});
+try {
+commandEncoder36.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 32 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+canvas10.getContext('webgl2');
+} catch {}
+let renderBundleEncoder15 = device2.createRenderBundleEncoder({
+  label: '\u3670\u5cb2\u7434\u{1f9e3}\u7bb7\u0726\u276f\ud72e\u6e80',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  depthReadOnly: true,
+});
+let renderBundle15 = renderBundleEncoder15.finish();
+try {
+commandEncoder36.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 35096, new Float32Array(19925), 1660, 3432);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(80)), /* required buffer size: 696_108 */
+{offset: 828, bytesPerRow: 56, rowsPerImage: 295}, {width: 20, height: 26, depthOrArrayLayers: 43});
+} catch {}
+try {
+adapter3.label = '\u1b62\u8c0b\uc896\u0d7b\ud3fd\u736e\u{1f9ef}\ue1aa\u{1fba5}\u0ee0\ua24e';
+} catch {}
+let renderBundleEncoder16 = device2.createRenderBundleEncoder({
+  label: '\u1235\u8274\u7a70\u9323\u{1fb8c}\u809a\uf1d1\u{1f739}',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle16 = renderBundleEncoder15.finish({label: '\u3435\u82ba\u01b1\u{1fe40}\u0d1b\u{1fa5f}\u0bba\u0955\u0930\u{1feb8}'});
+try {
+buffer4.unmap();
+} catch {}
+let bindGroup10 = device1.createBindGroup({layout: bindGroupLayout6, entries: []});
+let commandEncoder37 = device1.createCommandEncoder({label: '\ue054\u{1fd30}\u2aca\u0dc1\u{1fd72}\u{1fe57}\u96ef'});
+let textureView42 = texture10.createView({baseMipLevel: 2});
+let sampler13 = device1.createSampler({
+  label: '\ue128\ud88b\u{1fff5}\u7de4\u{1f6bf}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.15,
+  lodMaxClamp: 60.93,
+  compare: 'equal',
+  maxAnisotropy: 4,
+});
+let externalTexture24 = device1.importExternalTexture({label: '\u09a8\uee5f\u{1fe6e}\u6f1a\u029a\u4046\ue659', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder6.setBindGroup(8, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 313},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 48, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 51408, new Int16Array(53754), 10487, 3368);
+} catch {}
+let pipeline25 = device1.createComputePipeline({
+  label: '\u181b\ueec5\u041d\u92fa\uf83f\u534d',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let video5 = await videoWithData();
+let pipelineLayout6 = device2.createPipelineLayout({
+  label: '\u{1f9bb}\u0c37\ubb44\ua13c\u377b\ud03e\ufb38\ud7e7\ucd4b\ub3d1\u4802',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout15, bindGroupLayout15, bindGroupLayout15],
+});
+let commandEncoder38 = device2.createCommandEncoder({label: '\ub406\u0c86'});
+let textureView43 = texture20.createView({
+  label: '\u1fc7\u0ba2\uc39b\u{1fcf8}\u72d0\u0d4f\u0bfc\u{1f770}\u{1feb9}',
+  format: 'rg32sint',
+  mipLevelCount: 1,
+});
+let computePassEncoder12 = commandEncoder38.beginComputePass({label: '\u7d4b\u3180'});
+let renderBundleEncoder17 = device2.createRenderBundleEncoder({
+  label: '\ud8cc\u{1f809}\u09ce\u0a3c\u04d3\u0fc7',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  depthReadOnly: true,
+});
+let renderBundle17 = renderBundleEncoder16.finish({label: '\u1d1d\ua808\u{1f78e}\u{1fd2f}\u09d0'});
+let sampler14 = device2.createSampler({
+  label: '\u06f2\u0d67\uf690\ufdd9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.18,
+  lodMaxClamp: 76.25,
+});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5863, undefined, 4259827708, 3379676);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 15, depthOrArrayLayers: 41}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 9, y: 3 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas9.getContext('webgpu');
+let bindGroupLayout16 = device2.createBindGroupLayout({
+  label: '\u09b0\u3424',
+  entries: [
+    {
+      binding: 441,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 334,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let querySet21 = device2.createQuerySet({label: '\u0227\u{1fc0e}\ubfdb\u08a5', type: 'occlusion', count: 3062});
+let texture24 = device2.createTexture({
+  label: '\ue58b\u{1fe1b}\u0742\u0bd7\u76d4',
+  size: {width: 48, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float'],
+});
+let textureView44 = texture24.createView({label: '\u00ed\u0970\u0877\u0254\u1929\u{1fb24}\ued0b\u{1f7df}\u{1f845}\u{1fcf5}', baseMipLevel: 3});
+let renderBundle18 = renderBundleEncoder15.finish({});
+try {
+device2.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(891), /* required buffer size: 891 */
+{offset: 891, bytesPerRow: 220}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture25 = device2.createTexture({
+  label: '\u07d9\ua1bd\u{1fd40}\u{1feb8}\u9f08\u{1fb5a}\u3ef1',
+  size: {width: 24, height: 30, depthOrArrayLayers: 67},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let computePassEncoder13 = commandEncoder36.beginComputePass({});
+offscreenCanvas3.height = 240;
+let bindGroupLayout17 = device2.createBindGroupLayout({
+  label: '\u92c6\u{1f938}\u282c\u{1f725}\u0ad1\u{1fa67}\u0fa1\u6e41\u0fef',
+  entries: [
+    {
+      binding: 377,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 94, visibility: 0, externalTexture: {}},
+    {
+      binding: 851,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder39 = device2.createCommandEncoder();
+let texture26 = device2.createTexture({
+  label: '\u076b\u{1fc91}\u55d8\u0d18\u5bdc\u{1fbc2}\u05b0\u{1fba8}\u0f28\u0445',
+  size: [192, 240, 658],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let renderBundle19 = renderBundleEncoder16.finish({label: '\u{1fd93}\u0847\u79ad'});
+let externalTexture25 = device2.importExternalTexture({
+  label: '\u{1f904}\u48eb\u3676\uc2a4\u{1faad}\ue434\u0cbf\u6d68\u6f90\u0a4e\u1e80',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup9, new Uint32Array(8044), 4960, 0);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17286 */
+  offset: 17286,
+  bytesPerRow: 0,
+  buffer: buffer4,
+}, {width: 0, height: 30, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer4);
+} catch {}
+let img6 = await imageWithData(275, 101, '#cb425125', '#dbe6fef3');
+let imageBitmap12 = await createImageBitmap(imageBitmap5);
+let shaderModule3 = device2.createShaderModule({
+  label: '\u0fe9\u{1f6e3}\u0b63\u{1f788}\u01f3\ua457',
+  code: `@group(0) @binding(938)
+var<storage, read_write> parameter0: array<u32>;
+@group(3) @binding(938)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(3, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(1) f0: vec3<f16>,
+  @builtin(sample_index) f1: u32,
+  @builtin(position) f2: vec4<f32>,
+  @builtin(front_facing) f3: bool
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec3<f32>,
+  @location(0) f2: vec2<i32>,
+  @location(1) f3: vec3<f32>,
+  @location(2) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(a0: S5, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f43: vec4<f32>,
+  @location(1) f44: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout18 = device2.createBindGroupLayout({
+  label: '\u3f3a\uc405\u0c1c\u{1fe83}\u{1f6da}',
+  entries: [
+    {binding: 692, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false }},
+    {binding: 689, visibility: 0, externalTexture: {}},
+  ],
+});
+let bindGroup11 = device2.createBindGroup({
+  label: '\udfcb\u5530\u784a\u07cb\u2b25\u{1fb2e}',
+  layout: bindGroupLayout15,
+  entries: [{binding: 938, resource: sampler12}],
+});
+let commandEncoder40 = device2.createCommandEncoder({label: '\ud3f6\u079e\u{1fa91}\u07e8\ud7a3\u{1f8d5}\u6357'});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+commandEncoder40.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let img7 = await imageWithData(88, 122, '#7d6ed3be', '#d600113e');
+let pipelineLayout7 = device1.createPipelineLayout({
+  label: '\u{1ffb1}\u0d2f\u6032\u60fc\u7616\ue3bb\u{1f9e4}\u885d',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout13, bindGroupLayout6, bindGroupLayout12, bindGroupLayout11, bindGroupLayout7],
+});
+let querySet22 = device1.createQuerySet({label: '\u060d\uf8e4\u55f7\u9e39\u36cc\u0b66\uea54', type: 'occlusion', count: 2741});
+let texture27 = device1.createTexture({
+  label: '\u{1fd29}\uc89a\u{1ff7c}\u{1facf}\u{1fcd1}\u5a48\u{1fe40}\u0e4d\ucb64\ud6e7\u0c46',
+  size: {width: 192, height: 1, depthOrArrayLayers: 620},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView45 = texture11.createView({
+  label: '\u{1f91d}\u0441\u44dd\uba2f\u57da\u7a0c\u{1fb50}\u978f',
+  baseArrayLayer: 46,
+  arrayLayerCount: 132,
+});
+let computePassEncoder14 = commandEncoder31.beginComputePass({});
+let renderBundle20 = renderBundleEncoder10.finish({label: '\ud2a6\u{1fcf8}\u{1f870}\u9343\u889e\u89cb\u0c06\u0d83'});
+let externalTexture26 = device1.importExternalTexture({label: '\u0e8e\u0b86\ud092\u6db7\u1ce2', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup1, new Uint32Array(275), 73, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 156}
+*/
+{
+  source: video5,
+  origin: { x: 1, y: 5 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\uada5\u0b8b\u1110\u9b7e\u0237\u47a4';
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+  await promise4;
+} catch {}
+let canvas12 = document.createElement('canvas');
+let commandEncoder41 = device2.createCommandEncoder({label: '\ubb6a\uc976\u{1fe27}'});
+try {
+commandEncoder39.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+canvas12.getContext('webgl');
+} catch {}
+let commandEncoder42 = device1.createCommandEncoder({});
+let querySet23 = device1.createQuerySet({label: '\u{1fc5a}\ubc81', type: 'occlusion', count: 3749});
+pseudoSubmit(device1);
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u1b68\u0fc7\u0030\u{1fd03}\ue7e3\u69b5\u089d\u7692\u11bc\u5744',
+  colorFormats: ['bgra8unorm-srgb', 'rg32float'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(5, bindGroup6, new Uint32Array(1090), 193, 0);
+} catch {}
+try {
+device1.queue.submit([commandBuffer5]);
+} catch {}
+document.body.prepend(img2);
+let textureView46 = texture23.createView({baseMipLevel: 1});
+let renderBundleEncoder19 = device2.createRenderBundleEncoder({
+  label: '\u715e\u0956\u0c47\ub621\u0152\u0782\uf8c7\u4e54\ucef9',
+  colorFormats: ['rg32uint', 'rg8unorm', 'r32float', 'rgba16uint', 'rgba8unorm-srgb'],
+});
+try {
+device2.queue.writeBuffer(buffer4, 4980, new DataView(new ArrayBuffer(10375)), 9868, 56);
+} catch {}
+let canvas13 = document.createElement('canvas');
+let commandEncoder43 = device1.createCommandEncoder({label: '\u{1ff61}\u0eb7\u7e0f\u05dd\u{1ff67}\uc6ce\uf5ee\u{1fe9a}\u{1ff8c}\u06b3'});
+let querySet24 = device1.createQuerySet({label: '\u{1f7f3}\ue09d\u00f4\u{1f6c3}\u127e', type: 'occlusion', count: 2471});
+let renderBundle21 = renderBundleEncoder7.finish();
+let sampler15 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 11,
+});
+let externalTexture27 = device1.importExternalTexture({label: '\u{1f8be}\uc21b', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder11.setPipeline(pipeline18);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+try {
+device1.destroy();
+} catch {}
+try {
+  await promise5;
+} catch {}
+document.body.prepend(canvas1);
+let videoFrame10 = new VideoFrame(img5, {timestamp: 0});
+let videoFrame11 = new VideoFrame(canvas2, {timestamp: 0});
+let commandBuffer7 = commandEncoder41.finish({label: '\u{1f804}\ua82b\u042e\u{1fd0b}\uccb4'});
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({label: '\u09a0\u06e4', colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float']});
+let renderBundle22 = renderBundleEncoder20.finish({});
+let sampler16 = device2.createSampler({
+  label: '\udb25\u{1f7ac}\u1ea7\u234b\u{1fabf}\u01b4\uc5d6\ua248\ua41d\u0e83\u54d9',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.96,
+  lodMaxClamp: 96.73,
+  maxAnisotropy: 15,
+});
+let externalTexture28 = device2.importExternalTexture({label: '\u095e\ub4ca\u0b7c\u05db\u0fb4', source: video0});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline26 = device2.createRenderPipeline({
+  label: '\u300f\u0384\u710c',
+  layout: pipelineLayout6,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16float', writeMask: 0}, {format: 'rgba32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 1303975180,
+    stencilWriteMask: 3264571952,
+    depthBiasSlopeScale: 799.7425713901516,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 416, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 36, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+let offscreenCanvas10 = new OffscreenCanvas(483, 748);
+try {
+canvas13.getContext('webgpu');
+} catch {}
+let gpuCanvasContext12 = canvas11.getContext('webgpu');
+let commandEncoder44 = device2.createCommandEncoder({label: '\u4ae9\u{1ffe9}\u04c2\u13fe\ue544\u7f68\u20b1\u8a75\u0e19\u9f7d\u{1fabf}'});
+let texture28 = device2.createTexture({
+  label: '\u{1fad9}\u{1f9cc}\u09a8\ufad6\u{1ff0d}\ue591\u5e6c\u054a',
+  size: [24],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let renderBundleEncoder21 = device2.createRenderBundleEncoder({
+  label: '\u018b\ub369',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let promise6 = buffer4.mapAsync(GPUMapMode.READ, 79536, 11648);
+try {
+device2.queue.submit([commandBuffer7, commandBuffer6]);
+} catch {}
+let pipeline27 = device2.createRenderPipeline({
+  label: '\u53c8\u{1f912}\u{1fb59}\u0a60',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0x1bd67089},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'zero'},
+  },
+}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA}, {format: 'r16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 216,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 48, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+let textureView47 = texture28.createView({label: '\u88fa\u6225\u9aa7\u01ec\u{1fd3e}', baseArrayLayer: 0});
+let renderBundle23 = renderBundleEncoder16.finish({label: '\u{1fe13}\u01e3\u01c4\u{1fa04}\ube51\ua2a4\u40e0\u{1fb45}\ufbf1\u0f1f'});
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup11);
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas10.getContext('webgpu');
+document.body.prepend(video3);
+canvas6.height = 1146;
+let img8 = await imageWithData(23, 244, '#2b112ae8', '#d6b415ef');
+let renderBundle24 = renderBundleEncoder17.finish();
+let sampler17 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.16,
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup9, new Uint32Array(6938), 2162, 0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup9, new Uint32Array(913), 762, 0);
+} catch {}
+canvas2.height = 945;
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup11);
+} catch {}
+let buffer5 = device2.createBuffer({
+  label: '\u222a\ubcbb\u4cc7\u058c',
+  size: 125745,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder45 = device2.createCommandEncoder();
+let imageData8 = new ImageData(24, 156);
+try {
+  await promise6;
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let textureView48 = texture20.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder22 = device2.createRenderBundleEncoder({colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float']});
+let sampler18 = device2.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', lodMinClamp: 27.43});
+let externalTexture29 = device2.importExternalTexture({source: videoFrame10, colorSpace: 'srgb'});
+try {
+commandEncoder45.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline28 = device2.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let video6 = await videoWithData();
+let videoFrame12 = new VideoFrame(videoFrame3, {timestamp: 0});
+let textureView49 = texture24.createView({label: '\u{1ff41}\u{1fc1a}\u68ea\u417a\ueba6\u7bff\u193d\u7a2e', baseMipLevel: 2, mipLevelCount: 1});
+let promise7 = device2.popErrorScope();
+try {
+commandEncoder39.copyBufferToBuffer(buffer5, 1556, buffer4, 48032, 33692);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let pipeline29 = device2.createComputePipeline({
+  label: '\u{1fe0f}\u4315\u2500\u3e55\u7620\u3687\u08bd\ubbbe',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let device3 = await adapter3.requestDevice({
+  defaultQueue: {label: '\u57ce\uc02c\u0ea5'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'bgra8unorm-storage',
+  ],
+});
+let pipelineLayout8 = device2.createPipelineLayout({
+  label: '\ucc94\u26bc\u5196\uad4c\u03b6\ufcd4\u3991',
+  bindGroupLayouts: [bindGroupLayout16, bindGroupLayout18],
+});
+let texture29 = device2.createTexture({
+  label: '\u5198\u07ec\u94bb\ud17c\uc2e7\u003b',
+  size: {width: 96, height: 120, depthOrArrayLayers: 329},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let renderBundle25 = renderBundleEncoder20.finish({label: '\u838d\u749b\ue0db\u0031\u0d22'});
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22380 */
+  offset: 22376,
+  buffer: buffer5,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let texture30 = device3.createTexture({
+  size: {width: 192, height: 15, depthOrArrayLayers: 148},
+  mipLevelCount: 6,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView50 = texture30.createView({label: '\u09ea\u02c3\u65bf\u6cf7', mipLevelCount: 3, baseArrayLayer: 53, arrayLayerCount: 24});
+document.body.prepend(canvas13);
+try {
+device3.queue.submit([]);
+} catch {}
+let videoFrame13 = new VideoFrame(img6, {timestamp: 0});
+let imageData9 = new ImageData(120, 112);
+let commandEncoder46 = device2.createCommandEncoder({label: '\u4f2a\u94db\u{1fd9a}\u828b\ucda7\u039e'});
+let renderBundle26 = renderBundleEncoder19.finish({label: '\ue3a9\u9a39\u{1f777}'});
+let sampler19 = device2.createSampler({
+  label: '\u{1fc62}\u0976\u3b9d\u00f3\u92c1\u{1fff5}\ud93c\u2e9f\u0830\u{1f85a}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  lodMinClamp: 7.601,
+});
+let arrayBuffer0 = buffer4.getMappedRange(86424, 2268);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let textureView51 = texture24.createView({
+  label: '\uadf2\u{1fae1}\u0434\u0a4d\u{1f65b}',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  baseArrayLayer: 0,
+});
+let renderBundle27 = renderBundleEncoder16.finish({label: '\u0243\u7f4e\u0fac'});
+let sampler20 = device2.createSampler({
+  label: '\u{1f85b}\u0d41\u{1fd02}\u33b6\uddf4\u967b\uf665\u9d12\u0fbc\ua0db',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.51,
+  lodMaxClamp: 70.72,
+});
+try {
+renderBundleEncoder22.setVertexBuffer(350, undefined, 2139326674, 822084018);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let pipeline30 = await device2.createComputePipelineAsync({
+  label: '\uaf71\ue8f7\u0197\udf96\u952b\u{1faf9}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData10 = new ImageData(60, 156);
+let canvas14 = document.createElement('canvas');
+let img9 = await imageWithData(284, 247, '#59763e01', '#9321dac7');
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+try {
+canvas14.getContext('2d');
+} catch {}
+let shaderModule4 = device2.createShaderModule({
+  label: '\uf919\ub743\u{1ffe2}\u0015\u{1fef4}\uff1a\ub687\uac18',
+  code: `@group(1) @binding(689)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> local5: array<u32>;
+@group(0) @binding(334)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(4, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec2<f32>,
+  @location(2) f2: f32,
+  @location(0) f3: vec2<i32>,
+  @location(7) f4: vec4<u32>,
+  @location(1) f5: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(5) f0: vec4<f32>,
+  @location(0) f1: u32,
+  @location(4) f2: vec4<u32>,
+  @location(9) f3: u32,
+  @location(8) f4: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<i32>, @location(7) a1: vec4<f16>, a2: S6, @location(11) a3: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder47 = device2.createCommandEncoder({});
+let textureView52 = texture23.createView({label: '\u399f\u11b8\u00d3\u00ed\u03b3', mipLevelCount: 2});
+let renderBundle28 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder13.setPipeline(pipeline30);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let imageBitmap13 = await createImageBitmap(video4);
+let bindGroupLayout19 = device3.createBindGroupLayout({
+  label: '\uf9a0\ud9b7\u619e\u083a\u{1ff8d}\u09dc\u05b6\u{1fea5}\u07c6\uc05f\u040c',
+  entries: [{binding: 880, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let textureView53 = texture30.createView({
+  label: '\u0438\u0002\u09bb\u9cd4\u1495\u0823',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 91,
+});
+let renderBundleEncoder23 = device3.createRenderBundleEncoder({
+  label: '\u9ef8\u0588\u36d5\uf99d\ud9d6\ub57f\u9bb0\u0501',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle29 = renderBundleEncoder23.finish({label: '\u{1fb90}\u097c\u512f\u{1fa59}\u0172\uf843\u0b8a'});
+let videoFrame14 = new VideoFrame(canvas7, {timestamp: 0});
+let querySet25 = device2.createQuerySet({label: '\ud00b\u8138\ub564\u0279\uc111\u02c3', type: 'occlusion', count: 1649});
+let texture31 = device2.createTexture({
+  size: [96, 120, 151],
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16float'],
+});
+let sampler21 = device2.createSampler({
+  label: '\u0388\u8e0e\u4c39\u5a44\u0ca2\u{1fd63}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.07,
+  lodMaxClamp: 98.64,
+  maxAnisotropy: 2,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 30, depthOrArrayLayers: 67}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 165, y: 245 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 12, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline31 = await device2.createComputePipelineAsync({
+  label: '\u0651\ud383',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let img10 = await imageWithData(213, 122, '#89695b5c', '#23232c7b');
+let pipelineLayout9 = device3.createPipelineLayout({label: '\u{1f7a5}\ua8e1\u02a8\u{1f8f5}\u088a\u0b70\ud3c5\u32bb\u81b8\u80c5', bindGroupLayouts: []});
+let renderBundle30 = renderBundleEncoder23.finish({});
+let externalTexture30 = device3.importExternalTexture({
+  label: '\u054f\u7ff1\u2912\u{1fca3}\u081f\u08ff\u16ed\u{1fa3e}\u0234\u9e43\u{1faf3}',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext12.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let img11 = await imageWithData(256, 29, '#1014c864', '#942db6cd');
+try {
+adapter3.label = '\ua9d9\u01ba\u87d7\u049f\u21cc\ub89b\ue328\u6562\u07d3\u6857\u0d15';
+} catch {}
+let externalTexture31 = device2.importExternalTexture({label: '\u0621\ue6ad\u74d3\u{1fd14}\u9302\u2231', source: videoFrame9, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder21.setVertexBuffer(8124, undefined, 863413526);
+} catch {}
+try {
+commandEncoder47.pushDebugGroup('\u4700');
+} catch {}
+let textureView54 = texture23.createView({label: '\u3673\u{1ff94}\u{1fe8c}\ub5e4\udf7a', baseMipLevel: 1});
+let renderBundle31 = renderBundleEncoder20.finish({label: '\ubc84\u{1fce7}\u059b\u82dd\udc7e'});
+try {
+commandEncoder45.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let promise8 = device2.queue.onSubmittedWorkDone();
+let pipeline32 = await device2.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let querySet26 = device2.createQuerySet({type: 'occlusion', count: 2935});
+let commandBuffer8 = commandEncoder39.finish({label: '\u0fec\u5dee\u{1f7e2}\u16a4\u{1fefc}\u{1f7bb}\u0c00\ud387\u0d1b\u198d\u5462'});
+let texture32 = device2.createTexture({
+  label: '\u0a99\u6bb6',
+  size: {width: 192, height: 240, depthOrArrayLayers: 658},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16float'],
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline31);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder40.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 19244, new Float32Array(45834), 25482);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(8)), /* required buffer size: 544_643 */
+{offset: 407, bytesPerRow: 266, rowsPerImage: 62}, {width: 0, height: 0, depthOrArrayLayers: 34});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 10, y: 16 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise8;
+} catch {}
+let bindGroup12 = device3.createBindGroup({
+  label: '\ube3b\u{1fa7c}\u{1fb7d}\u7480\u545f\u194d\u3c96\u{1fc89}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture30}],
+});
+let textureView55 = texture30.createView({label: '\u{1f970}\u25ff\ua17d', dimension: '2d', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 75});
+let sampler22 = device3.createSampler({
+  label: '\u3289\u{1fe0e}',
+  minFilter: 'nearest',
+  lodMinClamp: 7.464,
+  lodMaxClamp: 97.93,
+  compare: 'never',
+});
+try {
+  await promise7;
+} catch {}
+try {
+externalTexture3.label = '\u{1fa9d}\u0dd0\u0b96\udc2d\u09ef\u1d80\uf797\ue60f';
+} catch {}
+let img12 = await imageWithData(201, 172, '#4fdd3888', '#652f7600');
+let texture33 = device2.createTexture({
+  label: '\u09f1\u{1fb2e}\ub343\ub53a\u05a5\u{1ff36}\u6bdd\u5211',
+  size: {width: 48},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView56 = texture18.createView({label: '\u89ed\u021e\u06ec\uf005\u1691\u4a9c\u0df9', aspect: 'all', format: 'rgba8unorm'});
+try {
+commandEncoder45.copyBufferToBuffer(buffer5, 72972, buffer4, 7160, 31792);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 43456 */
+  offset: 43456,
+  buffer: buffer4,
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer4);
+} catch {}
+let imageData11 = new ImageData(148, 172);
+let shaderModule5 = device2.createShaderModule({
+  label: '\u0fc6\u{1f974}\u289d\u{1f6be}\u08f3\u{1fa70}\u0e92\u{1febc}',
+  code: `@group(0) @binding(441)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(334)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> n5: array<u32>;
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(1) f1: vec3<f32>,
+  @location(4) f2: vec4<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(3) f4: vec4<u32>,
+  @location(0) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(9) f0: u32,
+  @location(6) f1: vec4<f32>,
+  @location(8) f2: vec3<i32>,
+  @location(1) f3: vec3<i32>,
+  @builtin(instance_index) f4: u32,
+  @location(0) f5: vec2<f16>,
+  @builtin(vertex_index) f6: u32,
+  @location(2) f7: u32,
+  @location(15) f8: vec4<f16>,
+  @location(10) f9: vec4<u32>,
+  @location(3) f10: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, @location(14) a1: vec3<f32>, a2: S7, @location(11) a3: vec2<u32>, @location(12) a4: f16, @location(13) a5: vec2<u32>, @location(7) a6: i32, @location(4) a7: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let querySet27 = device2.createQuerySet({label: '\u0189\u{1f9f4}\u06f7\u0f6d\ufc6a\u0b91\u4ea2', type: 'occlusion', count: 1827});
+let textureView57 = texture31.createView({baseArrayLayer: 22, arrayLayerCount: 72});
+let computePassEncoder15 = commandEncoder45.beginComputePass({});
+let renderBundleEncoder24 = device2.createRenderBundleEncoder({
+  label: '\u6a5e\u070a\u0056\u0e42\ueabd\ueee7\ucfa1\u{1fb0a}\uadce\u0da9',
+  colorFormats: ['rg32uint', 'rg8unorm', 'r32float', 'rgba16uint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let sampler23 = device2.createSampler({
+  label: '\u{1f61c}\u5af5\udfe4\ufaf6\u4396\u0218',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 95.00,
+  lodMaxClamp: 99.10,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder21.setVertexBuffer(7835, undefined);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9448 */
+  offset: 9448,
+  buffer: buffer5,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+let promise9 = device2.createComputePipelineAsync({
+  label: '\u9040\ua61d',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame15 = new VideoFrame(imageBitmap8, {timestamp: 0});
+let commandEncoder48 = device3.createCommandEncoder({label: '\u{1feee}\u{1fedf}'});
+let textureView58 = texture30.createView({
+  label: '\u0713\u03ff\u0f63\u4a5e',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 36,
+  arrayLayerCount: 96,
+});
+let renderBundle32 = renderBundleEncoder23.finish({label: '\u9a4b\u805d'});
+try {
+gpuCanvasContext2.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+gc();
+let textureView59 = texture18.createView({label: '\u2191\u7146\u00ea\u180a\u04ec\u0cf3', mipLevelCount: 1});
+let renderBundle33 = renderBundleEncoder20.finish({label: '\u03db\u{1fc27}\u0342\u0c5a\u{1f8fd}\u0ed9'});
+let externalTexture32 = device2.importExternalTexture({label: '\ud2f1\u{1fd8b}', source: videoFrame4, colorSpace: 'srgb'});
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 280 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10360 */
+  offset: 10360,
+  buffer: buffer5,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 6900, new BigUint64Array(57286), 42970, 576);
+} catch {}
+let promise10 = device2.createComputePipelineAsync({
+  label: '\u0ea8\ue4bc\u076b\u9930\u0af6',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let textureView60 = texture24.createView({
+  label: '\u18a7\ucf0b\u086e\u1392\u0073\u5a4d\u0781\udaf5\u016e\u0e8c\u0070',
+  baseMipLevel: 4,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let externalTexture33 = device2.importExternalTexture({label: '\u0c6e\u0d03\u0cfa\u4b97\u{1f61e}', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder13.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer5, 76776, buffer4, 75804, 14028);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 26768, new BigUint64Array(63799), 54232, 2720);
+} catch {}
+let commandEncoder49 = device3.createCommandEncoder({label: '\u4031\uf76e\uca66\ud98e\u{1f987}\ubcfc\u{1f6f8}\ueb01\u8e51\u2394'});
+let commandBuffer9 = commandEncoder49.finish({label: '\u2809\u0ed6\u{1fda1}\u978a\ua393'});
+let texture34 = device3.createTexture({
+  label: '\u{1f7de}\u{1fa0a}\ue922\u{1f72a}',
+  size: {width: 96, height: 7, depthOrArrayLayers: 834},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+gpuCanvasContext11.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+canvas0.height = 1702;
+let bindGroup13 = device3.createBindGroup({
+  label: '\u4b91\ue037',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture30}],
+});
+let querySet28 = device3.createQuerySet({label: '\u9456\u7b5c\u{1fb1a}', type: 'occlusion', count: 4087});
+let commandBuffer10 = commandEncoder48.finish({label: '\u059c\u0edf\u6fe6\ud53f\u9cfa\u0253\ue9a0\ud955\u0684\uefc0'});
+let renderBundle34 = renderBundleEncoder23.finish({label: '\u03ad\u07f1\u{1f754}\u88e7\ua894\u9b2b\u468a\u{1feed}\u18d0\u0da8\u0099'});
+let img13 = await imageWithData(7, 174, '#efbded0a', '#cc6f94ea');
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let canvas15 = document.createElement('canvas');
+let img14 = await imageWithData(300, 89, '#daeb108b', '#8ec33a06');
+canvas4.width = 2884;
+let promise11 = adapter0.requestAdapterInfo();
+document.body.prepend(canvas4);
+let offscreenCanvas11 = new OffscreenCanvas(64, 842);
+let img15 = await imageWithData(276, 197, '#f64fc61d', '#ab8cfd9e');
+let commandEncoder50 = device0.createCommandEncoder({label: '\ueb3a\u216d\u4094\u96aa\u0347'});
+let texture35 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 298},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let textureView61 = texture0.createView({label: '\u8ff1\u0e61\uf9bb\ua61c'});
+let sampler24 = device0.createSampler({
+  label: '\u9144\u{1fe23}\u{1fb79}\u0572\u0c5d\u536c\u5f30',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.22,
+  lodMaxClamp: 81.19,
+});
+let pipeline33 = device0.createComputePipeline({
+  label: '\u0852\u0e7d\u275b\u50ef\u1317\ua9b7\u{1f6d1}',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let video7 = await videoWithData();
+let imageBitmap14 = await createImageBitmap(videoFrame11);
+try {
+  await promise11;
+} catch {}
+let commandEncoder51 = device3.createCommandEncoder({label: '\u6d69\u4055\uf10e\u96d7\u017e\u64e7\u2014'});
+let textureView62 = texture30.createView({dimension: '2d', baseMipLevel: 3, baseArrayLayer: 16});
+let renderBundleEncoder25 = device3.createRenderBundleEncoder({
+  label: '\u07db\u097b\ud42d\u0fb6\u07fc\u0141\ud6eb',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+});
+let bindGroup14 = device3.createBindGroup({
+  label: '\u90a5\ue243\uf4d8\u{1ff79}\u0b53',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture30}],
+});
+let commandEncoder52 = device3.createCommandEncoder({label: '\u07c7\u{1feb8}\u{1f714}\u93fa\uf55d\u{1f9a5}\u0b0a\u{1ff43}'});
+let querySet29 = device3.createQuerySet({label: '\u{1ff91}\u{1fa47}\u06bc\u{1f6eb}', type: 'occlusion', count: 753});
+let textureView63 = texture30.createView({
+  label: '\u{1fde0}\u4943\u2b94\udba0\u030e\u{1f75f}\u080c\u0c6d',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 51,
+  arrayLayerCount: 3,
+});
+let computePassEncoder16 = commandEncoder51.beginComputePass({label: '\u{1f7bf}\u0072\u{1fecd}\u0198\u02ee\ua6fd\u0c78\ubaab\u039c'});
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout20 = device3.createBindGroupLayout({
+  label: '\u73fc\ude03\u{1fe1e}\u0bd5\u{1fec3}\u072c\u{1fede}\u056d',
+  entries: [
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 712,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView64 = texture34.createView({label: '\u7100\u{1fd22}\u3b6c\u336f\u146f', baseMipLevel: 3});
+let renderBundleEncoder26 = device3.createRenderBundleEncoder({
+  label: '\ue784\u53b7\u{1f9d6}\u0a2c\u{1fdb6}\u0168\u{1fa87}\u{1fefc}\u01fc\u7d8e\u{1fcf0}',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle35 = renderBundleEncoder26.finish({label: '\u0f87\u0741'});
+let externalTexture34 = device3.importExternalTexture({label: '\u99ad\ub4e6\u00ee\ub788\u{1fa1c}\u{1f6d3}\u{1fa1f}\u2d92', source: video6});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+offscreenCanvas4.width = 1757;
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let videoFrame16 = new VideoFrame(canvas11, {timestamp: 0});
+document.body.prepend(canvas10);
+let buffer6 = device3.createBuffer({
+  label: '\u9f22\u9359\u{1faab}\ue67c\u1a01\uf51f\u010c\u2516\ucf17',
+  size: 28197,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let querySet30 = device3.createQuerySet({
+  label: '\u2183\u0a4d\u093e\u024d\u8eba\u432d\u4ddd\u54a8\u2067\u{1fa91}\u3b30',
+  type: 'occlusion',
+  count: 3289,
+});
+let renderBundle36 = renderBundleEncoder25.finish({label: '\u8845\u{1fcf4}\u5472\u{1fa91}'});
+try {
+device3.queue.submit([commandBuffer9, commandBuffer10]);
+} catch {}
+let commandEncoder53 = device2.createCommandEncoder({label: '\u2834\u9ce4\u{1f79a}\u{1f9be}\u0992\u218a\u012a\ua981\u0c3b\u39f4\u0d22'});
+let texture36 = device2.createTexture({
+  label: '\u{1f753}\u0dc7\u{1fdf4}\u429f\u11db\ue38a\u776a\u{1fe4e}\u2d52\u{1fa02}',
+  size: [24, 30, 82],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let textureView65 = texture32.createView({
+  label: '\u6197\u0ad5\u0fd1\u44b3\u{1f62c}\u0470\u63ad\ub54e\ud440\u{1fb9e}\u6e23',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup11, new Uint32Array(5633), 2892, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 5, y: 45, z: 2},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 9_001_709 */
+{offset: 509, bytesPerRow: 1048, rowsPerImage: 128}, {width: 61, height: 13, depthOrArrayLayers: 68});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 7, depthOrArrayLayers: 20}
+*/
+{
+  source: img12,
+  origin: { x: 54, y: 38 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext14 = canvas15.getContext('webgpu');
+let videoFrame17 = new VideoFrame(video3, {timestamp: 0});
+let bindGroup15 = device3.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 880, resource: externalTexture30}]});
+let buffer7 = device3.createBuffer({size: 564751, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let querySet31 = device3.createQuerySet({label: '\u1811\u0d6d', type: 'occlusion', count: 3230});
+let texture37 = device3.createTexture({
+  label: '\u0c81\ue61a\u{1ff1e}\u{1f660}\u5aab\u0ac9',
+  size: {width: 192, height: 15, depthOrArrayLayers: 148},
+  mipLevelCount: 5,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView66 = texture37.createView({label: '\u3295\u0ab8\ub43b\u0f0e', dimension: '2d', baseMipLevel: 4, baseArrayLayer: 41});
+let computePassEncoder17 = commandEncoder52.beginComputePass({label: '\ub221\u087d\uf2aa\uef42\uf902\u7e8a\u95eb\uc10f'});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup15);
+} catch {}
+video6.height = 81;
+gc();
+let pipelineLayout10 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout20, bindGroupLayout20]});
+let textureView67 = texture34.createView({label: '\uc456\u{1fe78}\u{1fa9d}\u018b\u8951', mipLevelCount: 9});
+let sampler25 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 31.97,
+});
+let externalTexture35 = device3.importExternalTexture({source: video5, colorSpace: 'display-p3'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(761, 27);
+let textureView68 = texture37.createView({
+  label: '\u{1fd82}\u6c23\u8f8b\u04dd',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 145,
+});
+let renderBundle37 = renderBundleEncoder23.finish({label: '\udf75\u05ae\u0037\u0b64\u{1fc95}\u0627\ubcdc\u{1f8d1}'});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.WRITE, 0, 401004);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder54 = device2.createCommandEncoder({});
+let texture38 = device2.createTexture({
+  label: '\ued75\u70a2\u{1f957}',
+  size: {width: 96, height: 120, depthOrArrayLayers: 228},
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture39 = gpuCanvasContext8.getCurrentTexture();
+let renderBundle38 = renderBundleEncoder20.finish({label: '\u890e\ue4ab\u1e17\uc957\u00b9\u7c38\u{1fc42}\u{1f620}\u68c0'});
+let externalTexture36 = device2.importExternalTexture({
+  label: '\ue71f\u{1fdff}\u0f50\ud43e\u0a34\u2de0\u{1faff}\u0e97\u7e77\u086c',
+  source: video6,
+  colorSpace: 'display-p3',
+});
+let pipeline34 = await device2.createRenderPipelineAsync({
+  label: '\u0858\u0f6d\u14f2\u04ea\u83f4\ufdfc\u9eab\ud365',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32uint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 3454318136,
+    stencilWriteMask: 4050487106,
+    depthBiasClamp: 518.1881051320429,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 388, shaderLocation: 15},
+          {format: 'uint8x2', offset: 124, shaderLocation: 10},
+          {format: 'sint16x2', offset: 408, shaderLocation: 8},
+          {format: 'sint16x4', offset: 120, shaderLocation: 7},
+          {format: 'sint16x2', offset: 608, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 236,
+        attributes: [
+          {format: 'float16x2', offset: 28, shaderLocation: 0},
+          {format: 'uint8x2', offset: 2, shaderLocation: 13},
+          {format: 'float32x4', offset: 8, shaderLocation: 6},
+          {format: 'float16x2', offset: 44, shaderLocation: 12},
+          {format: 'float16x2', offset: 84, shaderLocation: 14},
+          {format: 'uint16x4', offset: 48, shaderLocation: 9},
+          {format: 'sint16x2', offset: 20, shaderLocation: 3},
+          {format: 'sint8x4', offset: 20, shaderLocation: 1},
+          {format: 'uint16x4', offset: 28, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 184, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 11},
+          {format: 'float32x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+});
+canvas9.width = 771;
+let adapter4 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas13 = new OffscreenCanvas(619, 1024);
+let bindGroupLayout21 = device2.createBindGroupLayout({
+  label: '\u{1fafa}\u8d3a\u1f58\u{1f66f}\uccd0\u{1faf6}',
+  entries: [
+    {
+      binding: 682,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 621, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder55 = device2.createCommandEncoder({label: '\ub81f\u{1f706}\u083a\ucbba\u04e0\u9644\u{1ff78}'});
+let querySet32 = device2.createQuerySet({label: '\u96a0\u0233\u2604\u327a\ua2b6\u98c2', type: 'occlusion', count: 178});
+let commandBuffer11 = commandEncoder55.finish({label: '\u29d3\u04c4\u9eb0\u7c13\ue50e\u2f55\u177e\u30e5'});
+let textureView69 = texture38.createView({label: '\ua1be\u0bec\ua0ee\u0780\u0843', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 158});
+let renderBundleEncoder27 = device2.createRenderBundleEncoder({
+  label: '\u237b\u076d\u0dd6',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture37 = device2.importExternalTexture({
+  label: '\u{1fe21}\u004f\u0f1c\u00ef\u01f8\u{1f718}\u0087\u0ca9\u{1fce4}\u804c\u0fd7',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup11, new Uint32Array(3069), 1816, 0);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 49036, new BigUint64Array(65452), 53075, 940);
+} catch {}
+let pipelineLayout11 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout19]});
+let commandEncoder56 = device3.createCommandEncoder({label: '\ucf5c\ud04b'});
+let querySet33 = device3.createQuerySet({
+  label: '\u03eb\u599b\u5f3a\u06b3\u7d3e\u088d\u8b3c\u5304\u{1f8cd}\u3e2c',
+  type: 'occlusion',
+  count: 3864,
+});
+let img16 = await imageWithData(127, 242, '#411c7fca', '#73c27641');
+let textureView70 = texture30.createView({
+  label: '\u1092\uf55b\u04da\u0a75\u80f6\u09f9\ue812\u{1fb59}\u{1fe52}\u{1fbd7}',
+  dimension: '2d-array',
+  baseArrayLayer: 126,
+  arrayLayerCount: 7,
+});
+let sampler26 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.45,
+  lodMaxClamp: 59.90,
+  maxAnisotropy: 5,
+});
+let externalTexture38 = device3.importExternalTexture({
+  label: '\u0efb\ueee8\u4bae\u0872\u8cd5\u0b5e\u7d32\u60ee\u0a95',
+  source: videoFrame7,
+  colorSpace: 'srgb',
+});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let texture40 = device3.createTexture({
+  label: '\u06ed\u1bb4\u1e96\u8679\u242c\udfb9\u8741\u{1f756}\u740e\u2808\u0e3f',
+  size: {width: 384, height: 30, depthOrArrayLayers: 148},
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg32sint'],
+});
+try {
+device3.pushErrorScope('validation');
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4207,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 2383,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 7774, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder57 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder11.beginComputePass({label: '\u0f7e\u75d9\u{1fb35}\u{1fbc3}\ue356\ucabc\u{1fefc}\u{1f6b4}\u78c1'});
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 199}
+*/
+{
+  source: imageData2,
+  origin: { x: 3, y: 7 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 89},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline35 = device0.createComputePipeline({
+  label: '\u8ff5\u{1f707}\u{1fa80}\ub31d\u5fc9\u1e38\u9ce5\uc0cf',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline36 = device0.createRenderPipeline({
+  label: '\u{1fa3d}\u0acf\u01fe\ue792\u3153\uea04\uaae8\u{1faa8}\u429c\u046e\u3694',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x86670483},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 3747169638,
+    stencilWriteMask: 2873571857,
+    depthBias: -645934877,
+    depthBiasSlopeScale: 115.33704766290413,
+    depthBiasClamp: 707.0267629742373,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3816,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 1312, shaderLocation: 16},
+          {format: 'uint32x4', offset: 584, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 1526, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 2540,
+        attributes: [
+          {format: 'snorm8x4', offset: 188, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 566, shaderLocation: 20},
+          {format: 'snorm8x2', offset: 62, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 15420,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 388, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw'},
+});
+let shaderModule6 = device3.createShaderModule({
+  label: '\uc883\u8145\u{1fb0a}\uebff\u2a1c\u9b4a\ud576\u{1ffa9}\u{1fb03}\u{1fa22}',
+  code: `@group(0) @binding(53)
+var<storage, read_write> function4: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> type8: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> field4: array<u32>;
+
+@compute @workgroup_size(7, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(2) f2: vec4<u32>,
+  @location(3) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(3) f0: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: f32, @location(13) a1: vec3<i32>, @location(0) a2: i32, a3: S8, @location(14) a4: u32, @location(9) a5: vec3<f16>, @location(8) a6: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer8 = device3.createBuffer({label: '\ua2a2\u{1fd98}\u{1fdff}', size: 342231, usage: GPUBufferUsage.STORAGE});
+let querySet34 = device3.createQuerySet({
+  label: '\u{1fa2a}\u9fc3\u0d08\u032f\u576d\ua694\u4ad6\u{1fa83}\u50f9\u0f62\u{1f96e}',
+  type: 'occlusion',
+  count: 2289,
+});
+let textureView71 = texture34.createView({label: '\u{1fb31}\udac1', baseMipLevel: 5, mipLevelCount: 1});
+let renderBundleEncoder28 = device3.createRenderBundleEncoder({
+  label: '\u84b8\uc73c\u0774\u0088\u2456\u035b\u4195\uf0a4\u0bcd\u083b',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle39 = renderBundleEncoder23.finish({label: '\u967b\u0fc7\u0af6\u8f72\u0a17'});
+try {
+renderBundleEncoder28.setVertexBuffer(8711, undefined, 0, 777555235);
+} catch {}
+try {
+device3.queue.submit([]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'stencil-only',
+}, arrayBuffer0, /* required buffer size: 3_080_228 */
+{offset: 536, bytesPerRow: 252, rowsPerImage: 121}, {width: 24, height: 0, depthOrArrayLayers: 102});
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter({});
+let commandEncoder58 = device2.createCommandEncoder();
+let querySet35 = device2.createQuerySet({label: '\u270e\u{1f88f}\u97ca\ub835', type: 'occlusion', count: 1839});
+let computePassEncoder19 = commandEncoder58.beginComputePass({label: '\u{1f754}\u{1fbb8}'});
+let renderBundleEncoder29 = device2.createRenderBundleEncoder({
+  label: '\u{1fb3c}\uf41f\u{1f95e}',
+  colorFormats: ['rg32uint', 'rg8unorm', 'r32float', 'rgba16uint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+let renderBundle40 = renderBundleEncoder16.finish({label: '\u{1fe3d}\u0eca\u1251\u0041\u63b4\u0098\ub7d9\u{1ff36}\u3939\u4332\u017a'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup11, new Uint32Array(2150), 2132, 0);
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas13.getContext('webgpu');
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+let video8 = await videoWithData();
+let sampler27 = device2.createSampler({
+  label: '\u0839\u{1fc51}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.72,
+  lodMaxClamp: 73.21,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder19.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 6556, new Int16Array(5307), 3486, 264);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 3, depthOrArrayLayers: 67}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 51, y: 9 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas16 = document.createElement('canvas');
+try {
+canvas16.getContext('bitmaprenderer');
+} catch {}
+try {
+window.someLabel = externalTexture12.label;
+} catch {}
+let texture41 = device2.createTexture({
+  label: '\u119f\u08cf\u114b\u{1f9e0}\uf118\uf419\u{1f94b}',
+  size: [48, 60, 1],
+  mipLevelCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup9, new Uint32Array(2699), 23, 0);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2084 */
+  offset: 2084,
+  rowsPerImage: 45,
+  buffer: buffer4,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer4);
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageData7);
+let textureView72 = texture34.createView({aspect: 'all', baseMipLevel: 8});
+let renderBundle41 = renderBundleEncoder26.finish();
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup16 = device3.createBindGroup({
+  label: '\u717b\u53b0',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture35}],
+});
+let commandEncoder59 = device3.createCommandEncoder({label: '\u{1fd68}\u0ec2\u2a9a\u8762\u5c39'});
+let textureView73 = texture40.createView({
+  label: '\uf8ef\u{1ff6c}\ue449\ud986\u{1f891}\u0dce\ue482\u4d92\u{1f64a}\u{1ff2a}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 31,
+});
+let renderBundleEncoder30 = device3.createRenderBundleEncoder({
+  label: '\u04f8\u0295\u0913',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder28.pushDebugGroup('\u0938');
+} catch {}
+try {
+renderBundleEncoder28.popDebugGroup();
+} catch {}
+let promise12 = device3.createComputePipelineAsync({layout: pipelineLayout11, compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}}});
+let pipeline37 = device3.createRenderPipeline({
+  label: '\u0789\u9057\u0c9d\u{1fba2}\u01d8',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', failOp: 'replace', depthFailOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 715201647,
+    stencilWriteMask: 1647194437,
+    depthBias: -1903088955,
+    depthBiasSlopeScale: -1.1326127624486872,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 540,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x4', offset: 112, shaderLocation: 3},
+          {format: 'float32x4', offset: 12, shaderLocation: 9},
+          {format: 'uint8x2', offset: 162, shaderLocation: 14},
+          {format: 'sint16x2', offset: 188, shaderLocation: 0},
+          {format: 'float32x3', offset: 344, shaderLocation: 15},
+          {format: 'sint32x4', offset: 44, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let offscreenCanvas14 = new OffscreenCanvas(253, 912);
+let buffer9 = device3.createBuffer({size: 163203, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder60 = device3.createCommandEncoder({label: '\u{1f78c}\ua09e\u7fd2\ub47b\u8dcc\u5edd\u{1f81a}\u88e3\u7c6e\u1f8b\u05fe'});
+let texture42 = device3.createTexture({
+  label: '\u3634\uc927\u3667\ucb29\u0fc2\u7507\u{1ff97}\u99e4',
+  size: [384],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let renderBundleEncoder31 = device3.createRenderBundleEncoder({
+  label: '\u0f7f\u{1f694}\u{1fd28}\u03bd\ud987\u05ad\u026c\u{1fcfa}\u0c66\u7e0b',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let externalTexture39 = device3.importExternalTexture({
+  label: '\u0058\u{1f9cb}\u0dd9\u{1fde4}\u9747\u0470\u0bb7\u5e8b\u{1fdef}\u{1f8e1}\u9c5a',
+  source: video8,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder56.copyBufferToBuffer(buffer7, 502220, buffer9, 72080, 45900);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+gc();
+let imageBitmap16 = await createImageBitmap(img0);
+try {
+offscreenCanvas14.getContext('webgl');
+} catch {}
+let pipelineLayout12 = device2.createPipelineLayout({label: '\u0384\u{1f67f}\u9cc0\u{1f955}', bindGroupLayouts: [bindGroupLayout15]});
+let commandEncoder61 = device2.createCommandEncoder({});
+let querySet36 = device2.createQuerySet({label: '\ud287\u4819\u2b5d\u0430', type: 'occlusion', count: 2730});
+let textureView74 = texture41.createView({dimension: '2d-array', format: 'r16sint', mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder46.beginComputePass({label: '\u33a5\u{1fb32}\u22ed\u{1fe30}\ua9d7\u{1f652}\u0bf6'});
+let sampler28 = device2.createSampler({
+  label: '\u9b6b\ufc4f\u{1fa12}\u0967\u0a8e\uf80a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup11, new Uint32Array(2188), 1855, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1326, undefined);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(buffer5, 89428, buffer4, 99852, 15344);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 1364, new Float32Array(48614), 32040);
+} catch {}
+let commandEncoder62 = device2.createCommandEncoder({label: '\u{1ff50}\u0758\uc121\u{1fee6}\u4f39\u73c7\u{1f710}\u07d6'});
+let texture43 = device2.createTexture({
+  label: '\u{1fe8b}\u158f\uefce\u39a5',
+  size: [192],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32float'],
+});
+let renderBundleEncoder32 = device2.createRenderBundleEncoder({
+  label: '\u{1fce5}\u0500\ufda0\ucfca\u0045\u3065\u06dd\u0d19\u9eb3\ub69f',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle42 = renderBundleEncoder20.finish({label: '\ud8e6\u{1f72a}\u1c5b\u0c3f\uda55\u0cd8\u0a16\u3ee0\u98ec\u0093'});
+let sampler29 = device2.createSampler({
+  label: '\u080d\u6908\ue53e\u4f14\u19e6\u094e',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.92,
+  lodMaxClamp: 87.05,
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2017, undefined);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer4, 59788, new DataView(new ArrayBuffer(39470)), 28684, 188);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 876_049 */
+{offset: 277, bytesPerRow: 314, rowsPerImage: 253}, {width: 13, height: 7, depthOrArrayLayers: 12});
+} catch {}
+let pipeline38 = device2.createRenderPipeline({
+  label: '\u{1fe54}\u77de\u02da\u0eba\u{1f7f8}\u{1f8eb}\u0b8a\uc027\u0fab',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba16uint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilWriteMask: 633714250,
+    depthBias: -232899329,
+    depthBiasSlopeScale: 903.5292013440437,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 16, shaderLocation: 9},
+          {format: 'float32x4', offset: 12, shaderLocation: 4},
+          {format: 'uint8x4', offset: 24, shaderLocation: 2},
+          {format: 'uint32x3', offset: 20, shaderLocation: 11},
+          {format: 'sint8x4', offset: 4, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 0},
+          {format: 'sint16x2', offset: 8, shaderLocation: 8},
+          {format: 'uint32x4', offset: 16, shaderLocation: 13},
+          {format: 'uint32x2', offset: 44, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 12},
+          {format: 'float32x3', offset: 4, shaderLocation: 15},
+          {format: 'float16x2', offset: 4, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 256,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 12, shaderLocation: 6}],
+      },
+      {arrayStride: 664, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32x3', offset: 152, shaderLocation: 1},
+          {format: 'sint32x2', offset: 1116, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 864, stepMode: 'instance', attributes: []},
+      {arrayStride: 80, attributes: []},
+      {arrayStride: 456, stepMode: 'instance', attributes: []},
+      {arrayStride: 500, attributes: [{format: 'sint32', offset: 44, shaderLocation: 5}]},
+    ],
+  },
+});
+let img17 = await imageWithData(180, 247, '#682a179c', '#1b740ed0');
+let imageBitmap17 = await createImageBitmap(imageBitmap0);
+let commandEncoder63 = device2.createCommandEncoder({label: '\u2719\u{1f777}\u0ad8\u5e11\u{1f793}\u164e\u{1f74d}\u92f6'});
+let renderBundle43 = renderBundleEncoder16.finish({label: '\ua481\u6337'});
+try {
+computePassEncoder12.setPipeline(pipeline28);
+} catch {}
+let pipeline39 = await device2.createRenderPipelineAsync({
+  label: '\u14b4\u0184\u6e52\u86fe\ufdf2\u{1f964}\u3fd0\u{1ff8e}\ue71f',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32float'}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 360529143,
+    stencilWriteMask: 3680488159,
+    depthBias: -1626210298,
+    depthBiasSlopeScale: 949.4089330344073,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 776, attributes: []},
+      {
+        arrayStride: 988,
+        attributes: [
+          {format: 'snorm8x4', offset: 132, shaderLocation: 11},
+          {format: 'sint32x3', offset: 40, shaderLocation: 2},
+          {format: 'float32x2', offset: 72, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 208, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 384, attributes: []},
+      {
+        arrayStride: 608,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 76, shaderLocation: 8}],
+      },
+      {arrayStride: 16, stepMode: 'vertex', attributes: [{format: 'uint32x4', offset: 0, shaderLocation: 0}]},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 144, shaderLocation: 9},
+          {format: 'uint32', offset: 104, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let canvas17 = document.createElement('canvas');
+try {
+window.someLabel = device2.queue.label;
+} catch {}
+let commandEncoder64 = device2.createCommandEncoder({});
+let querySet37 = device2.createQuerySet({label: '\ub0f0\u08e3\ua146\u{1fc7c}', type: 'occlusion', count: 1995});
+let texture44 = device2.createTexture({
+  label: '\ua2d6\u{1fa15}\u0a80\u51fe\u8420\ue7f7\u078b',
+  size: {width: 192, height: 240, depthOrArrayLayers: 62},
+  mipLevelCount: 7,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView75 = texture41.createView({label: '\ub7c2\u731b\u3620\u7b95\ue635\u0c89\u9997\u{1f613}', dimension: '2d-array'});
+let sampler30 = device2.createSampler({
+  label: '\u75ff\u93f7\u0f39\u0aa0',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.86,
+  compare: 'equal',
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.READ);
+} catch {}
+let bindGroupLayout23 = device2.createBindGroupLayout({
+  label: '\u35a9\u3ae2\u{1fb29}\u04e7\u{1fa82}\u0588\u02f9\u0c93\u0878\uc83e',
+  entries: [
+    {
+      binding: 937,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 805,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {binding: 47, visibility: 0, externalTexture: {}},
+  ],
+});
+let commandEncoder65 = device2.createCommandEncoder({label: '\u92b8\u080e\u46dc\u07f4\u0fde\u44ee\u1a5b\u{1f7e6}\u{1f79c}\u8002\u8f5a'});
+let querySet38 = device2.createQuerySet({
+  label: '\u07dc\u191d\u{1fada}\u05ed\u02c0\u0131\u0659\u0106\u{1fb8d}\u916c',
+  type: 'occlusion',
+  count: 1097,
+});
+let textureView76 = texture20.createView({label: '\u97d0\u2d0a\u0d36\u{1f731}\u0037'});
+let computePassEncoder21 = commandEncoder64.beginComputePass({label: '\u{1ff58}\u0b69\u098f\u77b7\u5793'});
+let externalTexture40 = device2.importExternalTexture({
+  label: '\u5f7d\ua819\u6de1\u{1f991}\u009d\u6ab0\u{1f741}\u6f20\u061e\uace1\u{1fde2}',
+  source: videoFrame9,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup11, new Uint32Array(3158), 1451, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(7760, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder32.insertDebugMarker('\u{1f97c}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline40 = await promise10;
+let videoFrame18 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+gc();
+let textureView77 = texture20.createView({
+  label: '\ue218\ubb6f\u34c6\uee34\u5a30\uaaf0\u8639\ubcd5\u21e3',
+  aspect: 'all',
+  format: 'rg32sint',
+  mipLevelCount: 1,
+});
+try {
+commandEncoder62.copyBufferToBuffer(buffer5, 107012, buffer4, 72652, 17172);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let gpuCanvasContext16 = canvas17.getContext('webgpu');
+offscreenCanvas14.height = 648;
+let offscreenCanvas15 = new OffscreenCanvas(269, 832);
+let querySet39 = device2.createQuerySet({label: '\u52d7\u0555\u{1fba2}\uc7a0\u{1fd49}\ue3c6', type: 'occlusion', count: 132});
+let texture45 = device2.createTexture({
+  label: '\u06e5\u011a\u{1f8c0}\u0885\u9447\u038b\u3258\u0d69\u{1fd1a}\u6a47',
+  size: {width: 192, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder33 = device2.createRenderBundleEncoder({
+  label: '\uedad\u02fc',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+let sampler31 = device2.createSampler({
+  label: '\u0612\u09d3\u0afc\u99eb\u{1f741}\u566f\u0f03\u3807',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 4.762,
+  lodMaxClamp: 33.76,
+});
+try {
+commandEncoder53.copyBufferToBuffer(buffer5, 84240, buffer4, 90336, 12612);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 2,
+  origin: {x: 0, y: 7, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 11, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer4, 58992);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 9, y: 45 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(72, 56);
+document.body.prepend(img13);
+let bindGroupLayout24 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 863,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 910, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder66 = device2.createCommandEncoder();
+let textureView78 = texture39.createView({label: '\u{1f643}\u{1fc00}\u{1f7eb}\u063d\u5e07\ua02c', dimension: '2d-array'});
+let computePassEncoder22 = commandEncoder63.beginComputePass({label: '\u{1fe66}\u056b\u1816\u06b8'});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let canvas18 = document.createElement('canvas');
+let bindGroupLayout25 = device2.createBindGroupLayout({
+  label: '\ub8b2\u1d60\u{1ffd8}',
+  entries: [{binding: 957, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }}],
+});
+let querySet40 = device2.createQuerySet({type: 'occlusion', count: 2067});
+let externalTexture41 = device2.importExternalTexture({label: '\uae83\u{1f9cd}\u0286\u1fa7\u94e0\u00db\u8c2d', source: video5, colorSpace: 'display-p3'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5176, undefined, 1706784525, 749469110);
+} catch {}
+let promise13 = buffer5.mapAsync(GPUMapMode.WRITE, 124416, 0);
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder65.pushDebugGroup('\u139b');
+} catch {}
+let pipeline41 = await promise9;
+try {
+canvas18.getContext('bitmaprenderer');
+} catch {}
+let renderBundleEncoder34 = device3.createRenderBundleEncoder({
+  label: '\u{1fb23}\u{1fbc2}\ue979\u{1f776}',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle44 = renderBundleEncoder25.finish({label: '\u8fcc\u0185\ud73e\u5a6c\ua1e2\u0aeb'});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer9, 53768, 55208);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 40924, new Float32Array(4516), 4041, 36);
+} catch {}
+let canvas19 = document.createElement('canvas');
+let imageBitmap18 = await createImageBitmap(imageData12);
+let imageData13 = new ImageData(160, 192);
+let externalTexture42 = device2.importExternalTexture({
+  label: '\u012b\u{1f615}\u0f54\u{1f9c2}\ueb3c\u9c3a\u2b3a\u0150\u1512',
+  source: videoFrame15,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(7940, undefined, 0, 1851985071);
+} catch {}
+let arrayBuffer1 = buffer4.getMappedRange(25216, 28500);
+try {
+gpuCanvasContext16.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 3, y: 28 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let bindGroup17 = device3.createBindGroup({
+  label: '\u3f4f\u{1fed4}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture38}],
+});
+let commandEncoder67 = device3.createCommandEncoder({label: '\u{1f682}\u5651\u0a23\uce87\u89c2\u29e9\ufc85'});
+let querySet41 = device3.createQuerySet({label: '\u043d\ud0a2\u8f66\u{1fea7}\u5723\uf702', type: 'occlusion', count: 3031});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup15);
+} catch {}
+let videoFrame19 = new VideoFrame(videoFrame3, {timestamp: 0});
+let canvas20 = document.createElement('canvas');
+let videoFrame20 = videoFrame10.clone();
+let gpuCanvasContext17 = offscreenCanvas15.getContext('webgpu');
+let canvas21 = document.createElement('canvas');
+let textureView79 = texture40.createView({
+  label: '\ue9ad\u00af\u3baa\u{1ff89}\u06b8\uc37c\u587b\u2ceb\u{1fc56}\u{1f8c8}\u{1fdf9}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  baseArrayLayer: 109,
+  arrayLayerCount: 18,
+});
+let computePassEncoder23 = commandEncoder56.beginComputePass({label: '\u7d3d\u3947\uefdd\u{1fd05}\u0551\u70f0\u00fe\u55f2\u0e1d\u{1fcf7}'});
+let renderBundleEncoder35 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture43 = device3.importExternalTexture({label: '\u0c90\ua12e', source: video5, colorSpace: 'display-p3'});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 10_434_395 */
+{offset: 595, bytesPerRow: 1050, rowsPerImage: 69}, {width: 125, height: 1, depthOrArrayLayers: 145});
+} catch {}
+let pipeline42 = device3.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x88a14490},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 260,
+        attributes: [
+          {format: 'uint16x4', offset: 40, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 14, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 72, shaderLocation: 15},
+          {format: 'sint32x3', offset: 16, shaderLocation: 13},
+          {format: 'sint32x3', offset: 24, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 84,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 0, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: false},
+});
+let gpuCanvasContext18 = canvas20.getContext('webgpu');
+let imageData14 = new ImageData(152, 180);
+try {
+canvas19.getContext('webgl');
+} catch {}
+let img18 = await imageWithData(233, 144, '#e9fcea36', '#8f62a15b');
+try {
+canvas21.getContext('bitmaprenderer');
+} catch {}
+let buffer10 = device3.createBuffer({
+  label: '\u{1fe8c}\uc864\u0c8f\u0534\u48a6\u2c2a',
+  size: 59858,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder68 = device3.createCommandEncoder();
+let textureView80 = texture37.createView({
+  label: '\u{1f9bd}\u0d58\u38e5\ud902\u7f26',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 28,
+  arrayLayerCount: 15,
+});
+let renderBundleEncoder36 = device3.createRenderBundleEncoder({
+  label: '\u04d4\u0ba4\u0bfa',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder31.setIndexBuffer(buffer6, 'uint32', 3652, 12962);
+} catch {}
+let pipeline43 = device3.createRenderPipeline({
+  label: '\u4f5b\uc3f6\u2e69\u7461\u{1f6db}\u73a1\u39d1\u{1fa44}\u0c03\u0df3\u98d2',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 792,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 208, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 120, shaderLocation: 15},
+          {format: 'sint16x4', offset: 12, shaderLocation: 3},
+          {format: 'uint16x2', offset: 36, shaderLocation: 14},
+          {format: 'sint32x3', offset: 716, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 204,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm16x4', offset: 4, shaderLocation: 8}],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 0, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas14);
+offscreenCanvas0.width = 1771;
+let videoFrame21 = videoFrame20.clone();
+gc();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video0.height = 229;
+let video9 = await videoWithData();
+let offscreenCanvas16 = new OffscreenCanvas(187, 525);
+let commandEncoder69 = device3.createCommandEncoder({label: '\u0b31\uf8ad\ua19c\ue115\u4a42\u08ea\u0a12\u{1fd98}\u{1f91e}\u{1f7ef}'});
+let textureView81 = texture42.createView({label: '\u0ab9\u5231\u{1f9ec}\u0c01\u05e5', dimension: '1d'});
+let sampler32 = device3.createSampler({
+  label: '\u7a34\u{1ff6d}\u46a1\u3db5\u95ab\ueb89\u{1fc64}\u{1fe34}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.50,
+  lodMaxClamp: 78.76,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup14, new Uint32Array(301), 254, 0);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer6, 'uint32', 17408, 4747);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.WRITE, 0, 560676);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 26},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer1), /* required buffer size: 12_795_127 */
+{offset: 91, bytesPerRow: 1225, rowsPerImage: 290}, {width: 142, height: 5, depthOrArrayLayers: 37});
+} catch {}
+let pipeline44 = device3.createRenderPipeline({
+  label: '\u{1fc0c}\u9fb3\u4310\u0052\u0e0d\u0535\u3a39\u{1f772}\uaf4d\u1bc0',
+  layout: pipelineLayout9,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 2546409613,
+    stencilWriteMask: 4192496882,
+    depthBias: -1218391126,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 808.7689740341951,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 168, shaderLocation: 13},
+          {format: 'float32', offset: 1024, shaderLocation: 9},
+          {format: 'sint32x2', offset: 384, shaderLocation: 3},
+          {format: 'uint32x3', offset: 316, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 638, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 188, shaderLocation: 8},
+          {format: 'sint32x3', offset: 192, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise13;
+} catch {}
+let video10 = await videoWithData();
+let gpuCanvasContext19 = offscreenCanvas16.getContext('webgpu');
+let offscreenCanvas17 = new OffscreenCanvas(883, 129);
+let video11 = await videoWithData();
+let renderBundle45 = renderBundleEncoder17.finish({label: '\udca3\u57c9\uddae\u05fb\ub5a0\u3d49\u0dab\u036d'});
+try {
+commandEncoder65.copyBufferToBuffer(buffer5, 103628, buffer4, 6740, 21960);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder47.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 20},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 10_832_501 */
+{offset: 67, bytesPerRow: 1006, rowsPerImage: 125}, {width: 52, height: 18, depthOrArrayLayers: 87});
+} catch {}
+let pipeline45 = device2.createRenderPipeline({
+  label: '\u04ae\u00d7\u{1f82b}',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {format: 'rg8unorm'}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'replace'},
+    stencilBack: {failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilWriteMask: 1572662107,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 980, attributes: [{format: 'unorm8x4', offset: 152, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let video12 = await videoWithData();
+let externalTexture44 = device2.importExternalTexture({
+  label: '\u44ba\ub356\ue203\u02be\u{1f941}\uba33\udf7a\u{1f6dc}\u0c66\u{1fb35}\u0675',
+  source: video9,
+  colorSpace: 'srgb',
+});
+try {
+gpuCanvasContext15.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let imageBitmap19 = await createImageBitmap(videoFrame6);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder70 = device3.createCommandEncoder({});
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup17, new Uint32Array(8879), 1519, 0);
+} catch {}
+try {
+offscreenCanvas17.getContext('webgl');
+} catch {}
+let videoFrame22 = new VideoFrame(video9, {timestamp: 0});
+let commandEncoder71 = device2.createCommandEncoder({});
+let textureView82 = texture28.createView({label: '\u43e2\ue714\u9fab', dimension: '1d'});
+let sampler33 = device2.createSampler({
+  label: '\u75bc\u{1fba1}\u0973\u08a0\u1c02\u0da5\u03c9\u3330\u{1fa3f}\u{1fedc}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 19.07,
+  lodMaxClamp: 57.73,
+});
+let canvas22 = document.createElement('canvas');
+let img19 = await imageWithData(104, 112, '#b1d9018c', '#ef2f121f');
+let imageData15 = new ImageData(68, 28);
+let commandBuffer12 = commandEncoder52.finish({});
+let renderBundle46 = renderBundleEncoder36.finish({label: '\uc612\u0527\u{1fef3}\u0804'});
+try {
+commandEncoder70.copyBufferToBuffer(buffer10, 52756, buffer9, 53988, 6712);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let canvas23 = document.createElement('canvas');
+let img20 = await imageWithData(285, 209, '#e75a4d3e', '#e7863b0b');
+try {
+canvas22.getContext('webgl');
+} catch {}
+video10.width = 245;
+let img21 = await imageWithData(215, 160, '#4529bda1', '#ed01bc78');
+let shaderModule7 = device3.createShaderModule({
+  label: '\u{1fe41}\u0198',
+  code: `@group(2) @binding(53)
+var<storage, read_write> field5: array<u32>;
+@group(3) @binding(880)
+var<storage, read_write> type9: array<u32>;
+@group(0) @binding(712)
+var<storage, read_write> function5: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> field6: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> parameter2: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> type10: array<u32>;
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(3) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(12) a1: f32, @location(8) a2: vec4<u32>, @location(2) a3: vec3<u32>, @location(1) a4: f32, @location(0) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let externalTexture45 = device3.importExternalTexture({label: '\u00db\u{1f834}\u0f99', source: video2});
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 2800 widthInBlocks: 350 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1544 */
+  offset: 1544,
+  bytesPerRow: 2816,
+  rowsPerImage: 230,
+  buffer: buffer10,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 6},
+  aspect: 'all',
+}, {width: 350, height: 3, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer10);
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer9, 46684, 76216);
+dissociateBuffer(device3, buffer9);
+} catch {}
+gc();
+let commandEncoder72 = device3.createCommandEncoder();
+let texture46 = device3.createTexture({
+  size: [192, 15, 148],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let textureView83 = texture46.createView({
+  label: '\u3ac4\u05aa\ue3b8\u056d\u0b5c\u0246\u8f0e\u0e04\uf5bc\u{1fd0a}\ufceb',
+  baseMipLevel: 1,
+  baseArrayLayer: 81,
+  arrayLayerCount: 21,
+});
+let renderBundleEncoder37 = device3.createRenderBundleEncoder({
+  label: '\uf4b2\u{1f8d3}\u1792\ufea0\uc07b\u6dbc\u1456\ucfa3\u63ad\u487e',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler34 = device3.createSampler({
+  label: '\u0132\u0242',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.68,
+  lodMaxClamp: 82.75,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer6, 0);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer11 = device2.createBuffer({size: 685304, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView84 = texture39.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+buffer4.destroy();
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 240 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 32976 */
+  offset: 32976,
+  buffer: buffer4,
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img17,
+  origin: { x: 1, y: 85 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video4);
+try {
+canvas23.getContext('webgl');
+} catch {}
+let querySet42 = device3.createQuerySet({label: '\u{1fe36}\ud5a9\u37dd\u8591\u07bc\ue678\u0bcf\u09a1', type: 'occlusion', count: 1501});
+let textureView85 = texture42.createView({});
+let renderBundleEncoder38 = device3.createRenderBundleEncoder({
+  label: '\u{1f937}\u206c\ua5a8\u{1fd17}',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup17, new Uint32Array(4700), 1990, 0);
+} catch {}
+try {
+commandEncoder67.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2256 widthInBlocks: 141 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 15744 */
+  offset: 15744,
+  bytesPerRow: 2304,
+  buffer: buffer9,
+}, {width: 141, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer9, 55052, 40360);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 28404, new BigUint64Array(48654), 347, 428);
+} catch {}
+offscreenCanvas12.height = 1154;
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video13 = await videoWithData();
+let commandEncoder73 = device2.createCommandEncoder({label: '\u{1f7f3}\uf0f3\u03bb\u{1f733}\uc0b0\ube8b\ua501\u0466\uaa1d\uedf0\u{1ff5b}'});
+let textureView86 = texture39.createView({
+  label: '\u{1f7f4}\u0c3b\u{1fa8c}\u{1fe95}\u1d26\u10d6\u3e17\u52cf',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 0,
+});
+let renderBundle47 = renderBundleEncoder24.finish({label: '\u97a1\u0b9a\u8d69\u080e\u{1fa0e}\u{1fce5}\uf91d\ub200\ufcc3'});
+let sampler35 = device2.createSampler({
+  label: '\ue120\u{1fb7f}\u{1fdb0}\u3113\ue58a\u1197\u0d67\u0060',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 22.98,
+  lodMaxClamp: 75.52,
+});
+try {
+computePassEncoder15.setPipeline(pipeline41);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer5, 4856, buffer4, 46228, 61220);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let pipeline46 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0xba5213a7},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 8, shaderLocation: 11},
+          {format: 'uint16x4', offset: 16, shaderLocation: 9},
+          {format: 'float16x2', offset: 0, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 32, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 32, shaderLocation: 0},
+          {format: 'sint32x2', offset: 12, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 128,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 48, shaderLocation: 2},
+          {format: 'uint8x4', offset: 4, shaderLocation: 10},
+          {format: 'sint16x2', offset: 20, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 48,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 4, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 15},
+          {format: 'sint32x3', offset: 0, shaderLocation: 5},
+          {format: 'sint8x2', offset: 6, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 160, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 292,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 12, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 728,
+        attributes: [
+          {format: 'uint8x4', offset: 48, shaderLocation: 13},
+          {format: 'sint16x2', offset: 32, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let videoFrame23 = new VideoFrame(imageBitmap11, {timestamp: 0});
+let querySet43 = device3.createQuerySet({label: '\u0dcf\u0a57\uc733\ubd7b\u51de\u0426\uaaa9\u58ce\u4cde', type: 'occlusion', count: 3174});
+let texture47 = device3.createTexture({
+  size: {width: 192, height: 15, depthOrArrayLayers: 148},
+  mipLevelCount: 7,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView87 = texture46.createView({baseMipLevel: 1, baseArrayLayer: 81, arrayLayerCount: 6});
+let externalTexture46 = device3.importExternalTexture({source: video1});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup15, new Uint32Array(3442), 99, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer10, 34400, buffer9, 150820, 5060);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 13176, new BigUint64Array(56504), 20809, 1416);
+} catch {}
+gc();
+let textureView88 = texture40.createView({
+  label: '\u70ba\u3700\u{1f7f6}\u5edf\u7d69\u0762',
+  format: 'rg32sint',
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+  arrayLayerCount: 134,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup15, new Uint32Array(5758), 3611, 0);
+} catch {}
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder68.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4112 widthInBlocks: 257 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 33184 */
+  offset: 29072,
+  rowsPerImage: 172,
+  buffer: buffer9,
+}, {width: 257, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+let videoFrame24 = new VideoFrame(img3, {timestamp: 0});
+let textureView89 = texture37.createView({
+  label: '\u9e77\u4012\u{1fa18}\u9d7c\uda2c\ud2bd\u72c7\uc4c9\u90ba\u031a',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 14,
+  arrayLayerCount: 1,
+});
+let computePassEncoder24 = commandEncoder72.beginComputePass({label: '\ubca7\u{1ffae}\uf9d0\u{1fa55}\u3a25\uf670\u6a0d\u{1f85e}\u2df1'});
+let promise14 = buffer10.mapAsync(GPUMapMode.WRITE, 18856, 13736);
+try {
+commandEncoder68.clearBuffer(buffer9, 10732, 139364);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let video14 = await videoWithData();
+let videoFrame25 = new VideoFrame(canvas6, {timestamp: 0});
+let querySet44 = device2.createQuerySet({
+  label: '\u4141\u{1f9ad}\u{1fd78}\u{1f8b2}\u{1ff22}\uec7c\u7568\u0759\u01be',
+  type: 'occlusion',
+  count: 2380,
+});
+let textureView90 = texture36.createView({label: '\u0810\u2a8c\u{1f8cc}\ucea4\u0099\u398c\u42fb\u0dc1', baseMipLevel: 3, mipLevelCount: 1});
+try {
+computePassEncoder15.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+let pipeline47 = await device2.createRenderPipelineAsync({
+  label: '\u08cb\u{1f7ec}\ud1b5\u{1fac9}',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x91f91643},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.RED}, {format: 'r16float'}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 512,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 0, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+  await promise14;
+} catch {}
+canvas23.height = 246;
+let offscreenCanvas18 = new OffscreenCanvas(936, 120);
+let promise15 = adapter2.requestAdapterInfo();
+let textureView91 = texture42.createView({label: '\u{1face}\u4e31\uf624\u{1fc45}\u2401\u0304\u0429\u6c90\u2c78', mipLevelCount: 1});
+let renderBundle48 = renderBundleEncoder34.finish({label: '\u09ad\u{1f783}'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer9, 20176, 62188);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let pipeline48 = await promise12;
+let commandEncoder74 = device2.createCommandEncoder({label: '\u0995\u897f\u23c5\ueb85\u06e1\u9707\uc736\u2d0c\ub5b1'});
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1080 */
+  offset: 1080,
+  buffer: buffer5,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 16848 */
+  offset: 16848,
+  rowsPerImage: 103,
+  buffer: buffer11,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 30, depthOrArrayLayers: 67}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 142, y: 42 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 36},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 17, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let textureView92 = texture23.createView({label: '\u08cc\u07b5\u6f70\u0e1c\uc377\u900b', mipLevelCount: 1});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup9, new Uint32Array(1024), 30, 0);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6724 */
+  offset: 6724,
+  buffer: buffer11,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let imageData16 = new ImageData(156, 156);
+try {
+offscreenCanvas18.getContext('webgl2');
+} catch {}
+let buffer12 = device2.createBuffer({
+  label: '\u{1fbf9}\u0a7f\u97d2\u5c23',
+  size: 303338,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder75 = device2.createCommandEncoder({label: '\u0f06\u{1fe05}\u74d9\u455b\u1804\uecc4\u0944\u49f3\u551f'});
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+commandEncoder62.insertDebugMarker('\u73c7');
+} catch {}
+let promise16 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 65 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 3,
+  origin: {x: 3, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter5.label = '\u{1f6eb}\u094c\ueb45\u{1fcb9}';
+} catch {}
+let canvas24 = document.createElement('canvas');
+try {
+canvas24.getContext('webgl2');
+} catch {}
+let querySet45 = device3.createQuerySet({label: '\uc072\u{1f675}\u{1fa24}\u5dbe\u{1f6d0}\u{1f745}', type: 'occlusion', count: 3251});
+let texture48 = device3.createTexture({
+  size: {width: 48, height: 3, depthOrArrayLayers: 148},
+  mipLevelCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView93 = texture47.createView({label: '\uc298\u1d51\u071c\u8ce7\u27f5', baseMipLevel: 6, baseArrayLayer: 114, arrayLayerCount: 19});
+let computePassEncoder25 = commandEncoder69.beginComputePass({label: '\uef44\u8506\u9cb1\u75d1\u{1fbb1}'});
+let sampler36 = device3.createSampler({
+  label: '\u28b2\u057c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 98.12,
+  compare: 'always',
+});
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup13, []);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup16, new Uint32Array(3912), 371, 0);
+} catch {}
+let bindGroupLayout26 = device2.createBindGroupLayout({
+  label: '\uc469\u9dd8\uab48\u{1fede}\u5fe4',
+  entries: [
+    {
+      binding: 623,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 127, visibility: 0, externalTexture: {}},
+  ],
+});
+let commandEncoder76 = device2.createCommandEncoder({label: '\ud06d\ufc3c\u0cfd\u{1fcba}\u030f\u3f6b\u5cee\u{1feef}\u{1ff9c}\uec15'});
+let textureView94 = texture41.createView({
+  label: '\u0466\u3bea\u7dfc\u05bd\uedda\u3ccd\u0760\u3c73\u4517\u6163\u0d27',
+  format: 'r16sint',
+  baseMipLevel: 0,
+});
+let renderBundle49 = renderBundleEncoder20.finish();
+try {
+renderBundleEncoder22.setVertexBuffer(1061, undefined, 0, 2752508691);
+} catch {}
+try {
+texture20.destroy();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(24)), /* required buffer size: 1_326_680 */
+{offset: 481, bytesPerRow: 203, rowsPerImage: 148}, {width: 0, height: 22, depthOrArrayLayers: 45});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 96, height: 120, depthOrArrayLayers: 329}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 19, y: 2 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 18, y: 14, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder77 = device1.createCommandEncoder({});
+let querySet46 = device1.createQuerySet({label: '\u{1fa91}\u0248\u0bc5', type: 'occlusion', count: 153});
+let texture49 = device1.createTexture({
+  label: '\u2dea\u{1f747}\u34f3\u8a79\u9ad1\u7991\u9aa4',
+  size: {width: 192, height: 1, depthOrArrayLayers: 1194},
+  mipLevelCount: 7,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder26 = commandEncoder21.beginComputePass({});
+try {
+renderBundleEncoder11.setPipeline(pipeline18);
+} catch {}
+let pipeline49 = device1.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise15;
+} catch {}
+let imageData17 = new ImageData(44, 140);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+adapter5.label = '\u0aa8\u9413\u49cd\u{1fd75}\u41e0\u043d\u0b13\u359d';
+} catch {}
+video0.width = 108;
+try {
+window.someLabel = device0.label;
+} catch {}
+try {
+  await promise16;
+} catch {}
+let querySet47 = device3.createQuerySet({label: '\uc280\u3fa3', type: 'occlusion', count: 3655});
+let textureView95 = texture47.createView({
+  label: '\u{1f7f7}\u9a26\ue790\u6788\ud593\u0b50\u8f94\u{1fb92}\ucb53\u0b1b',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 137,
+});
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\u{1ff7e}');
+} catch {}
+let promise17 = device3.queue.onSubmittedWorkDone();
+let videoFrame26 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+let offscreenCanvas19 = new OffscreenCanvas(203, 306);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView96 = texture47.createView({
+  label: '\u{1f859}\u626a\u093f\u0477\u06f6',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 29,
+  arrayLayerCount: 92,
+});
+let sampler37 = device3.createSampler({
+  label: '\ud4c2\u081c',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 10.57,
+  lodMaxClamp: 12.55,
+});
+try {
+renderBundleEncoder35.setVertexBuffer(7, buffer6, 0, 5899);
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer9, 72664, 77004);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 11},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(0)), /* required buffer size: 40_124_061 */
+{offset: 785, bytesPerRow: 2823, rowsPerImage: 209}, {width: 175, height: 1, depthOrArrayLayers: 69});
+} catch {}
+let pipeline50 = device3.createComputePipeline({
+  label: '\u5f79\u{1fc27}\u0a11\u{1f8d0}\u63a4\u06e5\u1c6b\u8c00',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas19.getContext('webgpu');
+} catch {}
+let shaderModule8 = device3.createShaderModule({
+  label: '\u0935\u0dda\u{1fcbc}\u08ee',
+  code: `@group(0) @binding(53)
+var<storage, read_write> field7: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec3<i32>,
+  @location(3) f2: vec4<u32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f45: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<i32>, @location(7) a1: vec2<i32>, @location(0) a2: vec3<i32>, @location(5) a3: vec3<u32>, @location(8) a4: i32, @location(14) a5: vec4<f32>, @location(1) a6: vec4<f32>, @location(10) a7: vec3<i32>, @location(4) a8: vec2<f16>, @location(12) a9: f16, @location(13) a10: vec4<u32>, @location(6) a11: vec2<f32>, @location(11) a12: vec4<f16>, @location(3) a13: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout27 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 71,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 653, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let bindGroup18 = device3.createBindGroup({
+  label: '\u{1fb9c}\u{1f7b7}\u0efc\u0ab1\u0091\u{1f6e0}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture46}],
+});
+let querySet48 = device3.createQuerySet({label: '\u6f17\u9823', type: 'occlusion', count: 3013});
+let textureView97 = texture47.createView({
+  label: '\udf6f\u{1f928}\u01e5\u14a3\ub339\u{1f6dc}',
+  format: 'rgba32uint',
+  mipLevelCount: 3,
+  baseArrayLayer: 118,
+  arrayLayerCount: 4,
+});
+let sampler38 = device3.createSampler({
+  label: '\u{1fb54}\u079d\u9aff\ubbea',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.037,
+  lodMaxClamp: 86.78,
+});
+let arrayBuffer2 = buffer7.getMappedRange(273976, 102996);
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(12_087_829), /* required buffer size: 12_087_829 */
+{offset: 637, bytesPerRow: 1498, rowsPerImage: 74}, {width: 83, height: 3, depthOrArrayLayers: 110});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+document.body.prepend(img4);
+document.body.prepend(video10);
+let commandEncoder78 = device2.createCommandEncoder({label: '\u{1fed4}\u0dda\ue56b\u{1fd96}'});
+let querySet49 = device2.createQuerySet({type: 'occlusion', count: 3482});
+let texture50 = device2.createTexture({
+  label: '\u{1fb89}\u4f73\u0534\u79f3\u0f0f\uec30\u0f4c\u{1f7e0}\ub16a\u0494\u{1fbc3}',
+  size: [24],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder39 = device2.createRenderBundleEncoder({
+  label: '\u{1fa7e}\u0d2b',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 14, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 113, depthOrArrayLayers: 1});
+} catch {}
+let pipeline51 = device2.createComputePipeline({layout: pipelineLayout12, compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}}});
+let commandEncoder79 = device3.createCommandEncoder({});
+let querySet50 = device3.createQuerySet({
+  label: '\u8216\u{1f8dd}\u99e3\u5e8f\u08c3\u{1fe15}\ue6d7\ub2f1\u23fc\ucae0\u0c89',
+  type: 'occlusion',
+  count: 3148,
+});
+let computePassEncoder27 = commandEncoder60.beginComputePass({label: '\u253b\u{1ff7b}\u{1f78d}'});
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer9, 78368, 57276);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let commandEncoder80 = device3.createCommandEncoder({label: '\u{1fa13}\u5bb6\u5e4d\u{1ff5e}\u{1fa77}\u9829\u{1f890}\ue25e\u47c9\u2861\ub4a1'});
+let texture51 = device3.createTexture({
+  label: '\u2bb8\u7cc8\ub5cf',
+  size: {width: 96, height: 7, depthOrArrayLayers: 1254},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView98 = texture30.createView({
+  label: '\ue17b\ue27c\u0e84\uc10e\u{1fb5b}',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  baseArrayLayer: 100,
+  arrayLayerCount: 10,
+});
+let renderBundle50 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder23.setPipeline(pipeline48);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 112, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet51 = device3.createQuerySet({label: '\u7c49\uf6bc\u5e95\u4f72', type: 'occlusion', count: 1034});
+let textureView99 = texture51.createView({label: '\u90f6\u9121\u{1fea3}\u{1f7e8}\u0e75\u0a81\u{1f630}\udc74', baseMipLevel: 5});
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({
+  label: '\ue350\u8f1d\u02df\uea0f\u221a\uce69\u0166\ua201\u07b3\u986e\u5b21',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle51 = renderBundleEncoder36.finish({label: '\u42cc\u2711'});
+try {
+renderBundleEncoder38.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup15, new Uint32Array(5525), 3097, 0);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(0, buffer6, 0, 669);
+} catch {}
+let video15 = await videoWithData();
+let commandEncoder81 = device3.createCommandEncoder();
+let renderBundle52 = renderBundleEncoder34.finish({label: '\u0e0c\udd5d\u0d98\u03f3\u18a0\u0b04'});
+let externalTexture47 = device3.importExternalTexture({label: '\u96b8\ub3a9', source: videoFrame10, colorSpace: 'srgb'});
+try {
+buffer8.destroy();
+} catch {}
+let img22 = await imageWithData(296, 221, '#3f6f104a', '#347f5d2f');
+let commandEncoder82 = device2.createCommandEncoder();
+let computePassEncoder28 = commandEncoder40.beginComputePass({label: '\ua35c\ua609\u11e9\u6287\u{1ff95}\u{1fb4d}\ub856\u683c\u{1fb22}\u0ab7'});
+let renderBundle53 = renderBundleEncoder27.finish({label: '\u{1f650}\u372c'});
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 23, y: 37 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 3,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let textureView100 = texture44.createView({
+  label: '\u449b\u1d44\u0796\u036f\u2520\uab88\u0916\u02ba\u01c0\u{1fb46}',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 20,
+});
+try {
+commandEncoder62.copyBufferToBuffer(buffer5, 119432, buffer12, 248752, 716);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9140 */
+  offset: 9140,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer4);
+} catch {}
+let pipeline52 = await device2.createComputePipelineAsync({
+  label: '\u0f00\u4d02\u0f55\u0e5e\u0a9a\ubb55\uc7c3',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let bindGroup19 = device3.createBindGroup({
+  label: '\u{1f8dc}\u0dc0\uff3c',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture46}],
+});
+let pipelineLayout13 = device3.createPipelineLayout({
+  label: '\u068c\u6045\u0444\ud8f8\u{1f8ac}\u{1f7fc}\u6041\u{1fece}\ub645',
+  bindGroupLayouts: [bindGroupLayout19],
+});
+let querySet52 = device3.createQuerySet({label: '\u0626\u0893\u09fa\u505c', type: 'occlusion', count: 1336});
+let textureView101 = texture40.createView({format: 'rg32sint', baseMipLevel: 1, baseArrayLayer: 108, arrayLayerCount: 24});
+let externalTexture48 = device3.importExternalTexture({label: '\uc0bb\u{1febe}\u8b01\uc16e\ue298', source: video9});
+try {
+computePassEncoder23.setPipeline(pipeline48);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 20},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 6_268_929 */
+{offset: 369, bytesPerRow: 533, rowsPerImage: 196}, {width: 60, height: 1, depthOrArrayLayers: 61});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline53 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 3420985590,
+    depthBiasSlopeScale: 448.7716452811251,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 92,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 8, shaderLocation: 1},
+          {format: 'uint16x4', offset: 16, shaderLocation: 0},
+          {format: 'uint8x4', offset: 8, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 12},
+          {format: 'uint32x3', offset: 4, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandBuffer13 = commandEncoder82.finish({label: '\u7be4\u568b\u43e9\u8182\u56e1\u0274\uc872\u0144\u0815\u{1f7d5}\u00d6'});
+let texture52 = device2.createTexture({
+  label: '\u5008\u590b\ue656\ud313\ua9c8\u067c\u0b23',
+  size: [48, 60, 164],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let textureView102 = texture23.createView({label: '\u01ea\u73b9\u18d0\u{1ffa5}', dimension: '3d'});
+try {
+commandEncoder66.copyBufferToBuffer(buffer5, 105248, buffer12, 98680, 4756);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer12, 92828, 187916);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise18 = device2.queue.onSubmittedWorkDone();
+let videoFrame27 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let querySet53 = device2.createQuerySet({type: 'occlusion', count: 3666});
+let textureView103 = texture24.createView({label: '\uec00\u0277\uc17a\u51f0\u1440', baseMipLevel: 1});
+let renderBundleEncoder41 = device2.createRenderBundleEncoder({
+  label: '\u2c20\u5518\uc32e\u085d',
+  colorFormats: ['rg32uint', 'rg8unorm', 'r32float', 'rgba16uint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder15.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(8445, undefined, 1062293948, 308087539);
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(689, 530);
+let commandEncoder83 = device2.createCommandEncoder({label: '\u{1ff36}\u815e\u03e6\u0555\u3dea\u084b'});
+let textureView104 = texture41.createView({label: '\u0a5e\uc62e\u0c8d', dimension: '2d-array', aspect: 'all'});
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup11, new Uint32Array(5978), 2046, 0);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7056 */
+  offset: 7056,
+  buffer: buffer5,
+}, {
+  texture: texture45,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4596 */
+  offset: 4596,
+  bytesPerRow: 0,
+  rowsPerImage: 286,
+  buffer: buffer4,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer11);
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 4},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 225_803 */
+{offset: 353, bytesPerRow: 72, rowsPerImage: 142}, {width: 9, height: 8, depthOrArrayLayers: 23});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 192, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 158, y: 10 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 54, y: 48, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let canvas25 = document.createElement('canvas');
+let img23 = await imageWithData(49, 135, '#9cf0eeae', '#cbb683f7');
+let imageData18 = new ImageData(24, 32);
+let commandBuffer14 = commandEncoder53.finish();
+let computePassEncoder29 = commandEncoder73.beginComputePass({});
+let renderBundleEncoder42 = device2.createRenderBundleEncoder({
+  label: '\u4f9b\u{1f7f7}\u0440\u9434\u0e3b\u076b\u{1fe91}\u63e1\u{1ff2b}\u7035',
+  colorFormats: ['rg32uint', 'rg8unorm', 'r32float', 'rgba16uint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+});
+try {
+commandEncoder46.copyBufferToBuffer(buffer5, 78140, buffer12, 5540, 16104);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 3, depthOrArrayLayers: 10}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 14, y: 59 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 6,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline54 = await device2.createRenderPipelineAsync({
+  label: '\uc0b0\u{1f81b}\u{1ff81}\uf78e\u0fcd\u426b\uca50\u{1f9e2}',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'r32float', writeMask: 0}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 148, attributes: []},
+      {arrayStride: 404, attributes: [{format: 'float32x4', offset: 52, shaderLocation: 15}]},
+    ],
+  },
+});
+try {
+adapter2.label = '\u06c8\uf29e\u{1ff99}\u0ca4\u8501\u0b37';
+} catch {}
+try {
+canvas25.getContext('bitmaprenderer');
+} catch {}
+video0.width = 93;
+let gpuCanvasContext20 = offscreenCanvas20.getContext('webgpu');
+canvas19.height = 934;
+let video16 = await videoWithData();
+document.body.prepend(canvas15);
+let imageData19 = new ImageData(132, 20);
+let videoFrame28 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let commandBuffer15 = commandEncoder79.finish({label: '\u{1fe0c}\u{1fd02}\u{1f8b3}\u00b1\u{1fb0f}\u3b19\u0ab0\u51c1\u4527\ue0f7'});
+let textureView105 = texture37.createView({dimension: '2d-array', mipLevelCount: 4, baseArrayLayer: 104, arrayLayerCount: 12});
+let renderBundle54 = renderBundleEncoder34.finish();
+let externalTexture49 = device3.importExternalTexture({
+  label: '\u0588\u0962\u0faf\u{1fa1e}\u06ac\u0027\ue1df\u8ee2\u{1f863}\u1af0',
+  source: video7,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder35.setIndexBuffer(buffer6, 'uint16', 4058, 6606);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer10, 55092, buffer9, 98428, 2716);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 9, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 127, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let textureView106 = texture46.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 130});
+let computePassEncoder30 = commandEncoder68.beginComputePass({label: '\u{1ffb4}\u6e9e'});
+let renderBundleEncoder43 = device3.createRenderBundleEncoder({
+  label: '\uac0b\uc088\u068a\u7903\u3323\u{1f862}\u8eeb\u0093\ucd7f\u0921',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup14, new Uint32Array(1244), 1200, 0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(2788, undefined);
+} catch {}
+let canvas26 = document.createElement('canvas');
+let commandBuffer16 = commandEncoder70.finish({label: '\u{1fcda}\udfd0\u0b3c\u0584\u9764'});
+let textureView107 = texture47.createView({
+  label: '\u29d9\u3bdd\ub71d\u0ad5\u04fd\u282c\u34c1\ue4f4\u8ff8\u97fb',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 6,
+  arrayLayerCount: 89,
+});
+let renderBundle55 = renderBundleEncoder38.finish({label: '\u{1fead}\u05b0\u58a3\ue777\u03fe\u{1f610}\u{1fb41}\u0559\u7f2a'});
+try {
+computePassEncoder23.setPipeline(pipeline48);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup17, new Uint32Array(7379), 5134, 0);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer10, 38012, buffer9, 90892, 13836);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 6500, new Float32Array(48899), 47701, 924);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 11, y: 1, z: 2},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 32_266_841 */
+{offset: 893, bytesPerRow: 844, rowsPerImage: 277}, {width: 84, height: 4, depthOrArrayLayers: 139});
+} catch {}
+let pipeline55 = device3.createComputePipeline({layout: pipelineLayout13, compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise18;
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let querySet54 = device2.createQuerySet({label: '\u{1fa4f}\u8d3a\ub989', type: 'occlusion', count: 344});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup9, new Uint32Array(6159), 1773, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5390, undefined, 2607571381, 1266366569);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 4,
+  origin: {x: 1, y: 1, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 7, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder41.insertDebugMarker('\u007f');
+} catch {}
+let gpuCanvasContext21 = canvas26.getContext('webgpu');
+let adapter6 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let textureView108 = texture38.createView({
+  label: '\u8c22\u6df4\ud9fa\ufb36\u{1fc47}\u0f8f\u7cc6\u00ae',
+  baseMipLevel: 1,
+  baseArrayLayer: 125,
+  arrayLayerCount: 72,
+});
+let computePassEncoder31 = commandEncoder62.beginComputePass({label: '\u1905\uf91a\u0425\u{1fbdf}\ub88f\u91ae'});
+let sampler39 = device2.createSampler({
+  label: '\u8d43\ua0a6\u2506\u02d5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 76.69,
+  lodMaxClamp: 85.65,
+});
+let externalTexture50 = device2.importExternalTexture({label: '\u{1f8ad}\u{1f6af}\uc1ab\u0725\u8453', source: videoFrame4, colorSpace: 'srgb'});
+try {
+device2.queue.writeBuffer(buffer12, 47088, new DataView(new ArrayBuffer(20419)), 8390, 484);
+} catch {}
+let pipeline56 = device2.createRenderPipeline({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'replace'},
+    stencilBack: {compare: 'never', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilReadMask: 2517343187,
+    stencilWriteMask: 4294967295,
+    depthBias: 1169084176,
+    depthBiasSlopeScale: 353.16829015265523,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 508,
+        attributes: [
+          {format: 'sint32x2', offset: 252, shaderLocation: 8},
+          {format: 'float32x3', offset: 12, shaderLocation: 11},
+          {format: 'sint16x4', offset: 16, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 432, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 220,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 8, shaderLocation: 0}],
+      },
+      {arrayStride: 72, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 284,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 8, shaderLocation: 5}],
+      },
+      {arrayStride: 516, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 20,
+        attributes: [{format: 'uint16x4', offset: 0, shaderLocation: 9}, {format: 'uint16x4', offset: 4, shaderLocation: 4}],
+      },
+      {arrayStride: 36, attributes: [{format: 'unorm16x2', offset: 4, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let imageBitmap20 = await createImageBitmap(video2);
+let commandBuffer17 = commandEncoder59.finish({label: '\u{1fa89}\u{1fa3e}\u{1f81f}\u20c3\u{1f9cb}\u0f6b'});
+let textureView109 = texture42.createView({label: '\u3a66\u{1f6df}\u0b6f\u60a6\u2d2d\u{1ff9a}\u61bf\u0671\ucabf'});
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup14, new Uint32Array(1512), 818, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 6912, new DataView(new ArrayBuffer(20459)), 14155, 1652);
+} catch {}
+let pipeline57 = await device3.createComputePipelineAsync({
+  label: '\u002d\u{1fb97}',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule6, entryPoint: 'compute0'},
+});
+let pipeline58 = device3.createRenderPipeline({
+  label: '\ubcae\u0ea1\u06ab\u0c86',
+  layout: 'auto',
+  multisample: {mask: 0x9e493252},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 351146044,
+    stencilWriteMask: 2829517915,
+    depthBias: 950423095,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 616,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 12, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 8},
+          {format: 'sint16x4', offset: 116, shaderLocation: 3},
+          {format: 'sint32x3', offset: 100, shaderLocation: 13},
+          {format: 'sint32x4', offset: 56, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 68,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x4', offset: 8, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+document.body.prepend(video1);
+let adapter7 = await navigator.gpu.requestAdapter();
+let shaderModule9 = device2.createShaderModule({
+  label: '\u2679\u056f\u45d3\u0a97\ua16f\u4513\u49bd\u4edf\u0953\u4b4b',
+  code: `
+
+@compute @workgroup_size(8, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(1) f1: vec3<f32>,
+  @location(3) f2: vec2<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(2) f4: vec4<f32>,
+  @location(0) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec4<u32>, @location(7) a1: vec4<i32>, @builtin(instance_index) a2: u32, @location(1) a3: vec3<i32>, @location(12) a4: f16, @location(8) a5: vec2<i32>, @location(3) a6: vec3<i32>, @builtin(vertex_index) a7: u32, @location(6) a8: f16, @location(15) a9: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder84 = device2.createCommandEncoder({label: '\u8a47\u77b7\u{1fc61}\u940d\u5bc1\u{1f7d2}\ue046\u00f1\u05d9\u7b65'});
+let textureView110 = texture45.createView({label: '\ufe59\u09fb\uc988\u{1fc85}\uec7e\u0be3', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler40 = device2.createSampler({
+  label: '\u04c6\u047c\u59d2\ue558',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 84.91,
+});
+try {
+renderBundleEncoder41.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(3, bindGroup11, new Uint32Array(104), 20, 0);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 34560 */
+  offset: 34040,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {width: 1, height: 3, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer4);
+} catch {}
+let promise19 = device2.queue.onSubmittedWorkDone();
+let canvas27 = document.createElement('canvas');
+let textureView111 = texture48.createView({
+  label: '\u7cc6\u{1fcef}\u{1fb98}\uc075\u1f89\u0e9a\uc2cf\u2521\u069b',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 140,
+});
+let sampler41 = device3.createSampler({
+  label: '\u1507\ue9aa\u6184\u{1febe}\u052e\u{1fe16}\uf184\uf4e3',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.31,
+  maxAnisotropy: 15,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 54, y: 3, z: 90},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(80)), /* required buffer size: 1_151_396 */
+{offset: 100, bytesPerRow: 922, rowsPerImage: 78}, {width: 80, height: 1, depthOrArrayLayers: 17});
+} catch {}
+let pipeline59 = await device3.createRenderPipelineAsync({
+  label: '\ub519\u0e9d\u0e68\u1b8a\u9039\u0e7b\u06fa\u0067\u06a4',
+  layout: pipelineLayout13,
+  multisample: {count: 4, mask: 0x15209b0f},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 648,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 68, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 408, shaderLocation: 1},
+          {format: 'uint16x2', offset: 92, shaderLocation: 0},
+          {format: 'uint32x2', offset: 192, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let gpuCanvasContext22 = canvas27.getContext('webgpu');
+let canvas28 = document.createElement('canvas');
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let commandEncoder85 = device2.createCommandEncoder({label: '\u{1fdb8}\u{1f718}\uec1d\u5192\u{1f6d9}\u0181\uffa1\u{1fd78}\u6f4e\u1700'});
+let querySet55 = device2.createQuerySet({label: '\u6ce3\u0eaf\ua138\u{1fa57}\u0a41\ub8da\u{1fac3}\u6ac1\u065f', type: 'occlusion', count: 1516});
+let texture53 = device2.createTexture({
+  label: '\u{1f668}\u0a17\u{1f6ed}\u0c60\u9b34\u04a8\u{1fed3}\u0ebc\u0ee4',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView112 = texture29.createView({label: '\u4f9c\u5af7\uf365\u06ce', baseArrayLayer: 0});
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(buffer5, 412, buffer11, 297928, 124276);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 1, y: 13, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 12, y: 15, z: 42},
+  aspect: 'all',
+},
+{width: 44, height: 13, depthOrArrayLayers: 164});
+} catch {}
+let pipeline60 = await device2.createRenderPipelineAsync({
+  label: '\uface\u0002\u5368\u2691\u0453\u2e1d\udc90\u0e61\uff53',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint'}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float'}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 1938483374,
+    stencilWriteMask: 1608199353,
+    depthBias: -45938710,
+    depthBiasSlopeScale: 130.458106762919,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 792, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 536,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 88, shaderLocation: 7},
+          {format: 'uint16x2', offset: 208, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 120,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 48, shaderLocation: 1},
+          {format: 'sint16x4', offset: 32, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 6},
+          {format: 'sint16x4', offset: 8, shaderLocation: 8},
+          {format: 'sint32x2', offset: 12, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let gpuCanvasContext23 = canvas28.getContext('webgpu');
+let imageData20 = new ImageData(148, 140);
+try {
+  await promise19;
+} catch {}
+let commandEncoder86 = device2.createCommandEncoder({label: '\u{1fa10}\uc4d8\u3216\u017f\ucdd1\u0551\u9dc8\u{1fd27}'});
+let querySet56 = device2.createQuerySet({label: '\u{1fb19}\u{1f7fe}\u39e7\u{1f9c7}\u165b', type: 'occlusion', count: 3199});
+let texture54 = device2.createTexture({
+  label: '\u{1f9a9}\u0541\u{1ffcb}',
+  size: [24],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint'],
+});
+let computePassEncoder32 = commandEncoder47.beginComputePass({label: '\u6734\u0fa7\ua1b0\ua1e3\u02eb\ufff3'});
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 280 */
+  offset: 280,
+  buffer: buffer5,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4540 */
+  offset: 4540,
+  rowsPerImage: 31,
+  buffer: buffer4,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer12, 225132, 33280);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+device2.queue.submit([commandBuffer14]);
+} catch {}
+let pipelineLayout14 = device3.createPipelineLayout({
+  label: '\uf5b4\ua61a\u{1fa1c}\u{1fe49}',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout20, bindGroupLayout20],
+});
+let querySet57 = device3.createQuerySet({label: '\u{1fa2c}\ua81d\uc8e0\u965f\ud717\u4d13\ua5e0', type: 'occlusion', count: 2379});
+let texture55 = device3.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let renderBundle56 = renderBundleEncoder30.finish({label: '\u054c\u{1f786}'});
+try {
+commandEncoder81.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5744 widthInBlocks: 359 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 18960 */
+  offset: 18960,
+  buffer: buffer9,
+}, {width: 359, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 2628, new Int16Array(4485), 4269, 20);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas13.width = 32;
+let textureView113 = texture42.createView({label: '\u0094\u{1fd25}'});
+let renderBundleEncoder44 = device3.createRenderBundleEncoder({
+  label: '\u4fdf\u{1ff45}\u1b72\u09eb',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup15, new Uint32Array(7233), 5058, 0);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer6, 'uint32');
+} catch {}
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer7, 563032, buffer9, 137144, 812);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder81.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1888 widthInBlocks: 118 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1904 */
+  offset: 16,
+  buffer: buffer9,
+}, {width: 118, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder80.clearBuffer(buffer9, 31796, 40880);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 244_334 */
+{offset: 564, bytesPerRow: 1270, rowsPerImage: 6}, {width: 75, height: 6, depthOrArrayLayers: 32});
+} catch {}
+let textureView114 = texture24.createView({mipLevelCount: 3, baseArrayLayer: 0});
+let sampler42 = device2.createSampler({
+  label: '\u47d0\u5a20\uacdc\u67d4\u{1fa3e}\u{1f8d3}\u022b\uc83f\u{1f71a}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.40,
+  compare: 'less',
+});
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer5, 83132, buffer12, 147240, 35756);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 11946 */
+  offset: 10408,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture45,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 7, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder78.clearBuffer(buffer11, 630860);
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer12, 113848, new BigUint64Array(4933), 1813, 292);
+} catch {}
+let pipeline61 = device2.createRenderPipeline({
+  label: '\ua4c1\u66e2',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0x98e0dba3},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one'},
+  },
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 332, stepMode: 'instance', attributes: []},
+      {arrayStride: 380, attributes: [{format: 'unorm10-10-10-2', offset: 40, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'back'},
+});
+let imageData21 = new ImageData(40, 196);
+let querySet58 = device3.createQuerySet({label: '\u03e9\u0a20', type: 'occlusion', count: 2260});
+let texture56 = device3.createTexture({
+  label: '\u933a\uc5dd\uaf91\ud8e1\u09ab\u01f1\ub6d5\u17f2',
+  size: [192, 15, 87],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let sampler43 = device3.createSampler({
+  label: '\u963b\u642b\u21e4\u0cff',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.21,
+  lodMaxClamp: 83.90,
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder31.setIndexBuffer(buffer6, 'uint32', 13116, 1671);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder87 = device2.createCommandEncoder({label: '\u{1fcfb}\u073e\u{1febf}'});
+let renderBundleEncoder45 = device2.createRenderBundleEncoder({
+  label: '\u{1fd76}\u5fb0\uc116\u01f0\u816f\ubbe4\ub0f5\u9387',
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder15.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline54);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 128 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 27440 */
+  offset: 27440,
+  rowsPerImage: 13,
+  buffer: buffer5,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+device2.queue.submit([commandBuffer13, commandBuffer11, commandBuffer8]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer11, 24144, new DataView(new ArrayBuffer(51892)));
+} catch {}
+let pipeline62 = device2.createComputePipeline({
+  label: '\u0c14\u5bf1\u637f\u{1f7dd}\u45ee\u330f\u444a\u{1fed4}\ucea1',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let imageData22 = new ImageData(96, 48);
+let sampler44 = device3.createSampler({
+  label: '\u0af3\u9201\u7673\u0861\u{1fb83}\u6723\u05d4\u0002\u{1ff2d}\uc465',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 50.91,
+  lodMaxClamp: 95.94,
+});
+let pipeline63 = device3.createComputePipeline({
+  label: '\u0385\uebaf\u{1feee}\u0be5\u01ee\u2c13\u29b0\u7292\u09c6',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let video17 = await videoWithData();
+let img24 = await imageWithData(187, 65, '#46082b25', '#110d0300');
+try {
+adapter7.label = '\uc583\u0c91\u2665';
+} catch {}
+let commandEncoder88 = device3.createCommandEncoder();
+let querySet59 = device3.createQuerySet({type: 'occlusion', count: 2315});
+let textureView115 = texture51.createView({
+  label: '\u{1ff13}\u086a\u{1fb4a}\u48a7\u{1f7bf}\ua3f5\uea90\u0eb3\uaefa\ub9a2',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let computePassEncoder33 = commandEncoder80.beginComputePass({});
+let externalTexture51 = device3.importExternalTexture({source: video12, colorSpace: 'srgb'});
+try {
+computePassEncoder24.setPipeline(pipeline63);
+} catch {}
+try {
+commandEncoder81.clearBuffer(buffer9, 143832, 16360);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let pipeline64 = await device3.createRenderPipelineAsync({
+  label: '\ub9ee\u{1fa3a}\u{1fba0}',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x3c3bc582},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilWriteMask: 433876342,
+    depthBias: 1669531084,
+    depthBiasSlopeScale: 928.8050955796568,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 44,
+        attributes: [
+          {format: 'snorm16x2', offset: 0, shaderLocation: 9},
+          {format: 'uint32x4', offset: 4, shaderLocation: 14},
+          {format: 'sint8x4', offset: 4, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 16, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 104,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 36, shaderLocation: 0},
+          {format: 'sint8x2', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 224,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 28, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+gc();
+let pipelineLayout15 = device3.createPipelineLayout({
+  label: '\u{1ff89}\u0c87\u{1fe7a}\u06c2\u9ee0\u0fc1',
+  bindGroupLayouts: [bindGroupLayout20, bindGroupLayout19],
+});
+let querySet60 = device3.createQuerySet({label: '\u6897\ue7c7\u292f\u{1f6dc}\u2aad\ua5fe\u380b', type: 'occlusion', count: 3341});
+let textureView116 = texture47.createView({format: 'rgba32uint', baseArrayLayer: 58, arrayLayerCount: 69});
+let computePassEncoder34 = commandEncoder56.beginComputePass({label: '\ua459\u{1f736}\u{1fb0e}\ub07d\u8f8e\u9511\u{1fe73}\u{1f77b}'});
+let renderBundle57 = renderBundleEncoder26.finish({label: '\u4133\u{1f847}\ud4d8\uc21e'});
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer10, 2776, buffer9, 146144, 7788);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let shaderModule10 = device3.createShaderModule({
+  label: '\u6c08\u8db0\u{1f9e3}\u7dee\u024e\u030e\u04e8\u02db\ud969',
+  code: `@group(3) @binding(880)
+var<storage, read_write> global3: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> n6: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> parameter4: array<u32>;
+@group(2) @binding(53)
+var<storage, read_write> global4: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> type11: array<u32>;
+@group(2) @binding(712)
+var<storage, read_write> local6: array<u32>;
+
+@compute @workgroup_size(5, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @location(12) f0: vec2<i32>,
+  @location(7) f1: vec2<f32>,
+  @location(15) f2: f16,
+  @builtin(sample_mask) f3: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(3) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(1) f3: vec4<i32>,
+  @location(0) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec4<f16>, a1: S9, @location(5) a2: vec2<f16>, @builtin(position) a3: vec4<f32>, @location(11) a4: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f46: vec4<f16>,
+  @location(4) f47: vec2<u32>,
+  @location(2) f48: vec2<f32>,
+  @location(5) f49: vec2<f16>,
+  @location(7) f50: vec2<f32>,
+  @location(10) f51: vec2<u32>,
+  @location(6) f52: vec3<f16>,
+  @location(11) f53: vec2<f32>,
+  @location(1) f54: vec2<f16>,
+  @builtin(position) f55: vec4<f32>,
+  @location(15) f56: f16,
+  @location(9) f57: vec3<f32>,
+  @location(3) f58: vec2<i32>,
+  @location(12) f59: vec2<i32>,
+  @location(8) f60: vec2<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(3) a1: i32, @location(4) a2: vec3<f16>, @location(10) a3: vec2<u32>, @location(13) a4: vec2<u32>, @builtin(vertex_index) a5: u32, @location(1) a6: vec3<u32>, @location(9) a7: vec2<i32>, @location(15) a8: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder89 = device3.createCommandEncoder({});
+let texture57 = device3.createTexture({
+  size: {width: 96, height: 7, depthOrArrayLayers: 54},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let textureView117 = texture55.createView({aspect: 'all', format: 'rgba8uint'});
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup19, new Uint32Array(2895), 825, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 232 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 22072 */
+  offset: 21840,
+  buffer: buffer9,
+}, {width: 29, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 8_464_260 */
+{offset: 873, bytesPerRow: 391, rowsPerImage: 169}, {width: 12, height: 14, depthOrArrayLayers: 129});
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let shaderModule11 = device3.createShaderModule({
+  code: `@group(0) @binding(712)
+var<storage, read_write> type12: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> local7: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(3) f2: vec4<u32>,
+  @location(0) f3: vec2<i32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: u32, @builtin(instance_index) a1: u32, @location(9) a2: vec4<i32>, @location(10) a3: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder90 = device3.createCommandEncoder({label: '\u3deb\u94ea\u{1fff9}\u88a0\u59b6\u{1ff59}\u0b52'});
+let commandBuffer18 = commandEncoder81.finish({label: '\u{1f884}\u6cba'});
+let textureView118 = texture47.createView({
+  label: '\u050e\u{1fbf6}\ua254\u0523\u6f9c',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+  baseArrayLayer: 68,
+  arrayLayerCount: 9,
+});
+let renderBundleEncoder46 = device3.createRenderBundleEncoder({
+  label: '\u66a5\u06c3\u359f\ud664\u0ace\u2feb\u01e3\u2c0e\uc4c2\u6087',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder24.dispatchWorkgroupsIndirect(buffer6, 1756);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer9, 93280, 69380);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 30780, new Int16Array(1139), 1049, 56);
+} catch {}
+let buffer13 = device2.createBuffer({
+  label: '\u9232\ud3d6\ub8d5\u0601\u151c\u2c63\u6c20\u{1fd10}\u5088',
+  size: 148588,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let textureView119 = texture18.createView({label: '\u05e8\u0cb5\u2e25\ua05a\u505a\u0dae\u{1fc72}\u017d', format: 'rgba8unorm-srgb'});
+try {
+commandEncoder54.copyBufferToBuffer(buffer13, 17584, buffer12, 234344, 63860);
+dissociateBuffer(device2, buffer13);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder65.popDebugGroup();
+} catch {}
+let shaderModule12 = device2.createShaderModule({
+  label: '\u1a11\ud29c',
+  code: `@group(0) @binding(938)
+var<storage, read_write> function6: array<u32>;
+@group(1) @binding(938)
+var<storage, read_write> function7: array<u32>;
+@group(3) @binding(938)
+var<storage, read_write> n8: array<u32>;
+
+@compute @workgroup_size(4, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(7) f2: vec4<i32>,
+  @location(2) f3: vec4<f32>,
+  @location(3) f4: vec3<f32>,
+  @location(0) f5: i32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec2<i32>, @location(7) a1: u32, @location(3) a2: u32, @location(10) a3: vec2<u32>, @location(9) a4: vec3<i32>, @location(6) a5: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let querySet61 = device2.createQuerySet({label: '\u{1fab0}\u0275\uab46', type: 'occlusion', count: 1715});
+let texture58 = device2.createTexture({
+  label: '\u3cd8\u{1fdbd}\u{1f9c5}\u161a',
+  size: [24, 30, 1],
+  mipLevelCount: 5,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView120 = texture53.createView({baseMipLevel: 0});
+let sampler45 = device2.createSampler({
+  label: '\ua974\u4be0\u25c3\u{1f968}\u0dfa',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 93.50,
+  lodMaxClamp: 95.13,
+  compare: 'never',
+});
+try {
+commandEncoder54.copyBufferToBuffer(buffer5, 71240, buffer12, 49408, 53412);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer12, 7736, new DataView(new ArrayBuffer(42193)), 31465, 3560);
+} catch {}
+let pipeline65 = await device2.createRenderPipelineAsync({
+  label: '\u3a98\u95ac\uec05\u0dc1\u0a49\u8027\u5db3\uba06\u3d25',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 732, attributes: []},
+      {
+        arrayStride: 644,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 36, shaderLocation: 6},
+          {format: 'uint16x2', offset: 40, shaderLocation: 3},
+          {format: 'uint32', offset: 60, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 0, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 4, shaderLocation: 14}],
+      },
+      {arrayStride: 160, attributes: [{format: 'sint16x4', offset: 24, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let textureView121 = texture45.createView({
+  label: '\u{1f868}\u1e79\uc047\u{1fbd8}\u060e\u24d5\u{1fdd8}\u0733\u5a9c',
+  dimension: '2d-array',
+  format: 'r16float',
+  mipLevelCount: 3,
+});
+let computePassEncoder35 = commandEncoder87.beginComputePass({label: '\u06f2\u071c\u{1f9c6}\u780e\u{1f90a}\u0e1a\ud9fc'});
+try {
+computePassEncoder31.setPipeline(pipeline32);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer13, 147240, buffer12, 101480, 448);
+dissociateBuffer(device2, buffer13);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer11);
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer11, 91012, new Float32Array(23808));
+} catch {}
+let pipeline66 = device2.createComputePipeline({
+  label: '\ufcdd\u{1ff58}\u{1f8b8}\u0926\u{1f606}\u5ba3\uba26',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder91 = device2.createCommandEncoder({label: '\ube16\u{1fc44}\u59ee\u0475\u0f37'});
+let externalTexture52 = device2.importExternalTexture({label: '\u7f3f\ufec7\u7463\u9c76\u7a88', source: video15, colorSpace: 'display-p3'});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline32);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12264 */
+  offset: 12264,
+  buffer: buffer12,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer12);
+} catch {}
+document.body.prepend(img13);
+let bindGroup20 = device3.createBindGroup({
+  label: '\u{1fd64}\u68b6\u0412\ue259\u235f\u{1fdd3}\u{1fe23}\u3f77\u7df1\u826e\u45b2',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 653, resource: externalTexture45},
+    {binding: 71, resource: {buffer: buffer8, offset: 84224, size: 215244}},
+  ],
+});
+let commandEncoder92 = device3.createCommandEncoder({label: '\u760c\u0764\u{1fddd}\u05d5\u246a'});
+let querySet62 = device3.createQuerySet({label: '\u0d1a\ud973\ude4e\u{1fabc}\ua4e4\u1207\ucf4d\u0061\u2ec0', type: 'occlusion', count: 4032});
+let renderBundleEncoder47 = device3.createRenderBundleEncoder({
+  label: '\uef91\u{1fe34}\u14d0\u0a65\u128d\u0b73\u7cb1',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+});
+let renderBundle58 = renderBundleEncoder28.finish();
+let pipeline67 = await device3.createComputePipelineAsync({
+  label: '\u9d19\u{1fd5e}\u165f\u03b9\u7c60\u01c2\uffb1\ud536',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup21 = device3.createBindGroup({
+  label: '\uaacb\u0d3e\u09bf\u35d3\u008a\ub940',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture47}],
+});
+let textureView122 = texture46.createView({label: '\uf2e0\u606d', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 74});
+let computePassEncoder36 = commandEncoder89.beginComputePass({label: '\u0585\u0455\ud7d7\ud74d\u007c\u9ec1\u1ca7\u{1fc2a}\u8175\u8d3a'});
+let renderBundle59 = renderBundleEncoder47.finish();
+try {
+commandEncoder67.copyBufferToBuffer(buffer7, 274836, buffer9, 42952, 19656);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer9, 113112, 8456);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 3604, new DataView(new ArrayBuffer(63973)), 60503, 176);
+} catch {}
+let promise20 = device3.queue.onSubmittedWorkDone();
+let offscreenCanvas21 = new OffscreenCanvas(920, 773);
+let shaderModule13 = device2.createShaderModule({
+  label: '\u268f\u{1ffba}\udeca\u{1f659}\u949c\ub10a\u0765\u0529\u4d49\u9069',
+  code: `@group(0) @binding(334)
+var<storage, read_write> n9: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> function8: array<u32>;
+@group(1) @binding(689)
+var<storage, read_write> parameter6: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(4) f1: vec4<f32>,
+  @location(0) f2: vec4<u32>,
+  @location(1) f3: vec3<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(2) f5: f32
+}
+
+@fragment
+fn fragment0(@location(1) a0: f32, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(13) f0: vec2<u32>,
+  @location(2) f1: i32,
+  @location(12) f2: f16,
+  @builtin(vertex_index) f3: u32,
+  @location(7) f4: vec2<f16>,
+  @location(0) f5: i32,
+  @location(15) f6: i32
+}
+struct VertexOutput0 {
+  @location(1) f61: f32,
+  @builtin(position) f62: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<i32>, @location(3) a1: vec2<f32>, @builtin(instance_index) a2: u32, @location(6) a3: vec4<u32>, @location(5) a4: vec3<f16>, @location(14) a5: vec2<i32>, a6: S10, @location(1) a7: vec3<f32>, @location(11) a8: vec2<i32>, @location(10) a9: vec4<f16>, @location(8) a10: vec3<f32>, @location(4) a11: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture59 = device2.createTexture({
+  label: '\u4064\u07f6\ud28e\ub077\u{1f79d}\u2dd3\uf7f9\u{1fb49}\u0a5e\u0135',
+  size: [192, 240, 125],
+  mipLevelCount: 7,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+let textureView123 = texture50.createView({});
+let sampler46 = device2.createSampler({
+  label: '\ufb30\uaef6\ufd90\u4e56\u0499\ud207\uf20e\u{1fd50}\ud581\u{1faa8}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 66.07,
+  lodMaxClamp: 93.86,
+});
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup11, new Uint32Array(3203), 2243, 0);
+} catch {}
+try {
+commandEncoder85.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 81, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 148 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15432 */
+  offset: 15284,
+  buffer: buffer11,
+}, {width: 37, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+gpuCanvasContext20.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+adapter5.label = '\u2a4d\ue2bf\u{1fa4b}';
+} catch {}
+let commandEncoder93 = device2.createCommandEncoder({});
+let sampler47 = device2.createSampler({
+  label: '\u0822\u{1f86c}\u0986\u2cb8\u{1fd82}\ucc19\u{1fee3}\ua455\u{1f8e8}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.55,
+  compare: 'less',
+  maxAnisotropy: 17,
+});
+try {
+commandEncoder85.copyBufferToBuffer(buffer13, 21748, buffer12, 194244, 7272);
+dissociateBuffer(device2, buffer13);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 25968 */
+  offset: 25968,
+  buffer: buffer5,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 2, y: 20, z: 14},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer11);
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer11, 104904, new Int16Array(50605), 20469);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+let gpuCanvasContext24 = offscreenCanvas21.getContext('webgpu');
+try {
+computePassEncoder12.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer11);
+dissociateBuffer(device2, buffer11);
+} catch {}
+let commandEncoder94 = device2.createCommandEncoder({label: '\u03dc\u{1f67a}\u{1fe2c}\uda50\u{1fa33}\u0f70'});
+let texture60 = device2.createTexture({
+  label: '\u{1fd1a}\u{1fc96}\u4faa\u03ef\u{1f91e}\u163b\u0623\ud31f\u0b82\u0964',
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let textureView124 = texture18.createView({label: '\u{1faf9}\u649a\u{1ffeb}\uf468\u{1fb7a}\u{1f710}\u911f\u{1fc02}\u0ffc', format: 'rgba8unorm'});
+let renderBundleEncoder48 = device2.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle60 = renderBundleEncoder16.finish({label: '\u3c87\ua2c3\u54b9\u7dae\ubc31\u00a0\u0514\u0762\u318d\ucdb0\u{1fe3c}'});
+let externalTexture53 = device2.importExternalTexture({
+  label: '\u89d2\u{1fb25}\u91e7\u{1fa54}\ubcca\uf028\ua993\uc713\ua9e2\u725c',
+  source: video4,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder45.setBindGroup(0, bindGroup9);
+} catch {}
+let promise21 = device2.popErrorScope();
+try {
+commandEncoder91.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+let pipeline68 = device2.createComputePipeline({
+  label: '\u6afa\u{1f841}\u0235\u54c5\u2094\u1709\ue451\u8e6e',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let pipeline69 = await device2.createRenderPipelineAsync({
+  label: '\u65ea\u0d35\uf8f2\u{1fdcd}\u26e5',
+  layout: 'auto',
+  multisample: {mask: 0x1f5b37b2},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+  },
+}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'zero', passOp: 'invert'},
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilWriteMask: 1304785301,
+    depthBias: 74442864,
+    depthBiasSlopeScale: 246.09344607236625,
+    depthBiasClamp: 410.6206840819989,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 760, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 76,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 4, shaderLocation: 15},
+          {format: 'uint16x2', offset: 0, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 26, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 788, attributes: []},
+      {
+        arrayStride: 112,
+        attributes: [
+          {format: 'sint32', offset: 0, shaderLocation: 7},
+          {format: 'sint8x2', offset: 2, shaderLocation: 1},
+          {format: 'sint16x2', offset: 20, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 1632,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 408, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 812,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 56, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let querySet63 = device3.createQuerySet({label: '\u00a7\u3df6\u0a1b', type: 'occlusion', count: 814});
+let texture61 = device3.createTexture({
+  label: '\u63e6\u{1fd60}\u045c\u{1fe05}\u0d21\uf725\u{1fcae}\u{1fe7e}\u54d6',
+  size: {width: 96, height: 7, depthOrArrayLayers: 148},
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth32float', 'depth32float'],
+});
+let textureView125 = texture42.createView({label: '\u384f\ubb7c\ua0a4', format: 'rgba32uint', arrayLayerCount: 1});
+let renderBundle61 = renderBundleEncoder37.finish({label: '\u{1fbcd}\ub469\uf64c\u8673\ued6a\ub3a4\u0e95'});
+try {
+computePassEncoder24.setPipeline(pipeline55);
+} catch {}
+let pipeline70 = await device3.createComputePipelineAsync({
+  label: '\u8bbc\ueae9\u0de8\u7db5\u0013\u08d4\u2a68',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let texture62 = device2.createTexture({
+  size: [96],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint'],
+});
+let renderBundle62 = renderBundleEncoder45.finish({label: '\u0590\u329b\u9914\ucb40\u8eb9\u{1fd34}\ufa7d\ud98d\u0dca\u8cb5'});
+let externalTexture54 = device2.importExternalTexture({label: '\u54fd\u766c\u{1f83d}\ue009\u10f3', source: videoFrame24, colorSpace: 'srgb'});
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8974 */
+  offset: 8974,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture45,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 15, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 1, y: 3, z: 2},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 293_470 */
+{offset: 332, bytesPerRow: 233, rowsPerImage: 74}, {width: 3, height: 1, depthOrArrayLayers: 18});
+} catch {}
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u5e86\ubc2f\u0915\ud704\u{1fc3b}\u77e7\uace8\uf98b\ua8fd',
+  colorFormats: ['bgra8unorm-srgb', 'rgba8unorm-srgb', 'rgba32float'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.08,
+  lodMaxClamp: 30.25,
+});
+let promise22 = device0.popErrorScope();
+let bindGroup22 = device2.createBindGroup({
+  label: '\u0e60\ue131\uca12\u8c6f\u097a',
+  layout: bindGroupLayout15,
+  entries: [{binding: 938, resource: sampler18}],
+});
+let texture63 = device2.createTexture({
+  label: '\ub08f\u494a\u{1ff2b}\u0d9c\u35d7',
+  size: [24, 30, 1],
+  mipLevelCount: 4,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView126 = texture36.createView({label: '\u0c3a\ucfeb\u5e1e', baseMipLevel: 1});
+try {
+renderBundleEncoder48.setPipeline(pipeline54);
+} catch {}
+let arrayBuffer3 = buffer13.getMappedRange(0, 107132);
+try {
+commandEncoder84.copyBufferToBuffer(buffer13, 15824, buffer12, 220112, 78924);
+dissociateBuffer(device2, buffer13);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 104 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 23912 */
+  offset: 23912,
+  buffer: buffer12,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer12, 17396, new DataView(new ArrayBuffer(7664)), 4782, 456);
+} catch {}
+let pipeline71 = await device2.createComputePipelineAsync({
+  label: '\ude5b\ue577\u9366',
+  layout: 'auto',
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+device2.destroy();
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+  await promise20;
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+gc();
+gc();
+let promise23 = adapter6.requestAdapterInfo();
+document.body.prepend(img20);
+let commandEncoder95 = device3.createCommandEncoder({});
+let texture64 = device3.createTexture({
+  size: [48, 3, 148],
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth32float', 'depth32float', 'depth32float'],
+});
+try {
+computePassEncoder24.dispatchWorkgroupsIndirect(buffer6, 12860);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(1, bindGroup17, new Uint32Array(8251), 6818, 0);
+} catch {}
+try {
+computePassEncoder24.pushDebugGroup('\udf43');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 9_158_694 */
+{offset: 6, bytesPerRow: 1176, rowsPerImage: 236}, {width: 144, height: 0, depthOrArrayLayers: 34});
+} catch {}
+gc();
+let canvas29 = document.createElement('canvas');
+let video18 = await videoWithData();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let img25 = await imageWithData(162, 90, '#25d069e2', '#3149f048');
+try {
+  await promise22;
+} catch {}
+offscreenCanvas2.height = 791;
+let offscreenCanvas22 = new OffscreenCanvas(825, 584);
+let imageBitmap21 = await createImageBitmap(img24);
+let videoFrame29 = new VideoFrame(imageBitmap19, {timestamp: 0});
+let texture65 = device1.createTexture({
+  size: [48, 1, 4],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle63 = renderBundleEncoder12.finish();
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 788},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 14, height: 1, depthOrArrayLayers: 27});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 578_132 */
+{offset: 150, bytesPerRow: 206, rowsPerImage: 55}, {width: 19, height: 1, depthOrArrayLayers: 52});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 156}
+*/
+{
+  source: offscreenCanvas16,
+  origin: { x: 28, y: 8 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline72 = device1.createComputePipeline({
+  label: '\u0dc9\u4804\u00d9\u5364\u5ae3\u09ea\u0a46\u5593\u2ff2\u8250\u0baf',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext25 = offscreenCanvas22.getContext('webgpu');
+gc();
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(746, 641);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img14);
+video11.height = 274;
+try {
+offscreenCanvas23.getContext('webgpu');
+} catch {}
+let commandEncoder96 = device3.createCommandEncoder({});
+let texture66 = device3.createTexture({
+  label: '\uac23\u11ea\u{1fce2}\uc2a3',
+  size: [96],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder37 = commandEncoder96.beginComputePass({label: '\u957c\ua3e4\uaa4b\u0b1e\u1831'});
+let renderBundleEncoder50 = device3.createRenderBundleEncoder({
+  label: '\u{1ff7d}\u06b0\u9e43\uda96\u{1f9f4}\u08c9\ue019\u69d8\ua55c\ub6bd\u{1f95f}',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline67);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.submit([commandBuffer17, commandBuffer15]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 334_159 */
+{offset: 737, bytesPerRow: 295, rowsPerImage: 113}, {width: 9, height: 1, depthOrArrayLayers: 11});
+} catch {}
+let videoFrame30 = new VideoFrame(img4, {timestamp: 0});
+try {
+  await promise21;
+} catch {}
+let querySet64 = device3.createQuerySet({
+  label: '\ua4f7\u44a5\u{1fc6e}\u479b\u1147\u{1ffea}\u1c56\u7682\uc4fb\u{1f767}\u941b',
+  type: 'occlusion',
+  count: 1328,
+});
+let textureView127 = texture56.createView({label: '\u0ad3\u4802\u84e7\u5b80\uf288\ucd8a\ucdff', dimension: '3d', mipLevelCount: 1});
+let renderBundle64 = renderBundleEncoder37.finish({label: '\u0689\u{1fdd4}\u0a33'});
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup19, new Uint32Array(6406), 3198, 0);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer10, 25180, buffer9, 155788, 3900);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 42320, new Int16Array(26758), 9116, 644);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1_448_520 */
+{offset: 412, bytesPerRow: 1020, rowsPerImage: 281}, {width: 182, height: 15, depthOrArrayLayers: 6});
+} catch {}
+canvas12.width = 1255;
+try {
+canvas29.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+video12.height = 142;
+let commandEncoder97 = device3.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder90.beginComputePass();
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer6, 14528, 3388);
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer10, 17244, buffer9, 73304, 38820);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+offscreenCanvas1.height = 519;
+let imageData23 = new ImageData(80, 192);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img6);
+let imageData24 = new ImageData(248, 212);
+let imageBitmap22 = await createImageBitmap(canvas16);
+let videoFrame31 = new VideoFrame(offscreenCanvas17, {timestamp: 0});
+let textureView128 = texture61.createView({dimension: '2d', aspect: 'all', baseMipLevel: 2, baseArrayLayer: 96});
+let sampler49 = device3.createSampler({
+  label: '\uc4d3\u01aa\ue34f\u0596\u042a\u5b35\u{1ff4e}\u{1f808}\u3a2f',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.68,
+  lodMaxClamp: 68.92,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup16, new Uint32Array(6126), 2482, 0);
+} catch {}
+let arrayBuffer4 = buffer7.getMappedRange(492208, 21932);
+try {
+computePassEncoder24.popDebugGroup();
+} catch {}
+let pipeline73 = device3.createComputePipeline({
+  label: '\u0b55\u{1f6f5}\u{1fe2f}\u{1fdc2}\uf284\u{1fcac}\u09d3',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise23;
+} catch {}
+offscreenCanvas3.width = 278;
+let canvas30 = document.createElement('canvas');
+let gpuCanvasContext26 = canvas30.getContext('webgpu');
+let canvas31 = document.createElement('canvas');
+let bindGroup23 = device3.createBindGroup({
+  label: '\ue73f\ua507\u0f77\u{1fc6a}\uc393\u0132\u0fd2\u036a\uc92d\u046c',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture47}],
+});
+let texture67 = device3.createTexture({
+  label: '\u3ca0\u1d9e',
+  size: [192, 15, 148],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let textureView129 = texture64.createView({label: '\u{1facb}\u140d\u67f2\u6c07', dimension: '2d', baseMipLevel: 0, baseArrayLayer: 140});
+let renderBundleEncoder51 = device3.createRenderBundleEncoder({
+  label: '\u0323\u07aa\ude44\u{1fcfc}\u00b9\u6c1d',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder92.copyBufferToBuffer(buffer10, 21696, buffer9, 92188, 536);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+renderBundleEncoder51.pushDebugGroup('\udbc1');
+} catch {}
+try {
+renderBundleEncoder51.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 4820, new BigUint64Array(37238), 12871, 1624);
+} catch {}
+let gpuCanvasContext27 = canvas31.getContext('webgpu');
+gc();
+let imageData25 = new ImageData(148, 144);
+let querySet65 = device3.createQuerySet({label: '\u9962\u{1f645}', type: 'occlusion', count: 334});
+let texture68 = gpuCanvasContext1.getCurrentTexture();
+let textureView130 = texture57.createView({label: '\u22c8\u{1f8cf}\ub6a2\u{1f871}\u1436\u0e66', format: 'rg32sint', baseMipLevel: 1});
+let sampler50 = device3.createSampler({
+  label: '\u0c30\u{1fe6e}\u63c9\u0116\u08d8\u0bef\u6051',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.01,
+  lodMaxClamp: 93.88,
+});
+let externalTexture55 = device3.importExternalTexture({label: '\u4a13\u{1f81e}\u{1f6db}\u939a\u31e1\u5f08', source: video7, colorSpace: 'srgb'});
+let arrayBuffer5 = buffer7.getMappedRange(475704, 13696);
+try {
+commandEncoder97.copyBufferToBuffer(buffer10, 54800, buffer9, 9272, 820);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 3_540_597 */
+{offset: 189, bytesPerRow: 181, rowsPerImage: 170}, {width: 3, height: 11, depthOrArrayLayers: 116});
+} catch {}
+gc();
+gc();
+let adapter8 = await navigator.gpu.requestAdapter({});
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = pipeline19.label;
+} catch {}
+let bindGroup24 = device3.createBindGroup({
+  label: '\u{1ff09}\u0b4d\u34aa\u{1f62c}\u37e9',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture38}],
+});
+let renderBundle65 = renderBundleEncoder31.finish({label: '\u0de9\u0cfe\u89c7\u2c26\u9da9\u{1f933}\u{1ff71}'});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+computePassEncoder29.label = '\u0ed8\u{1fe4b}\uc259\u90b0';
+} catch {}
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+let img26 = await imageWithData(25, 146, '#fedf3c13', '#2549d7e8');
+let querySet66 = device3.createQuerySet({label: '\u0c02\u06cb\ucf2c\u0b6f\u3711', type: 'occlusion', count: 440});
+let computePassEncoder39 = commandEncoder97.beginComputePass({label: '\u{1f6ce}\ua105\u660a\u{1fd5e}\u{1ff28}\u{1fdf7}\u8f22'});
+try {
+renderBundleEncoder51.setBindGroup(3, bindGroup13, new Uint32Array(1077), 128, 0);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let pipeline74 = device3.createComputePipeline({
+  label: '\u{1ffd9}\u7764\uc57c\u0c35\u766f\u0639\u{1f79b}',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder98 = device3.createCommandEncoder({label: '\u{1fdbf}\uea00\ub54d\u44fa\u2337\u51f0\u{1fdf7}'});
+let querySet67 = device3.createQuerySet({label: '\u{1f8ff}\u0b9c\u{1fac5}\u0b97\u3a1d\u41f2\uc372', type: 'occlusion', count: 189});
+let computePassEncoder40 = commandEncoder88.beginComputePass({label: '\u{1f629}\uea31\uf893\ua5d2\u05ef'});
+let renderBundle66 = renderBundleEncoder40.finish({label: '\u1aa2\ued70\u5792\u6fe9\udb54\u064a\u{1fd90}\u35ac\u{1fe56}\u6fc9\u7074'});
+try {
+gpuCanvasContext24.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise24 = device3.queue.onSubmittedWorkDone();
+let promise25 = device3.createComputePipelineAsync({
+  label: '\ub53b\u372b\u2dbc\u0dae\u14cb\u0d3a\u846d\uc514\u7ee6',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandBuffer19 = commandEncoder95.finish({label: '\u4584\u{1f6b5}\u286b\u05ec\u0920'});
+let textureView131 = texture66.createView({label: '\u041e\u{1f723}\u{1fccc}\u0ca8\u04f8\u5914\u0694', dimension: '1d', baseMipLevel: 0});
+let renderBundle67 = renderBundleEncoder30.finish({label: '\u{1fd09}\ufa5c\u9fa7\u0709'});
+let sampler51 = device3.createSampler({
+  label: '\ue10c\u2eb0\u42e7\ue6be\udd8c\uae81\uceea\u{1fd61}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.52,
+  lodMaxClamp: 87.51,
+  compare: 'greater-equal',
+});
+try {
+commandEncoder67.copyBufferToBuffer(buffer7, 8688, buffer9, 106052, 44260);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+pipeline31.label = '\u{1ff3e}\ue018\u9767';
+} catch {}
+try {
+  await promise24;
+} catch {}
+let img27 = await imageWithData(186, 206, '#487d9ca7', '#20cbd108');
+let bindGroup25 = device3.createBindGroup({
+  label: '\u932b\u4a27\u8888\u{1f8cc}',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 653, resource: externalTexture38},
+    {binding: 71, resource: {buffer: buffer8, offset: 161792, size: 168004}},
+  ],
+});
+let commandEncoder99 = device3.createCommandEncoder({label: '\u{1fc73}\uc7b8\u9e53\u0e2b\u{1fcce}\u{1fd98}\uff49\u0ccd\u{1ff03}\u{1f8cd}\ub99d'});
+let externalTexture56 = device3.importExternalTexture({label: '\u{1faed}\u59a6\u{1febd}\u9f87\u1c44\u00f5\u0e9d', source: videoFrame12, colorSpace: 'srgb'});
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline75 = device3.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x784d7e2c},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-wrap',
+    },
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 1719910835,
+    stencilWriteMask: 321093977,
+    depthBias: -1632251525,
+    depthBiasSlopeScale: 732.7316502322387,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'uint32', offset: 0, shaderLocation: 5},
+          {format: 'sint8x2', offset: 70, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 4},
+          {format: 'sint16x4', offset: 28, shaderLocation: 10},
+          {format: 'uint32', offset: 36, shaderLocation: 3},
+          {format: 'float16x4', offset: 108, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 12, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 36, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 36, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 28, shaderLocation: 14},
+          {format: 'float16x4', offset: 0, shaderLocation: 1},
+          {format: 'sint32', offset: 8, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 168, attributes: [{format: 'float32x3', offset: 32, shaderLocation: 11}]},
+      {arrayStride: 380, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, attributes: [{format: 'sint8x2', offset: 0, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', unclippedDepth: true},
+});
+canvas5.height = 63;
+let bindGroupLayout28 = device3.createBindGroupLayout({label: '\u337e\u0014\u{1f668}\u0659\u{1f987}\u1b79\u3a92\u0817\u04ac\u6421', entries: []});
+let commandEncoder100 = device3.createCommandEncoder({label: '\u05a1\u{1f8b4}\u9637\u0970\u{1fd45}\u1813\u{1fb45}\ufed2\u0224\u0a73'});
+let texture69 = device3.createTexture({
+  size: {width: 48, height: 3, depthOrArrayLayers: 221},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundle68 = renderBundleEncoder46.finish({label: '\u032f\u0d3d\uc9d4\u047d\u5f97\u6a6c\u7b71\u4c0a\u37d4\u0852\uf67d'});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(3, buffer6, 9620);
+} catch {}
+try {
+querySet42.destroy();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 18, y: 6, z: 9},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 13_926_429 */
+{offset: 504, bytesPerRow: 1593, rowsPerImage: 213}, {width: 189, height: 9, depthOrArrayLayers: 42});
+} catch {}
+let pipeline76 = device3.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 8},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 11_697_523 */
+{offset: 695, bytesPerRow: 676, rowsPerImage: 143}, {width: 71, height: 0, depthOrArrayLayers: 122});
+} catch {}
+let imageBitmap23 = await createImageBitmap(imageBitmap19);
+let imageBitmap24 = await createImageBitmap(videoFrame20);
+canvas0.height = 113;
+gc();
+try {
+bindGroup1.label = '\u031d\u{1fb74}\u0fa7\uf630\u{1f84f}';
+} catch {}
+let commandEncoder101 = device1.createCommandEncoder({label: '\ucae3\u2e12\u3e15\u{1f8c0}\u64c1\u93b1\u{1f9af}'});
+let textureView132 = texture19.createView({
+  label: '\u0877\u0f96\u{1ff08}\u0752\u{1f650}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 612,
+  arrayLayerCount: 223,
+});
+let sampler52 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 28.98,
+  lodMaxClamp: 61.36,
+});
+try {
+renderBundleEncoder14.setIndexBuffer(buffer2, 'uint16', 53210, 3313);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(8, buffer3, 65808, 3817);
+} catch {}
+try {
+commandEncoder29.insertDebugMarker('\uaadc');
+} catch {}
+let promise26 = device1.queue.onSubmittedWorkDone();
+video8.height = 12;
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+  await promise26;
+} catch {}
+let img28 = await imageWithData(68, 14, '#76c02760', '#3df92fa6');
+let imageData26 = new ImageData(204, 60);
+try {
+computePassEncoder39.setBindGroup(3, bindGroup17, new Uint32Array(1446), 678, 0);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 78540, new Int16Array(11296), 785, 680);
+} catch {}
+let img29 = await imageWithData(180, 135, '#2eecd4ea', '#ea0f4f3c');
+let querySet68 = device3.createQuerySet({label: '\u{1fa24}\u6f31\u0145\u2cdc\uab5a', type: 'occlusion', count: 2974});
+let computePassEncoder41 = commandEncoder98.beginComputePass({label: '\u3cf5\u5a43\u2975'});
+let sampler53 = device3.createSampler({
+  label: '\u8eb0\u3590\u09d7\u{1fdfe}\uac4b\u6d28\u8d25\u3243\uf998\u43dd',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 23.40,
+  lodMaxClamp: 40.94,
+});
+let externalTexture57 = device3.importExternalTexture({label: '\u06b3\u0724\u0988\u0a81\u61da\u313e\u0f52', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 15884, new DataView(new ArrayBuffer(18334)), 17371, 68);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 10},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1_236_751 */
+{offset: 29, bytesPerRow: 151, rowsPerImage: 234}, {width: 8, height: 1, depthOrArrayLayers: 36});
+} catch {}
+let video19 = await videoWithData();
+let imageBitmap25 = await createImageBitmap(videoFrame7);
+try {
+renderBundleEncoder9.label = '\u0219\u07c8\uf61c\u{1f941}';
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let bindGroupLayout29 = pipeline67.getBindGroupLayout(0);
+let commandEncoder102 = device3.createCommandEncoder({label: '\u0c87\ua25c\ub8bb\u12ea'});
+let querySet69 = device3.createQuerySet({type: 'occlusion', count: 679});
+let computePassEncoder42 = commandEncoder68.beginComputePass({label: '\u{1f679}\u2d7c\u75e0\u7972\u18df\ud5c5\u048a\u4034\u6ff8'});
+let renderBundle69 = renderBundleEncoder23.finish();
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 59848);
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer7, 553872, buffer9, 98156, 4776);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 54664, new Float32Array(41351), 21821, 3952);
+} catch {}
+let imageBitmap26 = await createImageBitmap(imageBitmap2);
+try {
+window.someLabel = bindGroupLayout12.label;
+} catch {}
+let bindGroupLayout30 = device3.createBindGroupLayout({
+  label: '\ucf24\u8e8c\u989c\u{1fac4}\u093f\u023b\u{1fb71}',
+  entries: [{binding: 907, visibility: 0, externalTexture: {}}],
+});
+let sampler54 = device3.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.60,
+  lodMaxClamp: 97.70,
+});
+let imageBitmap27 = await createImageBitmap(videoFrame30);
+canvas30.height = 3058;
+let img30 = await imageWithData(205, 218, '#c791d20e', '#77efea32');
+let bindGroup26 = device3.createBindGroup({
+  label: '\ub127\uf740\u036a',
+  layout: bindGroupLayout30,
+  entries: [{binding: 907, resource: externalTexture34}],
+});
+let querySet70 = device3.createQuerySet({label: '\u19af\u0ee7\u04c4\u{1f7b6}\u0d7d\ub993', type: 'occlusion', count: 2137});
+let textureView133 = texture34.createView({
+  label: '\u590f\u046a\u3551\u{1f746}\u955f\uad0a\u{1fc05}\u9272\u60f2\u3fc5\uc5a0',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+let computePassEncoder43 = commandEncoder67.beginComputePass({label: '\ub050\u060a\u0bb3\u{1f6be}\u06be\u{1fb8f}'});
+let renderBundle70 = renderBundleEncoder44.finish({label: '\u6dc7\u0a08\u037a\u{1f7dc}\u18a6'});
+try {
+computePassEncoder33.end();
+} catch {}
+let promise27 = device3.popErrorScope();
+let pipeline77 = device3.createRenderPipeline({
+  label: '\u{1fc12}\u0637\ue3ab\u0b49\ufbf9\u0b26\u5ee7',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 520,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 88, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 9},
+          {format: 'sint32x2', offset: 40, shaderLocation: 0},
+          {format: 'sint32x2', offset: 4, shaderLocation: 3},
+          {format: 'float32x2', offset: 208, shaderLocation: 15},
+          {format: 'sint32x3', offset: 28, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 216, attributes: [{format: 'uint16x4', offset: 72, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(img6);
+canvas29.width = 97;
+let textureView134 = texture47.createView({
+  label: '\u563b\u{1fff3}\u{1f9f2}\u{1f8b1}\u{1fec3}\u529e\u0458\u573e\u{1fac1}\u71ce\ufe39',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 147,
+});
+let computePassEncoder44 = commandEncoder92.beginComputePass({});
+try {
+commandEncoder102.copyBufferToBuffer(buffer10, 24520, buffer9, 76924, 11756);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 5},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 18_215_772 */
+{offset: 492, bytesPerRow: 2972, rowsPerImage: 136}, {width: 179, height: 9, depthOrArrayLayers: 46});
+} catch {}
+let promise28 = device3.queue.onSubmittedWorkDone();
+let pipeline78 = device3.createComputePipeline({
+  label: '\u4cb2\uc8e2\u064b\u{1faa5}\u{1f896}\u0bfa\u036b\u138b',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap28 = await createImageBitmap(videoFrame3);
+let video20 = await videoWithData();
+try {
+externalTexture45.label = '\u3b2b\uda0d\u014d\u99ea\u0404\uce85\u008a\u0179\uf271\u0632\uf065';
+} catch {}
+let textureView135 = texture51.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle71 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup21, new Uint32Array(3753), 1956, 0);
+} catch {}
+try {
+querySet31.destroy();
+} catch {}
+try {
+commandEncoder102.copyTextureToBuffer({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 248 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 83312 */
+  offset: 5752,
+  bytesPerRow: 256,
+  rowsPerImage: 75,
+  buffer: buffer9,
+}, {width: 31, height: 3, depthOrArrayLayers: 5});
+dissociateBuffer(device3, buffer9);
+} catch {}
+let promise29 = device3.queue.onSubmittedWorkDone();
+let pipeline79 = device3.createRenderPipeline({
+  layout: pipelineLayout14,
+  multisample: {count: 4, mask: 0x8f5a2ea3},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: [{format: 'sint8x2', offset: 1062, shaderLocation: 9}]},
+      {
+        arrayStride: 28,
+        attributes: [{format: 'sint8x2', offset: 8, shaderLocation: 10}, {format: 'uint16x2', offset: 8, shaderLocation: 4}],
+      },
+    ],
+  },
+});
+offscreenCanvas1.height = 1373;
+try {
+  await promise28;
+} catch {}
+let texture70 = device3.createTexture({
+  label: '\u47b5\u0d7a\u5559\u{1f63c}\ufa12\u{1f774}\u{1fb9c}\u0b32',
+  size: [384, 30, 148],
+  mipLevelCount: 9,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth32float'],
+});
+let textureView136 = texture56.createView({label: '\u796a\u0675\ufee0\u2a25\u{1fc2f}\u{1f6b3}'});
+let renderBundleEncoder52 = device3.createRenderBundleEncoder({
+  label: '\u{1fb30}\u0dd9\u0fd7',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+});
+let externalTexture58 = device3.importExternalTexture({
+  label: '\uc926\u0746\u{1faef}\u04f1\u3139\u{1fa5e}\u1d95\u1351\u{1fc5e}\u{1f82a}\udbed',
+  source: video19,
+  colorSpace: 'display-p3',
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img31 = await imageWithData(151, 187, '#d79cbf48', '#cb33bf10');
+let promise30 = adapter5.requestAdapterInfo();
+let texture71 = device3.createTexture({
+  label: '\ua719\u0c3b\ubad3\u01eb\ub0a3\u0d81\ub9f7\u6e76\u{1fa84}\u{1fb6e}\u0d92',
+  size: {width: 96},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let textureView137 = texture30.createView({
+  label: '\u6712\u549d\u8066\u{1f653}',
+  dimension: '2d',
+  format: 'rgba8unorm',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 85,
+});
+let renderBundleEncoder53 = device3.createRenderBundleEncoder({
+  label: '\ubde2\u09a2\u27c6\uf97b\ucfe2',
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder80.clearBuffer(buffer9, 25572, 114232);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let commandEncoder103 = device3.createCommandEncoder({label: '\u03de\u2411'});
+let texture72 = device3.createTexture({
+  label: '\u3825\ub947\u0fb2\u47f1\uf027\ub038\u0665\u{1f96a}',
+  size: [192],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8uint'],
+});
+let renderBundleEncoder54 = device3.createRenderBundleEncoder({
+  label: '\u41ca\u{1ff41}\u0ada\u9be5\u{1fef1}',
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+});
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer6, 16700, 243);
+} catch {}
+try {
+gpuCanvasContext13.configure({device: device3, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 774 */
+{offset: 774}, {width: 43, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline80 = device3.createComputePipeline({
+  label: '\u{1ff45}\u5bdb\u6d6b\u0eb9\u57d4\u{1f932}\u{1fb1a}\uee1c\u80d4\u96f9\u06b2',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let imageData27 = new ImageData(168, 244);
+try {
+  await promise30;
+} catch {}
+let bindGroup27 = device3.createBindGroup({layout: bindGroupLayout28, entries: []});
+let commandEncoder104 = device3.createCommandEncoder();
+let textureView138 = texture42.createView({label: '\u0476\uc93f', aspect: 'all', baseArrayLayer: 0});
+let renderBundle72 = renderBundleEncoder40.finish({});
+try {
+computePassEncoder40.setPipeline(pipeline73);
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer7, 102816, buffer9, 138168, 16880);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 114076, new Float32Array(9142), 3265, 1384);
+} catch {}
+gc();
+try {
+device0.queue.label = '\ucb95\ud0ae\ue441\u0317\ub1e3\u0448\u34b4\uc291\ud93a';
+} catch {}
+let bindGroup28 = device3.createBindGroup({
+  label: '\u0d58\u{1fc2e}\u3025\ue3e2',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 653, resource: externalTexture58},
+    {binding: 71, resource: {buffer: buffer8, offset: 193792, size: 140244}},
+  ],
+});
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 31400, new Int16Array(57338), 54706, 988);
+} catch {}
+let videoFrame32 = new VideoFrame(video8, {timestamp: 0});
+let videoFrame33 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let img32 = await imageWithData(9, 280, '#dcaea932', '#1dd3c081');
+let videoFrame34 = new VideoFrame(img16, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame35 = new VideoFrame(videoFrame27, {timestamp: 0});
+let textureView139 = texture42.createView({label: '\ufc1c\uc9ad\ub1bb\u0c87', dimension: '1d'});
+let renderBundleEncoder55 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup19);
+} catch {}
+let promise31 = device3.queue.onSubmittedWorkDone();
+try {
+  await promise27;
+} catch {}
+let videoFrame36 = new VideoFrame(videoFrame18, {timestamp: 0});
+try {
+device3.label = '\u{1fb1a}\u{1f6b7}\u7842';
+} catch {}
+let pipelineLayout16 = device3.createPipelineLayout({label: '\ud1a1\ueed2\uef2f\ub8ed\u0d82', bindGroupLayouts: [bindGroupLayout28]});
+let commandEncoder105 = device3.createCommandEncoder({label: '\u{1fba4}\u{1fa0a}\u0111\uc966\u7dbb\u48da\u0035\u4bbe\u734d\u0510\u6556'});
+let textureView140 = texture70.createView({
+  label: '\ub206\u{1ff3b}\ufde7\ud574\u1407\u{1f8bb}\u0ce7\u2d97\u{1f87d}\ub175',
+  aspect: 'depth-only',
+  mipLevelCount: 7,
+  baseArrayLayer: 14,
+  arrayLayerCount: 96,
+});
+try {
+renderBundleEncoder53.setIndexBuffer(buffer6, 'uint32', 15604);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer6, 0, 14975);
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 10944, new Int16Array(40555), 14145, 1328);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 40, y: 1, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 5_819_957 */
+{offset: 841, bytesPerRow: 543, rowsPerImage: 90}, {width: 41, height: 7, depthOrArrayLayers: 120});
+} catch {}
+let img33 = await imageWithData(94, 172, '#358261f3', '#66b35462');
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let textureView141 = texture56.createView({label: '\u4906\u{1f613}\u06ed\u{1f7c2}\udb50\u6c0a\u3dce\u0fdc'});
+let renderBundle73 = renderBundleEncoder43.finish({});
+try {
+commandEncoder103.clearBuffer(buffer9, 71848, 30900);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 3052, new Int16Array(12918), 9485, 64);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let video21 = await videoWithData();
+let videoFrame37 = new VideoFrame(canvas4, {timestamp: 0});
+let textureView142 = texture69.createView({format: 'rgb10a2uint', mipLevelCount: 2});
+let computePassEncoder45 = commandEncoder80.beginComputePass({label: '\u0135\u10fc\uf4b6\u2e68'});
+let sampler55 = device3.createSampler({
+  label: '\ub825\u0f42\u00eb',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 45.02,
+  lodMaxClamp: 75.00,
+});
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 57192, new BigUint64Array(35074), 18688, 1428);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let texture73 = device3.createTexture({
+  label: '\u8bb1\u{1fd5f}',
+  size: [192, 15, 1784],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView143 = texture37.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 50});
+let renderBundle74 = renderBundleEncoder35.finish({label: '\u839b\ua090\u5fec\u{1f67d}\u{1fffc}\u{1fbda}\u{1ffc9}\u03a4\ueb36\u0266\u{1fd64}'});
+let externalTexture59 = device3.importExternalTexture({source: videoFrame24});
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup24, new Uint32Array(4080), 754, 0);
+} catch {}
+let arrayBuffer6 = buffer7.getMappedRange(514144, 18376);
+try {
+commandEncoder102.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 68 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7200 */
+  offset: 7200,
+  buffer: buffer9,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+let pipeline81 = await device3.createRenderPipelineAsync({
+  label: '\u0c74\ud37e\u{1fe8c}\u0653\u{1feac}\ub36b\u212b',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilWriteMask: 728140127,
+    depthBiasSlopeScale: 748.3722744982978,
+    depthBiasClamp: 673.8214251219156,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 60,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 8, shaderLocation: 3},
+          {format: 'float32x2', offset: 4, shaderLocation: 4},
+          {format: 'float16x2', offset: 24, shaderLocation: 15},
+          {format: 'uint16x4', offset: 0, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 148, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 488,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 4, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 76,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 16, shaderLocation: 1}],
+      },
+      {arrayStride: 264, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 0, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let bindGroupLayout31 = device3.createBindGroupLayout({
+  label: '\u3c89\ubf24\u0cc0\u4eb0\u0ff2\u{1f63e}\u461d\ucf61\ufac5',
+  entries: [
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 756, visibility: 0, sampler: { type: 'comparison' }},
+    {binding: 892, visibility: 0, sampler: { type: 'comparison' }},
+  ],
+});
+let renderBundle75 = renderBundleEncoder51.finish();
+try {
+device3.queue.writeBuffer(buffer9, 90652, new Float32Array(31512), 17745, 8088);
+} catch {}
+let video22 = await videoWithData();
+try {
+externalTexture31.label = '\ud10f\u{1f7c8}\ub6e3\u{1f98d}\u0a96';
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({});
+try {
+externalTexture23.label = '\u2125\uf439\u1e56\u20d2\ub616\u06e1';
+} catch {}
+let imageBitmap29 = await createImageBitmap(offscreenCanvas17);
+let textureView144 = texture68.createView({label: '\u{1f993}\u0ff6\u0c7d\u14f3'});
+let computePassEncoder46 = commandEncoder100.beginComputePass({label: '\u{1fbec}\uf22b\u0e43\u01a1\u58a1\u0245\u067a\ufadf'});
+let renderBundle76 = renderBundleEncoder36.finish({label: '\u0e9c\u{1fe62}\u{1fc42}\u1ba2\u0993\u72d3'});
+try {
+computePassEncoder39.setPipeline(pipeline78);
+} catch {}
+try {
+device3.pushErrorScope('validation');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 37668, new BigUint64Array(38050), 8785, 140);
+} catch {}
+gc();
+try {
+  await promise31;
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(633, 796);
+let commandEncoder106 = device3.createCommandEncoder({label: '\u4090\u34bc'});
+let commandBuffer20 = commandEncoder106.finish({label: '\uec7b\ua711\uf7b7\ub12b\u{1fc7b}\udb9a\u4a57'});
+let renderBundle77 = renderBundleEncoder52.finish();
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer6, 5896);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer10, 54880, buffer9, 40560, 1808);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder102.clearBuffer(buffer9, 148592, 9756);
+dissociateBuffer(device3, buffer9);
+} catch {}
+gc();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video4.width = 110;
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 197 */
+{offset: 197}, {width: 191, height: 0, depthOrArrayLayers: 1});
+} catch {}
+canvas8.width = 946;
+let video23 = await videoWithData();
+let videoFrame38 = new VideoFrame(canvas16, {timestamp: 0});
+let commandBuffer21 = commandEncoder105.finish({label: '\u0777\u4aa8\u080c\ue306'});
+let textureView145 = texture69.createView({label: '\u{1fdf0}\uafc7\ud804\u0f34\u5287\u{1fe0a}\u{1fd6c}', baseMipLevel: 5, mipLevelCount: 1});
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer6, 0, 3435);
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer10, 31056, buffer9, 6208, 1496);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+renderBundleEncoder55.insertDebugMarker('\u0658');
+} catch {}
+let commandEncoder107 = device3.createCommandEncoder({label: '\u0b18\u34fb\u056d\u0850\u{1f89a}\ubec9\u1375'});
+let computePassEncoder47 = commandEncoder104.beginComputePass({label: '\u37ee\u{1fff9}\u8171\u{1f971}\u4811'});
+let sampler56 = device3.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.95,
+  lodMaxClamp: 91.07,
+  maxAnisotropy: 15,
+});
+let externalTexture60 = device3.importExternalTexture({
+  label: '\u079d\u{1fc91}\u02c6\u06fb\u010b\u04d7\u07b7\u0369\u{1fea5}\u7092\u08f8',
+  source: videoFrame7,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder40.dispatchWorkgroups(3, 5, 1);
+} catch {}
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer6, 18816);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(0, bindGroup27);
+} catch {}
+let pipeline82 = await device3.createRenderPipelineAsync({
+  label: '\u8f8f\u130e\u0ff6\u653e',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2712107637,
+    stencilWriteMask: 2281970268,
+    depthBiasClamp: 949.142760988693,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 124,
+        attributes: [
+          {format: 'uint32', offset: 4, shaderLocation: 14},
+          {format: 'sint8x4', offset: 0, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 15},
+          {format: 'float32x2', offset: 0, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 4, shaderLocation: 9}],
+      },
+      {arrayStride: 352, attributes: [{format: 'sint32x3', offset: 16, shaderLocation: 13}]},
+      {arrayStride: 296, attributes: []},
+      {
+        arrayStride: 524,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 44, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+gc();
+let bindGroup29 = device1.createBindGroup({
+  label: '\uf1b6\u29d9\u0ca6\u02a2\u3760\u829a\ub31b\uea1e\u3bc4\ue51d\uc955',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 2668, resource: sampler7},
+    {binding: 3641, resource: sampler11},
+    {binding: 7224, resource: externalTexture26},
+  ],
+});
+let querySet71 = device1.createQuerySet({label: '\ua94e\u{1fd75}\u0350\u1e20', type: 'occlusion', count: 539});
+let textureView146 = texture17.createView({
+  label: '\ufc4a\u6525\u058c\u0e7e\u3074\ub01e\u8c0d\u6589',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 225,
+});
+let computePassEncoder48 = commandEncoder37.beginComputePass();
+try {
+device1.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 32},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 64_301_387 */
+{offset: 59, bytesPerRow: 2804, rowsPerImage: 294}, {width: 175, height: 0, depthOrArrayLayers: 79});
+} catch {}
+let shaderModule14 = device3.createShaderModule({
+  label: '\u0118\u{1f9be}\u094f\u5e85\u01c1\u330a\udcdd',
+  code: `@group(1) @binding(53)
+var<storage, read_write> type13: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(front_facing) f1: bool
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(7) f1: vec4<u32>,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: u32, @location(3) a1: f32, @location(4) a2: vec2<f16>, @location(1) a3: f32, @location(5) a4: vec4<f32>, @location(11) a5: vec2<u32>, a6: S12, @builtin(position) a7: vec4<f32>, @builtin(sample_index) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(12) f0: vec2<f32>,
+  @location(3) f1: vec2<f16>,
+  @location(0) f2: vec3<i32>,
+  @location(4) f3: vec4<u32>,
+  @location(2) f4: vec4<f16>,
+  @location(8) f5: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(13) f63: u32,
+  @builtin(position) f64: vec4<f32>,
+  @location(4) f65: vec2<f16>,
+  @location(3) f66: f32,
+  @location(11) f67: vec2<u32>,
+  @location(1) f68: f32,
+  @location(5) f69: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: i32, @location(13) a1: vec4<f16>, @location(5) a2: vec3<f16>, @builtin(vertex_index) a3: u32, @builtin(instance_index) a4: u32, @location(7) a5: i32, @location(6) a6: vec4<f16>, @location(9) a7: vec4<i32>, @location(10) a8: vec4<i32>, a9: S11, @location(1) a10: vec3<f32>, @location(14) a11: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup30 = device3.createBindGroup({
+  label: '\u0677\uad73',
+  layout: bindGroupLayout30,
+  entries: [{binding: 907, resource: externalTexture49}],
+});
+let computePassEncoder49 = commandEncoder107.beginComputePass();
+let renderBundle78 = renderBundleEncoder55.finish({label: '\u4d06\u98f5\ua052\uef51\u7da1\u5ee6\u{1fe6d}\uee62\uc2e5\u2ff9\u2fe3'});
+try {
+renderBundleEncoder53.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+commandEncoder102.copyBufferToBuffer(buffer7, 217076, buffer9, 94332, 30644);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 28},
+  aspect: 'depth-only',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 16, y: 4, z: 0},
+  aspect: 'depth-only',
+},
+{width: 96, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u0f7e');
+} catch {}
+try {
+device3.queue.submit([commandBuffer19, commandBuffer18]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer5), /* required buffer size: 606_435 */
+{offset: 17, bytesPerRow: 330, rowsPerImage: 167}, {width: 26, height: 1, depthOrArrayLayers: 12});
+} catch {}
+let promise32 = device3.queue.onSubmittedWorkDone();
+let pipeline83 = await promise25;
+let pipeline84 = device3.createRenderPipeline({
+  layout: pipelineLayout14,
+  multisample: {count: 4, mask: 0x990accd2},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 124, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 96,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 8, shaderLocation: 10}],
+      },
+      {arrayStride: 892, attributes: [{format: 'sint32x4', offset: 188, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder108 = device3.createCommandEncoder({label: '\u0fcf\u3df9\u{1fd6c}\u3972\u358c'});
+let texture74 = device3.createTexture({
+  label: '\u0561\u{1f9f1}\u04f3\u912d\u9a2f\u4c86\u02bd\u55d1\u03e1',
+  size: [384, 30, 148],
+  mipLevelCount: 6,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView147 = texture48.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 89});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup16, new Uint32Array(4256), 877, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline63);
+} catch {}
+try {
+commandEncoder103.clearBuffer(buffer9, 29956, 99732);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 33408, new DataView(new ArrayBuffer(57415)), 26759, 3060);
+} catch {}
+let pipeline85 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 124, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 176, shaderLocation: 12},
+          {format: 'uint16x2', offset: 552, shaderLocation: 8},
+          {format: 'uint32', offset: 384, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 300, attributes: []},
+      {arrayStride: 120, attributes: [{format: 'uint16x4', offset: 4, shaderLocation: 2}]},
+      {arrayStride: 268, attributes: [{format: 'float32x3', offset: 164, shaderLocation: 1}]},
+    ],
+  },
+});
+let img34 = await imageWithData(17, 230, '#f87fcf0b', '#ff9e4eb6');
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+gc();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline52);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder32.insertDebugMarker('\u4bbd');
+} catch {}
+let pipeline86 = device2.createComputePipeline({
+  label: '\uf4c9\u0d12\u{1f62e}\u61a7\u42ca',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+offscreenCanvas19.height = 1210;
+let commandEncoder109 = device3.createCommandEncoder({label: '\u03a4\u7a0e\u{1f8f4}\u1f47'});
+let querySet72 = device3.createQuerySet({type: 'occlusion', count: 3802});
+let texture75 = device3.createTexture({
+  label: '\u5ce0\u8aff\u0f29\ua99d\u0cf1\u838d\u071b\u0c6d\ueabf\u{1fd6b}',
+  size: [96],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 113, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline87 = device3.createRenderPipeline({
+  label: '\u6eff\uf3a9\u983d\u0acf\u0afa',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x9f5cc991},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 356, stepMode: 'instance', attributes: []},
+      {arrayStride: 904, attributes: [{format: 'sint32x4', offset: 4, shaderLocation: 9}]},
+      {arrayStride: 52, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 332,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 44, shaderLocation: 4}],
+      },
+      {arrayStride: 448, attributes: []},
+      {arrayStride: 68, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 260,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 20, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+canvas27.height = 79;
+let imageData28 = new ImageData(208, 208);
+let buffer14 = device3.createBuffer({label: '\ud79e\u0e29\u0da6\u{1fe48}\ua209', size: 228935, usage: GPUBufferUsage.COPY_SRC});
+let textureView148 = texture30.createView({
+  label: '\u99d3\uf95f\u01f0\u{1ffe8}\u94a9\u{1faf5}',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 57,
+  arrayLayerCount: 4,
+});
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer6, 5656);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'depth-only',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 74, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.submit([commandBuffer12]);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 13740, new DataView(new ArrayBuffer(46203)), 25493, 1576);
+} catch {}
+let img35 = await imageWithData(143, 83, '#e26b0b3c', '#18fa3284');
+document.body.prepend(img34);
+let videoFrame39 = new VideoFrame(imageBitmap1, {timestamp: 0});
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let textureView149 = texture61.createView({
+  label: '\u18e6\u2464\ud711\u29b9\u0404\u0cb5\u0257\ude94',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 77,
+  arrayLayerCount: 1,
+});
+let computePassEncoder50 = commandEncoder102.beginComputePass({label: '\u{1fe02}\u364b\u{1f618}\u{1fee0}\u{1fc9f}'});
+try {
+commandEncoder99.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 113, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 272 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 23936 */
+  offset: 23936,
+  buffer: buffer9,
+}, {width: 17, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+let pipeline88 = await device3.createRenderPipelineAsync({
+  label: '\u7a7c\uda4e\u9b11\u{1feab}\u8bc2\ud3ba\u0e0b',
+  layout: pipelineLayout14,
+  multisample: {mask: 0x75bd8be3},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 176,
+        attributes: [
+          {format: 'sint32x4', offset: 88, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 4},
+          {format: 'uint32x4', offset: 12, shaderLocation: 10},
+          {format: 'uint8x2', offset: 28, shaderLocation: 1},
+          {format: 'uint16x2', offset: 28, shaderLocation: 13},
+          {format: 'sint8x2', offset: 4, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+externalTexture51.label = '\u23bc\u0ccc\u{1fda9}\u0da7\uf91f';
+} catch {}
+let bindGroup31 = device3.createBindGroup({
+  label: '\u0629\uddba\ue555\u85f7\u0ac3\u6815\u449f',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture39}],
+});
+let pipelineLayout17 = device3.createPipelineLayout({label: '\u8711\u0bf9\u{1fce2}\u06cb\u2562\uf3e2', bindGroupLayouts: []});
+let commandEncoder110 = device3.createCommandEncoder({});
+let querySet73 = device3.createQuerySet({label: '\ud8cc\u0371\u0071', type: 'occlusion', count: 3375});
+let texture76 = device3.createTexture({
+  label: '\u{1f762}\uf222\u548c\u034b\u{1f977}',
+  size: [48, 3, 845],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView150 = texture51.createView({
+  label: '\u8149\u5ae9\ua308\u1111\u2247\u0d99\u0459\u008f\u6713\u02f4',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let renderBundle79 = renderBundleEncoder40.finish({label: '\ub110\ue585\u0b69\u0a41\u7d87\u0931'});
+let sampler57 = device3.createSampler({
+  label: '\u067e\u3e34\u{1fb02}\u{1fa51}\u0161\u552d\u593f\ua952\u4070\u0ad9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.976,
+  lodMaxClamp: 20.32,
+  compare: 'equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer6, 18232);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer7, 80980, buffer9, 127980, 11144);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer9, 36116, 114992);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline89 = device3.createRenderPipeline({
+  label: '\u{1ff13}\u7b11\u0898\udd7c\u3b1f\u8028\u65fa\u0ed2',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1872,
+        attributes: [
+          {format: 'sint8x2', offset: 394, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 15},
+          {format: 'sint32x4', offset: 100, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 648, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 48,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 9},
+          {format: 'uint32x3', offset: 0, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 64, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 388,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 8, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+let imageBitmap30 = await createImageBitmap(offscreenCanvas19);
+let commandBuffer22 = commandEncoder103.finish({label: '\u81d5\u070a\u{1fd90}\ue767\u521c\u55b1\u{1fdcb}\uf886\uafc5\u0fc9\u{1fe20}'});
+let computePassEncoder51 = commandEncoder99.beginComputePass({});
+try {
+commandEncoder109.copyBufferToBuffer(buffer14, 94996, buffer9, 58128, 72004);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext24.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 33268, new Int16Array(8281), 2715, 44);
+} catch {}
+let pipeline90 = device3.createComputePipeline({
+  label: '\u08dc\u060c\u0eff\u79f4\u538b',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+externalTexture11.label = '\ue91d\u01dc\u304a';
+} catch {}
+document.body.prepend(video9);
+let promise33 = adapter3.requestAdapterInfo();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let video24 = await videoWithData();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+canvas20.width = 1238;
+let bindGroupLayout32 = device1.createBindGroupLayout({label: '\u9407\u{1f8ee}\u0674\u85b8\u0922\u0988\ucb5c\ube6c\ua07b\u84f4', entries: []});
+let computePassEncoder52 = commandEncoder34.beginComputePass({label: '\u0391\u9b70\ub85c\u{1fc4d}\u{1f8dd}\u0a8d\u{1fbb0}\u{1ffa1}\uc027'});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer3, 46620, 4208);
+dissociateBuffer(device1, buffer3);
+} catch {}
+let bindGroup32 = device3.createBindGroup({
+  label: '\u0762\u3bfd\u0202\u1fd6\u{1ffaf}\u0d2e\u43b2\u{1fde7}',
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 756, resource: sampler36},
+    {binding: 892, resource: sampler36},
+    {binding: 58, resource: sampler51},
+  ],
+});
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup27, new Uint32Array(7216), 134, 0);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer6, 'uint16', 22986);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 31064, new Int16Array(21391), 16831, 24);
+} catch {}
+let renderBundleEncoder56 = device3.createRenderBundleEncoder({
+  label: '\u7ef2\u0e37\u{1fc5c}\u0eb2\u342c\u58b5\u0e0b\u002d\ue6af\ua243',
+  colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'],
+  depthReadOnly: true,
+});
+let externalTexture61 = device3.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer6, 7212);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline74);
+} catch {}
+let imageData29 = new ImageData(44, 56);
+let videoFrame40 = new VideoFrame(imageBitmap21, {timestamp: 0});
+let externalTexture62 = device3.importExternalTexture({source: videoFrame37});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup17, new Uint32Array(326), 116, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline80);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(3, bindGroup17, new Uint32Array(3993), 2811, 0);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(0, buffer6);
+} catch {}
+let pipeline91 = await device3.createComputePipelineAsync({
+  label: '\u34e2\u{1f61f}\u09da\u0989\u0222\u{1fd88}\u06be\u0192',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise33;
+} catch {}
+let commandEncoder111 = device3.createCommandEncoder({});
+let texture77 = device3.createTexture({
+  label: '\u0af8\u1c02\u9331\u{1f710}',
+  size: {width: 96, height: 7, depthOrArrayLayers: 148},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView151 = texture47.createView({label: '\u0120\u0407', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 133});
+try {
+device3.queue.writeBuffer(buffer9, 53616, new BigUint64Array(61916), 54551, 636);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 10},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 701_739 */
+{offset: 7, bytesPerRow: 90, rowsPerImage: 113}, {width: 1, height: 1, depthOrArrayLayers: 70});
+} catch {}
+let promise34 = device3.createComputePipelineAsync({
+  label: '\ue624\u4dfc\u53e5\ued49\u0894\uaffd\u0051\u070e\u0aa3\u15e7',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+try {
+adapter5.label = '\u0e88\ua001\u4f17\u{1f931}\ua39c\u0cc9';
+} catch {}
+gc();
+let canvas32 = document.createElement('canvas');
+let commandEncoder112 = device3.createCommandEncoder({label: '\u86be\u2218\u8761\u3430\u{1fe18}\u02f3'});
+let textureView152 = texture73.createView({baseMipLevel: 4, mipLevelCount: 2});
+try {
+computePassEncoder39.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(2, bindGroup26, new Uint32Array(2605), 1107, 0);
+} catch {}
+let pipeline92 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 92, shaderLocation: 9},
+          {format: 'uint8x4', offset: 100, shaderLocation: 14},
+          {format: 'sint8x2', offset: 36, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 428,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 172, shaderLocation: 13},
+          {format: 'float32x3', offset: 76, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 244, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+canvas10.height = 672;
+let video25 = await videoWithData();
+let gpuCanvasContext28 = canvas32.getContext('webgpu');
+let img36 = await imageWithData(176, 206, '#7b908427', '#b85c8c45');
+let bindGroupLayout33 = device3.createBindGroupLayout({
+  label: '\u4a95\u9f21\u9e83\u071e\u06b9\uc0ef',
+  entries: [
+    {
+      binding: 988,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let renderBundleEncoder57 = device3.createRenderBundleEncoder({
+  label: '\u0db1\uc688\u08cf\u{1ff9e}',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+});
+let sampler58 = device3.createSampler({
+  label: '\u9d96\u{1f7f1}\ue0dc\uf8d0\u{1fa24}\u{1faad}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.66,
+  lodMaxClamp: 94.97,
+  compare: 'greater',
+  maxAnisotropy: 10,
+});
+try {
+commandEncoder109.clearBuffer(buffer9, 62840, 62624);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 29856, new BigUint64Array(19088), 9019, 2640);
+} catch {}
+let promise35 = device3.queue.onSubmittedWorkDone();
+let pipeline93 = device3.createComputePipeline({
+  label: '\ucdad\u{1f904}\ue358\u{1f91e}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise32;
+} catch {}
+let buffer15 = device3.createBuffer({label: '\u0df1\u0e75\u{1f8ce}\u0cc6', size: 329307, usage: GPUBufferUsage.UNIFORM});
+let querySet74 = device3.createQuerySet({
+  label: '\uf998\u6329\ud8e0\u{1f697}\uf661\u362b\u2654\u0b0a\uad23\u{1fdd4}\u598f',
+  type: 'occlusion',
+  count: 3248,
+});
+let computePassEncoder53 = commandEncoder110.beginComputePass({label: '\uf4f9\u07bd'});
+try {
+computePassEncoder16.dispatchWorkgroups(1, 3, 2);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline55);
+} catch {}
+try {
+renderBundleEncoder56.setIndexBuffer(buffer6, 'uint16');
+} catch {}
+let promise36 = buffer10.mapAsync(GPUMapMode.WRITE, 52080, 5856);
+try {
+commandEncoder112.clearBuffer(buffer9, 68328, 79184);
+dissociateBuffer(device3, buffer9);
+} catch {}
+document.body.prepend(video22);
+let bindGroupLayout34 = device2.createBindGroupLayout({
+  entries: [
+    {binding: 80, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 964, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 671, visibility: 0, externalTexture: {}},
+  ],
+});
+let externalTexture63 = device2.importExternalTexture({
+  label: '\u635f\u{1fb24}\u8608\u0eca\u00cc\u020a\u04dd\u0af6\u{1fe9d}\u0d6a\ua816',
+  source: video13,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder39.setPipeline(pipeline54);
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5970 */
+  offset: 5188,
+  bytesPerRow: 256,
+  rowsPerImage: 154,
+  buffer: buffer11,
+}, {width: 7, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer11);
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer12, 8064, 23876);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+  await promise36;
+} catch {}
+let canvas33 = document.createElement('canvas');
+gc();
+let renderBundle80 = renderBundleEncoder53.finish();
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder109.clearBuffer(buffer9, 94112, 44392);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 2124, new Int16Array(26113), 22526, 36);
+} catch {}
+let pipeline94 = device3.createRenderPipeline({
+  label: '\uc643\u89bf',
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 168,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 12, shaderLocation: 10},
+          {format: 'uint8x4', offset: 24, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 732, stepMode: 'vertex', attributes: []},
+      {arrayStride: 304, stepMode: 'instance', attributes: []},
+      {arrayStride: 348, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 408, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder113 = device3.createCommandEncoder({label: '\u{1fdfa}\u{1fe38}\u0df8\u0f54\u06e9\ua3e4'});
+let texture78 = gpuCanvasContext8.getCurrentTexture();
+try {
+computePassEncoder36.setPipeline(pipeline76);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer9, 9728, 103616);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 29072, new DataView(new ArrayBuffer(27414)), 1347, 21328);
+} catch {}
+try {
+  await promise35;
+} catch {}
+let imageBitmap31 = await createImageBitmap(img30);
+let gpuCanvasContext29 = canvas33.getContext('webgpu');
+let imageData30 = new ImageData(4, 140);
+let pipelineLayout18 = device3.createPipelineLayout({label: '\u079d\ucbdd\ua880', bindGroupLayouts: [bindGroupLayout19]});
+let querySet75 = device3.createQuerySet({label: '\u87cb\u27ea\u4782\u5b26\u375b', type: 'occlusion', count: 3097});
+let commandBuffer23 = commandEncoder113.finish({label: '\u0232\u39ee\u81ef\u359d\u0b60'});
+try {
+commandEncoder109.clearBuffer(buffer9, 117832, 2172);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+renderBundleEncoder50.insertDebugMarker('\u9bc8');
+} catch {}
+offscreenCanvas9.height = 962;
+let bindGroup33 = device3.createBindGroup({
+  label: '\u{1ffb1}\u3b7b\u0398\u04d8\u0de6\ud295\u{1fc8f}',
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 892, resource: sampler22},
+    {binding: 756, resource: sampler57},
+    {binding: 58, resource: sampler58},
+  ],
+});
+let externalTexture64 = device3.importExternalTexture({source: videoFrame27, colorSpace: 'srgb'});
+try {
+device3.queue.writeBuffer(buffer9, 35440, new Float32Array(63325), 32681, 552);
+} catch {}
+let pipeline95 = await promise34;
+let pipeline96 = await device3.createRenderPipelineAsync({
+  label: '\u2eb5\u{1f997}\uaec2\u0a8f\ud23d\u0a56\u{1fa52}\u9954\u0d23\uf153\u0ce6',
+  layout: pipelineLayout13,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'keep', passOp: 'decrement-wrap'},
+    stencilReadMask: 529051401,
+    stencilWriteMask: 1588162592,
+    depthBias: 0,
+    depthBiasClamp: 377.3360369890543,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 344,
+        attributes: [
+          {format: 'uint16x4', offset: 44, shaderLocation: 5},
+          {format: 'float16x2', offset: 44, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 1},
+          {format: 'uint32x3', offset: 16, shaderLocation: 13},
+          {format: 'float32', offset: 20, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 60, shaderLocation: 11},
+          {format: 'sint32x4', offset: 76, shaderLocation: 0},
+          {format: 'sint32x4', offset: 72, shaderLocation: 8},
+          {format: 'uint32', offset: 4, shaderLocation: 3},
+          {format: 'sint32x2', offset: 236, shaderLocation: 2},
+          {format: 'sint16x2', offset: 20, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 46, shaderLocation: 14},
+          {format: 'sint32', offset: 24, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+document.body.prepend(canvas16);
+let canvas34 = document.createElement('canvas');
+let imageBitmap32 = await createImageBitmap(video20);
+let commandEncoder114 = device2.createCommandEncoder();
+let textureView153 = texture36.createView({label: '\u{1ff64}\u7780\u0733\ub9a7\u{1fbad}', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundleEncoder58 = device2.createRenderBundleEncoder({colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float'], depthReadOnly: true});
+try {
+querySet56.destroy();
+} catch {}
+try {
+commandEncoder83.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7312 */
+  offset: 7312,
+  bytesPerRow: 512,
+  buffer: buffer5,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer12, 282892, 16576);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap33 = await createImageBitmap(imageData0);
+try {
+canvas34.getContext('2d');
+} catch {}
+let commandEncoder115 = device2.createCommandEncoder({label: '\u{1f608}\uff98\u905c\u8add\u{1f775}\ufc56'});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.READ, 251488, 2020);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer5, 54520, buffer4, 61592, 49852);
+dissociateBuffer(device2, buffer5);
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4572 */
+  offset: 4572,
+  buffer: buffer4,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer4);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer4);
+dissociateBuffer(device2, buffer4);
+} catch {}
+gc();
+let commandEncoder116 = device3.createCommandEncoder({label: '\u184e\u{1fc2d}\ubaba\u{1fe44}\u30c1\u113c'});
+let texture79 = device3.createTexture({
+  label: '\u43a8\u06aa',
+  size: {width: 192, height: 15, depthOrArrayLayers: 148},
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer6, 18340, 8890);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(64_100), /* required buffer size: 64_100 */
+{offset: 650, bytesPerRow: 45, rowsPerImage: 235}, {width: 8, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let pipeline97 = device3.createRenderPipeline({
+  label: '\u0da1\u5aaf\u08ac\u2c05',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.RED}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x4', offset: 280, shaderLocation: 1},
+          {format: 'uint32x4', offset: 472, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 352,
+        attributes: [
+          {format: 'uint32', offset: 4, shaderLocation: 0},
+          {format: 'float16x2', offset: 320, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 464, attributes: [{format: 'uint16x2', offset: 8, shaderLocation: 2}]},
+    ],
+  },
+});
+document.body.prepend(img30);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let canvas35 = document.createElement('canvas');
+let gpuCanvasContext30 = canvas35.getContext('webgpu');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let canvas36 = document.createElement('canvas');
+let imageBitmap34 = await createImageBitmap(imageBitmap27);
+let video26 = await videoWithData();
+let texture80 = device3.createTexture({
+  size: [48, 3, 148],
+  mipLevelCount: 3,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let textureView154 = texture57.createView({label: '\ud6e9\u071b\u5066\u{1fdbc}\u2f13\u004b\u{1fe84}\u4ce0\u2c8d\udc6c\u6a96', mipLevelCount: 1});
+let renderBundleEncoder59 = device3.createRenderBundleEncoder({
+  label: '\u0195\ub182\u3857',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let sampler59 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.56,
+  lodMaxClamp: 67.42,
+});
+try {
+computePassEncoder27.setPipeline(pipeline83);
+} catch {}
+try {
+commandEncoder116.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6064 widthInBlocks: 379 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 18240 */
+  offset: 18240,
+  buffer: buffer9,
+}, {width: 379, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let videoFrame41 = new VideoFrame(video19, {timestamp: 0});
+let adapter10 = await navigator.gpu.requestAdapter({});
+gc();
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let textureView155 = texture68.createView({
+  label: '\u0b5d\u057b\u1e4d\u7531\uf589\u8371\u05ba\u5ff3\u7e63\u0487\ud8f6',
+  dimension: '2d-array',
+  format: 'bgra8unorm',
+});
+let renderBundle81 = renderBundleEncoder56.finish({});
+let externalTexture65 = device3.importExternalTexture({label: '\u{1f689}\ua28b\u9a77\u{1fcd0}\u4de4', source: video18, colorSpace: 'srgb'});
+try {
+commandEncoder109.copyBufferToBuffer(buffer7, 313188, buffer9, 60788, 37440);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 192, height: 15, depthOrArrayLayers: 148}
+*/
+{
+  source: offscreenCanvas19,
+  origin: { x: 13, y: 60 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 58},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline98 = await device3.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}}});
+let img37 = await imageWithData(138, 156, '#856d1ef3', '#eaa7ad8c');
+let bindGroupLayout35 = device3.createBindGroupLayout({entries: []});
+let textureView156 = texture37.createView({
+  label: '\u7dea\u{1fd76}\u03ea\ubd19',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 58,
+});
+let computePassEncoder54 = commandEncoder109.beginComputePass({label: '\u2502\ue931\u{1f855}\u237b\u3606\u{1f601}\u045a\u8c6c\u5914\u6ed1\u5168'});
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(buffer14, 2024, buffer9, 81796, 18876);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture61,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 122, y: 14, z: 0},
+  aspect: 'all',
+},
+{width: 48, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline99 = await device3.createComputePipelineAsync({
+  label: '\u6463\u0d23\ue9fa\u5393\uda88\u1091\u0c37',
+  layout: 'auto',
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let canvas37 = document.createElement('canvas');
+try {
+canvas36.getContext('webgl');
+} catch {}
+document.body.prepend(canvas5);
+let textureView157 = texture0.createView({label: '\u9b20\udcaa\u098c'});
+let computePassEncoder55 = commandEncoder1.beginComputePass({label: '\u0a9b\u7918\u{1fd43}\u31b6'});
+let renderBundle82 = renderBundleEncoder2.finish({label: '\u08a8\u56e0\u705a\u633d\u0998\uac25\u9993\u{1fc54}'});
+try {
+renderBundleEncoder49.setVertexBuffer(270, undefined, 1856926576);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap35 = await createImageBitmap(imageBitmap25);
+let imageBitmap36 = await createImageBitmap(videoFrame21);
+document.body.prepend(canvas3);
+offscreenCanvas21.width = 29;
+gc();
+let imageData31 = new ImageData(204, 96);
+try {
+window.someLabel = externalTexture23.label;
+} catch {}
+document.body.prepend(canvas0);
+let img38 = await imageWithData(198, 278, '#196f8715', '#0c4dec72');
+let textureView158 = texture77.createView({
+  label: '\u016e\uc478\u9fef\u{1fcbb}\u0d8f\udcf6\u0feb\u013d\u27b7\u{1fd09}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 120,
+});
+let sampler60 = device3.createSampler({
+  label: '\u0bb6\u{1fe68}\u{1f6ec}\u{1f952}\u0d50\u{1f864}\u2629\u0f1e',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.22,
+  lodMaxClamp: 58.33,
+});
+try {
+commandEncoder111.copyBufferToBuffer(buffer14, 154680, buffer9, 121380, 36036);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 845 */
+{offset: 845}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder50.label = '\u0df9\u06a9\u{1f86a}\u2ab6\uc7a2\u{1f968}\u0b83\u084c\u0014';
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame42 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let buffer16 = device3.createBuffer({
+  label: '\u{1fd56}\u{1f80a}\u{1fbe4}\u9dc3\u734c\u9382\u0b89',
+  size: 132257,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer24 = commandEncoder108.finish();
+let textureView159 = texture37.createView({label: '\uc08e\u2a04\u1472', dimension: '2d', baseMipLevel: 1, mipLevelCount: 4, baseArrayLayer: 85});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup13, new Uint32Array(2516), 501, 0);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer16, 84204, buffer9, 23848, 8228);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5392 widthInBlocks: 337 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 7088 */
+  offset: 1696,
+  buffer: buffer9,
+}, {width: 337, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder111.copyTextureToTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 13, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline100 = device3.createRenderPipeline({
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'replace'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 3165905960,
+    depthBiasSlopeScale: 151.23953386082485,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 44,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 0, shaderLocation: 3},
+          {format: 'uint32x2', offset: 0, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 4},
+          {format: 'uint8x2', offset: 0, shaderLocation: 13},
+          {format: 'uint8x4', offset: 16, shaderLocation: 1},
+          {format: 'sint32x2', offset: 0, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img20);
+let gpuCanvasContext31 = canvas37.getContext('webgpu');
+offscreenCanvas11.width = 712;
+try {
+  await adapter7.requestAdapterInfo();
+} catch {}
+let commandEncoder117 = device3.createCommandEncoder({label: '\uc2f5\u9689\u69f8\u7e1a\u9f38\u97b0\u00e1\u4174\u0c68'});
+let querySet76 = device3.createQuerySet({label: '\uc7ba\u01bb\u42d5\u3cff\u69da\u0f28\u2c9e\ue649\u90b6\u4e9d', type: 'occlusion', count: 3094});
+let renderBundle83 = renderBundleEncoder40.finish({label: '\u{1f6f7}\u1fab\u036d\u29e6\u0d82\u0613\u29d6\u1395\u{1fd1e}'});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+canvas2.width = 3820;
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap37 = await createImageBitmap(videoFrame3);
+let bindGroup34 = device2.createBindGroup({
+  label: '\ub1b9\uf275\u1a74\ub9e7\u9dc0\ud451\u{1fbdc}\u0b43\u7a60\u9ad3',
+  layout: bindGroupLayout25,
+  entries: [{binding: 957, resource: sampler31}],
+});
+let querySet77 = device2.createQuerySet({type: 'occlusion', count: 1919});
+let textureView160 = texture52.createView({label: '\ue518\ue212\uc9fa\u{1fd08}\u{1f6cb}', aspect: 'all', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder60 = device2.createRenderBundleEncoder({colorFormats: ['r16sint', 'rg8unorm', 'r32float', 'r16float', 'rgba32float']});
+let externalTexture66 = device2.importExternalTexture({
+  label: '\u0e03\u8d9e\u0e9f\u7e31\u09e6\ucc10\u{1fb14}\u0209\u1a5a',
+  source: videoFrame28,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder22.setVertexBuffer(468, undefined);
+} catch {}
+let img39 = await imageWithData(171, 265, '#44749390', '#5e06c6b6');
+let bindGroupLayout36 = pipeline98.getBindGroupLayout(2);
+try {
+renderBundleEncoder54.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+commandEncoder112.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 5_709 */
+{offset: 173}, {width: 346, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(966, 666);
+let img40 = await imageWithData(148, 153, '#ce78ed7f', '#b9102c94');
+let imageBitmap38 = await createImageBitmap(offscreenCanvas23);
+let videoFrame43 = videoFrame0.clone();
+let bindGroupLayout37 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 665,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 396,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup35 = device3.createBindGroup({
+  label: '\u{1f943}\u{1fe88}\u096e\u{1fc95}\u59bd\u0481',
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 756, resource: sampler58},
+    {binding: 892, resource: sampler32},
+    {binding: 58, resource: sampler57},
+  ],
+});
+let pipelineLayout19 = device3.createPipelineLayout({label: '\u6a1a\u5e2a', bindGroupLayouts: [bindGroupLayout28, bindGroupLayout19]});
+let commandEncoder118 = device3.createCommandEncoder();
+let querySet78 = device3.createQuerySet({
+  label: '\u5cfb\u4f0e\u757c\u{1ff67}\ue538\u4487\u4e5d\u03b8\u0143\u3793\udfba',
+  type: 'occlusion',
+  count: 1040,
+});
+let commandBuffer25 = commandEncoder111.finish();
+let textureView161 = texture72.createView({label: '\u{1f6ab}\ub427\u0c24\u{1f728}\u9d58\u026e\uae78', aspect: 'all', arrayLayerCount: 1});
+try {
+  await buffer16.mapAsync(GPUMapMode.WRITE, 27744, 75872);
+} catch {}
+canvas14.height = 134;
+let offscreenCanvas26 = new OffscreenCanvas(99, 475);
+try {
+offscreenCanvas25.getContext('webgl');
+} catch {}
+let commandEncoder119 = device3.createCommandEncoder({label: '\u5da9\u{1f6d1}\u0374\u040d\u0dbe\ub6af\u063c\u45b0\u8f80'});
+let textureView162 = texture64.createView({
+  label: '\u7358\u0a4f\u1599\u{1fb30}\ub458\u94f0\u960b\u321c\u{1f7c0}\u0a41\uc1c6',
+  baseMipLevel: 0,
+  baseArrayLayer: 76,
+  arrayLayerCount: 54,
+});
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder116.copyBufferToBuffer(buffer7, 194432, buffer9, 148952, 8640);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 284 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 52844 */
+  offset: 52844,
+  buffer: buffer14,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 71, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer14);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer9, 29272, 108788);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.submit([commandBuffer16]);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline101 = device3.createRenderPipeline({
+  label: '\u{1f92d}\u{1f73c}\u0ff3\u60fb',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 338638472,
+    stencilWriteMask: 3677775825,
+    depthBias: 0,
+    depthBiasClamp: -78.47079446191876,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 48,
+        attributes: [
+          {format: 'uint8x4', offset: 4, shaderLocation: 13},
+          {format: 'sint32x2', offset: 0, shaderLocation: 9},
+          {format: 'uint16x4', offset: 0, shaderLocation: 10},
+          {format: 'sint32x2', offset: 0, shaderLocation: 3},
+          {format: 'uint8x4', offset: 0, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 104,
+        attributes: [
+          {format: 'float32x3', offset: 12, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+commandEncoder118.clearBuffer(buffer9, 88704, 28544);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+computePassEncoder40.insertDebugMarker('\u{1f746}');
+} catch {}
+canvas18.height = 350;
+let promise37 = adapter7.requestDevice({
+  label: '\u87b6\u07a3\u03c8\u8ea4\u0baf\ud203\u1663\ucfae',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 42,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 65422,
+    maxStorageTexturesPerShaderStage: 29,
+    maxStorageBuffersPerShaderStage: 13,
+    maxDynamicStorageBuffersPerPipelineLayout: 21646,
+    maxDynamicUniformBuffersPerPipelineLayout: 63317,
+    maxBindingsPerBindGroup: 3934,
+    maxTextureArrayLayers: 1464,
+    maxTextureDimension1D: 14649,
+    maxTextureDimension2D: 11213,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 77433266,
+    maxStorageBufferBindingSize: 231660757,
+    maxUniformBuffersPerShaderStage: 30,
+    maxSampledTexturesPerShaderStage: 42,
+    maxInterStageShaderVariables: 100,
+    maxInterStageShaderComponents: 111,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let bindGroupLayout38 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 171,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 262, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 296, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder120 = device3.createCommandEncoder({label: '\u{1fb97}\u0e74\u5c95\u0d2e\u{1fcda}\u470f\u{1f81e}\u0904'});
+let textureView163 = texture70.createView({
+  label: '\u{1fa63}\u{1f751}\u3448\u{1f664}\u04d3\u0b37\u3c44\u9de4',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 4,
+  mipLevelCount: 4,
+  baseArrayLayer: 140,
+});
+let renderBundle84 = renderBundleEncoder25.finish({label: '\u0e35\ub7c2'});
+let sampler61 = device3.createSampler({
+  label: '\ub949\ua0b6\u2359',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.38,
+  lodMaxClamp: 55.51,
+  maxAnisotropy: 7,
+});
+try {
+commandEncoder112.clearBuffer(buffer9, 71204, 46220);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer2), /* required buffer size: 606_694 */
+{offset: 298, bytesPerRow: 141, rowsPerImage: 86}, {width: 6, height: 1, depthOrArrayLayers: 51});
+} catch {}
+let pipeline102 = device3.createComputePipeline({
+  label: '\u0aba\u{1fb3a}\ua66a\uac47\ub7c2\u{1fc44}\u4a3d\u8bba\u0e3d\u0886',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+let canvas38 = document.createElement('canvas');
+let video27 = await videoWithData();
+let bindGroup36 = device3.createBindGroup({
+  layout: bindGroupLayout38,
+  entries: [
+    {binding: 296, resource: sampler55},
+    {binding: 262, resource: externalTexture43},
+    {binding: 171, resource: textureView105},
+  ],
+});
+let pipelineLayout20 = device3.createPipelineLayout({
+  label: '\u9049\u0ad4\u6d94\u{1f6d7}\u2ba8\uaa26\u468f\uf995\ud8d0\u{1f76f}\ud5ee',
+  bindGroupLayouts: [],
+});
+let commandEncoder121 = device3.createCommandEncoder();
+try {
+renderBundleEncoder59.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 55404, new Float32Array(745), 536, 8);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img32,
+  origin: { x: 0, y: 44 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData32 = new ImageData(244, 96);
+try {
+offscreenCanvas26.getContext('webgl');
+} catch {}
+let commandEncoder122 = device3.createCommandEncoder({});
+let renderBundleEncoder61 = device3.createRenderBundleEncoder({
+  label: '\u{1fb2d}\u{1ff8d}\u{1fd71}\u{1faba}\u29a8\u211a\u7a44',
+  colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'],
+});
+let sampler62 = device3.createSampler({
+  label: '\u00a8\u7804\u{1ffe9}\u9ac1\u0a73\u02d4\uf7cc',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 80.82,
+  lodMaxClamp: 81.00,
+  compare: 'always',
+});
+try {
+computePassEncoder42.setPipeline(pipeline99);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(5, buffer6, 20704, 2763);
+} catch {}
+try {
+commandEncoder121.copyBufferToBuffer(buffer16, 120928, buffer9, 56888, 8516);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.submit([commandBuffer24, commandBuffer22, commandBuffer21, commandBuffer20]);
+} catch {}
+let gpuCanvasContext32 = canvas38.getContext('webgpu');
+let video28 = await videoWithData();
+let imageBitmap39 = await createImageBitmap(canvas1);
+let imageData33 = new ImageData(40, 160);
+let commandEncoder123 = device3.createCommandEncoder({label: '\u1871\u{1f89c}\u07f6\u3059\u0c8a\u0d82\u0bbd\u06f1\u326e\u{1fb83}\u8962'});
+let computePassEncoder56 = commandEncoder119.beginComputePass({label: '\u{1f85d}\u45a1\u5bb4\ue215'});
+let renderBundleEncoder62 = device3.createRenderBundleEncoder({label: '\u{1faa7}\u06fd', colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'], depthReadOnly: true});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+commandEncoder117.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 20},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder121.clearBuffer(buffer9, 90568, 9880);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let video29 = await videoWithData();
+let commandEncoder124 = device3.createCommandEncoder({label: '\uebca\u5f3b\u2a06\u079d\u3067\u7e0c\u0546\ud9b5'});
+let textureView164 = texture47.createView({label: '\u1c41\u{1ff09}\u4250\u0206\u420c\u0f7c', baseArrayLayer: 82, arrayLayerCount: 40});
+let renderBundleEncoder63 = device3.createRenderBundleEncoder({
+  label: '\u001c\u01f1\u0004\u8786\u{1fa63}',
+  colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder41.pushDebugGroup('\u0490');
+} catch {}
+let pipeline103 = device3.createRenderPipeline({
+  label: '\u{1fd9c}\u0163\u08e0\uc486\u2ee6\u{1f9c9}\ue4b6\u8a46',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xe6c94f2d},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 896,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 84, shaderLocation: 9}],
+      },
+      {arrayStride: 424, attributes: []},
+      {
+        arrayStride: 116,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 18, shaderLocation: 4},
+          {format: 'sint16x4', offset: 32, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back'},
+});
+let img41 = await imageWithData(296, 181, '#614bdab2', '#8db86548');
+try {
+adapter3.label = '\u099b\uc590\u{1fda1}\u{1f7b0}\u859e\u1acb\u00bb\ud9d0';
+} catch {}
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let videoFrame44 = videoFrame15.clone();
+let video30 = await videoWithData();
+let bindGroup37 = device3.createBindGroup({
+  label: '\uf744\u5d32\u7fcb\u8205\u0b37\u{1fc56}\u0230\u30e5\u0a93\u{1fda4}\u0bf2',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 71, resource: {buffer: buffer8, offset: 320768, size: 18976}},
+    {binding: 653, resource: externalTexture34},
+  ],
+});
+let commandEncoder125 = device3.createCommandEncoder({label: '\u3783\u0674\u5fc5\u1ef3\uc1e2\u{1f627}\u08ea\ub216'});
+let computePassEncoder57 = commandEncoder120.beginComputePass();
+let renderBundle85 = renderBundleEncoder56.finish({label: '\u38d3\u0902\u{1face}'});
+try {
+renderBundleEncoder50.setVertexBuffer(2, buffer6, 0, 9752);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer9, 21116, 86744);
+dissociateBuffer(device3, buffer9);
+} catch {}
+gc();
+let computePassEncoder58 = commandEncoder116.beginComputePass({});
+try {
+renderBundleEncoder54.setIndexBuffer(buffer6, 'uint32', 21068);
+} catch {}
+let pipeline104 = device3.createRenderPipeline({
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 196,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 52, shaderLocation: 2},
+          {format: 'sint16x4', offset: 64, shaderLocation: 11},
+          {format: 'sint16x4', offset: 24, shaderLocation: 0},
+          {format: 'sint16x2', offset: 0, shaderLocation: 9},
+          {format: 'sint8x4', offset: 12, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 432,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 182, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 13},
+          {format: 'float32', offset: 180, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'sint16x2', offset: 52, shaderLocation: 10},
+          {format: 'uint32x2', offset: 148, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 136, attributes: []},
+      {
+        arrayStride: 544,
+        attributes: [
+          {format: 'sint32x4', offset: 92, shaderLocation: 7},
+          {format: 'float32x3', offset: 44, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 988,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 116, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 6},
+          {format: 'uint32', offset: 108, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let img42 = await imageWithData(163, 284, '#2218888c', '#ed1b73fc');
+let videoFrame45 = new VideoFrame(offscreenCanvas15, {timestamp: 0});
+let textureView165 = texture40.createView({label: '\u9915\u22c5', dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 138, arrayLayerCount: 7});
+let renderBundle86 = renderBundleEncoder31.finish();
+let sampler63 = device3.createSampler({
+  label: '\u983f\u0d96\u0534\u97fe',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.33,
+  lodMaxClamp: 90.44,
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup14, new Uint32Array(9352), 1680, 0);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(1, buffer6, 0);
+} catch {}
+try {
+texture57.destroy();
+} catch {}
+let pipeline105 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  multisample: {},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 448,
+        attributes: [
+          {format: 'uint16x2', offset: 12, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 8, shaderLocation: 15},
+          {format: 'uint32x2', offset: 20, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 26, shaderLocation: 4},
+          {format: 'sint16x2', offset: 204, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 212,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 16, shaderLocation: 9}],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint16x2', offset: 0, shaderLocation: 10}]},
+    ],
+  },
+});
+document.body.prepend(img39);
+let commandEncoder126 = device1.createCommandEncoder({label: '\u0b00\u47b8\u39ad\u794f\u04b0'});
+let commandBuffer26 = commandEncoder77.finish({label: '\u56d7\ua7ff\u34b3\u{1fbcc}\u620f\ueacf'});
+let computePassEncoder59 = commandEncoder28.beginComputePass({label: '\u{1fed0}\u{1f89e}\u{1fddf}\u0a4e\u{1fbef}\u7621'});
+try {
+computePassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer3, 55968, 10163);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 24},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer3, 36680, 23096);
+dissociateBuffer(device1, buffer3);
+} catch {}
+let texture81 = device3.createTexture({
+  label: '\u64dd\u{1fb37}\u0a06\u{1fd65}\u8451\u008f\ufdc7\uea56\ubcd0\u6c0b',
+  size: {width: 1384, height: 8, depthOrArrayLayers: 166},
+  mipLevelCount: 10,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x8-unorm-srgb'],
+});
+try {
+computePassEncoder49.setPipeline(pipeline70);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(buffer16, 13648, buffer9, 68676, 32312);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder124.clearBuffer(buffer9, 38852, 106548);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  label: '\ua572\ueb1f\u34d7\ucaca',
+  code: `@group(3) @binding(3977)
+var<storage, read_write> local8: array<u32>;
+@group(4) @binding(3234)
+var<storage, read_write> n10: array<u32>;
+@group(2) @binding(2980)
+var<storage, read_write> n11: array<u32>;
+@group(2) @binding(3234)
+var<storage, read_write> function9: array<u32>;
+@group(3) @binding(3234)
+var<storage, read_write> global5: array<u32>;
+@group(2) @binding(3977)
+var<storage, read_write> local9: array<u32>;
+@group(4) @binding(3977)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(2980)
+var<storage, read_write> type14: array<u32>;
+@group(0) @binding(3234)
+var<storage, read_write> local10: array<u32>;
+@group(1) @binding(3977)
+var<storage, read_write> local11: array<u32>;
+@group(1) @binding(3234)
+var<storage, read_write> parameter8: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(5) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(3) f0: vec3<f16>,
+  @location(5) f1: vec3<i32>,
+  @location(7) f2: f16,
+  @location(1) f3: vec2<i32>,
+  @location(23) f4: vec3<f16>,
+  @location(19) f5: vec3<u32>
+}
+
+@vertex
+fn vertex0(a0: S13, @location(13) a1: vec3<u32>, @location(4) a2: vec4<f16>, @location(17) a3: i32, @builtin(instance_index) a4: u32, @location(10) a5: vec3<i32>, @builtin(vertex_index) a6: u32, @location(14) a7: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let buffer17 = device0.createBuffer({label: '\u{1fe60}\ue4f0\u0ab7', size: 6854, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView166 = texture1.createView({label: '\uba87\u0c84\u255d\u0aef\uc00e\u0163\u0be1\u051c', baseMipLevel: 3});
+let computePassEncoder60 = commandEncoder57.beginComputePass({label: '\u{1fdd1}\ua5e0\u{1ffe8}'});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 29},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 388, new Int16Array(27039), 7349, 1368);
+} catch {}
+let canvas39 = document.createElement('canvas');
+let offscreenCanvas27 = new OffscreenCanvas(934, 599);
+let canvas40 = document.createElement('canvas');
+let pipelineLayout21 = device3.createPipelineLayout({label: '\u{1f9da}\ubacc\u7bc2\u0256\u1f12\u2e2c\u3501', bindGroupLayouts: []});
+let texture82 = device3.createTexture({
+  label: '\u{1fbab}\u0491',
+  size: {width: 48, height: 3, depthOrArrayLayers: 48},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8sint'],
+});
+let textureView167 = texture30.createView({
+  label: '\u0db8\u850c\uce60\u968d\u03ae\u0b80\u3e91\u00f6\u03bb',
+  baseMipLevel: 2,
+  baseArrayLayer: 24,
+  arrayLayerCount: 28,
+});
+let renderBundleEncoder64 = device3.createRenderBundleEncoder({
+  label: '\ua268\u05d0\u07a3\u{1fc51}\u7c4c\u1de1\u085d\u0cb7\u44be',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let externalTexture67 = device3.importExternalTexture({label: '\u{1fdd4}\u3c52\u7908', source: videoFrame12, colorSpace: 'display-p3'});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup24, new Uint32Array(507), 355, 0);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(0, buffer6, 19224, 6113);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 72, y: 2, z: 7},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer1), /* required buffer size: 3_055_790 */
+{offset: 206, bytesPerRow: 568, rowsPerImage: 255}, {width: 39, height: 25, depthOrArrayLayers: 22});
+} catch {}
+document.body.prepend(video10);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+canvas30.height = 898;
+document.body.prepend(video0);
+try {
+canvas39.getContext('2d');
+} catch {}
+let video31 = await videoWithData();
+let texture83 = device3.createTexture({
+  label: '\u022b\uc418\u05cd\ubd24\u{1fe76}\uf31d',
+  size: [192, 15, 131],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder65 = device3.createRenderBundleEncoder({
+  label: '\u{1ffd9}\u{1f998}\uc8ee',
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline48);
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+querySet34.destroy();
+} catch {}
+try {
+commandEncoder124.copyBufferToBuffer(buffer14, 134448, buffer9, 116140, 8036);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+computePassEncoder41.popDebugGroup();
+} catch {}
+let gpuCanvasContext33 = canvas40.getContext('webgpu');
+let bindGroupLayout39 = device3.createBindGroupLayout({
+  label: '\u{1fd5e}\u005d\ud79e\u0c32\u{1f687}\u{1f82e}\u{1f7d6}\u02fe\u{1fcdd}\u1767\u{1f610}',
+  entries: [
+    {
+      binding: 727,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture84 = device3.createTexture({
+  label: '\u423c\u{1fae1}\u09bd',
+  size: [192],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let renderBundle87 = renderBundleEncoder31.finish({label: '\ucc6e\u{1fcc5}\u{1fb56}\u91d2'});
+let externalTexture68 = device3.importExternalTexture({
+  label: '\u0d50\u5abf\u0e05\uce53\u{1faa4}\uc86a\u0267\uf2de\ua6d9\u{1f8f0}\uf305',
+  source: videoFrame9,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(6, buffer6, 0, 20812);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 2976 widthInBlocks: 186 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8080 */
+  offset: 8080,
+  rowsPerImage: 116,
+  buffer: buffer14,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 186, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer14);
+} catch {}
+try {
+commandEncoder124.clearBuffer(buffer9, 93172, 5044);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.submit([commandBuffer25]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 6, y: 1, z: 14},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 971 */
+{offset: 971, bytesPerRow: 651}, {width: 310, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let texture85 = device0.createTexture({
+  label: '\u60cf\u{1f654}\u{1ff6e}\u049f\u9834\u6c25',
+  size: [24],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let renderBundle88 = renderBundleEncoder1.finish({label: '\u{1feb9}\uf588\u7722\u49ed\u34d8\u282c\u006d\uf2e2\u0ed3'});
+let sampler64 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 47.07});
+try {
+renderBundleEncoder49.setVertexBuffer(5059, undefined, 1735208444, 1418001222);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer0, 16800, buffer17, 1004, 1812);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 728 widthInBlocks: 182 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16308 */
+  offset: 16308,
+  bytesPerRow: 768,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 182, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 3072, new Float32Array(22281), 14524, 80);
+} catch {}
+let textureView168 = texture48.createView({
+  label: '\u04ed\u2ad1\uf8c2\uc060\u{1fc3d}\ud367',
+  dimension: '2d',
+  aspect: 'depth-only',
+  format: 'depth32float',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 98,
+});
+let computePassEncoder61 = commandEncoder121.beginComputePass({label: '\u{1fed6}\u2cd7\u0fd5\u4f98\u{1f810}\u{1f792}\u{1fe58}\u{1f85c}\u{1fbe8}\u5d08\u0624'});
+let renderBundle89 = renderBundleEncoder57.finish();
+try {
+commandEncoder124.clearBuffer(buffer9, 33288, 25240);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(232, 503);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+video26.height = 59;
+let adapter11 = await navigator.gpu.requestAdapter({});
+let video32 = await videoWithData();
+let imageBitmap40 = await createImageBitmap(imageData2);
+let bindGroup38 = device3.createBindGroup({
+  label: '\u5cfa\uec6b\u0e9c',
+  layout: bindGroupLayout19,
+  entries: [{binding: 880, resource: externalTexture55}],
+});
+let commandBuffer27 = commandEncoder118.finish({label: '\u{1fe35}\u018d\u{1fed5}\u0779'});
+let textureView169 = texture78.createView({
+  label: '\u81e0\u01bf\u562e\ub13e\u03ef\u8af7\u0bee\ua4c8\u{1f776}',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseArrayLayer: 0,
+});
+let externalTexture69 = device3.importExternalTexture({label: '\u0812\u{1fe40}', source: videoFrame10});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup27, new Uint32Array(9493), 890, 0);
+} catch {}
+try {
+computePassEncoder39.dispatchWorkgroupsIndirect(buffer6, 27512);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+texture48.destroy();
+} catch {}
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10248 */
+  offset: 10248,
+  buffer: buffer9,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+document.body.prepend(canvas24);
+let canvas41 = document.createElement('canvas');
+try {
+canvas41.getContext('webgl2');
+} catch {}
+let buffer18 = device3.createBuffer({label: '\u03c7\u{1fdb1}\u3aab\u4d83\u396b\u3892', size: 153011, usage: GPUBufferUsage.INDEX});
+let texture86 = device3.createTexture({
+  label: '\u94e5\uf5f9\u{1fa44}',
+  size: [192, 15, 220],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle90 = renderBundleEncoder52.finish();
+try {
+commandEncoder117.clearBuffer(buffer9, 28604, 22424);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let gpuCanvasContext34 = offscreenCanvas28.getContext('webgpu');
+video32.height = 164;
+let canvas42 = document.createElement('canvas');
+let imageData34 = new ImageData(12, 76);
+let renderBundle91 = renderBundleEncoder44.finish({label: '\ue795\u537b\ud056\u{1fddb}\uf2a4\u375d\u{1fa78}\u07f7'});
+try {
+commandEncoder122.clearBuffer(buffer9, 144748, 5400);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 11816, new DataView(new ArrayBuffer(15274)), 8305, 1240);
+} catch {}
+let pipeline106 = await device3.createComputePipelineAsync({
+  label: '\u{1fa89}\uca51\uf359\udc12\udadd\ua71c\u0cb2\u0531\u0057',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video15);
+let video33 = await videoWithData();
+let adapter12 = await navigator.gpu.requestAdapter();
+let imageBitmap41 = await createImageBitmap(canvas15);
+try {
+texture27.label = '\u{1fcee}\ue535\u3eda\u0c60\u{1fece}\u{1fc97}\u8727';
+} catch {}
+let img43 = await imageWithData(241, 60, '#7bf1d396', '#68683a75');
+let video34 = await videoWithData();
+let imageBitmap42 = await createImageBitmap(img29);
+let imageData35 = new ImageData(48, 256);
+gc();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap43 = await createImageBitmap(img16);
+let texture87 = device3.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba32sint'],
+});
+let textureView170 = texture46.createView({
+  label: '\u0b7f\u07fd\u2052\u6a62\u0250\u6b20\u164e\u9723\u{1fe5b}\u0acc\u{1fa07}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 133,
+});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup17, new Uint32Array(8584), 8258, 0);
+} catch {}
+let promise38 = device3.createRenderPipelineAsync({
+  label: '\u{1f692}\u0efb\u678f\u0440\u6eff\u9b6f\u4819\u1c94',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 3038842031,
+    stencilWriteMask: 639805907,
+    depthBias: -1170270683,
+    depthBiasSlopeScale: 452.2346140265389,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 40, shaderLocation: 3},
+          {format: 'float16x4', offset: 128, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 30, shaderLocation: 13},
+          {format: 'float32', offset: 112, shaderLocation: 12},
+          {format: 'uint16x2', offset: 168, shaderLocation: 4},
+          {format: 'sint32x2', offset: 16, shaderLocation: 0},
+          {format: 'sint16x2', offset: 4, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 0, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 6},
+          {format: 'sint8x2', offset: 50, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 36, shaderLocation: 8},
+          {format: 'uint8x4', offset: 28, shaderLocation: 14},
+          {format: 'float32x3', offset: 40, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 278, shaderLocation: 2}],
+      },
+      {arrayStride: 268, attributes: [{format: 'sint8x2', offset: 40, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let img44 = await imageWithData(115, 220, '#5a875507', '#8633ff88');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas27.getContext('webgpu');
+let gpuCanvasContext36 = canvas42.getContext('webgpu');
+offscreenCanvas26.width = 141;
+let commandBuffer28 = commandEncoder117.finish({});
+let texture88 = device3.createTexture({
+  label: '\u{1fb99}\u{1fc3e}\u867b\u05ba\ueef9\u{1fb60}\u7891\u7a4b\u0297\uec2e\u422d',
+  size: [192],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder62.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer18, 'uint32', 144916, 6495);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(6, buffer6, 4628, 13819);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 8_272_050 */
+{offset: 430, bytesPerRow: 305, rowsPerImage: 226}, {width: 5, height: 1, depthOrArrayLayers: 121});
+} catch {}
+let promise39 = device3.queue.onSubmittedWorkDone();
+let imageData36 = new ImageData(240, 60);
+gc();
+let texture89 = device3.createTexture({
+  size: {width: 384, height: 30, depthOrArrayLayers: 148},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let textureView171 = texture64.createView({
+  label: '\u5983\u8cf3\u0d9b\u0475\udb5e',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 9,
+  arrayLayerCount: 131,
+});
+let renderBundleEncoder66 = device3.createRenderBundleEncoder({
+  label: '\u5e9a\u785a\u6a33\u{1f7a2}\u{1fbdc}\ubca5\u7f3a\u{1f862}\u07b5\u0ef2\ua995',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle92 = renderBundleEncoder34.finish({label: '\u0045\uba3d'});
+try {
+computePassEncoder50.dispatchWorkgroups(3);
+} catch {}
+try {
+computePassEncoder43.insertDebugMarker('\u{1f87b}');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 35968, new BigUint64Array(49234), 40661, 1276);
+} catch {}
+try {
+  await promise39;
+} catch {}
+let canvas43 = document.createElement('canvas');
+try {
+textureView1.label = '\u5d6e\u480f\u0a52\u3be1';
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(342, 810);
+let bindGroupLayout40 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 122,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture90 = device3.createTexture({
+  label: '\u722f\ubfe8\uc3eb\u0eab\u{1fbb7}\u45c0\u073a',
+  size: [96],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let sampler65 = device3.createSampler({
+  label: '\u0d30\ub0c0\u{1ff8c}\u65c3\u{1fe1a}\uf8d1\u7c98\uc070\u2338',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.27,
+  lodMaxClamp: 91.11,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup19, new Uint32Array(9328), 2817, 0);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(1, bindGroup18, new Uint32Array(2656), 1783, 0);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder112.copyTextureToBuffer({
+  texture: texture83,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 12848 */
+  offset: 12848,
+  bytesPerRow: 0,
+  rowsPerImage: 152,
+  buffer: buffer9,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1_196 */
+{offset: 508}, {width: 86, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise40 = device3.queue.onSubmittedWorkDone();
+let pipeline107 = device3.createComputePipeline({
+  label: '\uf538\u{1fa75}\u4996\u{1ff0a}\ue274\u{1fd97}\u2760\u{1fa1b}\u{1fd7d}\u8e0b\udb88',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+let texture91 = device3.createTexture({
+  label: '\uf6f7\u5ef3\u{1faab}\u0ce5\u0c9c\ud776\u03fa',
+  size: [384],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let sampler66 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 69.57,
+  lodMaxClamp: 90.94,
+});
+try {
+commandEncoder122.copyBufferToBuffer(buffer10, 31376, buffer9, 26704, 14584);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline108 = await device3.createComputePipelineAsync({
+  label: '\u722b\uefa6\u0ea6\u7ada',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap44 = await createImageBitmap(imageBitmap28);
+let imageBitmap45 = await createImageBitmap(videoFrame13);
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+try {
+  await promise40;
+} catch {}
+let canvas44 = document.createElement('canvas');
+let imageData37 = new ImageData(212, 40);
+let video35 = await videoWithData();
+let img45 = await imageWithData(17, 47, '#c90e7906', '#8ef05fb6');
+let videoFrame46 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let commandEncoder127 = device1.createCommandEncoder({label: '\u225e\u0e83\u{1febb}\udd61\u497c\u0813\u5f89\uf87b\ucf08\u6f82'});
+let textureView172 = texture12.createView({
+  label: '\ufec3\u0afe\u03da\u0462\ubd6c\u0c07',
+  format: 'stencil8',
+  baseMipLevel: 4,
+  baseArrayLayer: 27,
+  arrayLayerCount: 890,
+});
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({
+  label: '\u086e\u0cbb\ud295\u0f2e\u{1f9b0}\u3e44\ua7de',
+  colorFormats: ['bgra8unorm-srgb', 'rg32float'],
+});
+let sampler67 = device1.createSampler({label: '\udacf\ue3e0\u{1ff5f}\u0833', addressModeU: 'clamp-to-edge', lodMaxClamp: 98.47});
+let promise41 = device1.popErrorScope();
+try {
+gpuCanvasContext34.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 10884, new Float32Array(58389), 46402, 1232);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 187},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(14_160_752), /* required buffer size: 14_160_752 */
+{offset: 38, bytesPerRow: 293, rowsPerImage: 179}, {width: 24, height: 1, depthOrArrayLayers: 271});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame47 = new VideoFrame(img39, {timestamp: 0});
+let commandEncoder128 = device3.createCommandEncoder({label: '\u7f99\u51fa\u071f'});
+let querySet79 = device3.createQuerySet({type: 'occlusion', count: 2993});
+let texture92 = device3.createTexture({
+  label: '\u3aed\u{1f87b}',
+  size: [192, 15, 148],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView173 = texture68.createView({label: '\u821a\ua4f9\ucffd\u998b\u{1fd4e}', dimension: '2d', mipLevelCount: 1});
+let computePassEncoder62 = commandEncoder124.beginComputePass({label: '\u2807\u38e2\uf035\u873d\u{1f7ed}\uec04\u{1fbca}\uba9e\uad70\u0db5'});
+try {
+device3.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder123.clearBuffer(buffer9, 70100, 12700);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 96, height: 7, depthOrArrayLayers: 148}
+*/
+{
+  source: imageBitmap28,
+  origin: { x: 19, y: 14 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout41 = pipeline95.getBindGroupLayout(1);
+let renderBundle93 = renderBundleEncoder52.finish();
+try {
+commandEncoder112.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline109 = device3.createComputePipeline({
+  label: '\u0769\u8794\u0bf3\u596d\u0e21\u3e3e\ue00d',
+  layout: pipelineLayout21,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas29.getContext('2d');
+} catch {}
+try {
+  await promise41;
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(128, 957);
+let offscreenCanvas31 = new OffscreenCanvas(877, 419);
+let textureView174 = texture91.createView({label: '\u{1ff37}\u4d07\u{1f968}\ude5a\u0b6f\u7abe\u{1ff66}\u655d\u08f7\u{1ff3e}', aspect: 'all'});
+let renderBundleEncoder68 = device3.createRenderBundleEncoder({
+  label: '\ubb89\ubf13\u16ea\u91e9\u0755\u2c72\u4736\u{1f84e}',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+});
+let externalTexture70 = device3.importExternalTexture({
+  label: '\u6552\u{1f65d}\uea9b\ube2d\ue0b1\u{1fa29}\uc061\u2ecf\ua27b\u294b\u42d0',
+  source: videoFrame19,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup31, new Uint32Array(9453), 3288, 0);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(1, bindGroup33, new Uint32Array(1798), 1542, 0);
+} catch {}
+try {
+commandEncoder123.copyBufferToBuffer(buffer16, 107152, buffer9, 144408, 18744);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder112.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 938 */
+{offset: 938, rowsPerImage: 68}, {width: 227, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video23);
+let img46 = await imageWithData(107, 203, '#5fc61a21', '#7127b160');
+try {
+renderBundleEncoder61.setVertexBuffer(1, buffer6);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer9, 140632, 9752);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 192, height: 15, depthOrArrayLayers: 148}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 5, y: 73 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 22},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageData38 = new ImageData(192, 60);
+let buffer19 = device3.createBuffer({label: '\u02d5\u9f85\u0298', size: 604917, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder129 = device3.createCommandEncoder({label: '\u372c\ucdd7\u53e9\u0815\u{1f9d0}\u41e5\u0997\udad3\u06ed\u046b'});
+let textureView175 = texture64.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 72});
+let computePassEncoder63 = commandEncoder112.beginComputePass({label: '\ud8cc\u45c8\u{1fd91}\u51d9\u05c7\u0379\u0f7e\u6b77\u0b71\ua9bc'});
+let externalTexture71 = device3.importExternalTexture({label: '\u0b7b\u7c9d\u5add\ue22f\u0d03\ud02d\u{1fe41}\u07a3', source: video21, colorSpace: 'srgb'});
+try {
+commandEncoder123.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  label: '\u{1fb4d}\uc898\uafd0\u0ff1\ueed6\ua7b7\u0840\u{1f684}',
+  entries: [
+    {binding: 3709, visibility: 0, externalTexture: {}},
+    {
+      binding: 2388,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let textureView176 = texture85.createView({label: '\u51ac\u7226\u0f03\u003d'});
+try {
+commandEncoder17.clearBuffer(buffer17, 5540, 352);
+dissociateBuffer(device0, buffer17);
+} catch {}
+canvas35.width = 4488;
+let imageData39 = new ImageData(104, 188);
+canvas11.width = 729;
+try {
+canvas44.getContext('webgpu');
+} catch {}
+try {
+externalTexture27.label = '\u0dc0\u{1f683}\u27e0\u0158\u1593';
+} catch {}
+try {
+offscreenCanvas30.getContext('2d');
+} catch {}
+let commandEncoder130 = device3.createCommandEncoder({label: '\ud1c8\u{1fdc8}\u0aa5\u0ff9\u{1ff00}\u5ed6\u0fe9\u4be8\u7b04'});
+let texture93 = device3.createTexture({
+  label: '\u2afc\u4e06\ucb68\u0684\u65b9\ua1c8',
+  size: {width: 192, height: 15, depthOrArrayLayers: 148},
+  mipLevelCount: 7,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+let textureView177 = texture72.createView({label: '\u{1f886}\u461a\u{1f8cc}\u{1fa47}\u7303\u6028\u449f\u03cc\u4b25\ufaae', dimension: '1d'});
+try {
+computePassEncoder62.setPipeline(pipeline55);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer19, 152136, new DataView(new ArrayBuffer(37020)), 10615, 2844);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img29,
+  origin: { x: 1, y: 18 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas37);
+gc();
+let gpuCanvasContext37 = offscreenCanvas31.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let canvas45 = document.createElement('canvas');
+let textureView178 = texture74.createView({label: '\ue9f8\uc98c\u020e', dimension: '2d', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 70});
+let renderBundleEncoder69 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle94 = renderBundleEncoder51.finish({label: '\ua0e8\u0fd4'});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup33, new Uint32Array(7519), 1356, 0);
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline73);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(9_547_335), /* required buffer size: 9_547_335 */
+{offset: 135, bytesPerRow: 400, rowsPerImage: 234}, {width: 17, height: 0, depthOrArrayLayers: 103});
+} catch {}
+let commandBuffer29 = commandEncoder13.finish({label: '\u8109\ud304\uc2ab\u01fb\u{1fb71}\u0f2b\u2516\u1463\u0b7b'});
+let texture94 = device0.createTexture({
+  label: '\u9011\u6fb1\u{1f845}\ue758\u{1fd4f}',
+  size: [433, 1, 334],
+  mipLevelCount: 6,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView179 = texture85.createView({});
+let renderBundle95 = renderBundleEncoder1.finish({});
+try {
+renderBundleEncoder49.setVertexBuffer(5952, undefined, 0);
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let pipeline110 = await device0.createComputePipelineAsync({
+  label: '\u9151\u7fcf\u{1f755}\u0458\uc2f8\u0d48\u019c\ue6f4\u38ce\u04d4\u7ed2',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let video36 = await videoWithData();
+let bindGroup39 = device3.createBindGroup({
+  label: '\ua170\u250b\u{1f6ea}\u79f9\u195f\u0ba1\u0756\u0c21',
+  layout: bindGroupLayout30,
+  entries: [{binding: 907, resource: externalTexture46}],
+});
+let pipelineLayout22 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout41, bindGroupLayout27, bindGroupLayout38, bindGroupLayout35]});
+let texture95 = device3.createTexture({
+  label: '\u06d5\u7ba1\u0540\u66ee',
+  size: [96, 7, 148],
+  mipLevelCount: 7,
+  dimension: '2d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+let renderBundleEncoder70 = device3.createRenderBundleEncoder({label: '\u7283\uac5c\u{1f77c}', colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint']});
+let renderBundle96 = renderBundleEncoder68.finish({label: '\u{1f838}\u{1f759}\u051b\u05ad\udbda\u0195\ufa22\u{1fda5}\u0e2e'});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline73);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28552 */
+  offset: 28552,
+  rowsPerImage: 191,
+  buffer: buffer9,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({label: '\u016b\u{1f7fe}\u01fb\u035f\ub85e\u8847\u1f64\u0b75'});
+let querySet80 = device0.createQuerySet({label: '\u22f7\u{1ffcc}\u7de4\u09ee\ub9b2\u09be\u076a', type: 'occlusion', count: 231});
+let texture96 = device0.createTexture({
+  label: '\u{1fcbd}\ubcf6\u05d4\u9d4d\ua555\u{1fd6a}\u27cc\uca31\u96d7\ua90c\u3369',
+  size: {width: 1734, height: 1, depthOrArrayLayers: 391},
+  mipLevelCount: 11,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+});
+let renderBundle97 = renderBundleEncoder5.finish({label: '\ueb8a\u42ed\u0e61\u0a2a'});
+let sampler68 = device0.createSampler({
+  label: '\u6043\uc379\u0d1a\ue314\ua735\ucf3b\u0455',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 62.35,
+  maxAnisotropy: 16,
+});
+let externalTexture72 = device0.importExternalTexture({label: '\uf42d\u04f6\u527e\u35b1', source: videoFrame35});
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1907, undefined, 3675404426);
+} catch {}
+try {
+  await buffer17.mapAsync(GPUMapMode.READ, 0, 728);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 520 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2796 */
+  offset: 2276,
+  buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline111 = device0.createRenderPipeline({
+  label: '\u5bda\u10ab\u08d8\u0e8e',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 3112999151,
+    stencilWriteMask: 2956358747,
+    depthBiasSlopeScale: 198.45525302546173,
+    depthBiasClamp: 529.316909393153,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 29256,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 924, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 1200, shaderLocation: 7},
+          {format: 'sint8x4', offset: 1100, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 6208, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 3532,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 4, shaderLocation: 11},
+          {format: 'sint32x3', offset: 448, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 72, shaderLocation: 8},
+          {format: 'sint32', offset: 420, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 320, shaderLocation: 22},
+          {format: 'uint32', offset: 96, shaderLocation: 0},
+          {format: 'uint16x2', offset: 380, shaderLocation: 3},
+          {format: 'sint16x4', offset: 60, shaderLocation: 19},
+          {format: 'float32', offset: 48, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 17984, stepMode: 'instance', attributes: []},
+      {arrayStride: 13604, attributes: [{format: 'unorm16x2', offset: 1064, shaderLocation: 6}]},
+      {arrayStride: 8344, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 23024,
+        attributes: [
+          {format: 'sint8x2', offset: 2280, shaderLocation: 15},
+          {format: 'float32x4', offset: 268, shaderLocation: 17},
+          {format: 'float32x3', offset: 1816, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 13624, shaderLocation: 10},
+          {format: 'uint32x3', offset: 13648, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: false},
+});
+let commandEncoder132 = device3.createCommandEncoder();
+let textureView180 = texture77.createView({
+  label: '\u{1f9eb}\uf49d\u234e\u861b',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 63,
+  arrayLayerCount: 1,
+});
+let computePassEncoder64 = commandEncoder123.beginComputePass({label: '\u0a5e\u{1fc96}\u{1fd63}\u622c\uaac0'});
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 32},
+  aspect: 'all',
+},
+{
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder125.clearBuffer(buffer9, 69664, 16356);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 6, y: 38 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline112 = await device3.createComputePipelineAsync({
+  label: '\uc883\ue467\u{1f8b9}\ue5c9\u0111\u00d7\u51b8',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let externalTexture73 = device2.importExternalTexture({label: '\u54a4\u{1f868}', source: video7, colorSpace: 'srgb'});
+let video37 = await videoWithData();
+let buffer20 = device3.createBuffer({size: 356668, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let textureView181 = texture86.createView({
+  label: '\u987e\u{1fbd7}\u9fe9\u{1f8ba}\ucc00\u081d\u{1fdbb}\u{1fe9f}\u00cb\u0f41',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let computePassEncoder65 = commandEncoder69.beginComputePass({});
+let renderBundleEncoder71 = device3.createRenderBundleEncoder({
+  label: '\u5e1b\ued72\u81af\u09e1',
+  colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(1, bindGroup31, new Uint32Array(722), 717, 0);
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(6, buffer6, 16240, 6135);
+} catch {}
+try {
+buffer19.destroy();
+} catch {}
+try {
+commandEncoder129.copyBufferToBuffer(buffer14, 11964, buffer9, 124540, 29796);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise42 = device3.createComputePipelineAsync({
+  label: '\u819d\ue243\ufd01\u025a\u6b14\u063c\ua55b\ud6d8\u{1fb25}\uecaa',
+  layout: 'auto',
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame48 = new VideoFrame(imageBitmap24, {timestamp: 0});
+document.body.prepend(img2);
+let bindGroupLayout43 = device3.createBindGroupLayout({
+  label: '\u9743\uc899\u38c4\u{1fee8}\u7c55\u73a5\u2e97\uda71\uc2d7\u0e5d',
+  entries: [
+    {
+      binding: 127,
+      visibility: 0,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 222,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 376, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let textureView182 = texture72.createView({label: '\u{1fb7c}\u{1fb76}\u07c0\u0920\u{1f7a6}\u905d\ueb23\ua68e'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+buffer16.destroy();
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer16, 664, buffer19, 77152, 55004);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.submit([commandBuffer28]);
+} catch {}
+canvas19.height = 527;
+let imageData40 = new ImageData(164, 112);
+let gpuCanvasContext38 = canvas45.getContext('webgpu');
+let videoFrame49 = new VideoFrame(videoFrame32, {timestamp: 0});
+let gpuCanvasContext39 = canvas43.getContext('webgpu');
+try {
+  await adapter10.requestAdapterInfo();
+} catch {}
+video22.height = 124;
+let texture97 = device3.createTexture({
+  label: '\u{1fb72}\u51f2\u0d2e\u{1fb45}\ua557',
+  size: {width: 96, height: 7, depthOrArrayLayers: 1937},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let textureView183 = texture90.createView({
+  label: '\u3389\u0e16\u06c1\u39d6\u0374\ub5bc\u955c\u5f48\u{1fb98}\u0282',
+  format: 'rg32sint',
+  baseMipLevel: 0,
+});
+try {
+renderBundleEncoder59.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+commandEncoder128.clearBuffer(buffer9, 25784, 108540);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+renderBundleEncoder50.insertDebugMarker('\u2dce');
+} catch {}
+document.body.prepend(canvas34);
+let video38 = await videoWithData();
+let device4 = await adapter5.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 33,
+    maxVertexBufferArrayStride: 29699,
+    maxStorageTexturesPerShaderStage: 39,
+    maxStorageBuffersPerShaderStage: 10,
+    maxDynamicStorageBuffersPerPipelineLayout: 46884,
+    maxDynamicUniformBuffersPerPipelineLayout: 49536,
+    maxBindingsPerBindGroup: 6221,
+    maxTextureArrayLayers: 879,
+    maxTextureDimension1D: 12281,
+    maxTextureDimension2D: 9347,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 240760147,
+    maxStorageBufferBindingSize: 181038751,
+    maxUniformBuffersPerShaderStage: 25,
+    maxSampledTexturesPerShaderStage: 25,
+    maxInterStageShaderVariables: 30,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+gc();
+let commandEncoder133 = device4.createCommandEncoder();
+let externalTexture74 = device4.importExternalTexture({
+  label: '\uf045\ud770\u0741\u01fb\u{1fc12}\u{1fcdd}\u{1f842}\u{1faed}\u{1fa53}\u84e8',
+  source: videoFrame20,
+});
+try {
+gpuCanvasContext33.unconfigure();
+} catch {}
+let imageData41 = new ImageData(184, 8);
+let commandEncoder134 = device3.createCommandEncoder();
+let renderBundle98 = renderBundleEncoder64.finish({label: '\u{1fe3f}\u8fa4\u0350\ua29f\uac6b'});
+let sampler69 = device3.createSampler({
+  label: '\ufdee\u{1f851}\u{1f8bd}\u{1fd12}\uc4d0\u{1fa3a}\u{1fd91}\ued20\u039c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMinClamp: 30.22,
+});
+let arrayBuffer7 = buffer7.getMappedRange(87744, 16176);
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 512 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 17056 */
+  offset: 17056,
+  buffer: buffer16,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 123, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 563_874 */
+{offset: 116, bytesPerRow: 713, rowsPerImage: 19}, {width: 122, height: 12, depthOrArrayLayers: 42});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout23 = device3.createPipelineLayout({
+  label: '\u06b0\u0c4e\u0b61',
+  bindGroupLayouts: [bindGroupLayout36, bindGroupLayout31, bindGroupLayout37, bindGroupLayout39],
+});
+let commandEncoder135 = device3.createCommandEncoder({label: '\u{1f7ee}\u{1fb51}\u56eb\u{1f871}\u{1fde5}\ufd60\ub5d9\u637d\u{1f8a4}\ue429'});
+let texture98 = device3.createTexture({
+  label: '\u0f9d\ua514\ud6cc\uce8d\uff20\u{1f800}',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture75 = device3.importExternalTexture({label: '\ua1bc\u3ff1', source: video38, colorSpace: 'srgb'});
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder128.copyBufferToBuffer(buffer14, 152592, buffer19, 177276, 55192);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder129.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 45, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer9, 118188, 17496);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let pipeline113 = device3.createComputePipeline({
+  label: '\u0c13\ue9b8\u53b0',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+let imageBitmap46 = await createImageBitmap(img22);
+let textureView184 = texture76.createView({label: '\u331b\u03f6', baseMipLevel: 1});
+let renderBundle99 = renderBundleEncoder30.finish();
+try {
+renderBundleEncoder70.setVertexBuffer(7, buffer6, 0, 24696);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1152 */
+  offset: 1152,
+  bytesPerRow: 0,
+  rowsPerImage: 278,
+  buffer: buffer16,
+}, {
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 6});
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+commandEncoder129.clearBuffer(buffer9, 32556, 125648);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let canvas46 = document.createElement('canvas');
+let img47 = await imageWithData(262, 193, '#07d6b024', '#a9c59795');
+let renderBundleEncoder72 = device4.createRenderBundleEncoder({
+  label: '\u{1f9a0}\u{1fd1d}\u04f3\u0d9e\udb0a\u{1ffa3}\u{1f789}\u0726\u842d\u6bc7',
+  colorFormats: ['rgba16float', 'bgra8unorm-srgb', 'r32uint', 'rg16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture76 = device4.importExternalTexture({
+  label: '\u{1f8ea}\u51fc\uca47\u0007\ua6e2\u13a0\u{1fe12}\u677e\u{1fd56}\ubab1',
+  source: videoFrame13,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder72.pushDebugGroup('\u01c2');
+} catch {}
+gc();
+let textureView185 = texture68.createView({
+  label: '\u0d90\uec51\u092c\u{1f802}\u065e\u52d0\u829c',
+  dimension: '2d-array',
+  format: 'bgra8unorm',
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder73 = device3.createRenderBundleEncoder({
+  label: '\u7115\uc652\u0f8a\u2e9a\u1b91\u0072\uccc5',
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  depthReadOnly: true,
+});
+let sampler70 = device3.createSampler({
+  label: '\u535e\u{1f849}\u5cc9\uc58c',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 30.31,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder65.setIndexBuffer(buffer18, 'uint32', 147760, 1358);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(4, buffer20);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer10, 55364, buffer9, 147964, 3576);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext33.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 5468, new Int16Array(29611), 17498, 2396);
+} catch {}
+let promise43 = device3.createRenderPipelineAsync({
+  label: '\u{1fd12}\u925a\u04b0',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 72,
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 2},
+          {format: 'uint8x4', offset: 8, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 1},
+          {format: 'uint32x4', offset: 8, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 28, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let textureView186 = texture66.createView({label: '\u2b54\u0dfe'});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup13, new Uint32Array(3889), 1557, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline112);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(5, buffer20, 320916, 14150);
+} catch {}
+try {
+commandEncoder129.copyBufferToBuffer(buffer7, 433244, buffer9, 109192, 21828);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 388 */
+  offset: 388,
+  buffer: buffer14,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer14);
+} catch {}
+try {
+commandEncoder135.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2280 */
+  offset: 2280,
+  buffer: buffer19,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder135.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 29},
+  aspect: 'depth-only',
+},
+{
+  texture: texture70,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 474 */
+{offset: 474}, {width: 157, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device3.queue.onSubmittedWorkDone();
+let promise45 = device3.createComputePipelineAsync({
+  label: '\u0f08\ud4c3\u14ea\u0278',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext40 = canvas46.getContext('webgpu');
+let canvas47 = document.createElement('canvas');
+try {
+adapter11.label = '\u27e2\u33dc\uec95\u09bd\u18ee\u{1fa59}\u{1f961}';
+} catch {}
+let commandEncoder136 = device4.createCommandEncoder({});
+let commandBuffer30 = commandEncoder136.finish({label: '\u66c4\u1784\u9be9'});
+let texture99 = device4.createTexture({
+  label: '\u{1ff53}\u{1f93a}\u07c2\uf273\uc6c3\u0646\u0239\u{1f8b0}\u0ef4\uc9d5\u12e4',
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+try {
+renderBundleEncoder72.setVertexBuffer(8265, undefined, 3374429561);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 593 */
+{offset: 593}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout44 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4154,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let querySet81 = device4.createQuerySet({label: '\u7f6d\u{1fbd3}', type: 'occlusion', count: 2630});
+let textureView187 = texture99.createView({label: '\u0c8b\u7c28\u0e4a\uc17f\u0bce', mipLevelCount: 2});
+let computePassEncoder66 = commandEncoder133.beginComputePass({label: '\u4568\u9b3a\u3a8a\u988b\u59dd'});
+try {
+device4.queue.submit([commandBuffer30]);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer4), /* required buffer size: 976 */
+{offset: 708, rowsPerImage: 289}, {width: 67, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let gpuCanvasContext41 = canvas47.getContext('webgpu');
+let commandEncoder137 = device2.createCommandEncoder();
+let computePassEncoder67 = commandEncoder78.beginComputePass({label: '\u065e\u{1ff5c}\u67b2\u{1ff62}\u{1ffeb}\u{1fbb0}\u4089\u52ac\u2c67'});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup11, new Uint32Array(9952), 5404, 0);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(0, bindGroup34, []);
+} catch {}
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13884 */
+  offset: 13884,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 14, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer5);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 192, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas17,
+  origin: { x: 5, y: 11 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 15, y: 53, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder138 = device4.createCommandEncoder({label: '\u5ed3\u7b6e\u3276\u{1fa9e}\ua070\udd13'});
+let querySet82 = device4.createQuerySet({label: '\u0841\u{1fe9c}\ud8aa\uaf32\u0fe2\u{1fecd}', type: 'occlusion', count: 2570});
+let textureView188 = texture99.createView({
+  label: '\u40df\u0ecd\udcd8\u012c\u{1faf9}\uf372\u0390\u0b74\u{1fe92}',
+  format: 'bgra8unorm',
+  baseMipLevel: 2,
+});
+try {
+gpuCanvasContext11.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas48 = document.createElement('canvas');
+let commandEncoder139 = device3.createCommandEncoder({label: '\u{1f6c5}\u{1f8ff}\u0e91\u{1fee3}\u1d0d'});
+let querySet83 = device3.createQuerySet({
+  label: '\u0b99\u{1f973}\u0a4f\u{1ff0e}\u{1f7a8}\u0c17\ua20d\u253d\u5b6d\u0fbe',
+  type: 'occlusion',
+  count: 1347,
+});
+let renderBundleEncoder74 = device3.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle100 = renderBundleEncoder62.finish();
+let externalTexture77 = device3.importExternalTexture({source: video25, colorSpace: 'srgb'});
+try {
+computePassEncoder51.dispatchWorkgroups(5, 2, 5);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(4, buffer20);
+} catch {}
+try {
+device3.pushErrorScope('validation');
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 44420);
+} catch {}
+try {
+commandEncoder128.clearBuffer(buffer19, 199816, 255572);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let pipeline114 = device3.createComputePipeline({
+  label: '\ub1ba\u84e6\u{1fba9}\u03f0\u{1fb1b}\u055f',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas24);
+try {
+adapter11.label = '\u6c3a\u6288\u6ae6\u9105\u0390\u2d4f\u0f99\ube41\ucc13\u{1f7e1}\u023a';
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroupLayout45 = device4.createBindGroupLayout({
+  label: '\u{1ff71}\u07e6\u68e6\u0682\u95ee\u30b7\u5d5c\ud3b5\ua8d2',
+  entries: [{binding: 4575, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let commandEncoder140 = device4.createCommandEncoder();
+let textureView189 = texture99.createView({label: '\u9bdf\u{1f965}', baseMipLevel: 0});
+let externalTexture78 = device4.importExternalTexture({label: '\u74a2\u0ca9\u0609\u0857', source: videoFrame22});
+try {
+renderBundleEncoder72.setVertexBuffer(1727, undefined);
+} catch {}
+try {
+commandEncoder140.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video1);
+let commandEncoder141 = device1.createCommandEncoder({label: '\u08c3\u0bff\ube8d'});
+let querySet84 = device1.createQuerySet({label: '\u6eed\u{1fe40}\u{1fcd3}\u02d2\u2010\ub1fc', type: 'occlusion', count: 662});
+let texture100 = device1.createTexture({
+  label: '\u0b6e\u{1f643}\ub002\u51d0\u{1fc33}\u{1fea0}\u0152',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView190 = texture19.createView({baseMipLevel: 2, baseArrayLayer: 1106, arrayLayerCount: 33});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  label: '\u4abc\u{1fdf6}\ue569\ubb71\u5863\ub387\u{1f8ec}',
+  colorFormats: ['rgba32float', 'rg16uint', 'rg8uint', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder75.setBindGroup(6, bindGroup4, []);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 2_230_472 */
+{offset: 452, bytesPerRow: 953, rowsPerImage: 45}, {width: 58, height: 0, depthOrArrayLayers: 53});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 156}
+*/
+{
+  source: canvas19,
+  origin: { x: 12, y: 68 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 99, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup40 = device3.createBindGroup({
+  label: '\u0352\u8df8\u0a24\u0401',
+  layout: bindGroupLayout38,
+  entries: [
+    {binding: 262, resource: externalTexture46},
+    {binding: 296, resource: sampler53},
+    {binding: 171, resource: textureView185},
+  ],
+});
+let commandEncoder142 = device3.createCommandEncoder({label: '\u7b97\u442c\u0bf9\u{1fa93}\u8f44\ued02\u9d58'});
+let commandBuffer31 = commandEncoder122.finish({});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(2, bindGroup30);
+} catch {}
+let pipeline115 = device3.createRenderPipeline({
+  label: '\u4045\u16ee',
+  layout: 'auto',
+  multisample: {count: 1, mask: 0x6d6bb76e},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 216,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 4, shaderLocation: 6},
+          {format: 'sint8x4', offset: 0, shaderLocation: 0},
+          {format: 'float16x2', offset: 4, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 13},
+          {format: 'sint32x2', offset: 68, shaderLocation: 11},
+          {format: 'sint8x4', offset: 24, shaderLocation: 9},
+          {format: 'float16x4', offset: 16, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 96,
+        attributes: [
+          {format: 'sint16x4', offset: 8, shaderLocation: 10},
+          {format: 'sint32x3', offset: 24, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 5},
+          {format: 'uint32', offset: 32, shaderLocation: 14},
+          {format: 'float32x4', offset: 8, shaderLocation: 1},
+          {format: 'uint16x4', offset: 8, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 2},
+          {format: 'sint8x4', offset: 8, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let offscreenCanvas32 = new OffscreenCanvas(669, 823);
+let img48 = await imageWithData(176, 149, '#9ec164f0', '#43f57ce2');
+let gpuCanvasContext42 = canvas48.getContext('webgpu');
+try {
+offscreenCanvas32.getContext('webgpu');
+} catch {}
+let shaderModule16 = device3.createShaderModule({
+  label: '\uaf53\u04b2\u0a79\u{1fedd}\u4391\u08d3\u7fb8',
+  code: `@group(0) @binding(712)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> global7: array<u32>;
+@group(1) @binding(71)
+var<storage, read_write> function10: array<u32>;
+@group(1) @binding(653)
+var<storage, read_write> n12: array<u32>;
+@group(2) @binding(296)
+var<storage, read_write> local12: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec2<i32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup41 = device3.createBindGroup({
+  label: '\u4210\ubba9\u{1fece}',
+  layout: bindGroupLayout40,
+  entries: [{binding: 122, resource: textureView143}],
+});
+let commandEncoder143 = device3.createCommandEncoder({label: '\ue0da\u0ee0\u0376\u9273\u{1f70f}'});
+let textureView191 = texture40.createView({label: '\u{1feaf}\u914f\ua946\ucd2f\u5a7e\u{1f88a}\uf4c0', dimension: '2d', baseArrayLayer: 77});
+try {
+renderBundleEncoder63.setVertexBuffer(6, buffer20, 0, 78937);
+} catch {}
+let arrayBuffer8 = buffer10.getMappedRange(8288, 2908);
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 549, y: 15 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img24);
+gc();
+let commandEncoder144 = device4.createCommandEncoder({label: '\u{1fcd9}\uf850\u7c6d\uf0c4\u0f32\u{1fac3}\ubade'});
+let querySet85 = device4.createQuerySet({
+  label: '\u0c3a\u0fb7\u0d46\u7a8b\ub468\u04b2\u76e1\u{1fd2d}\u{1f7de}\ufa9c',
+  type: 'occlusion',
+  count: 1934,
+});
+let textureView192 = texture99.createView({
+  label: '\uefeb\u0bed\u{1fa67}\u9b35\u{1feb1}\uf7c9\ucad7\ufe19',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+});
+let sampler71 = device4.createSampler({
+  label: '\u00c3\u46c9\u8cf6\u38cf\u{1f738}\u{1f9d4}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.84,
+  compare: 'greater-equal',
+  maxAnisotropy: 9,
+});
+try {
+renderBundleEncoder72.setVertexBuffer(800, undefined, 0, 2003275349);
+} catch {}
+try {
+commandEncoder140.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup42 = device3.createBindGroup({
+  label: '\u0781\uffe2\u{1fcdd}',
+  layout: bindGroupLayout31,
+  entries: [
+    {binding: 892, resource: sampler51},
+    {binding: 58, resource: sampler62},
+    {binding: 756, resource: sampler36},
+  ],
+});
+let commandEncoder145 = device3.createCommandEncoder({label: '\u23a7\ufa3b\ub28b\u{1f6da}\ucea2'});
+let texture101 = device3.createTexture({
+  label: '\u0128\ube6b',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView193 = texture72.createView({label: '\u0262\u43d1', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundle101 = renderBundleEncoder52.finish({});
+try {
+device3.queue.writeBuffer(buffer9, 34972, new Float32Array(45901), 20861, 5716);
+} catch {}
+let pipeline116 = await promise43;
+try {
+  await promise44;
+} catch {}
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+let imageBitmap47 = await createImageBitmap(imageBitmap45);
+try {
+window.someLabel = device2.label;
+} catch {}
+let bindGroupLayout46 = pipeline75.getBindGroupLayout(3);
+let textureView194 = texture84.createView({label: '\u{1f6c0}\u309c\ub25f\u0cff\u002c\u28b9\u0572\u3f74\u{1f9b9}\ua8ef\u0338'});
+let computePassEncoder68 = commandEncoder125.beginComputePass({label: '\u49a9\u4183\u8c79\u84fd'});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 96, height: 7, depthOrArrayLayers: 148}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 243, y: 36 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 20, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipeline117 = await device3.createComputePipelineAsync({
+  label: '\u395f\uac33\u5ab6\u0d1d\u{1f96f}\u9494',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+video27.height = 13;
+let buffer21 = device4.createBuffer({
+  label: '\u0be6\u{1fca4}\u169f\u0d5c\uccfb\ud1fd\ud988',
+  size: 110331,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+});
+let commandEncoder146 = device4.createCommandEncoder({label: '\u0fa3\uf4c3\u01ec\u044c\u{1f6e0}\u0b09\u0148\u0a20'});
+let externalTexture79 = device4.importExternalTexture({source: videoFrame21, colorSpace: 'display-p3'});
+try {
+device4.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer7), /* required buffer size: 1_336 */
+{offset: 376}, {width: 240, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout24 = device4.createPipelineLayout({
+  label: '\u0026\u8b3a\u44c4',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout45, bindGroupLayout44, bindGroupLayout45],
+});
+let commandEncoder147 = device4.createCommandEncoder({label: '\u84cd\u80b4\u0c5f\ub371'});
+let computePassEncoder69 = commandEncoder140.beginComputePass({label: '\u{1fdb7}\u{1f733}\uefc8\u79da\u739c\u0402\u54bd\ud71a\u{1f706}\u791b\uaf5b'});
+try {
+renderBundleEncoder72.setVertexBuffer(9405, undefined, 3919568980, 228805418);
+} catch {}
+try {
+device4.pushErrorScope('validation');
+} catch {}
+gc();
+let img49 = await imageWithData(156, 79, '#595a1f32', '#48be7a09');
+let bindGroup43 = device4.createBindGroup({
+  label: '\u0e2a\u7cd6\u{1fc9a}\u844f\u0024\ud223\uc33f\u000d\u0404',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture78}],
+});
+let texture102 = device4.createTexture({
+  size: {width: 960, height: 1, depthOrArrayLayers: 215},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView195 = texture102.createView({label: '\uf5a5\uabf0\u94d6'});
+let externalTexture80 = device4.importExternalTexture({label: '\u9c81\u2c37\u00dc\u08c3\uf5b2', source: videoFrame5, colorSpace: 'srgb'});
+try {
+device4.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 976 */
+{offset: 976, rowsPerImage: 11}, {width: 135, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let videoFrame50 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let commandEncoder148 = device3.createCommandEncoder({label: '\uce54\ub3a9\ub17c\u3f9e\u8cae\u2ad9'});
+let querySet86 = device3.createQuerySet({label: '\ua36a\u0f14\uac7a\u{1fd49}\ufe01\u65f0\u{1faec}\u7fba', type: 'occlusion', count: 2018});
+let textureView196 = texture101.createView({label: '\u0378\u6c9a\u{1fb1e}\u3488\u1733\uf999\uafc8\u13b5\u05b5\u7266'});
+let externalTexture81 = device3.importExternalTexture({source: videoFrame27, colorSpace: 'display-p3'});
+try {
+computePassEncoder49.setPipeline(pipeline106);
+} catch {}
+try {
+renderBundleEncoder59.setIndexBuffer(buffer18, 'uint16', 112740, 36645);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder134.clearBuffer(buffer9, 116912, 11716);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 18876, new Float32Array(22116), 21838, 16);
+} catch {}
+let commandEncoder149 = device3.createCommandEncoder({label: '\u053f\uff56\u{1f874}\u97d3\u{1fd38}\u9ab5\u056f'});
+let textureView197 = texture88.createView({label: '\u42e9\udf4f\u5fb7\u0b62\ub072\u45a6\u7369\u053d\u{1f977}\uf2d3\ud3bb', mipLevelCount: 1});
+let renderBundleEncoder76 = device3.createRenderBundleEncoder({
+  label: '\u7a6b\u{1fe14}\uc0d1\udb13\u075f\ud99e\u0544',
+  colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'],
+  depthReadOnly: true,
+});
+let renderBundle102 = renderBundleEncoder69.finish({label: '\u{1f949}\u2cfa\u{1fb97}\u3ea5\u0f8b'});
+let sampler72 = device3.createSampler({
+  label: '\u57d6\u06ab\u0c11\u092d\ue188\u0742\u{1f82e}\u{1f736}\u04e7\uc1da\u{1f945}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.31,
+  lodMaxClamp: 97.74,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(2, buffer20, 216916);
+} catch {}
+try {
+commandEncoder149.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext42.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView198 = texture102.createView({label: '\ud766\u0a2e\u00f5', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder77 = device4.createRenderBundleEncoder({
+  label: '\u8f11\u0bfe',
+  colorFormats: ['rgba16float', 'bgra8unorm-srgb', 'r32uint', 'rg16float'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let sampler73 = device4.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 37.98,
+  lodMaxClamp: 62.16,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder72.setBindGroup(1, bindGroup43);
+} catch {}
+let computePassEncoder70 = commandEncoder17.beginComputePass();
+let renderBundle103 = renderBundleEncoder6.finish({label: '\u0d2f\u{1fa31}\u03f8\u88de\u{1f7c2}\u02af'});
+let arrayBuffer9 = buffer17.getMappedRange(0, 228);
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer32 = commandEncoder147.finish({label: '\ua120\u1d1a\u4642\u8583\u8fc6\u4622\ub646'});
+let textureView199 = texture102.createView({label: '\u6cbe\u0afe\ua999\u{1fa70}\u0636\u8566\u2cec\u{1f7e4}'});
+offscreenCanvas21.height = 8;
+let canvas49 = document.createElement('canvas');
+let video39 = await videoWithData();
+try {
+adapter3.label = '\u0b68\u{1faca}\u0b5a\u{1f879}\u0e85\u8958\ub37b';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView200 = texture95.createView({dimension: '2d', baseArrayLayer: 2});
+let computePassEncoder71 = commandEncoder128.beginComputePass();
+let renderBundleEncoder78 = device3.createRenderBundleEncoder({
+  label: '\u{1fc16}\u0177\u{1f93a}\u58d9\uc955',
+  colorFormats: ['rgba8uint', 'rg32uint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler74 = device3.createSampler({
+  label: '\u0f44\u0183\uad6c\ucf62\u4b43\u0228\ue5f6\ud516\u0d9f\ucfe3',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 48.43,
+  lodMaxClamp: 59.83,
+});
+try {
+commandEncoder129.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 660 widthInBlocks: 165 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2688 */
+  offset: 2688,
+  buffer: buffer9,
+}, {width: 165, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 566_625 */
+{offset: 225, bytesPerRow: 472, rowsPerImage: 50}, {width: 15, height: 0, depthOrArrayLayers: 25});
+} catch {}
+let pipeline118 = device3.createComputePipeline({layout: pipelineLayout22, compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}}});
+let video40 = await videoWithData();
+let shaderModule17 = device3.createShaderModule({
+  label: '\u0a3f\u{1fe92}\u6354\u{1f880}',
+  code: `@group(0) @binding(880)
+var<storage, read_write> global8: array<u32>;
+@group(2) @binding(53)
+var<storage, read_write> function11: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> global9: array<u32>;
+@group(2) @binding(712)
+var<storage, read_write> n13: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec4<i32>,
+  @location(5) f3: vec2<f32>,
+  @location(4) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: f16, @location(15) a1: vec4<u32>, @builtin(front_facing) a2: bool, @location(1) a3: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(3) f70: u32,
+  @location(9) f71: vec4<f32>,
+  @builtin(position) f72: vec4<f32>,
+  @location(15) f73: vec4<u32>,
+  @location(0) f74: f16,
+  @location(2) f75: vec2<f16>,
+  @location(5) f76: f16,
+  @location(12) f77: vec3<i32>,
+  @location(1) f78: vec4<f16>,
+  @location(13) f79: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: f32, @location(6) a1: vec2<f16>, @location(2) a2: vec2<u32>, @location(12) a3: vec2<f32>, @location(8) a4: vec2<i32>, @location(1) a5: vec3<i32>, @location(11) a6: vec4<f16>, @location(13) a7: vec4<u32>, @location(7) a8: vec3<f16>, @location(0) a9: f16, @location(14) a10: f32, @location(3) a11: vec3<f32>, @location(15) a12: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder150 = device3.createCommandEncoder();
+let querySet87 = device3.createQuerySet({type: 'occlusion', count: 931});
+let computePassEncoder72 = commandEncoder149.beginComputePass({label: '\u0f58\u0ac1\uc452'});
+let renderBundleEncoder79 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+commandEncoder142.copyBufferToBuffer(buffer7, 390900, buffer19, 256372, 159072);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 148}
+*/
+{
+  source: canvas3,
+  origin: { x: 21, y: 43 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule18 = device3.createShaderModule({
+  label: '\ud080\u02ac\u8a3b\ub6c1\u09f4\ue5f1\u0171\u00ad\ua703\uf6ef',
+  code: `@group(1) @binding(712)
+var<storage, read_write> parameter9: array<u32>;
+@group(0) @binding(712)
+var<storage, read_write> n14: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> function13: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(2) f1: vec4<u32>,
+  @location(1) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec2<f16>, @location(8) a1: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(11) f0: vec2<f16>,
+  @location(10) f1: vec3<f16>,
+  @location(8) f2: vec3<u32>,
+  @location(12) f3: u32,
+  @location(9) f4: i32,
+  @location(15) f5: vec3<u32>,
+  @location(7) f6: vec3<i32>,
+  @location(5) f7: u32,
+  @location(4) f8: vec2<u32>,
+  @location(2) f9: u32,
+  @location(0) f10: f16
+}
+struct VertexOutput0 {
+  @builtin(position) f80: vec4<f32>,
+  @location(1) f81: vec2<f32>,
+  @location(10) f82: f32,
+  @location(13) f83: vec2<f16>,
+  @location(7) f84: vec3<f16>,
+  @location(8) f85: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<u32>, @location(6) a1: vec2<u32>, a2: S14, @location(1) a3: vec3<i32>, @location(3) a4: vec2<f32>, @location(13) a5: vec4<u32>, @builtin(instance_index) a6: u32, @builtin(vertex_index) a7: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture103 = device3.createTexture({
+  label: '\u722d\u563b\u52ef\u5baa\u{1fd80}\u35c9\u{1fa7c}',
+  size: {width: 384, height: 30, depthOrArrayLayers: 148},
+  mipLevelCount: 9,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView201 = texture48.createView({
+  label: '\u{1fc10}\u06eb\u932a\u{1f9e3}\u{1f6c5}\u0b44\u17c7\ud44d\ua314',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 115,
+  arrayLayerCount: 21,
+});
+let renderBundleEncoder80 = device3.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rg32uint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder79.setVertexBuffer(3, buffer6, 13652);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 656 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 10432 */
+  offset: 9776,
+  buffer: buffer9,
+}, {width: 41, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer9);
+} catch {}
+let pipeline119 = device3.createRenderPipeline({
+  label: '\u0d53\u16cd\u0343\uee00\u{1fc3d}\u1be8\u4303\u{1fd33}',
+  layout: pipelineLayout22,
+  multisample: {count: 4, mask: 0x27670e52},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 160,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 0, shaderLocation: 13},
+          {format: 'sint32x4', offset: 20, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 12},
+          {format: 'sint8x2', offset: 6, shaderLocation: 8},
+          {format: 'sint16x4', offset: 8, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 744,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 3},
+          {format: 'uint8x2', offset: 118, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 56, shaderLocation: 5},
+          {format: 'sint32x3', offset: 108, shaderLocation: 9},
+          {format: 'float32', offset: 44, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 140, shaderLocation: 6},
+          {format: 'sint32x4', offset: 44, shaderLocation: 11},
+          {format: 'uint32x4', offset: 16, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 148, attributes: []},
+      {arrayStride: 988, attributes: []},
+      {arrayStride: 0, attributes: [{format: 'sint32x3', offset: 28, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let video41 = await videoWithData();
+let commandEncoder151 = device3.createCommandEncoder({});
+let textureView202 = texture74.createView({dimension: '2d', baseMipLevel: 4, baseArrayLayer: 124});
+let renderBundle104 = renderBundleEncoder57.finish({label: '\u5c7d\u09aa\u1bd3\u3bc0\u1146\u9743'});
+try {
+renderBundleEncoder65.setBindGroup(2, bindGroup27);
+} catch {}
+let gpuCanvasContext43 = canvas49.getContext('webgpu');
+canvas42.height = 307;
+let querySet88 = device3.createQuerySet({label: '\u{1f65e}\u6248\u166d\u63f9\u03b2\u407f', type: 'occlusion', count: 363});
+let sampler75 = device3.createSampler({
+  label: '\ub51e\u084f\ue90f',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.73,
+  lodMaxClamp: 99.89,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder50.setPipeline(pipeline99);
+} catch {}
+try {
+commandEncoder129.copyTextureToBuffer({
+  texture: texture69,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13604 */
+  offset: 13604,
+  bytesPerRow: 0,
+  rowsPerImage: 204,
+  buffer: buffer9,
+}, {width: 0, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer19, 98952, 388880);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas20,
+  origin: { x: 42, y: 28 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline120 = await promise45;
+let shaderModule19 = device4.createShaderModule({
+  label: '\u0854\uf899\u1c87\ucfb3\u406b',
+  code: `@group(2) @binding(4154)
+var<storage, read_write> n15: array<u32>;
+@group(3) @binding(4575)
+var<storage, read_write> local13: array<u32>;
+@group(1) @binding(4575)
+var<storage, read_write> local14: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(3) f1: vec3<f32>,
+  @location(2) f2: vec3<u32>,
+  @location(0) f3: vec4<f32>,
+  @location(4) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(26) a0: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f86: vec4<f32>,
+  @location(8) f87: u32,
+  @location(20) f88: vec4<f16>,
+  @location(29) f89: vec2<f32>,
+  @location(22) f90: vec4<f32>,
+  @location(5) f91: vec4<f32>,
+  @location(25) f92: vec3<u32>,
+  @location(3) f93: vec4<u32>,
+  @location(4) f94: vec2<f32>,
+  @location(0) f95: vec4<f16>,
+  @location(18) f96: f32,
+  @location(10) f97: vec2<u32>,
+  @location(14) f98: u32,
+  @location(28) f99: vec4<u32>,
+  @location(21) f100: vec2<f32>,
+  @location(26) f101: vec2<i32>,
+  @location(15) f102: vec4<f32>,
+  @location(13) f103: vec3<f16>,
+  @location(27) f104: vec4<f16>,
+  @location(24) f105: vec3<u32>,
+  @location(1) f106: vec4<i32>,
+  @location(12) f107: vec4<i32>,
+  @location(11) f108: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<u32>, @location(0) a1: u32, @location(4) a2: vec3<f32>, @location(2) a3: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let querySet89 = device4.createQuerySet({
+  label: '\u07f6\uc500\u{1fed5}\u03a4\u7465\u4fd6\u{1f6af}\u72ac\u0311\u0901',
+  type: 'occlusion',
+  count: 1664,
+});
+let renderBundleEncoder81 = device4.createRenderBundleEncoder({
+  label: '\ue0ea\u5e86\u0538\u024b\u0caa',
+  colorFormats: ['rgba16float', 'rg16float', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+buffer21.unmap();
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas28,
+  origin: { x: 28, y: 52 },
+  flipY: false,
+}, {
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 91, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline121 = await device4.createComputePipelineAsync({
+  label: '\uabee\u2548\u008f\u0aab\ue3d2',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let pipeline122 = device4.createRenderPipeline({
+  label: '\u{1fdbe}\ud116\u{1f60a}',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'always', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilWriteMask: 1153350215,
+    depthBiasClamp: 706.8743772036494,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 5152, attributes: [{format: 'uint32x4', offset: 16, shaderLocation: 8}]},
+      {
+        arrayStride: 1976,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 394, shaderLocation: 4},
+          {format: 'uint8x4', offset: 272, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 136, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let video42 = await videoWithData();
+let imageBitmap48 = await createImageBitmap(imageData35);
+let commandEncoder152 = device4.createCommandEncoder({label: '\u{1f76b}\u{1fcfb}\u1890\u67e1\ua18b\u57a9'});
+let querySet90 = device4.createQuerySet({label: '\ua0a7\u1ca0\u0885\u5261\uc1bc\u506e\u{1fa66}', type: 'occlusion', count: 234});
+let commandBuffer33 = commandEncoder144.finish({});
+let texture104 = gpuCanvasContext22.getCurrentTexture();
+try {
+renderBundleEncoder77.setBindGroup(3, bindGroup43, new Uint32Array(5230), 2152, 0);
+} catch {}
+let querySet91 = device4.createQuerySet({
+  label: '\u9727\u8e03\u07a2\u08f9\ub400\uab5e\ubca9\u084e\ua2c6\ube8d\u4af0',
+  type: 'occlusion',
+  count: 61,
+});
+let renderBundle105 = renderBundleEncoder77.finish({label: '\u{1f693}\u0c48\u{1fe8a}\u0eba\ufe83\uc48c\u0e8d'});
+try {
+renderBundleEncoder72.setBindGroup(0, bindGroup43, new Uint32Array(9041), 2660, 0);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(4437, undefined, 0);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+gc();
+let video43 = await videoWithData();
+let imageData42 = new ImageData(8, 240);
+let bindGroup44 = device3.createBindGroup({layout: bindGroupLayout46, entries: [{binding: 880, resource: externalTexture39}]});
+let commandEncoder153 = device3.createCommandEncoder({label: '\u4ba2\u3a50\u{1fa80}\ubcfe\u0c0c\u389c\ud47a\u{1f734}\u0ae8'});
+let renderBundle106 = renderBundleEncoder53.finish({label: '\ud533\ubccc\uab10\u3b5d\u0b24\u00f3\u{1fe88}'});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup36, new Uint32Array(9321), 7228, 0);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline102);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer7, 483296, buffer19, 407620, 22940);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 6, y: 1, z: 47},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 4_444_749 */
+{offset: 553, bytesPerRow: 216, rowsPerImage: 187}, {width: 53, height: 5, depthOrArrayLayers: 111});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 192, height: 15, depthOrArrayLayers: 148}
+*/
+{
+  source: offscreenCanvas13,
+  origin: { x: 0, y: 89 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipeline123 = await device3.createComputePipelineAsync({
+  label: '\uf201\u0975\u9721',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+let pipeline124 = await device3.createRenderPipelineAsync({
+  label: '\ub422\u9eb0\u0e12\u0473\u{1f6b4}\u{1ffd2}\u55b9\u0a98\u102d',
+  layout: pipelineLayout23,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilWriteMask: 81228114,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 0, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 9},
+          {format: 'sint16x2', offset: 20, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint16x2', offset: 260, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 1092, shaderLocation: 15},
+          {format: 'uint32x3', offset: 1148, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 20,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 0, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+window.someLabel = textureView177.label;
+} catch {}
+let bindGroupLayout47 = pipeline58.getBindGroupLayout(0);
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderBundleEncoder79.setBindGroup(3, bindGroup13, new Uint32Array(4253), 338, 0);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(buffer6, 'uint32', 3236, 12337);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(2, buffer20, 266564, 62975);
+} catch {}
+try {
+computePassEncoder72.insertDebugMarker('\u330a');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(80)), /* required buffer size: 4_945_412 */
+{offset: 794, bytesPerRow: 159, rowsPerImage: 219}, {width: 9, height: 1, depthOrArrayLayers: 143});
+} catch {}
+let pipeline125 = await device3.createRenderPipelineAsync({
+  label: '\u4175\u7519\u0df1\u1a95\ue995\u0513\ub807\u{1ffea}\u{1f7ea}',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 516,
+        attributes: [
+          {format: 'uint16x4', offset: 28, shaderLocation: 2},
+          {format: 'uint32x3', offset: 32, shaderLocation: 8},
+          {format: 'float32x3', offset: 160, shaderLocation: 1},
+          {format: 'float16x4', offset: 92, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 400, attributes: [{format: 'uint32x2', offset: 32, shaderLocation: 0}]},
+    ],
+  },
+});
+let video44 = await videoWithData();
+let imageBitmap49 = await createImageBitmap(video21);
+let imageData43 = new ImageData(20, 216);
+let textureView203 = texture102.createView({label: '\ubaab\ub1e1\u{1fb0e}\u94dc\u9e3d\u3242\u73df', baseMipLevel: 1, baseArrayLayer: 0});
+let sampler76 = device4.createSampler({
+  label: '\u0d11\u04b3\uf31a\u01a5',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.74,
+  lodMaxClamp: 99.90,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder81.setIndexBuffer(buffer21, 'uint32');
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(1051, undefined);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder154 = device4.createCommandEncoder({label: '\u{1fc5d}\u0069\uf799\u0176\u42c5\ue97b\u7268\u0994'});
+let texture105 = device4.createTexture({
+  label: '\ua46d\ue09d\u{1ffad}\u3970\ua0c8\u03c9\u26fe\ud280',
+  size: [1440, 1, 311],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float'],
+});
+let textureView204 = texture99.createView({baseMipLevel: 2});
+try {
+renderBundleEncoder81.setIndexBuffer(buffer21, 'uint32');
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(6459, undefined, 0, 1133669768);
+} catch {}
+offscreenCanvas11.height = 3368;
+let canvas50 = document.createElement('canvas');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap50 = await createImageBitmap(imageData24);
+let gpuCanvasContext44 = canvas50.getContext('webgpu');
+gc();
+let bindGroupLayout48 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4646,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder155 = device1.createCommandEncoder({});
+let textureView205 = texture12.createView({
+  label: '\u87c3\ud7ee\u0610\u{1ff36}\ufb12\u7e8c',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 130,
+  arrayLayerCount: 1000,
+});
+try {
+renderBundleEncoder75.setBindGroup(7, bindGroup7, new Uint32Array(9673), 8038, 0);
+} catch {}
+let promise46 = device1.createComputePipelineAsync({
+  label: '\ua477\u08fa\u1c71\u7019\u{1f74c}\ue6b9\u{1f643}\u{1f7a7}\u3852\u{1fd01}\u018c',
+  layout: 'auto',
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter13 = await navigator.gpu.requestAdapter();
+let imageBitmap51 = await createImageBitmap(video14);
+let imageData44 = new ImageData(24, 256);
+let bindGroup45 = device3.createBindGroup({
+  label: '\u{1ffff}\u211b\ubc11\u{1f993}\ucb99\u{1f824}',
+  layout: bindGroupLayout27,
+  entries: [
+    {binding: 71, resource: {buffer: buffer8, offset: 148224, size: 81092}},
+    {binding: 653, resource: externalTexture48},
+  ],
+});
+let querySet92 = device3.createQuerySet({label: '\u043e\ufc49\u4cf6\u{1f8f4}\ub4cb\u062e\ubfc8\u46fd\u04e2', type: 'occlusion', count: 1028});
+let textureView206 = texture91.createView({label: '\u0e58\u52bc\u0b3d\u{1f9b3}\u3d90\u0f60\u1aeb\u21be\u9ab8\u05d6'});
+try {
+renderBundleEncoder79.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer7, 88476, buffer9, 84544, 64060);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 688 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 26144 */
+  offset: 26144,
+  bytesPerRow: 768,
+  buffer: buffer9,
+}, {width: 43, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 19564, new Int16Array(5409), 3972, 212);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 109, y: 167 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline126 = device3.createRenderPipeline({
+  label: '\u{1f968}\u91ff\u1a59\u9c28\ue482\u00aa\u6169\u0e4e\u{1f64d}\u40f5',
+  layout: pipelineLayout13,
+  multisample: {mask: 0x83447ca7},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 116,
+        attributes: [
+          {format: 'unorm8x2', offset: 0, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 3},
+          {format: 'uint32x3', offset: 64, shaderLocation: 4},
+          {format: 'sint8x4', offset: 16, shaderLocation: 0},
+          {format: 'uint32', offset: 4, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 2},
+          {format: 'float32x3', offset: 4, shaderLocation: 6},
+          {format: 'sint8x2', offset: 16, shaderLocation: 11},
+          {format: 'float32', offset: 4, shaderLocation: 5},
+          {format: 'sint16x4', offset: 20, shaderLocation: 9},
+          {format: 'sint32x3', offset: 12, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 12},
+          {format: 'sint32x3', offset: 0, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 13},
+          {format: 'sint8x4', offset: 28, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'none', unclippedDepth: true},
+});
+let offscreenCanvas33 = new OffscreenCanvas(917, 923);
+let pipelineLayout25 = device3.createPipelineLayout({
+  label: '\uba65\u0ca9\ud1aa\u0a7f\u1b56\u1b2c\ubb5d\u72e6\u5a28',
+  bindGroupLayouts: [bindGroupLayout33, bindGroupLayout33, bindGroupLayout47, bindGroupLayout46],
+});
+let commandBuffer34 = commandEncoder145.finish();
+let renderBundle107 = renderBundleEncoder59.finish({label: '\u{1f8e1}\u7ed2\u02ef\ua2ff\u04a7'});
+try {
+renderBundleEncoder80.setVertexBuffer(2, buffer6, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder135.copyTextureToTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 7},
+  aspect: 'all',
+},
+{width: 64, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder132.clearBuffer(buffer9, 70280, 75636);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let computePassEncoder73 = commandEncoder135.beginComputePass();
+let renderBundle108 = renderBundleEncoder63.finish();
+try {
+renderBundleEncoder79.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer16, 16644, buffer9, 120324, 39184);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 5312 widthInBlocks: 332 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 14048 */
+  offset: 14048,
+  buffer: buffer14,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 332, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer14);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext36.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline127 = device3.createComputePipeline({
+  label: '\udb62\u04f4\u4927\ub948\u00d3\u281a\uc526\u6ec3\u{1fd6f}\u071f',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+gc();
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap40,
+  origin: { x: 0, y: 28 },
+  flipY: false,
+}, {
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline128 = device4.createComputePipeline({
+  label: '\u1028\uaf45',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img22);
+offscreenCanvas2.width = 181;
+canvas47.width = 1150;
+let video45 = await videoWithData();
+let pipelineLayout26 = device3.createPipelineLayout({
+  label: '\ucdb5\ucda8\u02dc\u0507\u{1fde3}',
+  bindGroupLayouts: [bindGroupLayout33, bindGroupLayout41, bindGroupLayout31],
+});
+let renderBundle109 = renderBundleEncoder79.finish({});
+try {
+commandEncoder129.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap52 = await createImageBitmap(imageBitmap33);
+let canvas51 = document.createElement('canvas');
+let commandEncoder156 = device3.createCommandEncoder({});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup32, new Uint32Array(7601), 2190, 0);
+} catch {}
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+renderBundleEncoder74.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder71.setIndexBuffer(buffer18, 'uint32', 26312);
+} catch {}
+try {
+commandEncoder150.copyTextureToBuffer({
+  texture: texture103,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 38},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 563368 */
+  offset: 19876,
+  bytesPerRow: 256,
+  rowsPerImage: 193,
+  buffer: buffer19,
+}, {width: 1, height: 1, depthOrArrayLayers: 12});
+dissociateBuffer(device3, buffer19);
+} catch {}
+let imageBitmap53 = await createImageBitmap(img41);
+let shaderModule20 = device4.createShaderModule({
+  code: `@group(1) @binding(4575)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(4154)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec4<f32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@location(8) a0: u32, @location(10) a1: vec3<u32>, @location(0) a2: vec2<i32>, @location(3) a3: f16, @builtin(front_facing) a4: bool, @builtin(position) a5: vec4<f32>, @builtin(sample_mask) a6: u32, @builtin(sample_index) a7: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(8) f109: u32,
+  @location(3) f110: f16,
+  @builtin(position) f111: vec4<f32>,
+  @location(0) f112: vec2<i32>,
+  @location(10) f113: vec3<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet93 = device4.createQuerySet({type: 'occlusion', count: 3002});
+let textureView207 = texture102.createView({baseMipLevel: 1});
+let renderBundleEncoder82 = device4.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rg16float', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder72.setVertexBuffer(2403, undefined);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 1876 widthInBlocks: 469 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12024 */
+  offset: 12024,
+  buffer: buffer21,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 469, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas31,
+  origin: { x: 33, y: 0 },
+  flipY: true,
+}, {
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup46 = device3.createBindGroup({
+  label: '\u{1f76e}\u{1fc15}\u24b3\u03d4\u9e04\u4bb7',
+  layout: bindGroupLayout47,
+  entries: [{binding: 880, resource: externalTexture61}],
+});
+let commandEncoder157 = device3.createCommandEncoder({label: '\u0e9c\u06a0'});
+let textureView208 = texture55.createView({dimension: '1d', aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder74 = commandEncoder110.beginComputePass({label: '\ud12e\u{1f777}\u6d85\u50d7\uda15'});
+try {
+renderBundleEncoder66.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder78.setBindGroup(2, bindGroup17, new Uint32Array(5276), 3887, 0);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer14, 33704, buffer19, 212576, 112932);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video37,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline129 = await promise42;
+let pipeline130 = await promise38;
+let commandEncoder158 = device3.createCommandEncoder({label: '\uc6d0\ubc3e'});
+let querySet94 = device3.createQuerySet({type: 'occlusion', count: 3382});
+let texture106 = device3.createTexture({
+  label: '\u0b5d\u{1fc96}\ud556\u{1ff82}',
+  size: {width: 384, height: 30, depthOrArrayLayers: 1318},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView209 = texture91.createView({baseArrayLayer: 0});
+try {
+computePassEncoder34.setPipeline(pipeline73);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder158.copyTextureToBuffer({
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 562076 */
+  offset: 10132,
+  bytesPerRow: 256,
+  rowsPerImage: 154,
+  buffer: buffer19,
+}, {width: 2, height: 1, depthOrArrayLayers: 15});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let video46 = await videoWithData();
+let bindGroupLayout49 = device3.createBindGroupLayout({label: '\u7f5d\u07b3\u69fa\ue84d\u08df', entries: []});
+let querySet95 = device3.createQuerySet({label: '\uf128\uacf6\uf550\u93f9\ubc0c\u0a9b\u77ab', type: 'occlusion', count: 3525});
+try {
+texture79.destroy();
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer16, 24008, buffer19, 39104, 64788);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder142.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData38,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext45 = canvas51.getContext('webgpu');
+let offscreenCanvas34 = new OffscreenCanvas(353, 592);
+let videoFrame51 = new VideoFrame(videoFrame31, {timestamp: 0});
+try {
+window.someLabel = renderBundleEncoder82.label;
+} catch {}
+let textureView210 = texture99.createView({
+  label: '\u0bf3\u2303\u4435\u3102\u7bf5\u1d30\uc949\ua3f8\u47d2\u6b71\u{1fa8e}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+});
+let sampler77 = device4.createSampler({
+  label: '\u{1f811}\u04b7\u{1ff37}\u{1fd45}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.11,
+  lodMaxClamp: 56.22,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup43, new Uint32Array(4804), 4039, 0);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline128);
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let imageData45 = new ImageData(232, 120);
+let querySet96 = device3.createQuerySet({label: '\u{1fd5a}\u0a0d\u0d37\ua223\u1c8a\u6c84\uab79\u07fa', type: 'occlusion', count: 1579});
+let texture107 = device3.createTexture({
+  label: '\u{1f6cf}\uc373\u3a28\ufcb7\ue5cf\u08a0\ude14\u6139\u0e81',
+  size: {width: 1000, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView211 = texture90.createView({label: '\u08cc\uc345\u0a0c\u001e\u{1fcea}\u3ac9\u0bad\ubeb9\u0ef3\u{1fec6}'});
+let renderBundle110 = renderBundleEncoder52.finish({label: '\u4e5e\u82d8\u0c66\u3228'});
+let sampler78 = device3.createSampler({
+  label: '\u0dd0\u01ff\u369d\u90c7\u18ab\u5fe6',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 84.58,
+  lodMaxClamp: 93.53,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder74.setBindGroup(3, bindGroup24, new Uint32Array(200), 58, 0);
+} catch {}
+try {
+commandEncoder153.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 116 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10716 */
+  offset: 10716,
+  rowsPerImage: 122,
+  buffer: buffer19,
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 33, y: 1, z: 82},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer19, 299540, 62076);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 10},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 598_076 */
+{offset: 376, bytesPerRow: 345, rowsPerImage: 173}, {width: 10, height: 3, depthOrArrayLayers: 11});
+} catch {}
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+let bindGroupLayout50 = device3.createBindGroupLayout({
+  label: '\u{1ff5d}\u9bbb\u033f\u7d5d',
+  entries: [
+    {
+      binding: 575,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let renderBundleEncoder83 = device3.createRenderBundleEncoder({
+  label: '\u9d98\u0fc5\u24c3',
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(0, buffer20, 0, 185914);
+} catch {}
+try {
+buffer19.destroy();
+} catch {}
+try {
+commandEncoder130.copyTextureToBuffer({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 8},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 576 widthInBlocks: 72 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 70224 */
+  offset: 7440,
+  bytesPerRow: 768,
+  rowsPerImage: 76,
+  buffer: buffer9,
+}, {width: 72, height: 6, depthOrArrayLayers: 2});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder132.clearBuffer(buffer9, 94380, 27668);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+canvas43.height = 563;
+let querySet97 = device3.createQuerySet({label: '\u2ffb\u{1fc3b}', type: 'occlusion', count: 2578});
+let textureView212 = texture80.createView({baseMipLevel: 1, baseArrayLayer: 22, arrayLayerCount: 95});
+try {
+computePassEncoder41.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder78.setIndexBuffer(buffer20, 'uint16');
+} catch {}
+try {
+commandEncoder129.copyTextureToBuffer({
+  texture: texture83,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 184640 */
+  offset: 7088,
+  bytesPerRow: 256,
+  rowsPerImage: 63,
+  buffer: buffer19,
+}, {width: 9, height: 1, depthOrArrayLayers: 12});
+dissociateBuffer(device3, buffer19);
+} catch {}
+let imageData46 = new ImageData(192, 136);
+let commandEncoder159 = device3.createCommandEncoder({label: '\u{1f618}\uc232'});
+let textureView213 = texture66.createView({label: '\u0e24\u0d83\uad27\uc7f9\u0458', aspect: 'all'});
+let renderBundleEncoder84 = device3.createRenderBundleEncoder({label: '\u8901\u037b\u0d19\ucb77\u{1fd99}', colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint']});
+let externalTexture82 = device3.importExternalTexture({
+  label: '\u0f46\uedcc\u{1fef6}\u8e9e\uca4f\u6f39\u7787\u0c0d\u01a9',
+  source: video30,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder132.clearBuffer(buffer19, 91152, 158164);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let imageData47 = new ImageData(104, 240);
+let texture108 = device4.createTexture({
+  label: '\u12be\u0dd2\uff5a\u8020\uc77d\u3c31\u035d\u{1fc87}\u05ab',
+  size: {width: 75, height: 60, depthOrArrayLayers: 528},
+  mipLevelCount: 6,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView214 = texture105.createView({
+  label: '\u772c\ucca2\u{1f622}\u{1ff06}\ue071\u4770\u{1fbe2}\u{1ff17}\uedc2\u34c4\u0a55',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 66,
+});
+let computePassEncoder75 = commandEncoder146.beginComputePass({label: '\u{1ff5b}\ua907\u0c05\u26fc\ue4a5\u1568\u{1f94b}\u{1f9b3}\u{1fffa}\u{1f91c}\uf323'});
+try {
+texture104.destroy();
+} catch {}
+try {
+commandEncoder154.copyTextureToTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext28.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline131 = await device4.createComputePipelineAsync({
+  label: '\u9b5d\uaaea\u0e6d\u0160',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let canvas52 = document.createElement('canvas');
+let offscreenCanvas35 = new OffscreenCanvas(561, 307);
+let textureView215 = texture97.createView({baseMipLevel: 1, mipLevelCount: 2, arrayLayerCount: 1});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 5_841_927 */
+{offset: 153, bytesPerRow: 938, rowsPerImage: 239}, {width: 106, height: 14, depthOrArrayLayers: 27});
+} catch {}
+let pipeline132 = await device3.createComputePipelineAsync({layout: pipelineLayout20, compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}}});
+let pipeline133 = device3.createRenderPipeline({
+  label: '\u0907\ua3d8\uffa3\u{1fd05}\u19cf\u0edf\u8bdd',
+  layout: pipelineLayout23,
+  multisample: {mask: 0x32b86c1e},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 2158168330,
+    stencilWriteMask: 3827442238,
+    depthBiasSlopeScale: 909.5565920829647,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 60, stepMode: 'instance', attributes: []},
+      {arrayStride: 476, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 336,
+        attributes: [
+          {format: 'sint8x4', offset: 20, shaderLocation: 3},
+          {format: 'uint32x2', offset: 68, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 36, shaderLocation: 4},
+          {format: 'uint32x4', offset: 96, shaderLocation: 10},
+          {format: 'uint16x2', offset: 8, shaderLocation: 1},
+          {format: 'sint16x2', offset: 156, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 36, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let videoFrame52 = new VideoFrame(canvas22, {timestamp: 0});
+canvas8.width = 213;
+let bindGroup47 = device4.createBindGroup({
+  label: '\u{1fc27}\u5fcb\uda6e\ua5f5\uc2fa\u0c32\u5a99\u0f14\u89db\u{1fe56}\u{1fbaa}',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture74}],
+});
+let texture109 = gpuCanvasContext28.getCurrentTexture();
+let renderBundle111 = renderBundleEncoder82.finish({});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup43, new Uint32Array(6785), 1574, 0);
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder81.setIndexBuffer(buffer21, 'uint16', 66972, 7711);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(9603, undefined);
+} catch {}
+let pipeline134 = device4.createComputePipeline({
+  label: '\u1c7c\u6b54',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup48 = device4.createBindGroup({
+  label: '\udab9\u0e8e',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture80}],
+});
+let commandEncoder160 = device4.createCommandEncoder({});
+let textureView216 = texture104.createView({dimension: '2d-array'});
+let computePassEncoder76 = commandEncoder154.beginComputePass();
+let renderBundle112 = renderBundleEncoder77.finish({label: '\u0510\u{1f6a0}\u0683'});
+try {
+device4.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder160.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 108, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline135 = await device4.createRenderPipelineAsync({
+  label: '\u{1f75c}\u9d8a\uf9ad\u{1fe75}\u3e2c\u{1fc52}\u41fb\u6dab\u0466\u5f31',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'zero'},
+    stencilReadMask: 3143756660,
+    depthBias: -526630943,
+    depthBiasSlopeScale: 405.2727248425881,
+  },
+  vertex: {module: shaderModule20, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let textureView217 = texture57.createView({label: '\udc80\ufa73\u08fe', format: 'rg32sint', baseMipLevel: 1});
+let renderBundle113 = renderBundleEncoder78.finish({label: '\u02ec\u22c8\u0d93\u595b\u073f\u0778'});
+try {
+computePassEncoder64.setPipeline(pipeline83);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+device3.queue.submit([commandBuffer23]);
+} catch {}
+let pipeline136 = device3.createRenderPipeline({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 632481920,
+    stencilWriteMask: 1622334246,
+    depthBias: 1880820744,
+    depthBiasSlopeScale: -50.73009375770368,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 88,
+        attributes: [
+          {format: 'float32x3', offset: 12, shaderLocation: 11},
+          {format: 'uint32x3', offset: 12, shaderLocation: 5},
+          {format: 'sint32x3', offset: 4, shaderLocation: 8},
+          {format: 'uint32x4', offset: 4, shaderLocation: 3},
+          {format: 'sint8x2', offset: 6, shaderLocation: 10},
+          {format: 'sint8x2', offset: 0, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 6},
+          {format: 'float32x3', offset: 0, shaderLocation: 1},
+          {format: 'sint32', offset: 0, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 144,
+        attributes: [
+          {format: 'sint16x2', offset: 0, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 24, shaderLocation: 12},
+          {format: 'uint32', offset: 32, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+});
+let gpuCanvasContext46 = canvas52.getContext('webgpu');
+let gpuCanvasContext47 = offscreenCanvas35.getContext('webgpu');
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+offscreenCanvas2.width = 110;
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+let commandEncoder161 = device3.createCommandEncoder();
+let texture110 = device3.createTexture({
+  label: '\u0618\u86dc\u00b3\u{1fdd3}\u{1fb72}\u20a9',
+  size: [192],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView218 = texture66.createView({});
+let renderBundle114 = renderBundleEncoder25.finish({label: '\u{1fff4}\u041f\u0269\u{1fb9f}\u0c72\uf917\ua729\u813a'});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder70.setIndexBuffer(buffer20, 'uint32', 62048, 105439);
+} catch {}
+let promise47 = buffer7.mapAsync(GPUMapMode.WRITE, 392104, 18880);
+try {
+commandEncoder88.copyBufferToBuffer(buffer14, 96492, buffer9, 61708, 67092);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 159, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas8,
+  origin: { x: 47, y: 55 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext46.unconfigure();
+} catch {}
+let gpuCanvasContext48 = offscreenCanvas33.getContext('webgpu');
+let commandBuffer35 = commandEncoder96.finish({label: '\u9df5\u{1fc33}'});
+let texture111 = device3.createTexture({
+  size: [96, 7, 148],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder85 = device3.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rg32uint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup19, []);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer20, 0, 178210);
+} catch {}
+gc();
+try {
+offscreenCanvas34.getContext('bitmaprenderer');
+} catch {}
+let renderBundle115 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder39.dispatchWorkgroupsIndirect(buffer6, 92);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(2, bindGroup13, new Uint32Array(5506), 3927, 0);
+} catch {}
+try {
+commandEncoder142.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(266), /* required buffer size: 266 */
+{offset: 266, bytesPerRow: 182}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise47;
+} catch {}
+let bindGroupLayout51 = device4.createBindGroupLayout({
+  label: '\u1798\u91df\u{1f8f6}\ubee8',
+  entries: [
+    {binding: 3227, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 3641,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 138688830, hasDynamicOffset: false },
+    },
+    {
+      binding: 2303,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let querySet98 = device4.createQuerySet({label: '\u{1f83d}\u0b99\u0a6c', type: 'occlusion', count: 1676});
+let computePassEncoder77 = commandEncoder138.beginComputePass({label: '\u9456\ue171\uc090\u0871\u4b18\u{1fdc9}\u59d3\u2274\u5555'});
+try {
+computePassEncoder77.end();
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline131);
+} catch {}
+try {
+commandEncoder160.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 112, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 480, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap49,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline137 = await device4.createRenderPipelineAsync({
+  label: '\u{1f69a}\u1b0c',
+  layout: pipelineLayout24,
+  multisample: {count: 4, mask: 0x9379b4a3},
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule20, entryPoint: 'vertex0', buffers: []},
+});
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let imageData48 = new ImageData(64, 20);
+let offscreenCanvas36 = new OffscreenCanvas(38, 543);
+try {
+gpuCanvasContext34.unconfigure();
+} catch {}
+let textureView219 = texture47.createView({
+  label: '\u98a9\u{1f99e}\u007b\u94b8\u514a\ubd98\u{1f6e9}',
+  dimension: '2d',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 144,
+});
+let renderBundleEncoder86 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let sampler79 = device3.createSampler({
+  label: '\ufccf\ube96\u04ed\uaa6c\u807d\u9d62\u0cee',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.81,
+  lodMaxClamp: 83.67,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder80.setBindGroup(0, bindGroup15, []);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer6, 24108, 518);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 89, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext47.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 824},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(48)), /* required buffer size: 1_988_430 */
+{offset: 240, bytesPerRow: 381, rowsPerImage: 13}, {width: 33, height: 6, depthOrArrayLayers: 402});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video19,
+  origin: { x: 0, y: 8 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule21 = device3.createShaderModule({
+  label: '\u0768\u8d36\u{1fe54}\u0076\u0b11',
+  code: `@group(0) @binding(712)
+var<storage, read_write> parameter11: array<u32>;
+@group(1) @binding(712)
+var<storage, read_write> local15: array<u32>;
+@group(3) @binding(880)
+var<storage, read_write> global11: array<u32>;
+@group(0) @binding(53)
+var<storage, read_write> field9: array<u32>;
+@group(1) @binding(53)
+var<storage, read_write> global12: array<u32>;
+@group(2) @binding(712)
+var<storage, read_write> parameter12: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(0) f1: vec3<i32>,
+  @location(2) f2: vec4<u32>,
+  @location(1) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(12) a0: vec2<u32>, @location(14) a1: vec4<i32>, @location(0) a2: vec2<i32>, @location(9) a3: f32, @builtin(front_facing) a4: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f114: vec2<f16>,
+  @location(0) f115: vec2<i32>,
+  @location(14) f116: vec4<i32>,
+  @location(9) f117: f32,
+  @location(12) f118: vec2<u32>,
+  @builtin(position) f119: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, @location(4) a1: vec4<f32>, @location(8) a2: vec3<i32>, @location(15) a3: vec3<f16>, @location(12) a4: vec3<f32>, @location(7) a5: vec4<f32>, @location(13) a6: vec4<f16>, @location(6) a7: i32, @location(1) a8: vec2<u32>, @location(3) a9: u32, @location(2) a10: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder162 = device3.createCommandEncoder({label: '\uf258\ucc09\ua714'});
+let commandBuffer36 = commandEncoder130.finish({label: '\u{1f62f}\u1eb4\u{1fbc1}\u04dc\u8d74\u{1f975}\u01fb'});
+let renderBundle116 = renderBundleEncoder68.finish({});
+let sampler80 = device3.createSampler({
+  label: '\uf0ba\uc18d\u018b\uf3ee',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 44.31,
+  lodMaxClamp: 80.58,
+});
+let externalTexture83 = device3.importExternalTexture({label: '\u{1feaa}\u7985\u4298\u3bb7\u082c\u3dde\u0e9d\u78a1', source: video44, colorSpace: 'srgb'});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 13452, new DataView(new ArrayBuffer(63913)), 18401, 2912);
+} catch {}
+let pipelineLayout27 = device4.createPipelineLayout({label: '\u0511\u09f3\u{1f8c2}\u99d2', bindGroupLayouts: [bindGroupLayout44, bindGroupLayout44]});
+let textureView220 = texture105.createView({
+  label: '\u0ba1\u00d4\u1219\uc90a',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 155,
+  arrayLayerCount: 93,
+});
+let externalTexture84 = device4.importExternalTexture({label: '\u0c3d\u743a\ucacc\uceda\u038a\u0da3\u0f54', source: videoFrame23, colorSpace: 'display-p3'});
+try {
+computePassEncoder66.end();
+} catch {}
+let pipeline138 = await device4.createRenderPipelineAsync({
+  label: '\u01a9\uf771',
+  layout: pipelineLayout24,
+  multisample: {},
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rg16float', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule20, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder163 = device4.createCommandEncoder({label: '\u467c\uf929\ua2d2\u022b\u0b6f\ua9f2'});
+let querySet99 = device4.createQuerySet({
+  label: '\u0946\udb9b\u{1f629}\u21a9\udd93\u5492\u15cf\ue782\u6600\u2129\u5040',
+  type: 'occlusion',
+  count: 3128,
+});
+let textureView221 = texture102.createView({
+  label: '\u{1fd23}\uba23\u0611\u4396\u{1ff8e}\u0a7f\u{1f910}\u{1f76f}\u0f81\u{1f61d}',
+  aspect: 'all',
+  baseMipLevel: 1,
+});
+let externalTexture85 = device4.importExternalTexture({
+  label: '\u{1faa2}\u80b7\u{1fec6}\u{1f740}\u{1fd73}\uab68\ua35b\u{1f85a}\u3748\u0593\u00e6',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline128);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(9902, undefined, 0, 3069686090);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(40)), /* required buffer size: 956 */
+{offset: 956}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline139 = device4.createRenderPipeline({
+  layout: pipelineLayout27,
+  multisample: {mask: 0x2bad21b9},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9884,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 880, shaderLocation: 4},
+          {format: 'uint8x2', offset: 1050, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 2140, shaderLocation: 2},
+          {format: 'uint16x2', offset: 0, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+});
+offscreenCanvas34.height = 68;
+let bindGroupLayout52 = device4.createBindGroupLayout({label: '\ube74\u0218\u01cf\u2eea\u184a', entries: []});
+let commandEncoder164 = device4.createCommandEncoder({});
+let textureView222 = texture109.createView({
+  label: '\u95e4\u{1fa95}\u3157\u3778\u{1f816}\ubc34\ud6ec\u054e\u01b1\u796a\u{1f7ff}',
+  dimension: '2d-array',
+  arrayLayerCount: 1,
+});
+let externalTexture86 = device4.importExternalTexture({label: '\u7460\uebe9\u0117', source: video35, colorSpace: 'srgb'});
+try {
+renderBundleEncoder81.setBindGroup(0, bindGroup47, []);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(2740, undefined, 0, 3377624301);
+} catch {}
+try {
+commandEncoder152.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 25256 */
+  offset: 25252,
+  buffer: buffer21,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+device4.queue.submit([commandBuffer33]);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder87 = device4.createRenderBundleEncoder({colorFormats: ['rgba16float', 'rg16float', 'rgb10a2unorm'], stencilReadOnly: false});
+let renderBundle117 = renderBundleEncoder81.finish({label: '\u072e\u83a9\u03a0\u0633'});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline134);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+try {
+commandEncoder152.copyTextureToTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 62, y: 7 },
+  flipY: false,
+}, {
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let shaderModule22 = device4.createShaderModule({
+  label: '\u5100\u5798\u{1f70f}\u{1fe64}\u{1fd92}\ud5a8',
+  code: `@group(1) @binding(4575)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(4154)
+var<storage, read_write> n16: array<u32>;
+@group(3) @binding(4575)
+var<storage, read_write> local16: array<u32>;
+@group(2) @binding(4154)
+var<storage, read_write> local17: array<u32>;
+
+@compute @workgroup_size(7, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(20) f0: vec4<f16>,
+  @builtin(front_facing) f1: bool,
+  @location(22) f2: vec3<f32>,
+  @builtin(position) f3: vec4<f32>,
+  @location(3) f4: vec2<i32>,
+  @location(26) f5: vec4<f32>,
+  @location(21) f6: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(29) a0: vec4<i32>, @location(17) a1: vec2<i32>, @builtin(sample_mask) a2: u32, @location(12) a3: i32, @location(25) a4: vec3<i32>, @location(2) a5: u32, @location(1) a6: i32, @builtin(sample_index) a7: u32, @location(16) a8: vec3<u32>, @location(8) a9: vec3<f32>, @location(18) a10: vec4<f32>, @location(10) a11: vec4<u32>, a12: S15) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(18) f120: vec4<f32>,
+  @location(17) f121: vec2<i32>,
+  @location(20) f122: vec4<f16>,
+  @location(21) f123: vec4<u32>,
+  @location(29) f124: vec4<i32>,
+  @location(22) f125: vec3<f32>,
+  @location(8) f126: vec3<f32>,
+  @location(16) f127: vec3<u32>,
+  @location(12) f128: i32,
+  @location(10) f129: vec4<u32>,
+  @location(2) f130: u32,
+  @location(25) f131: vec3<i32>,
+  @builtin(position) f132: vec4<f32>,
+  @location(3) f133: vec2<i32>,
+  @location(26) f134: vec4<f32>,
+  @location(1) f135: i32
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(12) a1: i32, @location(10) a2: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet100 = device4.createQuerySet({type: 'occlusion', count: 3164});
+let commandBuffer37 = commandEncoder160.finish({label: '\uf555\u87d3\ub62f\u4aaf\u5ad4\u0d6a\u4794\u7713\u{1fd0e}\u7c0b'});
+let textureView223 = texture102.createView({label: '\u8658\u04a5\u04f8\u0e71\ub763\ue17d\ue400\uacfd'});
+try {
+renderBundleEncoder87.draw(145, 332, 1_348_621_491, 526_554_304);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(33);
+} catch {}
+try {
+renderBundleEncoder72.setIndexBuffer(buffer21, 'uint16', 3852, 63627);
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2732 */
+  offset: 2732,
+  buffer: buffer21,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+commandEncoder140.pushDebugGroup('\u{1fd17}');
+} catch {}
+try {
+commandEncoder140.popDebugGroup();
+} catch {}
+try {
+device4.queue.submit([commandBuffer32]);
+} catch {}
+let pipeline140 = device4.createComputePipeline({
+  label: '\u{1fb36}\u0740\u3745\u{1fdfa}\u05ca\u0c23\u0c1c\u{1fd48}\u5665\ub63c',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule20, entryPoint: 'compute0'},
+});
+let pipeline141 = await device4.createRenderPipelineAsync({
+  layout: pipelineLayout27,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha-saturated'},
+  },
+}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-src-alpha'},
+  },
+}],
+},
+  vertex: {module: shaderModule20, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let canvas53 = document.createElement('canvas');
+offscreenCanvas27.height = 998;
+gc();
+let imageData49 = new ImageData(156, 120);
+let commandEncoder165 = device4.createCommandEncoder({});
+let renderBundle118 = renderBundleEncoder81.finish();
+try {
+computePassEncoder75.setBindGroup(2, bindGroup43, new Uint32Array(310), 72, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline131);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(25, 108, 250_456_053, 165_538_066, 669_894_954);
+} catch {}
+try {
+commandEncoder133.copyBufferToTexture({
+  /* bytesInLastRow: 596 widthInBlocks: 149 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15380 */
+  offset: 15380,
+  buffer: buffer21,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 149, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise48 = device4.queue.onSubmittedWorkDone();
+let commandEncoder166 = device4.createCommandEncoder({label: '\u6dca\u45b2\u07c5\u8fd5\u1f1e\u64ed\ub3f1\u0abb\u00d1'});
+let querySet101 = device4.createQuerySet({label: '\u567a\u0424\uc6f4', type: 'occlusion', count: 1463});
+let texture112 = device4.createTexture({
+  label: '\u7ffd\u0d23\u4e73\uabd9\u0334\u05e4\u0a66\u3def',
+  size: [240, 1, 111],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let renderBundle119 = renderBundleEncoder81.finish({});
+let externalTexture87 = device4.importExternalTexture({label: '\u0a71\uad53', source: videoFrame28, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder72.setBindGroup(0, bindGroup48, []);
+} catch {}
+try {
+renderBundleEncoder87.draw(91);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 22_677_328 */
+{offset: 70, bytesPerRow: 269, rowsPerImage: 164}, {width: 5, height: 7, depthOrArrayLayers: 515});
+} catch {}
+try {
+  await promise48;
+} catch {}
+let video47 = await videoWithData();
+let commandEncoder167 = device4.createCommandEncoder({label: '\u{1fc7e}\ub935\uce50\u0d9b'});
+let querySet102 = device4.createQuerySet({type: 'occlusion', count: 494});
+let computePassEncoder78 = commandEncoder166.beginComputePass({});
+let externalTexture88 = device4.importExternalTexture({label: '\ub2a5\u{1f6ec}\u11d0', source: videoFrame19, colorSpace: 'srgb'});
+try {
+renderBundleEncoder87.setBindGroup(0, bindGroup43, new Uint32Array(3263), 2820, 0);
+} catch {}
+try {
+renderBundleEncoder87.draw(418, 9, 93_726_680);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(2, 79, 161_039_203, 1_025_888_088, 817_163_401);
+} catch {}
+let pipeline142 = device4.createRenderPipeline({
+  label: '\u0f43\u4296\u{1f6f3}\u05bc',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: 0}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2784,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 388, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 292,
+        attributes: [{format: 'uint8x4', offset: 16, shaderLocation: 8}, {format: 'uint8x4', offset: 4, shaderLocation: 0}],
+      },
+      {arrayStride: 10748, attributes: []},
+      {arrayStride: 1384, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8348,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 2156, shaderLocation: 4}],
+      },
+    ],
+  },
+});
+let offscreenCanvas37 = new OffscreenCanvas(523, 876);
+let commandEncoder168 = device4.createCommandEncoder({label: '\ubce4\ue509\u0720\u1cd8\u06fd\u074f\u{1faec}\u008a\u63ac'});
+let texture113 = device4.createTexture({
+  label: '\ue9b9\u39f6\u{1fa12}\u274f',
+  size: {width: 960, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView224 = texture105.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 211});
+let computePassEncoder79 = commandEncoder140.beginComputePass({});
+let sampler81 = device4.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.70,
+  lodMaxClamp: 70.22,
+  compare: 'not-equal',
+  maxAnisotropy: 2,
+});
+let externalTexture89 = device4.importExternalTexture({
+  label: '\u0690\u0912\uadb7\u{1fffb}\u0a03\u0870\uf51c\u08ad',
+  source: video22,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder87.setIndexBuffer(buffer21, 'uint16', 107064, 3084);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+try {
+renderBundleEncoder72.popDebugGroup();
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter({});
+let imageBitmap54 = await createImageBitmap(video22);
+try {
+offscreenCanvas37.getContext('2d');
+} catch {}
+let commandEncoder169 = device4.createCommandEncoder({label: '\u3dc5\u{1fcba}\u05df\ud946\u07b3\u4ea3\u9e49'});
+let querySet103 = device4.createQuerySet({
+  label: '\uc685\u069b\u{1fe60}\u{1f947}\udee6\u{1f9ff}\u49ec\u0c95\u0bb1',
+  type: 'occlusion',
+  count: 2481,
+});
+let texture114 = device4.createTexture({
+  label: '\u04f2\u0302\u3e7d',
+  size: {width: 720, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2unorm'],
+});
+let textureView225 = texture108.createView({label: '\u79b0\uca2b\u0955\u3473\u0d49', dimension: '2d', baseMipLevel: 5, baseArrayLayer: 5});
+let renderBundleEncoder88 = device4.createRenderBundleEncoder({colorFormats: ['r32sint', 'r32sint', 'rg16sint'], depthReadOnly: true});
+let sampler82 = device4.createSampler({
+  label: '\u0e1e\uebfa\u068e\u0a6f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+});
+try {
+renderBundleEncoder72.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+renderBundleEncoder87.setBindGroup(2, bindGroup48, new Uint32Array(5856), 3180, 0);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(buffer21, 'uint16', 91626);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+let pipeline143 = await device4.createComputePipelineAsync({
+  label: '\u03a2\u70ed',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let textureView226 = texture108.createView({label: '\u27a3\u{1ff45}\u17e8\ucca6', baseMipLevel: 2, baseArrayLayer: 380, arrayLayerCount: 15});
+try {
+renderBundleEncoder87.draw(195, 125, 574_594_481, 54_559_818);
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 81508 */
+  offset: 81508,
+  bytesPerRow: 256,
+  rowsPerImage: 181,
+  buffer: buffer21,
+}, {
+  texture: texture114,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+renderBundleEncoder88.pushDebugGroup('\u81ec');
+} catch {}
+try {
+canvas53.getContext('bitmaprenderer');
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(753, 1020);
+try {
+  await adapter13.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext39.unconfigure();
+} catch {}
+let videoFrame53 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let commandEncoder170 = device4.createCommandEncoder({label: '\u79f0\u4d6a\u084c\u0a7f\u0a73\uf086\u8772\ub76a'});
+let querySet104 = device4.createQuerySet({label: '\ub1a5\u9ad5\u04a6\u{1fb49}\ue570\u7dc8\u377f\udc40', type: 'occlusion', count: 2270});
+let pipeline144 = await device4.createComputePipelineAsync({
+  label: '\u56d8\u{1feac}\u0726',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let img50 = await imageWithData(279, 10, '#d8e3bec3', '#8c26b01f');
+let canvas54 = document.createElement('canvas');
+let commandEncoder171 = device3.createCommandEncoder({label: '\u03ab\u02a5'});
+let texture115 = device3.createTexture({
+  label: '\u0fb9\u0a61\u2034\u196e',
+  size: [384],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder89 = device3.createRenderBundleEncoder({colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'], stencilReadOnly: true});
+let renderBundle120 = renderBundleEncoder64.finish({label: '\u02f3\u{1f9e2}\ub246\u{1fe96}\u0dab\u{1fb7e}\u2d55'});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup46, new Uint32Array(3209), 3, 0);
+} catch {}
+try {
+computePassEncoder51.dispatchWorkgroups(2, 5, 3);
+} catch {}
+try {
+renderBundleEncoder86.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(3, bindGroup16, new Uint32Array(7106), 126, 0);
+} catch {}
+let promise49 = device3.createRenderPipelineAsync({
+  label: '\u9af1\u0f7a\u0576',
+  layout: pipelineLayout20,
+  multisample: {mask: 0x99017ed1},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2312113619,
+    stencilWriteMask: 846420781,
+    depthBias: -1759828920,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 432,
+        attributes: [
+          {format: 'sint16x4', offset: 148, shaderLocation: 10},
+          {format: 'uint16x4', offset: 136, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 120, attributes: [{format: 'sint32x2', offset: 0, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let texture116 = device2.createTexture({
+  label: '\u0fac\ub471\u21a9\u6023\u6a83\u{1fa33}',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let computePassEncoder80 = commandEncoder75.beginComputePass({label: '\u08fe\u2645\u{1fad7}\u1e82\u{1fcd4}\uf0a8\uab0f\u3ed1'});
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer13, 104688, buffer12, 229536, 33320);
+dissociateBuffer(device2, buffer13);
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer11, 551336, 42172);
+dissociateBuffer(device2, buffer11);
+} catch {}
+let pipeline145 = await device2.createRenderPipelineAsync({
+  label: '\u368d\u0306\uefe8\u0661\u{1f6a9}\u{1fd5e}\ua511\u041f\ucfcf',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.RED}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16float', writeMask: 0}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 1378638531,
+    stencilWriteMask: 1622503728,
+    depthBias: 484742448,
+    depthBiasClamp: 272.38398886745233,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 456, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 416,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 4, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 5},
+          {format: 'uint8x4', offset: 160, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 18, shaderLocation: 11},
+          {format: 'uint32x2', offset: 0, shaderLocation: 9},
+          {format: 'sint32x4', offset: 12, shaderLocation: 2},
+          {format: 'uint32', offset: 28, shaderLocation: 4},
+          {format: 'sint32', offset: 172, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup49 = device3.createBindGroup({
+  label: '\ub9f4\u{1f9cc}\u6e75\u4b6b\ufa4b',
+  layout: bindGroupLayout39,
+  entries: [{binding: 727, resource: sampler66}],
+});
+let buffer22 = device3.createBuffer({
+  label: '\u083d\u0072',
+  size: 337420,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder172 = device3.createCommandEncoder();
+try {
+computePassEncoder16.dispatchWorkgroups(2, 4, 4);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline98);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer22, 290364, buffer19, 345532, 12144);
+dissociateBuffer(device3, buffer22);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 29164, new BigUint64Array(27179), 17564, 1228);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas36.getContext('webgpu');
+} catch {}
+let bindGroup50 = device3.createBindGroup({label: '\u{1f7ef}\uaa36\u0dd8\u1d28\u9230', layout: bindGroupLayout28, entries: []});
+try {
+computePassEncoder24.dispatchWorkgroups(4, 5);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(4, buffer6, 8880);
+} catch {}
+try {
+commandEncoder150.copyBufferToBuffer(buffer14, 77300, buffer9, 48684, 101700);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer9, 49232, 94620);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise50 = device3.queue.onSubmittedWorkDone();
+canvas39.height = 2538;
+video19.height = 191;
+let imageData50 = new ImageData(24, 144);
+try {
+canvas54.getContext('webgl2');
+} catch {}
+let textureView227 = texture114.createView({dimension: '2d-array', baseMipLevel: 6, arrayLayerCount: 1});
+try {
+renderBundleEncoder87.draw(158, 66, 1_262_732_072, 519_917_533);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+renderBundleEncoder88.popDebugGroup();
+} catch {}
+let pipeline146 = device4.createComputePipeline({
+  label: '\u981e\ufc88\uf8f4\u0ab4\u969d\u264c\u11a6\u8c9d\u0a9c\u14fd\u0765',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise50;
+} catch {}
+let gpuCanvasContext49 = offscreenCanvas38.getContext('webgpu');
+let imageData51 = new ImageData(84, 4);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+gc();
+let offscreenCanvas39 = new OffscreenCanvas(918, 186);
+let video48 = await videoWithData();
+let gpuCanvasContext50 = offscreenCanvas39.getContext('webgpu');
+let img51 = await imageWithData(61, 23, '#f67979c6', '#ba081ff3');
+try {
+computePassEncoder79.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(191);
+} catch {}
+try {
+commandEncoder152.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14960 */
+  offset: 14960,
+  buffer: buffer21,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+let pipeline147 = device4.createComputePipeline({
+  label: '\u0d8e\u{1f8f5}\u4fde\u{1f71c}\u{1fa7f}\u6d48',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+let canvas55 = document.createElement('canvas');
+try {
+canvas55.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroup51 = device4.createBindGroup({
+  label: '\u{1fab8}\u{1fba2}\u0101\u{1f644}\u56da\u0db1\uf802',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture79}],
+});
+let textureView228 = texture102.createView({label: '\u{1fa83}\u0183\uaae8\u18c3\u93f3\u0c67\u3158\u42ac\uf192\u87b0'});
+try {
+renderBundleEncoder87.draw(113);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 37, height: 30, depthOrArrayLayers: 528}
+*/
+{
+  source: imageBitmap43,
+  origin: { x: 38, y: 0 },
+  flipY: true,
+}, {
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 70},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise51 = device4.createRenderPipelineAsync({
+  label: '\uf753\u7d80\u2c3a\u5ffd',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float'}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 276,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 28, shaderLocation: 10},
+          {format: 'sint16x2', offset: 16, shaderLocation: 12},
+          {format: 'float32x2', offset: 0, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let canvas56 = document.createElement('canvas');
+let canvas57 = document.createElement('canvas');
+try {
+  await adapter11.requestAdapterInfo();
+} catch {}
+try {
+canvas56.getContext('webgl2');
+} catch {}
+let bindGroup52 = device3.createBindGroup({
+  label: '\u2498\u407c\u0d80\uc2de\u0314\u8681',
+  layout: bindGroupLayout30,
+  entries: [{binding: 907, resource: externalTexture47}],
+});
+let textureView229 = texture81.createView({
+  label: '\u0c65\u41f4\u{1fd6f}\u7930\u{1f934}\uea2c\udbcc\u595f\u0d87\u73be',
+  dimension: '2d',
+  baseMipLevel: 8,
+  mipLevelCount: 1,
+  baseArrayLayer: 108,
+});
+try {
+renderBundleEncoder84.setVertexBuffer(2, buffer20, 0, 240102);
+} catch {}
+try {
+commandEncoder90.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 275248 */
+  offset: 16688,
+  bytesPerRow: 256,
+  rowsPerImage: 202,
+  buffer: buffer19,
+}, {width: 1, height: 0, depthOrArrayLayers: 6});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img23,
+  origin: { x: 0, y: 44 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise52 = device3.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+let pipeline148 = device3.createRenderPipeline({
+  label: '\udd35\u5c58\u0135\uc10c\u{1fbbd}\u7bc4\u0f32\u2820',
+  layout: pipelineLayout15,
+  multisample: {count: 4, mask: 0xdbed4d86},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1144,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x2', offset: 152, shaderLocation: 1},
+          {format: 'uint32x3', offset: 24, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 156, shaderLocation: 4},
+          {format: 'sint16x4', offset: 180, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 284, shaderLocation: 15},
+          {format: 'sint16x4', offset: 320, shaderLocation: 3},
+          {format: 'uint32x2', offset: 72, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: false,
+},
+});
+let video49 = await videoWithData();
+let textureView230 = texture112.createView({label: '\ud307\uff94\u{1faf6}\u02f7\u8836\u07ee', baseMipLevel: 1, mipLevelCount: 3});
+let sampler83 = device4.createSampler({
+  label: '\u0aee\u3b4f\ub18e\u69f1\u0bbf',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.80,
+  lodMaxClamp: 42.08,
+  maxAnisotropy: 5,
+});
+let externalTexture90 = device4.importExternalTexture({label: '\ua58e\u9c86\u0786\u01ff\u5d16\u1287\u1ce2', source: video14, colorSpace: 'display-p3'});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder87.draw(139, 42);
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 620 */
+{offset: 620, rowsPerImage: 205}, {width: 105, height: 0, depthOrArrayLayers: 1});
+} catch {}
+canvas19.height = 55;
+let imageBitmap55 = await createImageBitmap(img26);
+let promise53 = adapter0.requestAdapterInfo();
+try {
+canvas57.getContext('webgl2');
+} catch {}
+let commandEncoder173 = device4.createCommandEncoder({label: '\u7a74\u97f2\u{1ffea}\u26ea\ud692\u2380\ua3a7\u{1f868}\u05e1'});
+let texture117 = device4.createTexture({
+  label: '\ud0bc\uea9f\u09e0\u09ee\u{1fb98}\uf4d9\u{1fc97}\ud80c\u0ce2',
+  size: [300, 240, 1],
+  mipLevelCount: 5,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let renderBundle121 = renderBundleEncoder81.finish();
+let externalTexture91 = device4.importExternalTexture({source: videoFrame6});
+let pipeline149 = device4.createRenderPipeline({
+  label: '\ue22e\u{1ffa6}',
+  layout: pipelineLayout27,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'keep', passOp: 'invert'},
+    stencilBack: {failOp: 'decrement-clamp', passOp: 'keep'},
+    stencilReadMask: 998260242,
+    stencilWriteMask: 2447714420,
+    depthBias: -2066015788,
+    depthBiasSlopeScale: 880.3791307017074,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9692,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 3812, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 248, shaderLocation: 2},
+          {format: 'float32x2', offset: 416, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 320, attributes: []},
+      {arrayStride: 2404, attributes: []},
+      {
+        arrayStride: 10732,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 736, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let canvas58 = document.createElement('canvas');
+let gpuCanvasContext51 = canvas58.getContext('webgpu');
+let videoFrame54 = new VideoFrame(canvas20, {timestamp: 0});
+let imageBitmap56 = await createImageBitmap(img28);
+canvas47.height = 1061;
+let imageData52 = new ImageData(148, 148);
+let renderBundleEncoder90 = device3.createRenderBundleEncoder({
+  label: '\u69a9\u58da\u0c2b\u{1f752}\u{1fe1a}\u{1fc8d}\u07ab',
+  colorFormats: ['rg32sint', 'rgba8sint', 'rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle122 = renderBundleEncoder54.finish({label: '\u2424\u0ec5\u4cc4\u068a\ued58\u05b9\u3e8f\u563a\u{1f960}\u0fd4\u579b'});
+let sampler84 = device3.createSampler({
+  label: '\u2124\ub2c1\u08b4\u83ad\u55b7\u0649\u{1fe65}\u8ba2',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 47.98,
+  lodMaxClamp: 83.54,
+});
+try {
+computePassEncoder41.dispatchWorkgroupsIndirect(buffer6, 26232);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(1, buffer6, 0);
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer10, 21256, buffer19, 515944, 9972);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder171.clearBuffer(buffer9, 125872, 6492);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame34,
+  origin: { x: 6, y: 187 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline150 = device3.createComputePipeline({
+  label: '\ub718\u18b1',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise53;
+} catch {}
+gc();
+let commandEncoder174 = device4.createCommandEncoder({});
+let texture118 = device4.createTexture({
+  label: '\u{1fec8}\u3056\u879f\u066c\u86cd\u{1fa0d}\u0628\u{1f785}\ua714',
+  size: {width: 75},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+try {
+renderBundleEncoder88.setIndexBuffer(buffer21, 'uint16', 21260, 18976);
+} catch {}
+try {
+commandEncoder165.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15108 */
+  offset: 15108,
+  rowsPerImage: 294,
+  buffer: buffer21,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(532, 286);
+let img52 = await imageWithData(98, 164, '#f6d2f04d', '#77a3adb8');
+let video50 = await videoWithData();
+let videoFrame55 = new VideoFrame(canvas50, {timestamp: 0});
+let gpuCanvasContext52 = offscreenCanvas40.getContext('webgpu');
+let img53 = await imageWithData(268, 176, '#a84ded9f', '#e12b110e');
+let bindGroupLayout53 = device3.createBindGroupLayout({
+  label: '\u0f4e\u0a44',
+  entries: [
+    {
+      binding: 752,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 803,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer23 = device3.createBuffer({
+  label: '\u19de\u5590\u594f\u59c4',
+  size: 320104,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandBuffer38 = commandEncoder143.finish({});
+let textureView231 = texture42.createView({label: '\u{1f8d0}\ueb80\uc4a9\u5bea'});
+try {
+commandEncoder129.copyBufferToBuffer(buffer16, 44404, buffer19, 207848, 41732);
+dissociateBuffer(device3, buffer16);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 22},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 335_496 */
+{offset: 813, bytesPerRow: 163, rowsPerImage: 228}, {width: 22, height: 2, depthOrArrayLayers: 10});
+} catch {}
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+gc();
+gc();
+canvas13.height = 189;
+let canvas59 = document.createElement('canvas');
+let offscreenCanvas41 = new OffscreenCanvas(790, 728);
+let querySet105 = device3.createQuerySet({label: '\u111b\u69f9\u{1f94a}\ufc40', type: 'occlusion', count: 2955});
+let textureView232 = texture107.createView({aspect: 'all', baseMipLevel: 3, mipLevelCount: 1});
+let sampler85 = device3.createSampler({
+  label: '\u0c20\u2625\u9615\u6e7f\ue7f2\uc233\u{1fa92}\u097e\u{1ff0d}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 25.36,
+  lodMaxClamp: 87.53,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder90.setVertexBuffer(7, buffer6, 11388, 13272);
+} catch {}
+let arrayBuffer10 = buffer23.getMappedRange(87240);
+try {
+commandEncoder158.copyBufferToTexture({
+  /* bytesInLastRow: 5184 widthInBlocks: 324 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8496 */
+  offset: 8496,
+  buffer: buffer14,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 324, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer14);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 2228, new Float32Array(11701), 9851, 1748);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(56)), /* required buffer size: 958_226 */
+{offset: 99, bytesPerRow: 1361, rowsPerImage: 50}, {width: 84, height: 4, depthOrArrayLayers: 15});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas58,
+  origin: { x: 6, y: 25 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext53 = offscreenCanvas41.getContext('webgpu');
+try {
+canvas59.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let textureView233 = texture111.createView({label: '\u3124\u{1ff66}\u{1feda}\uf671\u0a59\u0ef7', dimension: '2d', baseArrayLayer: 121});
+try {
+computePassEncoder24.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder153.clearBuffer(buffer23);
+dissociateBuffer(device3, buffer23);
+} catch {}
+let imageData53 = new ImageData(44, 84);
+document.body.prepend(img13);
+let texture119 = device4.createTexture({
+  label: '\u1e6e\u502e\uae8b\u31fa\u4028\u4d69\u253d',
+  size: {width: 720, height: 1, depthOrArrayLayers: 23},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView234 = texture104.createView({
+  label: '\u{1f89c}\u0b17\u0d4a\u858b\u0dd6\ud5f9\u{1f723}\u{1fec1}\u6059\u0c49\u46d8',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+let sampler86 = device4.createSampler({
+  label: '\u0170\u{1fbae}\u34d2\u{1ff1f}\uaafb\u4073\u{1f911}\u00fb',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.23,
+  lodMaxClamp: 66.32,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup51, new Uint32Array(212), 66, 0);
+} catch {}
+try {
+renderBundleEncoder87.draw(105);
+} catch {}
+try {
+commandEncoder174.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 74420 */
+  offset: 74416,
+  buffer: buffer21,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 167},
+  aspect: 'all',
+}, new ArrayBuffer(3_301_098), /* required buffer size: 3_301_098 */
+{offset: 601, bytesPerRow: 331, rowsPerImage: 255}, {width: 24, height: 27, depthOrArrayLayers: 40});
+} catch {}
+video14.width = 253;
+let device5 = await promise37;
+try {
+window.someLabel = externalTexture43.label;
+} catch {}
+let commandEncoder175 = device3.createCommandEncoder();
+let textureView235 = texture103.createView({
+  label: '\u{1f9b3}\uc97c',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+  baseArrayLayer: 62,
+});
+let sampler87 = device3.createSampler({
+  label: '\u0aaf\u4b4c\u{1fc82}\u{1fe93}\u72c5\uc83b\u{1fc60}\uc13e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.11,
+});
+try {
+computePassEncoder51.dispatchWorkgroups(2);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(1, bindGroup35, []);
+} catch {}
+try {
+commandEncoder150.clearBuffer(buffer9, 123104, 5088);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+gpuCanvasContext48.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 7500, new DataView(new ArrayBuffer(40563)), 40426, 16);
+} catch {}
+document.body.prepend(canvas42);
+let buffer24 = device5.createBuffer({size: 240756, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder176 = device5.createCommandEncoder({label: '\u{1f982}\ue865\u{1f73e}\u7227\u5f6e\u6f12\u{1f9f1}\u0660\u0b4a\ua5a3'});
+let texture120 = device5.createTexture({
+  label: '\u0ab6\u83c2',
+  size: {width: 126, height: 4, depthOrArrayLayers: 1686},
+  mipLevelCount: 11,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundleEncoder91 = device5.createRenderBundleEncoder({label: '\ufb62\u18ce', colorFormats: [], depthStencilFormat: 'stencil8'});
+let sampler88 = device5.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.39,
+  lodMaxClamp: 79.01,
+});
+let externalTexture92 = device5.importExternalTexture({label: '\u8ca8\u{1f867}\u0656\u010d\u2c1e\u8136\ua23d', source: videoFrame15});
+try {
+commandEncoder176.pushDebugGroup('\u2134');
+} catch {}
+try {
+adapter12.label = '\u71fd\u9e58\u44e6\u708e\u{1f6cb}\u026a';
+} catch {}
+let computePassEncoder81 = commandEncoder169.beginComputePass({label: '\uf4b7\u00d0'});
+let renderBundle123 = renderBundleEncoder77.finish({label: '\u455e\u{1fb13}\u2c2d\u{1f724}\u0948\u5112\u024f\udfb7'});
+let sampler89 = device4.createSampler({
+  label: '\u{1f7de}\u4698\u5fe5',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 85.83,
+  lodMaxClamp: 98.05,
+});
+let externalTexture93 = device4.importExternalTexture({label: '\u{1fb1e}\u{1f952}\u5700\u2ee9\ua3af\u1f92', source: video44, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder87.draw(439);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(405);
+} catch {}
+let pipeline151 = device4.createComputePipeline({
+  label: '\u{1fb64}\u2f9a\u0ba6\uadc0\u{1fdb1}\uc5f5\u6853\u{1f975}\u{1fca5}\uf4c9\ufffe',
+  layout: pipelineLayout27,
+  compute: {module: shaderModule20, entryPoint: 'compute0'},
+});
+let pipeline152 = await device4.createRenderPipelineAsync({
+  label: '\u66dd\ua808\u1a74',
+  layout: pipelineLayout27,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'dst'},
+  },
+}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7724,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 236, shaderLocation: 4},
+          {format: 'uint32x2', offset: 1056, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 2056, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7192,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 520, shaderLocation: 8},
+          {format: 'float16x4', offset: 376, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let adapter15 = await navigator.gpu.requestAdapter();
+let textureView236 = texture120.createView({label: '\u4edb\u{1f72c}\ud35b', dimension: '3d', baseMipLevel: 9, mipLevelCount: 1, arrayLayerCount: 1});
+let bindGroup53 = device4.createBindGroup({
+  label: '\u1f08\u2fa9\ua865\u1beb\ue785\u2906\u0f18\ub4b8\u8009',
+  layout: bindGroupLayout52,
+  entries: [],
+});
+let commandEncoder177 = device4.createCommandEncoder({label: '\ud90b\ufb53\u0e3a'});
+let textureView237 = texture118.createView({label: '\uaa3c\u{1f8c4}', baseArrayLayer: 0});
+let renderBundle124 = renderBundleEncoder72.finish();
+try {
+renderBundleEncoder87.draw(218, 220, 2_223_904_215, 2_137_137_596);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(63, 229, 695_149_699, -1_976_740_530);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 9, height: 7, depthOrArrayLayers: 528}
+*/
+{
+  source: videoFrame46,
+  origin: { x: 15, y: 68 },
+  flipY: false,
+}, {
+  texture: texture108,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video51 = await videoWithData();
+let shaderModule23 = device4.createShaderModule({
+  label: '\u2f33\ufd6d\u339c\u3e40\u3e2f\u07fd',
+  code: `@group(1) @binding(4154)
+var<storage, read_write> local18: array<u32>;
+@group(0) @binding(4154)
+var<storage, read_write> field11: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(2) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(6) f0: vec2<f32>,
+  @location(5) f1: vec2<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(2) f3: vec4<f16>,
+  @location(0) f4: u32
+}
+
+@vertex
+fn vertex0(@location(15) a0: f16, @location(3) a1: u32, @location(1) a2: vec3<u32>, a3: S16, @location(7) a4: vec3<f32>, @location(13) a5: vec2<f16>, @location(9) a6: vec3<u32>, @location(10) a7: vec4<f32>, @location(8) a8: vec4<f16>, @location(12) a9: vec3<i32>, @location(14) a10: vec4<f16>, @location(11) a11: vec3<u32>, @builtin(vertex_index) a12: u32, @location(4) a13: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup54 = device4.createBindGroup({
+  label: '\u827c\u4c9d\u0dc6\u0623\u{1f6e5}\u2cd0\uf84c\u970c',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture78}],
+});
+let commandEncoder178 = device4.createCommandEncoder({label: '\u002a\u900e\u886a\u53b1\u0998\u2051\u0d9b\ua224\u{1fca9}\u{1f77c}'});
+let textureView238 = texture105.createView({label: '\u0edf\u5592', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 136});
+try {
+buffer21.unmap();
+} catch {}
+let promise54 = device4.queue.onSubmittedWorkDone();
+let pipeline153 = await device4.createRenderPipelineAsync({
+  label: '\ufa0d\u08d0\udc6b\u{1f9f8}\u{1f849}\u{1fae4}\u449c',
+  layout: pipelineLayout27,
+  multisample: {count: 4, mask: 0xf815ce29},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'keep'},
+    stencilReadMask: 2231916052,
+    depthBias: -251448803,
+    depthBiasSlopeScale: 813.6486027402766,
+  },
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17156,
+        attributes: [
+          {format: 'unorm16x4', offset: 964, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 3832, shaderLocation: 5},
+          {format: 'uint32x2', offset: 856, shaderLocation: 11},
+          {format: 'uint32x2', offset: 2408, shaderLocation: 9},
+          {format: 'sint16x4', offset: 6256, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 18108,
+        attributes: [
+          {format: 'float32x2', offset: 1932, shaderLocation: 13},
+          {format: 'uint8x2', offset: 2892, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 4156, shaderLocation: 7},
+          {format: 'uint32x4', offset: 3164, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 3604, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 404, shaderLocation: 15},
+          {format: 'sint8x4', offset: 6088, shaderLocation: 4},
+          {format: 'float16x2', offset: 3276, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 36,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 14},
+          {format: 'uint32x3', offset: 0, shaderLocation: 0},
+          {format: 'float32x4', offset: 4, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+try {
+  await promise54;
+} catch {}
+let video52 = await videoWithData();
+try {
+adapter15.label = '\uddf8\u0f04\u0114';
+} catch {}
+let bindGroup55 = device3.createBindGroup({
+  label: '\u{1fb30}\uf47d\u9b6a\ua7fe\u{1f94f}\u4030\u0a8d\uc617\ub0bc\u9402',
+  layout: bindGroupLayout39,
+  entries: [{binding: 727, resource: sampler34}],
+});
+let texture121 = device3.createTexture({
+  label: '\u2ca8\u{1f6f2}\u124f',
+  size: {width: 48, height: 3, depthOrArrayLayers: 148},
+  mipLevelCount: 6,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView239 = texture95.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 1});
+let externalTexture94 = device3.importExternalTexture({label: '\u8eb3\u4db3', source: video1});
+try {
+commandEncoder119.copyBufferToBuffer(buffer14, 37016, buffer19, 101204, 1044);
+dissociateBuffer(device3, buffer14);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder158.copyTextureToBuffer({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18640 */
+  offset: 18640,
+  buffer: buffer19,
+}, {width: 68, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.submit([commandBuffer38, commandBuffer27]);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 38692, new DataView(new ArrayBuffer(15267)), 2156, 2968);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer7), /* required buffer size: 536 */
+{offset: 152, rowsPerImage: 97}, {width: 48, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture122 = device5.createTexture({
+  label: '\ue8ff\u188e\u6ed4\u0668\u039f',
+  size: [126, 4, 1081],
+  mipLevelCount: 6,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView240 = texture120.createView({
+  label: '\u{1fbd0}\u{1f8d5}\u91af\u0568\u5dfc\ub8d1\uffad\uadcf\uc843\u4fb8',
+  baseMipLevel: 8,
+  mipLevelCount: 1,
+});
+let computePassEncoder82 = commandEncoder176.beginComputePass({label: '\u{1febd}\ub984\ud236\u1f0b\ucb22\u0939\u0b0b\u{1fb65}\u0bc0\uaa85\u0790'});
+let externalTexture95 = device5.importExternalTexture({label: '\u8923\uf6ec\u1f76\u{1fc6a}\ud8d2\u0ccd', source: videoFrame36, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder91.setVertexBuffer(674, undefined, 53614623);
+} catch {}
+let textureView241 = texture99.createView({label: '\u0e1e\ua3d4\u0d2a\ua7de\u07a0', dimension: '2d-array', baseMipLevel: 2});
+let externalTexture96 = device4.importExternalTexture({label: '\u0767\u0b1e\uf7bd\ua84b\ub17a\u02a6\u{1f8dc}', source: video22, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder88.setBindGroup(2, bindGroup48, []);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(284, 61);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(buffer21, 'uint16');
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12100 */
+  offset: 12092,
+  buffer: buffer21,
+}, {
+  texture: texture114,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+try {
+window.someLabel = computePassEncoder45.label;
+} catch {}
+let commandEncoder179 = device3.createCommandEncoder({label: '\ubb8f\uca6f'});
+let textureView242 = texture46.createView({mipLevelCount: 1, baseArrayLayer: 44, arrayLayerCount: 56});
+let computePassEncoder83 = commandEncoder158.beginComputePass();
+let renderBundleEncoder92 = device3.createRenderBundleEncoder({
+  label: '\u59a3\u54f3\u0766\ub652\ucb49',
+  colorFormats: ['rg8sint', 'rgb10a2uint', 'r32uint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle125 = renderBundleEncoder80.finish({label: '\ueb67\u08a5\u0e2e'});
+try {
+renderBundleEncoder71.setBindGroup(2, bindGroup36, []);
+} catch {}
+try {
+renderBundleEncoder92.setVertexBuffer(1, buffer20);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer19, 4848, 257432);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.submit([commandBuffer36]);
+} catch {}
+let pipeline154 = device3.createRenderPipeline({
+  layout: pipelineLayout20,
+  multisample: {mask: 0xffffffff},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 2258933823,
+    depthBias: 439992611,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1248,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 52, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 332, shaderLocation: 8},
+          {format: 'uint32x4', offset: 72, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 268, attributes: []},
+      {arrayStride: 848, stepMode: 'instance', attributes: []},
+      {arrayStride: 296, attributes: []},
+      {arrayStride: 240, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm8x2', offset: 260, shaderLocation: 15},
+          {format: 'sint32x4', offset: 20, shaderLocation: 3},
+          {format: 'sint32x3', offset: 8, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 692, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 156,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 4, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView243 = texture109.createView({label: '\u26be\u{1f896}\u{1f92d}\u{1fdbe}\u4424\u476e\u{1f91b}'});
+try {
+renderBundleEncoder87.setBindGroup(1, bindGroup51);
+} catch {}
+let querySet106 = device5.createQuerySet({type: 'occlusion', count: 3693});
+let textureView244 = texture122.createView({
+  label: '\uc4ae\u218c\uee63\u6320\u9772\u9983\u42d5\u585f\u{1f9c4}',
+  dimension: '2d',
+  format: 'stencil8',
+  baseMipLevel: 3,
+  baseArrayLayer: 398,
+});
+let renderBundle126 = renderBundleEncoder91.finish({label: '\udbf1\u{1fadd}'});
+try {
+adapter6.label = '\u0d5c\u2595\u04c9\uc8e8\u01d9\u6e47\u0eea\u{1fc77}\uef9a';
+} catch {}
+let querySet107 = device4.createQuerySet({type: 'occlusion', count: 2964});
+let commandBuffer39 = commandEncoder177.finish({label: '\u{1f771}\u0802'});
+let textureView245 = texture114.createView({label: '\u{1fbea}\u5cde\u{1ffa6}\u0875\u0b2f\uaf38', dimension: '2d-array', baseMipLevel: 4});
+try {
+renderBundleEncoder88.setIndexBuffer(buffer21, 'uint32', 109868, 93);
+} catch {}
+let promise55 = device4.popErrorScope();
+gc();
+let video53 = await videoWithData();
+let commandEncoder180 = device5.createCommandEncoder();
+let computePassEncoder84 = commandEncoder180.beginComputePass({label: '\ube57\u02b2\u{1fc6e}\u0edf\u4da2\u{1ffaa}\u086e'});
+let renderBundle127 = renderBundleEncoder91.finish({label: '\uf1b0\u011d\u2e76'});
+let shaderModule24 = device1.createShaderModule({
+  code: `@group(1) @binding(3641)
+var<storage, read_write> field12: array<u32>;
+@group(5) @binding(8031)
+var<storage, read_write> n17: array<u32>;
+@group(3) @binding(8153)
+var<storage, read_write> function14: array<u32>;
+@group(1) @binding(7224)
+var<storage, read_write> n18: array<u32>;
+
+@compute @workgroup_size(2, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @builtin(vertex_index) f0: u32,
+  @location(14) f1: u32,
+  @location(6) f2: vec4<i32>,
+  @location(7) f3: vec2<i32>,
+  @location(8) f4: vec3<f16>,
+  @builtin(instance_index) f5: u32,
+  @location(5) f6: vec3<u32>,
+  @location(10) f7: u32,
+  @location(9) f8: f16,
+  @location(12) f9: i32,
+  @location(0) f10: vec3<f16>,
+  @location(11) f11: vec3<i32>,
+  @location(2) f12: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f32>, @location(4) a1: vec3<f16>, @location(3) a2: vec2<i32>, @location(1) a3: vec4<f32>, @location(16) a4: vec3<u32>, a5: S17, @location(13) a6: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let computePassEncoder85 = commandEncoder33.beginComputePass({label: '\u{1f881}\u5c59\u3b46\uea9b\u13ef\u6aa3\ub677\u{1fbf0}\u03c7\u5205'});
+let sampler90 = device1.createSampler({
+  label: '\u2a39\u7d68\u0986\u864e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.27,
+  lodMaxClamp: 36.61,
+});
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8568 */
+  offset: 8568,
+  bytesPerRow: 256,
+  rowsPerImage: 162,
+  buffer: buffer3,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+commandEncoder155.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 65});
+} catch {}
+let promise56 = device1.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'keep'},
+    stencilWriteMask: 2167654563,
+    depthBiasClamp: -3.2564684821665395,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1744,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 164, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 56, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 136, shaderLocation: 9},
+          {format: 'uint32x3', offset: 248, shaderLocation: 5},
+          {format: 'sint8x4', offset: 88, shaderLocation: 4},
+          {format: 'uint8x4', offset: 32, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 722, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 3144,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x3', offset: 208, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 248, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 352, shaderLocation: 15},
+          {format: 'float32x2', offset: 192, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 72, shaderLocation: 13},
+          {format: 'sint16x4', offset: 336, shaderLocation: 1},
+          {format: 'uint16x4', offset: 324, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 2892, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 672,
+        attributes: [
+          {format: 'float32x4', offset: 68, shaderLocation: 0},
+          {format: 'sint32x3', offset: 52, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 40, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw'},
+});
+let img54 = await imageWithData(229, 141, '#9121833c', '#583f39a7');
+try {
+window.someLabel = computePassEncoder77.label;
+} catch {}
+let sampler91 = device4.createSampler({
+  label: '\u182b\u9bd7\u2624\ua96a\u0da5\u150e',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.29,
+  lodMaxClamp: 62.19,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder76.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder87.draw(39);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(66, 114, 6_568_403, 193_798_461, 1_228_879_381);
+} catch {}
+try {
+commandEncoder167.copyBufferToTexture({
+  /* bytesInLastRow: 2024 widthInBlocks: 506 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23868 */
+  offset: 23868,
+  bytesPerRow: 2048,
+  buffer: buffer21,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 506, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 3,
+  origin: {x: 27, y: 0, z: 23},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 7, y: 15, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(27, 127);
+let videoFrame56 = new VideoFrame(img8, {timestamp: 0});
+try {
+sampler88.label = '\u682d\ufb30\u70e4\u{1ffdd}\u{1fb36}\u3b04\u98c8\u0de5\u8825\u0277\u{1fb70}';
+} catch {}
+let commandEncoder181 = device5.createCommandEncoder({label: '\u837f\ubaf8\u474f\u{1f623}\u{1f9ea}\u5a1f\u{1fc32}'});
+try {
+commandEncoder181.clearBuffer(buffer24, 145952);
+dissociateBuffer(device5, buffer24);
+} catch {}
+let canvas60 = document.createElement('canvas');
+let bindGroup56 = device4.createBindGroup({
+  label: '\u0778\u0027\u{1f8ca}\u{1fb9f}',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture88}],
+});
+let commandEncoder182 = device4.createCommandEncoder({label: '\uc402\u025f\u7745\u0e23\u9de9'});
+let textureView246 = texture117.createView({
+  label: '\uc50f\ua885\u3b8b\u0933\ua235\u39a0',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder93 = device4.createRenderBundleEncoder({
+  label: '\u0b98\u{1faa8}\u2fe0\u{1febe}\u0369\u1363\u56cd\u0a54\u2ce1',
+  colorFormats: ['rgba16float', 'bgra8unorm-srgb', 'r32uint', 'rg16float'],
+  sampleCount: 4,
+});
+let renderBundle128 = renderBundleEncoder88.finish();
+let sampler92 = device4.createSampler({addressModeU: 'repeat', lodMinClamp: 46.67, lodMaxClamp: 52.90});
+try {
+renderBundleEncoder87.draw(184, 500, 110_076_000, 309_218_510);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+try {
+commandEncoder173.copyBufferToTexture({
+  /* bytesInLastRow: 180 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11524 */
+  offset: 11344,
+  bytesPerRow: 256,
+  buffer: buffer21,
+}, {
+  texture: texture114,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 45, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 720, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: video13,
+  origin: { x: 6, y: 3 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 579, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas42.getContext('webgl');
+} catch {}
+canvas38.height = 141;
+try {
+  await promise55;
+} catch {}
+let shaderModule25 = device4.createShaderModule({
+  label: '\ue81e\u03aa\u77c8\udaf7\u0654\u09ca\u{1f7d5}\uaf9d\u0d42',
+  code: `@group(2) @binding(4154)
+var<storage, read_write> field13: array<u32>;
+@group(1) @binding(4575)
+var<storage, read_write> function15: array<u32>;
+@group(3) @binding(4575)
+var<storage, read_write> parameter13: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @location(7) f0: vec3<i32>,
+  @builtin(sample_mask) f1: u32,
+  @location(2) f2: u32,
+  @location(29) f3: vec4<f32>,
+  @location(5) f4: vec4<u32>,
+  @location(20) f5: vec3<i32>,
+  @builtin(front_facing) f6: bool,
+  @location(14) f7: vec4<u32>,
+  @location(13) f8: vec2<u32>,
+  @location(10) f9: vec4<f16>,
+  @location(11) f10: i32,
+  @location(8) f11: vec4<i32>,
+  @location(9) f12: vec3<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<i32>,
+  @location(0) f1: i32,
+  @location(1) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: vec4<u32>, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, a3: S19, @location(24) a4: f32, @location(4) a5: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(8) f0: vec4<i32>,
+  @location(14) f1: vec3<f16>,
+  @location(12) f2: vec2<f16>,
+  @location(11) f3: f32,
+  @location(0) f4: vec3<u32>,
+  @location(4) f5: f32
+}
+struct VertexOutput0 {
+  @location(13) f136: vec2<u32>,
+  @location(10) f137: vec4<f16>,
+  @location(29) f138: vec4<f32>,
+  @location(16) f139: vec4<u32>,
+  @location(5) f140: vec4<u32>,
+  @location(4) f141: vec2<f32>,
+  @location(9) f142: vec3<f32>,
+  @location(11) f143: i32,
+  @location(14) f144: vec4<u32>,
+  @location(7) f145: vec3<i32>,
+  @location(20) f146: vec3<i32>,
+  @location(24) f147: f32,
+  @location(8) f148: vec4<i32>,
+  @location(2) f149: u32,
+  @builtin(position) f150: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f32>, @location(6) a1: vec4<u32>, @location(5) a2: vec2<u32>, a3: S18, @builtin(instance_index) a4: u32, @location(3) a5: vec2<u32>, @location(9) a6: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder183 = device4.createCommandEncoder({label: '\ue6f8\u0269\ua322\u{1fa43}\uf116'});
+let sampler93 = device4.createSampler({
+  label: '\u073d\ua2fe\ud1c7\u11c2\u402f\uaa08\u{1fffd}\u013a\u4aea\u2418',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 84.86,
+  lodMaxClamp: 97.34,
+});
+try {
+renderBundleEncoder87.drawIndexed(503, 199, 677_240_452, 361_547_390, 488_574_395);
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 164 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26436 */
+  offset: 26436,
+  bytesPerRow: 512,
+  buffer: buffer21,
+}, {
+  texture: texture119,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 41, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer21);
+} catch {}
+let pipeline155 = await device4.createRenderPipelineAsync({
+  label: '\u0f1a\u0e1e\u8bc5\u{1f8b2}\u03b3\u0bfc\u6f48\u4ce7',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4092,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 156, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 736, shaderLocation: 2},
+          {format: 'float32x2', offset: 84, shaderLocation: 8},
+          {format: 'sint32x3', offset: 432, shaderLocation: 4},
+          {format: 'uint8x2', offset: 264, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 13212,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x2', offset: 668, shaderLocation: 15},
+          {format: 'sint32', offset: 1604, shaderLocation: 12},
+          {format: 'float16x4', offset: 3216, shaderLocation: 7},
+          {format: 'uint32x4', offset: 1256, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1304,
+        attributes: [
+          {format: 'uint8x2', offset: 534, shaderLocation: 11},
+          {format: 'uint32x4', offset: 664, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 204, shaderLocation: 13},
+          {format: 'float32x3', offset: 40, shaderLocation: 14},
+          {format: 'uint8x4', offset: 8, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 1156, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 4760,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 484, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let gpuCanvasContext54 = canvas60.getContext('webgpu');
+let videoFrame57 = new VideoFrame(video47, {timestamp: 0});
+let img55 = await imageWithData(125, 75, '#3ca451ca', '#50c843a3');
+let promise57 = adapter1.requestAdapterInfo();
+try {
+  await promise57;
+} catch {}
+let texture123 = device3.createTexture({
+  label: '\u0522\ub3f7\u05ad',
+  size: {width: 48, height: 3, depthOrArrayLayers: 685},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let renderBundleEncoder94 = device3.createRenderBundleEncoder({
+  label: '\u37cb\u3f15\u{1fdb1}\uaa39\ueea4\u06a1\u08c3\u09be\u{1f9ba}',
+  colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'],
+  stencilReadOnly: true,
+});
+let externalTexture97 = device3.importExternalTexture({label: '\uf67a\u{1f919}\u2e94\u7527\u0e81\u4455\u0bd3', source: videoFrame56});
+try {
+computePassEncoder39.dispatchWorkgroups(4, 1, 5);
+} catch {}
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer6, 2508);
+} catch {}
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 2_388_144 */
+{offset: 337, bytesPerRow: 241, rowsPerImage: 194}, {width: 55, height: 14, depthOrArrayLayers: 52});
+} catch {}
+let renderBundleEncoder95 = device5.createRenderBundleEncoder({
+  label: '\u{1f6c9}\uff85\u1417\u0cf3\u9143\ud7ff\ua170\ud893\u04a7\u{1fc1e}\u7730',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+let sampler94 = device5.createSampler({
+  label: '\u{1f731}\u02e3\u{1f84c}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 28.38,
+});
+let externalTexture98 = device5.importExternalTexture({label: '\ubc44\u{1f70c}\u{1fa1a}', source: videoFrame55, colorSpace: 'srgb'});
+let commandEncoder184 = device3.createCommandEncoder({});
+let querySet108 = device3.createQuerySet({type: 'occlusion', count: 407});
+let texture124 = device3.createTexture({
+  size: [96, 7, 927],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderBundleEncoder96 = device3.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rgba32sint', 'rgba8uint'], depthReadOnly: true});
+let sampler95 = device3.createSampler({
+  label: '\uc32a\u1845\uc489',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 81.76,
+  lodMaxClamp: 83.40,
+  compare: 'never',
+});
+try {
+renderBundleEncoder71.setVertexBuffer(0, buffer20, 0);
+} catch {}
+try {
+commandEncoder161.copyTextureToBuffer({
+  texture: texture83,
+  mipLevel: 2,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 98672 */
+  offset: 13648,
+  bytesPerRow: 512,
+  rowsPerImage: 82,
+  buffer: buffer9,
+}, {width: 2, height: 3, depthOrArrayLayers: 3});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video43,
+  origin: { x: 2, y: 14 },
+  flipY: false,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline156 = device3.createRenderPipeline({
+  label: '\u22fc\u{1fbea}\udd98\u90d5\u{1ffc5}\u5003\uf054\u0d8d\ufe73\u1d6d\u737f',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint'}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 561759248,
+    depthBiasClamp: 892.4874405454617,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 132,
+        attributes: [
+          {format: 'uint32x2', offset: 20, shaderLocation: 5},
+          {format: 'sint8x4', offset: 4, shaderLocation: 2},
+          {format: 'float32x4', offset: 20, shaderLocation: 11},
+          {format: 'uint16x2', offset: 8, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 16, shaderLocation: 12},
+          {format: 'sint32x2', offset: 16, shaderLocation: 10},
+          {format: 'sint32x3', offset: 4, shaderLocation: 8},
+          {format: 'sint8x4', offset: 36, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 98, shaderLocation: 7},
+          {format: 'uint8x2', offset: 494, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 224, attributes: [{format: 'float16x4', offset: 48, shaderLocation: 6}]},
+      {arrayStride: 92, attributes: [{format: 'float16x2', offset: 0, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+gc();
+let bindGroupLayout54 = device5.createBindGroupLayout({label: '\u3eb9\u0708\uc8e0', entries: []});
+let textureView247 = texture122.createView({label: '\u049c\udf7c\u0be7\u0ed7', dimension: '2d-array', baseArrayLayer: 630, arrayLayerCount: 333});
+let computePassEncoder86 = commandEncoder181.beginComputePass({});
+let sampler96 = device5.createSampler({
+  label: '\u0006\u3b44\u09e3',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.45,
+  lodMaxClamp: 59.33,
+});
+try {
+gpuCanvasContext25.configure({device: device5, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let videoFrame58 = new VideoFrame(video49, {timestamp: 0});
+let bindGroupLayout55 = pipeline143.getBindGroupLayout(0);
+let querySet109 = device4.createQuerySet({type: 'occlusion', count: 3153});
+let textureView248 = texture118.createView({label: '\u5126\ud950\u7a84\uabc8\u6543\u98a4\u{1fec3}\u3f3e\u0b3d'});
+let renderBundle129 = renderBundleEncoder88.finish({label: '\ucbdf\uca96\u0e59\ue05d\u01d8\ueaa2'});
+try {
+computePassEncoder78.setPipeline(pipeline146);
+} catch {}
+try {
+renderBundleEncoder87.draw(131, 56);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(buffer21, 'uint32', 13304, 88985);
+} catch {}
+try {
+  await device4.popErrorScope();
+} catch {}
+let pipeline157 = device4.createRenderPipeline({
+  label: '\u25c1\u05d0\ud1de\u3b23\u0454\u0456\u554c\u4a94\ud10a',
+  layout: pipelineLayout24,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 1382097748,
+    stencilWriteMask: 1907180175,
+    depthBias: -82551618,
+    depthBiasSlopeScale: 698.134724026422,
+    depthBiasClamp: 842.8840779466234,
+  },
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 336,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 16, shaderLocation: 10},
+          {format: 'sint32x2', offset: 12, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 7608, attributes: []},
+      {arrayStride: 3464, attributes: []},
+      {
+        arrayStride: 21764,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 3800, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroupLayout56 = device4.createBindGroupLayout({entries: []});
+let bindGroup57 = device4.createBindGroup({
+  label: '\u{1ffcd}\u{1f6ab}\uab6e\u0f22\u080b\u6857',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture78}],
+});
+let renderBundleEncoder97 = device4.createRenderBundleEncoder({label: '\ud86b\u6fdb', colorFormats: ['r32sint', 'r32sint', 'rg16sint']});
+let sampler97 = device4.createSampler({
+  label: '\u{1f87e}\u0379\u61e9\u00d5\u8de9\u512e',
+  addressModeU: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.59,
+  lodMaxClamp: 63.96,
+});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+canvas40.height = 41;
+gc();
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let imageBitmap57 = await createImageBitmap(offscreenCanvas7);
+let commandEncoder185 = device3.createCommandEncoder({});
+try {
+renderBundleEncoder84.setBindGroup(0, bindGroup27, new Uint32Array(9804), 451, 0);
+} catch {}
+try {
+commandEncoder69.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2128 */
+  offset: 2128,
+  bytesPerRow: 0,
+  buffer: buffer9,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.submit([commandBuffer35, commandBuffer31, commandBuffer34]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer10), /* required buffer size: 817 */
+{offset: 817, rowsPerImage: 185}, {width: 70, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline158 = await promise52;
+let video54 = await videoWithData();
+let bindGroupLayout57 = device3.createBindGroupLayout({
+  label: '\u8391\uf4e0\u{1fd0d}',
+  entries: [
+    {
+      binding: 161,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let querySet110 = device3.createQuerySet({type: 'occlusion', count: 3374});
+let computePassEncoder87 = commandEncoder134.beginComputePass();
+try {
+renderBundleEncoder76.setBindGroup(3, bindGroup38);
+} catch {}
+let pipeline159 = await device3.createComputePipelineAsync({
+  label: '\ub8de\udd69\uec3f\uaddd\u{1febf}\u81cd\u{1fee3}',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule6, entryPoint: 'compute0'},
+});
+let img56 = await imageWithData(52, 144, '#08fe7ab1', '#be4e05c2');
+let textureView249 = texture119.createView({baseMipLevel: 1, mipLevelCount: 3});
+try {
+computePassEncoder75.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(47, 273, 343_287_550);
+} catch {}
+try {
+commandEncoder168.copyBufferToTexture({
+  /* bytesInLastRow: 472 widthInBlocks: 118 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23568 */
+  offset: 23568,
+  buffer: buffer21,
+}, {
+  texture: texture99,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 118, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer21);
+} catch {}
+let texture125 = device4.createTexture({
+  label: '\u{1fad5}\u4d94\u0174\u{1fb49}\u7ff1\u0548\u05fe\u05a3\u3154\u{1f698}',
+  size: [720, 1, 307],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle130 = renderBundleEncoder97.finish({label: '\u{1fcff}\u5e55'});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderBundleEncoder87.setBindGroup(2, bindGroup48, new Uint32Array(22), 1, 0);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(216, 408, 2_025_702_644);
+} catch {}
+try {
+renderBundleEncoder93.setPipeline(pipeline152);
+} catch {}
+try {
+device4.queue.submit([commandBuffer39]);
+} catch {}
+canvas26.height = 842;
+try {
+adapter4.label = '\u{1ff25}\u9fb2\u0e23\uf43c\u{1f733}\u7a6b\ufda2\u3e7e\u{1f9c5}\u9046\ud657';
+} catch {}
+let textureView250 = texture122.createView({
+  label: '\uf0d5\u04e1\u0ed6\u{1f841}\ucea6\u48ce\u{1f84e}\u0241\u{1fa33}\u0f72',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  baseArrayLayer: 225,
+});
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+let computePassEncoder88 = commandEncoder139.beginComputePass();
+let sampler98 = device3.createSampler({
+  label: '\u0727\u{1f89b}\u0fb8\u07b6\ue363\u04ef\u32bc\u0e82\u11f2\ub4dc\u019c',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 94.84,
+});
+try {
+renderBundleEncoder50.setIndexBuffer(buffer20, 'uint32', 21576, 298892);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer10, 11000, buffer23, 62552, 35036);
+dissociateBuffer(device3, buffer10);
+dissociateBuffer(device3, buffer23);
+} catch {}
+try {
+commandEncoder151.copyBufferToTexture({
+  /* bytesInLastRow: 432 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 15824 */
+  offset: 15392,
+  rowsPerImage: 215,
+  buffer: buffer14,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer14);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 849 */
+{offset: 849, rowsPerImage: 88}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas48,
+  origin: { x: 52, y: 20 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle131 = renderBundleEncoder25.finish({label: '\u{1fb8d}\ufcd7\u0240\u15f3\u6115\uad0a\u{1fd3b}\udd41\u626c\u8e7b'});
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 9120 */
+  offset: 6560,
+  bytesPerRow: 256,
+  rowsPerImage: 10,
+  buffer: buffer9,
+}, {width: 4, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer9, 95808, 63656);
+dissociateBuffer(device3, buffer9);
+} catch {}
+let promise58 = device3.createRenderPipelineAsync({
+  label: '\uacdc\ua24c\u086e\u7a8c\u91c8\u87d1\u{1fcdc}\u{1fa65}\ud7a1\u3366\uda5e',
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0x705813a0},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 2021317657,
+    stencilWriteMask: 3698253699,
+    depthBias: 1075300251,
+    depthBiasSlopeScale: 683.1369145943817,
+    depthBiasClamp: 319.4725971749499,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 444,
+        attributes: [
+          {format: 'unorm8x2', offset: 154, shaderLocation: 2},
+          {format: 'sint16x4', offset: 116, shaderLocation: 7},
+          {format: 'sint16x4', offset: 28, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 5},
+          {format: 'float32x2', offset: 156, shaderLocation: 6},
+          {format: 'float32x2', offset: 16, shaderLocation: 3},
+          {format: 'sint32x4', offset: 36, shaderLocation: 8},
+          {format: 'sint16x2', offset: 68, shaderLocation: 0},
+          {format: 'float16x4', offset: 64, shaderLocation: 13},
+          {format: 'float32x2', offset: 120, shaderLocation: 12},
+          {format: 'float16x2', offset: 200, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 56,
+        attributes: [
+          {format: 'sint32x2', offset: 4, shaderLocation: 11},
+          {format: 'sint8x2', offset: 26, shaderLocation: 9},
+          {format: 'uint32x4', offset: 0, shaderLocation: 14},
+          {format: 'uint8x4', offset: 12, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let bindGroupLayout58 = pipeline131.getBindGroupLayout(1);
+let bindGroup58 = device4.createBindGroup({
+  label: '\uae9f\u{1fa87}',
+  layout: bindGroupLayout45,
+  entries: [{binding: 4575, resource: externalTexture85}],
+});
+let buffer25 = device4.createBuffer({
+  label: '\u{1fdcb}\u5299\u0f06\u{1f850}',
+  size: 27488,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle132 = renderBundleEncoder77.finish({label: '\u09c1\u{1fc86}'});
+let sampler99 = device4.createSampler({
+  label: '\u{1f766}\ufb97\ubc92\u607d\u18c7',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.47,
+  lodMaxClamp: 96.16,
+});
+try {
+computePassEncoder81.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(238, 352, 64_644_462, 692_496_700);
+} catch {}
+let pipeline160 = await device4.createComputePipelineAsync({
+  label: '\u0883\u{1f9ce}\u5ded\u5228',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout59 = device4.createBindGroupLayout({
+  label: '\u0098\u{1f81d}\u8d2b',
+  entries: [
+    {
+      binding: 4772,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder186 = device4.createCommandEncoder({});
+let computePassEncoder89 = commandEncoder173.beginComputePass({});
+let sampler100 = device4.createSampler({
+  label: '\u{1f861}\u{1fafb}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.34,
+  lodMaxClamp: 63.24,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder87.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(176);
+} catch {}
+try {
+commandEncoder183.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27068 */
+  offset: 27068,
+  buffer: buffer21,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer21);
+} catch {}
+let bindGroup59 = device5.createBindGroup({layout: bindGroupLayout54, entries: []});
+let buffer26 = device5.createBuffer({label: '\u004f\u097d\u{1fe1e}\u01f5\u0c28', size: 128782, usage: GPUBufferUsage.COPY_DST});
+let renderBundle133 = renderBundleEncoder91.finish({});
+let sampler101 = device5.createSampler({
+  label: '\ube2c\uc5a2',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 87.35,
+  lodMaxClamp: 94.20,
+});
+let imageBitmap58 = await createImageBitmap(imageBitmap49);
+try {
+adapter8.label = '\u0be9\u{1fa0c}\ud39a\ufe96\u{1fd58}\u0144\u0aa6\u{1f961}';
+} catch {}
+let imageData54 = new ImageData(216, 88);
+try {
+externalTexture41.label = '\u{1feb7}\uc476\u{1fb0d}\uccb0\u{1fdf3}\ua21a\u{1f6c1}\u0a0a\u426b\u{1fb56}\u13be';
+} catch {}
+let textureView251 = texture118.createView({label: '\u0013\u46f9\u7dee\u{1fc94}\ub655\u{1fba6}', aspect: 'all'});
+let renderBundleEncoder98 = device4.createRenderBundleEncoder({
+  label: '\u09ce\u031c\u0935\ub9c9\u3a91\u1e1f\ua205',
+  colorFormats: ['r32sint', 'r32sint', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle134 = renderBundleEncoder81.finish({label: '\u79a4\u7c13\u05b9\u3c22'});
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+try {
+computePassEncoder81.pushDebugGroup('\ueae6');
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 130 */
+{offset: 130, rowsPerImage: 72}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 37, height: 30, depthOrArrayLayers: 528}
+*/
+{
+  source: canvas51,
+  origin: { x: 213, y: 9 },
+  flipY: true,
+}, {
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 52},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline161 = await promise51;
+let bindGroup60 = device5.createBindGroup({
+  label: '\u0da2\u06b0\u9250\u{1f921}\u0278\u{1f7b1}\u0ab6\uf4ea',
+  layout: bindGroupLayout54,
+  entries: [],
+});
+let pipelineLayout28 = device5.createPipelineLayout({
+  label: '\uf850\u0fe2\u0190\ue5d9\u{1ff78}\u{1fc2d}',
+  bindGroupLayouts: [bindGroupLayout54, bindGroupLayout54, bindGroupLayout54],
+});
+let commandEncoder187 = device5.createCommandEncoder({});
+let textureView252 = texture120.createView({label: '\u6dfb\u7dfe\ud992\ub797\u{1fafe}', baseMipLevel: 4, mipLevelCount: 3});
+let canvas61 = document.createElement('canvas');
+let imageBitmap59 = await createImageBitmap(videoFrame31);
+try {
+adapter0.label = '\u0974\u9d95\u19bb\ue7cc\u0bae\uf8d9\uaecf\u408c\u8d84\u0363';
+} catch {}
+let textureView253 = texture108.createView({
+  label: '\udb2f\u1e65\u3ba3',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 101,
+  arrayLayerCount: 72,
+});
+try {
+computePassEncoder89.end();
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(55, 179, 642_923_415, -1_930_085_467, 366_601_541);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+try {
+device4.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder173.copyTextureToTexture({
+  texture: texture117,
+  mipLevel: 1,
+  origin: {x: 11, y: 7, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture119,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 51, height: 1, depthOrArrayLayers: 1});
+} catch {}
+canvas44.width = 990;
+let commandEncoder188 = device3.createCommandEncoder();
+let querySet111 = device3.createQuerySet({label: '\u{1fa00}\ue8fd\u333c', type: 'occlusion', count: 2788});
+let renderBundle135 = renderBundleEncoder63.finish({label: '\ue218\u{1f79b}\ueb20\u{1fe74}\u{1fdae}'});
+try {
+commandEncoder171.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer19, 258428, 324044);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 1_480_019 */
+{offset: 901, bytesPerRow: 54, rowsPerImage: 301}, {width: 1, height: 1, depthOrArrayLayers: 92});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 2, y: 2 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline162 = await promise49;
+let imageBitmap60 = await createImageBitmap(offscreenCanvas35);
+let commandEncoder189 = device4.createCommandEncoder({});
+let texture126 = device4.createTexture({
+  label: '\u4f66\u8c71\u980a\uf895\u0d4e\u{1fe59}\u7683\u03f8',
+  size: [720, 1, 1086],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let renderBundleEncoder99 = device4.createRenderBundleEncoder({
+  label: '\uc444\u{1f969}\u888b\u6b25\u0a82\u09c5\u0b5e\u4e6e\u{1ff6f}\ud88e\u00e6',
+  colorFormats: ['rgba16float', 'bgra8unorm-srgb', 'r32uint', 'rg16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder79.setPipeline(pipeline121);
+} catch {}
+try {
+renderBundleEncoder99.setIndexBuffer(buffer21, 'uint16', 88884, 21400);
+} catch {}
+try {
+device4.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder133.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 17, y: 11, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 1,
+  origin: {x: 4, y: 31, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 982 */
+{offset: 982, bytesPerRow: 576}, {width: 108, height: 29, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let video55 = await videoWithData();
+let bindGroup61 = device5.createBindGroup({layout: bindGroupLayout54, entries: []});
+let computePassEncoder90 = commandEncoder187.beginComputePass({label: '\u{1f8d3}\u0303\u{1f65b}\u{1f907}\u0aa4\u2994\u4df9'});
+let sampler102 = device5.createSampler({
+  label: '\ue251\uca03\u0dfb\u0d43\u6423\u7f7b\u{1f752}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.69,
+  lodMaxClamp: 53.68,
+  compare: 'always',
+});
+let externalTexture99 = device5.importExternalTexture({
+  label: '\u58ee\u{1f824}\ud6fd\ubd6e\u97d2\u5312\ud4c9\uc893\u967b',
+  source: videoFrame58,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder84.setBindGroup(3, bindGroup61, []);
+} catch {}
+try {
+  await buffer24.mapAsync(GPUMapMode.READ);
+} catch {}
+let videoFrame59 = new VideoFrame(imageBitmap31, {timestamp: 0});
+canvas56.height = 1967;
+let bindGroup62 = device1.createBindGroup({
+  label: '\u{1f861}\u12e2\u{1f86b}\u4058\ubefd\u0df8\u7b7c\uf15c\u03c3',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 3641, resource: sampler52},
+    {binding: 7224, resource: externalTexture8},
+    {binding: 2668, resource: sampler52},
+  ],
+});
+let commandEncoder190 = device1.createCommandEncoder({label: '\u{1fe47}\u0670\u0f5b\u07d4\ub233\u3828\u8494\ue342\u{1fdac}\u{1fee3}\u0c68'});
+let querySet112 = device1.createQuerySet({label: '\u{1fa3d}\u88e0\uc030\u{1f97a}\u0828\u{1ff11}\u0ac8', type: 'occlusion', count: 1498});
+let texture127 = device1.createTexture({
+  label: '\u{1fbe2}\u49a6\u10fe\u{1f866}\u035e\u0c7b\u4451\u4b91',
+  size: [384, 2, 484],
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView254 = texture21.createView({label: '\u{1fbb5}\u0371\u0ee2\ud268', baseMipLevel: 1});
+let computePassEncoder91 = commandEncoder29.beginComputePass({label: '\u9b3d\u0e02\u2265'});
+let sampler103 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.69,
+  lodMaxClamp: 54.69,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder6.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14828 */
+  offset: 14828,
+  rowsPerImage: 118,
+  buffer: buffer3,
+}, {
+  texture: texture14,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer3, 64480, 3004);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+renderBundleEncoder95.setBindGroup(3, bindGroup60);
+} catch {}
+let gpuCanvasContext55 = canvas61.getContext('webgpu');
+let querySet113 = device4.createQuerySet({
+  label: '\u326d\u71f5\u{1f856}\u431a\u{1f9c3}\u4cda\u1e14\u{1f74c}\u{1f797}\u{1faef}\u1faa',
+  type: 'occlusion',
+  count: 2212,
+});
+let textureView255 = texture99.createView({label: '\u{1fe16}\ufdac\u{1faa8}', dimension: '2d-array', mipLevelCount: 2});
+try {
+commandEncoder174.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 63},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 5, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: offscreenCanvas21,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 2,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise59 = device4.createRenderPipelineAsync({
+  label: '\ufc9f\u0a10',
+  layout: pipelineLayout24,
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint'}, {format: 'rg16sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 2752,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 1040, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 1584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 52, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 4},
+          {format: 'float32x4', offset: 216, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 284, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 220, shaderLocation: 14},
+          {format: 'uint32x2', offset: 1144, shaderLocation: 0},
+          {format: 'float16x4', offset: 304, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 140, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 816,
+        attributes: [
+          {format: 'uint32', offset: 100, shaderLocation: 5},
+          {format: 'uint32x4', offset: 256, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw'},
+});
+let offscreenCanvas43 = new OffscreenCanvas(286, 786);
+let img57 = await imageWithData(46, 220, '#a3c35ac1', '#8daf5c34');
+try {
+commandEncoder24.label = '\u9868\u1db4';
+} catch {}
+let imageData55 = new ImageData(180, 60);
+let textureView256 = texture118.createView({label: '\u210a\u029a\u665b'});
+try {
+renderBundleEncoder87.drawIndexed(73, 404, 346_353_895, 299_089_074, 1_077_632_113);
+} catch {}
+try {
+renderBundleEncoder99.setIndexBuffer(buffer21, 'uint32', 46256, 16614);
+} catch {}
+try {
+renderBundleEncoder99.setPipeline(pipeline152);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+let querySet114 = device4.createQuerySet({label: '\u33f1\u8e7d', type: 'occlusion', count: 3206});
+let texture128 = device4.createTexture({
+  label: '\u38f2\u04a8\u0e3e\u5584\u0e04\u{1fc55}\u5d61\u4a24\u{1ff94}\u0c91\ubbf4',
+  size: [240, 1, 534],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler104 = device4.createSampler({
+  label: '\uc94f\u{1fc7a}\ud241\u1e18\u2dd0\u{1fd87}\u05fc\u06cf\ucf92\u0e5e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.39,
+  lodMaxClamp: 35.94,
+  maxAnisotropy: 2,
+});
+let externalTexture100 = device4.importExternalTexture({label: '\u010c\uac57\uf791', source: videoFrame6, colorSpace: 'srgb'});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup54, new Uint32Array(6895), 6180, 0);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline147);
+} catch {}
+try {
+renderBundleEncoder87.draw(253, 14, 1_448_807_196, 47_622_306);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 37, height: 30, depthOrArrayLayers: 528}
+*/
+{
+  source: video18,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 6, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext54.unconfigure();
+} catch {}
+let commandEncoder191 = device5.createCommandEncoder({label: '\ua24b\u{1fe63}\u005d\u{1f848}'});
+try {
+computePassEncoder90.setBindGroup(6, bindGroup61, new Uint32Array(3791), 3626, 0);
+} catch {}
+try {
+renderBundleEncoder95.setBindGroup(6, bindGroup60, new Uint32Array(9669), 6476, 0);
+} catch {}
+try {
+device5.queue.writeBuffer(buffer26, 15764, new BigUint64Array(47197), 29740, 604);
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let commandEncoder192 = device5.createCommandEncoder({label: '\u{1fa81}\u{1f8c6}\u{1fc8b}\u073e\u0269'});
+try {
+renderBundleEncoder95.setBindGroup(4, bindGroup60);
+} catch {}
+try {
+device5.queue.writeBuffer(buffer26, 5432, new DataView(new ArrayBuffer(48770)), 29449, 2968);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+let videoFrame60 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(359, 694);
+let videoFrame61 = new VideoFrame(canvas56, {timestamp: 0});
+let img58 = await imageWithData(76, 71, '#dab909de', '#cc436f43');
+let commandEncoder193 = device5.createCommandEncoder({});
+let querySet115 = device5.createQuerySet({label: '\u{1f9f0}\u0b04\ua5d3\u08f9', type: 'occlusion', count: 576});
+let commandBuffer40 = commandEncoder193.finish();
+let texture129 = device5.createTexture({
+  label: '\u0a18\u5859\u{1f9a6}\u79af\uc209\u051f\u0469\ub0e1\ue3c0',
+  size: [384, 1, 1],
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+  await device5.popErrorScope();
+} catch {}
+try {
+commandEncoder192.clearBuffer(buffer24);
+dissociateBuffer(device5, buffer24);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device5,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device5.queue.writeBuffer(buffer26, 39672, new Int16Array(32229), 12287, 1060);
+} catch {}
+let promise60 = device5.queue.onSubmittedWorkDone();
+let gpuCanvasContext56 = offscreenCanvas43.getContext('webgpu');
+let video56 = await videoWithData();
+let img59 = await imageWithData(157, 237, '#1c96f2da', '#0de977af');
+let img60 = await imageWithData(64, 176, '#8947f1a7', '#c373976e');
+try {
+offscreenCanvas44.getContext('2d');
+} catch {}
+let commandEncoder194 = device4.createCommandEncoder({label: '\u{1fff8}\u{1fa15}\u0e17\u2785\u09c9\u532b\u3d4a\ud61d'});
+let querySet116 = device4.createQuerySet({label: '\u3194\uab35\u80d8\uc8ae\ud411\ub1b8\u{1f6c1}\uae71', type: 'occlusion', count: 657});
+let textureView257 = texture126.createView({label: '\uc89e\ua60f\u0457\uaba7\u03fd\u7eb1\u8f9b\u77dd', mipLevelCount: 2});
+let sampler105 = device4.createSampler({
+  label: '\u1919\u306e\u{1ff3b}\u3e1f\u0781\u{1fc48}\u6ba7\u{1fd41}\u{1f741}\u0713',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.18,
+  maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder87.drawIndexed(183, 97, 358_204_608, 265_187_447);
+} catch {}
+try {
+renderBundleEncoder93.setPipeline(pipeline152);
+} catch {}
+let pipeline163 = device4.createRenderPipeline({
+  label: '\u{1ffc9}\u1539',
+  layout: pipelineLayout24,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'constant'},
+  },
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 3024, shaderLocation: 15},
+          {format: 'sint32x2', offset: 3740, shaderLocation: 12},
+          {format: 'sint32x2', offset: 8028, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+let canvas62 = document.createElement('canvas');
+try {
+window.someLabel = commandBuffer40.label;
+} catch {}
+let textureView258 = texture122.createView({
+  label: '\u3369\u{1fc44}\u8093\u186a\u1ca8\u52f3',
+  aspect: 'stencil-only',
+  baseMipLevel: 5,
+  baseArrayLayer: 970,
+  arrayLayerCount: 27,
+});
+try {
+computePassEncoder90.setBindGroup(5, bindGroup61, []);
+} catch {}
+try {
+  await device5.popErrorScope();
+} catch {}
+let texture130 = device4.createTexture({
+  label: '\u01ae\uc50e\u17c4\u{1ffb5}\u{1fc4e}',
+  size: [300, 240, 1],
+  mipLevelCount: 3,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-5x4-unorm-srgb', 'astc-5x4-unorm'],
+});
+let renderBundle136 = renderBundleEncoder93.finish({label: '\u07bd\uef6b\u0124\u{1ff5c}\u{1f9a6}\ub309'});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderBundleEncoder87.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder87.drawIndexed(252, 51, 42_510_986, 397_744_783, 1_024_268_835);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline138);
+} catch {}
+try {
+renderBundleEncoder99.setVertexBuffer(5, buffer25, 21048, 1985);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img53,
+  origin: { x: 96, y: 17 },
+  flipY: true,
+}, {
+  texture: texture99,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext57 = canvas62.getContext('webgpu');
+document.body.prepend(img33);
+let texture131 = device3.createTexture({
+  label: '\u0d92\u{1fd9a}\u4d82\ud2c2\ua8ed\u3a43\u1d75\u044c\u605b',
+  size: [192],
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint'],
+});
+try {
+renderBundleEncoder85.setBindGroup(2, bindGroup24, new Uint32Array(8519), 2268, 0);
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer7, 293788, buffer19, 206016, 133036);
+dissociateBuffer(device3, buffer7);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder157.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 43, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder188.clearBuffer(buffer9, 25956, 134996);
+dissociateBuffer(device3, buffer9);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer9, 9348, new Int16Array(52056), 17713, 1496);
+} catch {}
+offscreenCanvas11.height = 108;
+let img61 = await imageWithData(187, 221, '#73b92547', '#f7208e8a');
+let pipelineLayout29 = device5.createPipelineLayout({
+  label: '\ua307\u7aa7\uea78\u3fc9\u{1fed3}\u0615\u{1fb7f}\ub993\uf789',
+  bindGroupLayouts: [bindGroupLayout54, bindGroupLayout54, bindGroupLayout54, bindGroupLayout54, bindGroupLayout54, bindGroupLayout54, bindGroupLayout54],
+});
+let querySet117 = device5.createQuerySet({label: '\u036d\u0c37\u0eba\u480b', type: 'occlusion', count: 408});
+let textureView259 = texture129.createView({label: '\ub2b0\u075b\u0a64', dimension: '2d', aspect: 'stencil-only', baseMipLevel: 1, mipLevelCount: 4});
+let renderBundleEncoder100 = device5.createRenderBundleEncoder({
+  label: '\ud668\u91cc\u51bc\u4a16\u22ee\u337c\u02f5\u5f07',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let renderBundle137 = renderBundleEncoder95.finish({label: '\u0c66\u10f0\ub60d\udf96\u{1fbd2}\uea1b\udb66'});
+let sampler106 = device5.createSampler({
+  label: '\u13d0\u{1f777}\u0b31\u0c49\u0344\u0971',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMinClamp: 4.781,
+  lodMaxClamp: 27.47,
+  compare: 'always',
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+  await promise60;
+} catch {}
+let bindGroup63 = device5.createBindGroup({label: '\ufc82\u82cb\u0c14\u04bc\u0091\ue315', layout: bindGroupLayout54, entries: []});
+let buffer27 = device5.createBuffer({label: '\u08f0\ua87c\u{1fbf6}', size: 39075, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let commandEncoder195 = device5.createCommandEncoder({label: '\u0eed\u2dfa\u2954\uef4b\u6470\u0e74\u{1fca4}\u{1fefb}\u4d3a\u2000'});
+let textureView260 = texture122.createView({
+  label: '\u{1fc78}\ubcaf\u0199\u2c02\ucef1\ub8bf\u55ac\u0fc1\u4789',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 366,
+  arrayLayerCount: 27,
+});
+let externalTexture101 = device5.importExternalTexture({label: '\uab6e\uf76d\u7d50\u91de\u0a5b', source: video24, colorSpace: 'srgb'});
+try {
+commandEncoder192.copyTextureToBuffer({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 384 widthInBlocks: 384 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2032 */
+  offset: 2032,
+  buffer: buffer26,
+}, {width: 384, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device5, buffer26);
+} catch {}
+let img62 = await imageWithData(63, 86, '#36062d06', '#387d6721');
+let buffer28 = device5.createBuffer({size: 190230, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let texture132 = device5.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 1394},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+let textureView261 = texture120.createView({
+  label: '\u3ead\u4ec3\ua97c\u050d\u4b5f\u{1fcd7}\u0298\udad3\u0b40\ue5fe',
+  dimension: '3d',
+  aspect: 'all',
+  baseMipLevel: 9,
+  mipLevelCount: 1,
+});
+let externalTexture102 = device5.importExternalTexture({label: '\u{1f8f3}\ud31f\u0057\u0eff', source: videoFrame15, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder100.setBindGroup(3, bindGroup61, new Uint32Array(1429), 703, 0);
+} catch {}
+try {
+commandEncoder191.clearBuffer(buffer26, 78556, 8648);
+dissociateBuffer(device5, buffer26);
+} catch {}
+let texture133 = device3.createTexture({
+  label: '\uec0b\ufb72\u00d2',
+  size: {width: 96, height: 7, depthOrArrayLayers: 148},
+  mipLevelCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView262 = texture37.createView({
+  label: '\u0671\u095d\u5e6e\u0bba\u{1f6b6}',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 5,
+});
+let sampler107 = device3.createSampler({
+  label: '\u17df\u{1f6a3}\ue34a\u0a99\u0db0\u0051\u0933\u{1fb05}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.80,
+  lodMaxClamp: 83.09,
+});
+let externalTexture103 = device3.importExternalTexture({label: '\ud016\u{1f66e}\u6b9c\u0984', source: videoFrame25});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 13, y: 3 },
+  flipY: true,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline164 = await promise58;
+let img63 = await imageWithData(255, 238, '#3286e846', '#3572c6e5');
+try {
+adapter11.label = '\u22c1\u86f8\u0122\u7dd7\uedcb';
+} catch {}
+let imageBitmap61 = await createImageBitmap(img37);
+let imageData56 = new ImageData(128, 180);
+try {
+window.someLabel = externalTexture84.label;
+} catch {}
+let bindGroup64 = device4.createBindGroup({
+  label: '\u01a2\u53ac',
+  layout: bindGroupLayout58,
+  entries: [{binding: 4575, resource: externalTexture88}],
+});
+let buffer29 = device4.createBuffer({
+  label: '\ucd2a\u87cd\u0c37\u05a1\u2d76\u0458',
+  size: 189772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder196 = device4.createCommandEncoder();
+let commandBuffer41 = commandEncoder178.finish();
+let textureView263 = texture118.createView({label: '\ub2ab\u0ec7\u{1f92d}'});
+let renderBundleEncoder101 = device4.createRenderBundleEncoder({
+  colorFormats: ['rg11b10ufloat', 'r8sint', 'r32float', 'r16float', 'bgra8unorm', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder87.drawIndexed(315, 634, 541_779_238, 301_121_755, 796_885_004);
+} catch {}
+try {
+commandEncoder186.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 3,
+  origin: {x: 53, y: 0, z: 111},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline165 = await device4.createRenderPipelineAsync({
+  label: '\u04e4\u5fea\u5882\u0630',
+  layout: pipelineLayout27,
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4380,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 1980, shaderLocation: 3},
+          {format: 'uint8x4', offset: 220, shaderLocation: 6},
+          {format: 'float16x2', offset: 440, shaderLocation: 4},
+          {format: 'float16x2', offset: 104, shaderLocation: 12},
+          {format: 'float32x4', offset: 264, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 7004,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 4520, shaderLocation: 2}],
+      },
+      {arrayStride: 2172, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7624,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 3328, shaderLocation: 5},
+          {format: 'uint8x2', offset: 610, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 40, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 2420,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 176, shaderLocation: 11}],
+      },
+      {arrayStride: 1136, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 7208, attributes: [{format: 'sint16x4', offset: 476, shaderLocation: 8}]},
+    ],
+  },
+});
+let buffer30 = device4.createBuffer({
+  label: '\u8223\ubd56\u05e2\u3e9e\u35e8\u794e\uf00b\uc137\ua20f\u{1f903}',
+  size: 33232,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture134 = device4.createTexture({
+  label: '\u6cc6\u{1f8ec}\u{1fed2}\u{1fb18}\u92fe',
+  size: [120, 1, 1],
+  mipLevelCount: 4,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView264 = texture104.createView({
+  label: '\u012e\u0bbb\u7519\u0ec0\u41d5\uc76e\u{1ffb2}\u{1fe32}\u0b4d',
+  dimension: '2d-array',
+  arrayLayerCount: 1,
+});
+let renderBundle138 = renderBundleEncoder101.finish({label: '\u{1ff40}\ud031\u8661'});
+let sampler108 = device4.createSampler({
+  label: '\uf442\u95b5\ue35a\u5f69\uacea',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 37.26,
+  lodMaxClamp: 62.06,
+});
+try {
+renderBundleEncoder99.setPipeline(pipeline152);
+} catch {}
+let pipeline166 = await promise59;
+let img64 = await imageWithData(162, 49, '#cb4b0738', '#8f27c62a');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame52.close();
+videoFrame53.close();
+videoFrame54.close();
+videoFrame55.close();
+videoFrame56.close();
+videoFrame57.close();
+videoFrame58.close();
+videoFrame59.close();
+videoFrame60.close();
+videoFrame61.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('DONE');
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -318,6 +318,7 @@ void PresentationContextIOSurface::present()
         computeDescriptor.dispatchType = MTLDispatchTypeSerial;
 
         id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoderWithDescriptor:computeDescriptor];
+        m_device->getQueue().setEncoderForBuffer(commandBuffer, computeEncoder);
         [computeEncoder setComputePipelineState:m_computePipelineState];
         id<MTLTexture> inputTexture = texturePtr->texture();
         [computeEncoder setTexture:inputTexture atIndex:0];
@@ -329,7 +330,7 @@ void PresentationContextIOSurface::present()
         threadgroupCount.height = (inputTexture.height + threadgroupSize.height - 1) / threadgroupSize.height;
         threadgroupCount.depth = 1;
         [computeEncoder dispatchThreadgroups:threadgroupCount threadsPerThreadgroup:threadgroupSize];
-        [computeEncoder endEncoding];
+        m_device->getQueue().endEncoding(computeEncoder, commandBuffer);
         m_device->getQueue().commitMTLCommandBuffer(commandBuffer);
     }
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -81,6 +81,7 @@ public:
     id<MTLCommandEncoder> encoderForBuffer(id<MTLCommandBuffer>) const;
     void clearTextureViewIfNeeded(TextureView&);
     static bool writeWillCompletelyClear(WGPUTextureDimension, uint32_t widthForMetal, uint32_t logicalSizeWidth, uint32_t heightForMetal, uint32_t logicalSizeHeight, uint32_t depthForMetal, uint32_t logicalSizeDepthOrArrayLayers);
+    void endEncoding(id<MTLCommandEncoder>, id<MTLCommandBuffer>) const;
 
 private:
     Queue(id<MTLCommandQueue>, Device&);


### PR DESCRIPTION
#### 03357c10dff8f6a1eddb15a6faeb1f8ee4ccb7d0
<pre>
-[MTLCommandBuffer commit] may be called while encoding is still in progress
<a href="https://bugs.webkit.org/show_bug.cgi?id=274275">https://bugs.webkit.org/show_bug.cgi?id=274275</a>
&lt;radar://128201828&gt;

Reviewed by Dan Glastonbury.

Ensure we don&apos;t leave encoders open or commit command buffers
before encoding has ended.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274275-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274275.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::endEncoding):
(WebGPU::CommandEncoder::runClearEncoder):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::~Queue):
(WebGPU::Queue::ensureBlitCommandEncoder):
(WebGPU::Queue::finalizeBlitCommandEncoder):
(WebGPU::Queue::endEncoding const):
(WebGPU::Queue::setEncoderForBuffer):
Centralize endEncoding calls.

Canonical link: <a href="https://commits.webkit.org/279008@main">https://commits.webkit.org/279008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5bb4b0bf8281f92891f601a32f659814e5a055a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54304 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29172 "1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23560 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57078 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27333 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49882 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45179 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49121 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11416 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29479 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64023 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28311 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12122 "Passed tests") | 
<!--EWS-Status-Bubble-End-->