### PR TITLE
Add missing includes

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "AXTextMarker.h"
 
+#include "AXIsolatedObject.h"
 #include "AXLogger.h"
 #include "AXObjectCache.h"
 #include "AXTreeStore.h"

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityTableRow.h"
 
+#include "AXObjectCache.h"
 #include "AccessibilityTable.h"
 #include "AccessibilityTableCell.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -32,6 +32,7 @@
 #import "AccessibilityObject.h"
 #import "AccessibilityTable.h"
 #import "DeprecatedGlobalSettings.h"
+#import "LocalFrameView.h"
 #import "RenderObject.h"
 #import "WebAccessibilityObjectWrapperMac.h"
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -45,6 +45,7 @@
 #import "TextCheckerClient.h"
 #import "TextCheckingHelper.h"
 #import "TextDecorationPainter.h"
+#import "TextIterator.h"
 #import <wtf/cocoa/SpanCocoa.h>
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AcceleratedEffect.h"
 #include "AnimationEffect.h"
 #include "AnimationEffectPhase.h"
 #include "BlendingKeyframes.h"

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMExceptionHandling.h"
 #include "LocalDOMWindow.h"
 #include "Node.h"
+#include "SVGNames.h"
 #include "Text.h"
 #include "TrustedTypePolicy.h"
 #include "TrustedTypePolicyFactory.h"

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -29,6 +29,7 @@
 #include "CommonVM.h"
 #include "CustomElementReactionQueue.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "HTMLSlotElement.h"
 #include "IdleCallbackController.h"
 #include "Microtasks.h"

--- a/Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm
+++ b/Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm
@@ -25,8 +25,11 @@
 #import "config.h"
 #import "WebCoreTextAttachment.h"
 
+#import <pal/spi/ios/UIKitSPI.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
+
+#import <pal/ios/UIKitSoftLink.h>
 
 id webCoreTextAttachmentMissingPlatformImage()
 {

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -39,6 +39,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameSelection.h"
+#include "GCReachableRef.h"
 #include "HTMLBRElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -40,6 +40,7 @@
 #include "HTMLNames.h"
 #include "HTMLSourceElement.h"
 #include "HTMLStyleElement.h"
+#include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "RawDataDocumentParser.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -29,6 +29,7 @@
 #import "Logging.h"
 #import "PlatformCALayer.h"
 #import "PlatformCALayerContentsDelayedReleaser.h"
+#import "ScrollingThread.h"
 #import "ScrollingTreeFixedNodeCocoa.h"
 #import "ScrollingTreeFrameHostingNode.h"
 #import "ScrollingTreeFrameScrollingNodeMac.h"

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "GameControllerHapticEngines.h"
 #include "PlatformGamepad.h"
 #include <wtf/RetainPtr.h>
 

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FloatRect.h"
 #include "IntSize.h"
 #include <wtf/RetainPtr.h>
 

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -30,6 +30,7 @@
 
 #import "ColorSpaceCG.h"
 #import "FloatRoundedRect.h"
+#import "GraphicsContext.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -40,6 +40,7 @@
 #include "NotificationClient.h"
 #include "NotificationPermission.h"
 #include "PushEvent.h"
+#include "PushNotificationEvent.h"
 #include "ServiceWorker.h"
 #include "ServiceWorkerContainer.h"
 #include "ServiceWorkerGlobalScope.h"


### PR DESCRIPTION
#### a4419835c757259fb8da9681e41f4d480eef2860
<pre>
Add missing includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=274288">https://bugs.webkit.org/show_bug.cgi?id=274288</a>
<a href="https://rdar.apple.com/128238584">rdar://128238584</a>

Unreviewed build fixes.

Add missing includes seen when experimenting with varying sizes of unified source bundles.

* Source/WebCore/accessibility/AXTextMarker.cpp:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/dom/TrustedType.cpp:
* Source/WebCore/dom/WindowEventLoop.cpp:
* Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
* Source/WebCore/html/ModelDocument.cpp:
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h:
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:

Canonical link: <a href="https://commits.webkit.org/278900@main">https://commits.webkit.org/278900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f248a3c7da9cc3616932575a6d89fcb6c9615a03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2286 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23338 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56742 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44865 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11334 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29138 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->