### PR TITLE
Add smart pointers to CookieStore and CookieJar

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -90,6 +90,7 @@ private:
 
     class MainThreadBridge;
     Ref<MainThreadBridge> m_mainThreadBridge;
+    Ref<MainThreadBridge> protectedMainThreadBridge() const;
 
     bool m_hasChangeEventListener { false };
     WeakPtr<CookieJar> m_cookieJar;

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -86,6 +86,7 @@ protected:
 
 private:
     Ref<StorageSessionProvider> m_storageSessionProvider;
+    Ref<StorageSessionProvider> protectedStorageSessionProvider() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -121,8 +121,12 @@ public:
     virtual void cookieEnabledStateMayHaveChanged() = 0;
 };
 
-class NetworkStorageSession : public CanMakeWeakPtr<NetworkStorageSession> {
-    WTF_MAKE_NONCOPYABLE(NetworkStorageSession); WTF_MAKE_FAST_ALLOCATED;
+class NetworkStorageSession
+    : public CanMakeWeakPtr<NetworkStorageSession>
+    , public CanMakeCheckedPtr<NetworkStorageSession> {
+    WTF_MAKE_NONCOPYABLE(NetworkStorageSession);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkStorageSession);
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     using TopFrameDomain = WebCore::RegistrableDomain;
     using SubResourceDomain = WebCore::RegistrableDomain;


### PR DESCRIPTION
#### 1963873fe29814ca67ea08fe3afea222fa6ad311
<pre>
Add smart pointers to CookieStore and CookieJar
<a href="https://bugs.webkit.org/show_bug.cgi?id=274285">https://bugs.webkit.org/show_bug.cgi?id=274285</a>
<a href="https://rdar.apple.com/128231784">rdar://128231784</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):
(WebCore::CookieStore::MainThreadBridge::get):
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::set):
(WebCore::CookieStore::eventListenersDidChange):
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::cookies const):
(WebCore::CookieJar::cookieRequestHeaderFieldProxy):
(WebCore::CookieJar::setCookies):
(WebCore::CookieJar::cookiesEnabled):
(WebCore::CookieJar::cookieRequestHeaderFieldValue const):
(WebCore::CookieJar::getRawCookies const):
(WebCore::CookieJar::setRawCookie):
(WebCore::CookieJar::deleteCookie):

Canonical link: <a href="https://commits.webkit.org/279064@main">https://commits.webkit.org/279064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d0a7e7a38299a2938680cc727d70c833c93bb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42496 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1882 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45176 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49125 "2 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11444 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->