### PR TITLE
[WebGPU] Queue may try to encode blit operations on detached encoder

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2129,6 +2129,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274317.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274334.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274334.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274289.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274289.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274289-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274289-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274289.html
+++ b/LayoutTests/fast/webgpu/fuzz-274289.html
@@ -1,0 +1,17784 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u5f2c\u4bc8',
+  defaultQueue: {label: '\u{1fd58}\u0dd9\u75ba\u5628\uff4b\u803b\u4dea\u2863\u0221\u0987\u{1f9db}'},
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 35,
+    maxVertexBufferArrayStride: 32093,
+    maxStorageTexturesPerShaderStage: 24,
+    maxDynamicStorageBuffersPerPipelineLayout: 10983,
+    maxDynamicUniformBuffersPerPipelineLayout: 7317,
+    maxBindingsPerBindGroup: 3942,
+    maxTextureArrayLayers: 1264,
+    maxTextureDimension1D: 12030,
+    maxTextureDimension2D: 14227,
+    maxVertexBuffers: 12,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 105226462,
+    maxStorageBufferBindingSize: 156491256,
+    maxUniformBuffersPerShaderStage: 43,
+    maxSampledTexturesPerShaderStage: 30,
+    maxInterStageShaderVariables: 75,
+    maxInterStageShaderComponents: 60,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder0.finish({label: '\u7ee7\u{1f6fd}\u{1fd74}\u001c\u{1f904}\u213a\ue406'});
+let promise1 = device0.popErrorScope();
+try {
+  await promise1;
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(786, 408);
+let commandEncoder1 = device0.createCommandEncoder({label: '\u6cea\u8435\u02b0\ua947\u0fc7\u{1fce4}\u0406'});
+let commandBuffer1 = commandEncoder1.finish({label: '\u{1f9cf}\u{1fb1a}\u1672'});
+let offscreenCanvas1 = new OffscreenCanvas(945, 305);
+let imageData0 = new ImageData(172, 240);
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+gc();
+let commandEncoder2 = device0.createCommandEncoder({});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u9062\uf1c5\uaf79',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let videoFrame0 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u0c91\ua744\u9a7a\u5d90\u{1fd01}\u0edd\u0fc1\u{1fdfc}\u61ae\u{1f828}\u2eef',
+  entries: [
+    {
+      binding: 2198,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 55,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 1303, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let externalTexture0 = device0.importExternalTexture({
+  label: '\u{1fff3}\u2a34\u08e9\u{1f83c}\u0d6f\u9003\u0fc0\u0a2e\uf038\u181d',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder0.setVertexBuffer(7346, undefined, 2335776161, 252579667);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let adapter1 = await promise0;
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({label: '\u{1fd33}\u4a5b\u95e7\u06e1\u0326\u9148\u4a0c', colorFormats: ['r32uint', 'r32uint']});
+let renderBundle0 = renderBundleEncoder1.finish({});
+let sampler0 = device0.createSampler({
+  label: '\u007a\ub3cc\ua247\u0397\ub5b6\u081f\u4584\u09b2',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 85.92,
+  lodMaxClamp: 86.40,
+});
+try {
+renderBundleEncoder0.setVertexBuffer(5583, undefined, 1966748848, 600005531);
+} catch {}
+let img0 = await imageWithData(179, 245, '#c2ceed2c', '#940dc4e9');
+try {
+offscreenCanvas0.getContext('webgl2');
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u0c2d\u488e\u10bd\u{1f957}\uacc9\u0f06\u51d1\u1255\u{1fe4f}\u0dc5\u0fb7',
+  entries: [{binding: 2477, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+let bindGroup0 = device0.createBindGroup({
+  label: '\u02ef\u8d87\u2fde',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 55, resource: sampler0},
+    {binding: 1303, resource: externalTexture0},
+    {binding: 2198, resource: sampler0},
+  ],
+});
+let texture0 = device0.createTexture({
+  label: '\u5f51\u09b4\ue54b\u7287\u{1fbd6}',
+  size: {width: 240, height: 768, depthOrArrayLayers: 929},
+  mipLevelCount: 5,
+  format: 'astc-12x12-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let bindGroup1 = device0.createBindGroup({
+  label: '\u5d24\uc9e3\u03c5',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 55, resource: sampler0},
+    {binding: 2198, resource: sampler0},
+    {binding: 1303, resource: externalTexture0},
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1]});
+let texture1 = device0.createTexture({
+  size: {width: 1920, height: 1, depthOrArrayLayers: 342},
+  mipLevelCount: 8,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let textureView0 = texture1.createView({
+  label: '\ua3c0\u{1f90f}\u0053\u0e21\u799a\u6c80\ube9b\u0024\u0bed\u5283',
+  dimension: '2d',
+  baseMipLevel: 7,
+  baseArrayLayer: 286,
+});
+let computePassEncoder0 = commandEncoder2.beginComputePass();
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.97,
+  lodMaxClamp: 90.63,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(6784), 2831, 0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(7202, undefined, 3106359825, 1175901162);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 74},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(48)), /* required buffer size: 7_702_335 */
+{offset: 351, bytesPerRow: 1823, rowsPerImage: 128}, {width: 408, height: 1, depthOrArrayLayers: 34});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u{1f9fa}\ubaa2\u7963',
+  code: `@group(0) @binding(2477)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(4, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec2<u32>,
+  @location(7) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(a0: S1, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(2) f0: f16,
+  @location(14) f1: vec4<f16>,
+  @location(0) f2: vec2<f32>,
+  @location(12) f3: vec2<u32>,
+  @location(1) f4: i32,
+  @location(3) f5: vec3<u32>,
+  @location(9) f6: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(4) a1: vec4<f16>, @location(5) a2: vec4<i32>, @location(13) a3: vec3<i32>, @builtin(vertex_index) a4: u32, a5: S0, @location(15) a6: vec4<i32>, @location(6) a7: vec4<f32>, @location(10) a8: f16, @location(11) a9: f16, @builtin(instance_index) a10: u32, @location(7) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({entries: []});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView1 = texture0.createView({label: '\u87d1\u{1fa9b}\u0655', dimension: '2d', baseMipLevel: 0, baseArrayLayer: 308});
+let sampler2 = device0.createSampler({
+  label: '\u0890\uf5ab\u0faa\u0a22\u0274\ub257\u018a\u0841',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.02,
+  lodMaxClamp: 99.63,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\uc157\u03ff\u5efd\u{1f6a8}\u12ea\uc2f5\u{1fe32}\u{1fa1a}\u0773\u52cc\u{1f6e0}',
+  code: `@group(0) @binding(2477)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(5, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @builtin(front_facing) f0: bool,
+  @builtin(position) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32,
+  @builtin(sample_index) f3: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(3) f1: u32,
+  @location(0) f2: vec4<u32>,
+  @location(6) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S2) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup2 = device0.createBindGroup({
+  label: '\ue598\u0b18\u{1fa10}\u03ed',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 2198, resource: sampler1},
+    {binding: 1303, resource: externalTexture0},
+    {binding: 55, resource: sampler0},
+  ],
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u9d48\u{1f754}\u2418\u2a73\u12da\u{1f6b6}\u0df6'});
+let texture2 = device0.createTexture({
+  label: '\u6d49\u27ea\u5213\u9635\u043a\u0367\u00a9\u4444\udfb8',
+  size: {width: 1401, height: 1, depthOrArrayLayers: 1069},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView2 = texture0.createView({
+  label: '\ua043\u5f39\u6909',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 719,
+  arrayLayerCount: 12,
+});
+try {
+renderBundleEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(7084), 4489, 0);
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({label: '\u1a66\u4ed9\u0546\u0683\u9fd5\u35a0\u09d9\u06fc\u6af5'});
+let computePassEncoder1 = commandEncoder5.beginComputePass({});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1ff44}\u076e\uc8b4\uc9ff\uca7a\uc4f3\u0c8a\u847b\u{1f7b8}\u9a67'});
+let sampler3 = device0.createSampler({
+  label: '\u0286\ufc7d\uce35\uef91\u{1fa58}\u{1ff0d}\u5680\u0821\u69fb\u{1f94e}\u0031',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.70,
+  lodMaxClamp: 92.39,
+  maxAnisotropy: 13,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let textureView3 = texture1.createView({
+  label: '\u994d\u03c4\u{1fcb4}\u2662\u{1f9ba}\u0cef\u2de3\u7f86\u9013',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 182,
+  arrayLayerCount: 56,
+});
+try {
+computePassEncoder0.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 49_091_917 */
+{offset: 333, bytesPerRow: 764, rowsPerImage: 251}, {width: 123, height: 0, depthOrArrayLayers: 257});
+} catch {}
+offscreenCanvas0.width = 744;
+let bindGroup3 = device0.createBindGroup({
+  label: '\u4654\u259f\ude77\u07ef\u{1f7c4}',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 55, resource: sampler0},
+    {binding: 2198, resource: sampler3},
+    {binding: 1303, resource: externalTexture0},
+  ],
+});
+let texture3 = device0.createTexture({
+  label: '\u{1f8fd}\u708f\u{1fea5}\u{1f9b2}\u36d5',
+  size: {width: 350, height: 1, depthOrArrayLayers: 1546},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32uint'],
+});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u0469\u02e1\u7e01\u{1f887}\u{1f811}\u1046\u42a9\u7854\u{1fcd9}\u23ad'});
+let externalTexture1 = device0.importExternalTexture({label: '\ue1ea\u22d8\uf758\u{1ff16}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+  label: '\u54fb\u1852\u{1f6d6}\ud63b\u1867\u08c8\u{1fd15}\u7cd4\u0a74\u57de',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout3 = device0.createBindGroupLayout({label: '\u021b\u08b6', entries: []});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u0852\u0b6c\u0280\udcdb\u778c\u621f\u6064\u0f82\u098d\ud6dd\u5f4c'});
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\ue594\ub7de\uadea\uee18\u0836',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x98d60d77},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilReadMask: 2912537652,
+    depthBias: -1496461161,
+    depthBiasSlopeScale: 227.52209491668606,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4500,
+        attributes: [
+          {format: 'sint32x4', offset: 880, shaderLocation: 15},
+          {format: 'sint32x4', offset: 168, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 656, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 12168, attributes: [{format: 'sint8x2', offset: 5672, shaderLocation: 13}]},
+      {
+        arrayStride: 12076,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 2892, shaderLocation: 10},
+          {format: 'float16x4', offset: 752, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 6852, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 648, shaderLocation: 4},
+          {format: 'uint32x4', offset: 1036, shaderLocation: 3},
+          {format: 'uint8x2', offset: 908, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 1604, shaderLocation: 0},
+          {format: 'uint8x4', offset: 3896, shaderLocation: 7},
+          {format: 'float16x2', offset: 928, shaderLocation: 11},
+          {format: 'float32', offset: 3548, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 1580, shaderLocation: 14},
+          {format: 'sint32x4', offset: 88, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'back'},
+});
+let video0 = await videoWithData();
+let bindGroup4 = device0.createBindGroup({label: '\u664a\u{1fd7f}\ub81d\u{1f8fe}', layout: bindGroupLayout3, entries: []});
+let commandEncoder9 = device0.createCommandEncoder({});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\uafd2\u0d91\u{1fd32}\ucf34\u{1faa2}\u6df2\u{1fca2}\u46c2\u49d4\u34e0'});
+try {
+computePassEncoder0.end();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(706, 1004);
+let imageBitmap0 = await createImageBitmap(videoFrame0);
+let bindGroup5 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 1303, resource: externalTexture1},
+    {binding: 2198, resource: sampler3},
+    {binding: 55, resource: sampler0},
+  ],
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({});
+let externalTexture2 = device0.importExternalTexture({
+  label: '\u1412\u2f43\u1bf3\u6941\u02bb\udbb8\u{1fb81}\u9a7b\u{1f6bf}\u41ad',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(5, bindGroup5, new Uint32Array(2682), 2499, 0);
+} catch {}
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let buffer0 = device0.createBuffer({
+  label: '\u041c\u8952\u0077\u99e5\u007a\u{1fd92}\ub34f\u{1f60a}',
+  size: 529896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let textureView4 = texture1.createView({
+  label: '\ub681\u3ea7\u0ee4\u1d09\u00ee\u07ce',
+  dimension: '2d',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 101,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u{1ff41}\u0c4c\u0b06\u8de0\u5d74\ucfa9',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(0)), /* required buffer size: 29_309_310 */
+{offset: 48, bytesPerRow: 311, rowsPerImage: 278}, {width: 11, height: 0, depthOrArrayLayers: 340});
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+offscreenCanvas1.height = 3294;
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandBuffer2 = commandEncoder9.finish({label: '\u{1ff4a}\u2ad4\u73a5\uaca7\u{1f850}'});
+let texture4 = device0.createTexture({
+  size: {width: 700, height: 1, depthOrArrayLayers: 1282},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true});
+let renderBundle4 = renderBundleEncoder3.finish({label: '\ubaa6\u028b\u2fae\u{1f79c}\udeb8\u{1ff1b}'});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(4, bindGroup2, new Uint32Array(9890), 9207, 0);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let video1 = await videoWithData();
+let textureView5 = texture0.createView({baseMipLevel: 1, baseArrayLayer: 215, arrayLayerCount: 205});
+let renderBundle5 = renderBundleEncoder2.finish();
+let externalTexture3 = device0.importExternalTexture({
+  label: '\u2115\u{1f638}\u6c66\u{1fca6}\ufcee\u{1fbb2}\u59aa\u6c1e\u0fda\u{1fc8e}\u1be1',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+adapter0.label = '\u{1fd49}\u0e01';
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\ua2f5\u{1f906}\u0d45\u{1f989}\u{1f95c}\ud6b0\u41cd',
+  code: `@group(0) @binding(2477)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(1) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(51) f0: vec2<f16>,
+  @location(15) f1: vec4<f16>,
+  @location(43) f2: f16,
+  @location(19) f3: vec4<f16>,
+  @location(16) f4: vec2<f16>,
+  @location(20) f5: vec3<f16>,
+  @location(67) f6: vec2<u32>,
+  @location(18) f7: vec3<f32>,
+  @location(34) f8: vec2<i32>,
+  @location(58) f9: i32,
+  @location(25) f10: vec4<f16>,
+  @location(13) f11: i32,
+  @location(35) f12: vec3<i32>,
+  @location(32) f13: f16,
+  @location(12) f14: i32,
+  @location(55) f15: vec3<u32>,
+  @location(24) f16: vec3<i32>,
+  @location(60) f17: vec2<i32>,
+  @location(1) f18: vec3<f32>,
+  @location(54) f19: vec3<i32>,
+  @location(10) f20: vec3<f32>,
+  @location(63) f21: i32,
+  @builtin(position) f22: vec4<f32>,
+  @location(47) f23: vec3<f32>,
+  @location(22) f24: vec2<f16>,
+  @location(38) f25: vec2<i32>,
+  @location(68) f26: f32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(9) a1: u32, @location(8) a2: vec4<f16>, @location(4) a3: vec3<i32>, @location(14) a4: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1fa65}\u8207\ua8b4\u0213\u0432\u555f\u{1fee9}'});
+let textureView6 = texture1.createView({dimension: '2d', baseMipLevel: 6, baseArrayLayer: 312});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler4 = device0.createSampler({
+  label: '\u{1f9d6}\uee7d\u9e3a\u9564\uafde\ua30e\u3424\u24e1\u7461\u{1ff62}\u2987',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.12,
+  lodMaxClamp: 32.46,
+  maxAnisotropy: 19,
+});
+try {
+commandEncoder7.clearBuffer(buffer0, 304092, 39096);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline2 = device0.createComputePipeline({
+  label: '\u{1fca3}\u{1fa08}\u016a\u7256\u0e37\uae6a',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup6 = device0.createBindGroup({label: '\u1673\u{1feb5}', layout: bindGroupLayout3, entries: []});
+let querySet0 = device0.createQuerySet({label: '\ua29b\u03de', type: 'occlusion', count: 814});
+let texture5 = device0.createTexture({
+  size: {width: 120, height: 384, depthOrArrayLayers: 171},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let textureView7 = texture1.createView({label: '\u05ad\u1988\u0843\u7c67\u992c\ud9c7', dimension: '2d', baseMipLevel: 6, baseArrayLayer: 264});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u8d90\u92f5\u57a4\ue7c9\u7206',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder4.setVertexBuffer(3965, undefined, 0);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 2, y: 51, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 9, depthOrArrayLayers: 4});
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let bindGroup7 = device0.createBindGroup({label: '\u4679\u201c\u{1fb14}\uc673', layout: bindGroupLayout3, entries: []});
+let commandEncoder11 = device0.createCommandEncoder({label: '\uf1ae\u085b\u{1fd8d}'});
+let commandBuffer3 = commandEncoder7.finish({label: '\u8385\u90a7\ue850\u7da0\u7c49'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u646c\u04e8\u0616\u0b15\u{1fec2}\uab5d',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture4 = device0.importExternalTexture({
+  label: '\u0af6\u{1fd16}\u{1f8e2}\u{1fcff}\u024a\u{1f6df}\u{1fa38}\ucbb3\uc66e\ub62c\u7002',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder4.setBindGroup(5, bindGroup3, new Uint32Array(2354), 1048, 0);
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({
+  label: '\u70aa\u1d27\u41b7\u7550\u7c7c\u079a\u3c27\u{1fb0a}\u9301\uc1f2\u8ba6',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame1 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u30a3\u027c\uea97', bindGroupLayouts: []});
+let computePassEncoder3 = commandEncoder3.beginComputePass({label: '\u3c05\u0f2e\u{1f619}\u{1f723}'});
+try {
+renderBundleEncoder6.setVertexBuffer(7666, undefined);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder8.insertDebugMarker('\u6d48');
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({});
+let textureView8 = texture1.createView({
+  label: '\u01f7\u1208\u1989\uc1f0',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 191,
+  arrayLayerCount: 147,
+});
+let computePassEncoder4 = commandEncoder6.beginComputePass({label: '\u707e\u4bde\u8d62\u3fc4\u0606'});
+let renderBundle6 = renderBundleEncoder5.finish({label: '\u04c2\u0e49\u072a\uf1de\u5c8a\u0a30'});
+let externalTexture5 = device0.importExternalTexture({
+  label: '\u{1f7b4}\u0ca1\u{1f60b}\u7ca2\u0d1e\u{1fb56}\ucfa4\u74c4\ua790',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline4 = device0.createComputePipeline({
+  label: '\u{1fb2a}\u{1f776}\u85b2\u097c\u066d\u2cbe\u02a1',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline5 = await device0.createRenderPipelineAsync({
+  label: '\u0384\u0e5a\u{1fea3}\u321b\u249c\u0b39\u0043\u{1fb55}\ub0ab\u0c91\u05d0',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xa998be1d},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 99745716,
+    stencilWriteMask: 898694763,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 176.07212433408068,
+  },
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', unclippedDepth: true},
+});
+gc();
+let video2 = await videoWithData();
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3796,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 3374, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\uaa59\u{1fab1}\u{1f9d2}\u3372\udd89\udf1e\u3a7b\u{1f765}\u04f7\u{1f71a}\u{1fd2a}'});
+let commandBuffer4 = commandEncoder10.finish({label: '\uc49c\ue976\u{1f8be}\u0ab7'});
+let sampler5 = device0.createSampler({
+  label: '\ud788\u06f1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.02,
+  lodMaxClamp: 96.79,
+  maxAnisotropy: 3,
+});
+let externalTexture6 = device0.importExternalTexture({label: '\ub4ab\u02ed\u10b4', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3, commandBuffer1, commandBuffer4, commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 31, z: 72},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(56)), /* required buffer size: 498_694 */
+{offset: 294, bytesPerRow: 412, rowsPerImage: 502}, {width: 73, height: 206, depthOrArrayLayers: 3});
+} catch {}
+let pipeline6 = device0.createRenderPipeline({
+  label: '\uc408\uce11\u{1fdf5}\u0ecc\u7e29\u4104',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 4888, attributes: []},
+      {
+        arrayStride: 10592,
+        attributes: [
+          {format: 'uint16x2', offset: 680, shaderLocation: 12},
+          {format: 'sint32x2', offset: 580, shaderLocation: 13},
+          {format: 'sint32x2', offset: 5096, shaderLocation: 15},
+          {format: 'sint32x4', offset: 980, shaderLocation: 5},
+          {format: 'uint16x4', offset: 1076, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 640,
+        attributes: [
+          {format: 'unorm16x2', offset: 104, shaderLocation: 4},
+          {format: 'float32x3', offset: 36, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 88, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 120, shaderLocation: 10},
+          {format: 'float32x3', offset: 76, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 140, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 160, shaderLocation: 0},
+          {format: 'sint32', offset: 4, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 8516,
+        attributes: [
+          {format: 'snorm8x2', offset: 1408, shaderLocation: 11},
+          {format: 'uint32x3', offset: 480, shaderLocation: 7},
+          {format: 'float16x2', offset: 4080, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let offscreenCanvas3 = new OffscreenCanvas(88, 244);
+let imageBitmap1 = await createImageBitmap(img0);
+let textureView9 = texture2.createView({
+  label: '\u21fc\u1278\ua02c\ue2e2\u13fb\u0034\u{1fe8f}\udcc7\u0343\u0b93',
+  baseMipLevel: 4,
+  mipLevelCount: 4,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u{1f6c8}\u4a7f\u02a9\uca82',
+  colorFormats: ['r32uint', 'r32uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle7 = renderBundleEncoder3.finish({label: '\u{1fa19}\uab21\u28b9'});
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 2, y: 2, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 17, y: 5, z: 12},
+  aspect: 'all',
+},
+{width: 4, height: 31, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas3.getContext('webgpu');
+let buffer1 = device0.createBuffer({size: 96532, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder14 = device0.createCommandEncoder({label: '\u{1fcbd}\u818b\u{1f995}\u0f2b\uf372'});
+let texture6 = device0.createTexture({
+  label: '\u0366\ua925\ufde0',
+  size: [960, 1, 589],
+  mipLevelCount: 2,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle8 = renderBundleEncoder5.finish();
+try {
+bindGroupLayout3.label = '\u020b\ub55f\u9f26\u0718';
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder({label: '\u7a05\ue307\u0739'});
+let textureView10 = texture5.createView({label: '\ued90\u77f5\u3a47\u9334\ud699\ua1ff\ud878\u2271', baseMipLevel: 3, mipLevelCount: 2});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({
+  label: '\u5807\u046f\uc706',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let canvas0 = document.createElement('canvas');
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u76a8\u1ed9\ueef9\uc24e\u{1fc40}\u09eb\u026d',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout4, bindGroupLayout0],
+});
+try {
+commandEncoder12.copyBufferToBuffer(buffer1, 41624, buffer0, 149572, 30820);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder11.insertDebugMarker('\ud6f1');
+} catch {}
+let imageData1 = new ImageData(4, 56);
+let commandBuffer5 = commandEncoder12.finish({label: '\u9512\u0eea\u8b4d\u{1f98c}\u{1fb35}'});
+let computePassEncoder5 = commandEncoder8.beginComputePass({label: '\u{1f8d6}\u6741\u00c3\u078f\u6b8d\u0c07\u3642'});
+try {
+computePassEncoder2.setBindGroup(4, bindGroup0, new Uint32Array(7651), 4156, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3802, undefined, 1945201148);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(0, 462044);
+try {
+device0.queue.label = '\u8a22\u053f\u0f20\ue618\u6729';
+} catch {}
+let querySet1 = device0.createQuerySet({label: '\u01c0\ua702\u7bc2\u0cd4\u20f0\u9a0b', type: 'occlusion', count: 3231});
+let commandBuffer6 = commandEncoder15.finish({});
+let texture7 = device0.createTexture({
+  label: '\u{1fb3c}\u03c9\u23c4\u5d4a\u02a0\u0778',
+  size: {width: 3840},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView11 = texture1.createView({
+  label: '\u{1f881}\u300d\u{1fa9a}\u39d7',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  baseArrayLayer: 212,
+  arrayLayerCount: 109,
+});
+let computePassEncoder6 = commandEncoder2.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({label: '\uea04\udf68\u{1fca6}', colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true});
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({label: '\u316b\u7e5e\u0f68\u{1f809}\u77ff'});
+let renderBundle9 = renderBundleEncoder8.finish();
+let externalTexture7 = device0.importExternalTexture({label: '\u08f8\u{1fbde}\u0e72\ud33b\u0edb\u1a16', source: video2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup7, new Uint32Array(8247), 1241, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(3925, undefined, 0, 1679238757);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer1, 1788, buffer0, 343808, 90632);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let gpuCanvasContext2 = canvas0.getContext('webgpu');
+let imageData2 = new ImageData(92, 96);
+let bindGroup8 = device0.createBindGroup({
+  label: '\u039e\u0820\u{1fcdc}\u{1fabf}\u{1fdd4}\u01a7\u{1f6de}',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 2198, resource: sampler0},
+    {binding: 1303, resource: externalTexture0},
+    {binding: 55, resource: sampler0},
+  ],
+});
+let querySet2 = device0.createQuerySet({label: '\u{1fc27}\u{1fb89}\u3d49', type: 'occlusion', count: 3414});
+let textureView12 = texture1.createView({label: '\u0b5f\u463d', baseMipLevel: 7, baseArrayLayer: 9, arrayLayerCount: 291});
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer1, 51740, buffer0, 204484, 27480);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u0f3d');
+} catch {}
+let imageData3 = new ImageData(52, 156);
+let buffer2 = device0.createBuffer({size: 192112, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let computePassEncoder7 = commandEncoder16.beginComputePass({label: '\u8ac5\udf0c\u53a1\uad78\u{1f698}\u{1f9b1}\u3d7b\u0db5'});
+try {
+renderBundleEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let pipeline8 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  multisample: {mask: 0xe7fdf9bc},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 3741752631,
+    stencilWriteMask: 888725712,
+    depthBiasClamp: 460.390339684998,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2932,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 708, shaderLocation: 14}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 4040, shaderLocation: 9},
+          {format: 'sint16x2', offset: 2284, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 5320, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+commandEncoder13.copyBufferToBuffer(buffer1, 1916, buffer2, 107348, 33992);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 528_843 */
+{offset: 175, bytesPerRow: 28, rowsPerImage: 239}, {width: 0, height: 1, depthOrArrayLayers: 80});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let pipeline9 = await device0.createComputePipelineAsync({
+  label: '\u0c95\u{1fee2}\u84a1\u6de4\u{1fd34}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let img1 = await imageWithData(67, 74, '#fb95c76e', '#94d5f2a1');
+let videoFrame2 = new VideoFrame(videoFrame0, {timestamp: 0});
+let textureView13 = texture3.createView({baseMipLevel: 2, mipLevelCount: 1});
+let externalTexture8 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+let pipeline10 = await device0.createComputePipelineAsync({
+  label: '\u01ea\u4607',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline11 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 3650025643,
+    stencilWriteMask: 2496916139,
+    depthBiasSlopeScale: 387.2467537514775,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 9},
+          {format: 'uint8x2', offset: 2910, shaderLocation: 12},
+          {format: 'sint8x4', offset: 25824, shaderLocation: 1},
+          {format: 'sint32x3', offset: 4108, shaderLocation: 15},
+          {format: 'float32x4', offset: 320, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 1076, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 8844, shaderLocation: 6},
+          {format: 'sint32x4', offset: 904, shaderLocation: 5},
+          {format: 'float32x2', offset: 19016, shaderLocation: 10},
+          {format: 'float32x2', offset: 984, shaderLocation: 4},
+          {format: 'uint32x4', offset: 1796, shaderLocation: 7},
+          {format: 'float16x4', offset: 6660, shaderLocation: 0},
+          {format: 'float32x3', offset: 3620, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 2968,
+        attributes: [
+          {format: 'unorm16x2', offset: 1388, shaderLocation: 11},
+          {format: 'sint16x2', offset: 708, shaderLocation: 13},
+          {format: 'uint8x2', offset: 196, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'back', unclippedDepth: true},
+});
+let pipelineLayout3 = device0.createPipelineLayout({label: '\u{1f90e}\u080d\u027f\u097a', bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1]});
+let renderBundle10 = renderBundleEncoder8.finish({label: '\u3d07\u0742\ub2b1\u{1f9c2}\u009e\uab24\u09c1\u0a51\u0c98\u{1fbcb}\u{1fe9d}'});
+try {
+computePassEncoder7.setBindGroup(4, bindGroup3, new Uint32Array(914), 750, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(620, undefined, 605654637, 3085304421);
+} catch {}
+let textureView14 = texture3.createView({label: '\u6beb\ue34c', baseMipLevel: 2});
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 0, y: 11, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise3;
+} catch {}
+document.body.prepend(video2);
+let canvas1 = document.createElement('canvas');
+let imageBitmap2 = await createImageBitmap(offscreenCanvas0);
+let texture8 = device0.createTexture({
+  label: '\u3f2b\u2639\u66cd\u59a9\u045e\u0431',
+  size: [7680, 1, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView15 = texture7.createView({label: '\u03a1\u{1fb15}\uc015\u{1fbb2}\u0f6c', dimension: '1d', arrayLayerCount: 1});
+let computePassEncoder8 = commandEncoder14.beginComputePass({label: '\u8c70\u5a08\uf31f\u72a2\u0c52\u6620\u{1fe70}\uf23b\u261c\u{1fc57}\u01dc'});
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2212 */
+  offset: 1696,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 3, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  label: '\uf3fe\u765e\u0984\u09fc\uf39a\u{1f606}\u217f\ud715\u{1f6d3}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'keep', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilWriteMask: 944860058,
+    depthBias: -804575044,
+    depthBiasSlopeScale: 306.1584293558759,
+    depthBiasClamp: 260.56673564009793,
+  },
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 448});
+let externalTexture9 = device0.importExternalTexture({label: '\u3b2e\u00ce\u1b91', source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 858, y: 0, z: 66},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 3_388_420 */
+{offset: 740, bytesPerRow: 312, rowsPerImage: 141}, {width: 74, height: 1, depthOrArrayLayers: 78});
+} catch {}
+try {
+  await promise4;
+} catch {}
+try {
+canvas1.getContext('webgpu');
+} catch {}
+let renderBundle11 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5091, undefined);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 68440, 924);
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer0, 429232);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\u08db\u0991\uaa38\u{1fe91}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline14 = await device0.createRenderPipelineAsync({
+  label: '\u{1f9b2}\u09a3',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1420,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 124, shaderLocation: 4},
+          {format: 'float32x3', offset: 168, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 484, shaderLocation: 2},
+          {format: 'sint32x4', offset: 224, shaderLocation: 1},
+          {format: 'uint32x3', offset: 896, shaderLocation: 3},
+          {format: 'float16x4', offset: 652, shaderLocation: 8},
+          {format: 'uint32x3', offset: 40, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 5544, attributes: [{format: 'float32x3', offset: 1272, shaderLocation: 6}]},
+      {
+        arrayStride: 5100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 1636, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 4800, shaderLocation: 9},
+          {format: 'float32', offset: 28, shaderLocation: 0},
+          {format: 'sint32', offset: 340, shaderLocation: 15},
+          {format: 'float32x3', offset: 124, shaderLocation: 14},
+          {format: 'uint16x4', offset: 2860, shaderLocation: 12},
+          {format: 'sint16x2', offset: 628, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 2220, attributes: [{format: 'sint32x3', offset: 60, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas4 = new OffscreenCanvas(565, 394);
+let commandEncoder17 = device0.createCommandEncoder();
+let commandBuffer7 = commandEncoder11.finish({label: '\u667e\uc184\u3927\u{1fdcb}'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u{1fb10}\ue0f3\u0196\u0060\u8263\u6084\u3f7b\u0426\uf512',
+  colorFormats: ['r32uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup8, new Uint32Array(2282), 1012, 0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer1, 27104, buffer0, 329900, 14880);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 1, y: 20, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 5, y: 7, z: 3},
+  aspect: 'all',
+},
+{width: 16, height: 10, depthOrArrayLayers: 35});
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\u0e88\ufe7d\u{1f850}\u0b64\u1e4b\u0f95\u12d7',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let canvas2 = document.createElement('canvas');
+let bindGroup9 = device0.createBindGroup({
+  label: '\u1bdf\u090a\u064f\u0856\u5aef\u01d0\u01a1\u0f80\u190f\u03b8\u{1fa4d}',
+  layout: bindGroupLayout2,
+  entries: [],
+});
+let textureView16 = texture4.createView({baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder9 = commandEncoder13.beginComputePass({label: '\uec23\u9c0c\ued29\u9c81\u{1fe67}\u06e5'});
+let renderPassEncoder0 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 375,
+  clearValue: { r: 355.0, g: -119.1, b: 762.9, a: -968.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView13,
+  depthSlice: 36,
+  clearValue: { r: -957.7, g: 833.4, b: -67.64, a: -227.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 91648402,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u3c86\u4924\u6f04\u062f\u{1f962}\u7336\u0a8a\u0b3a\u4a0c\u{1f7fa}\u088e',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder0.finish({label: '\uf8c3\u5fe4\u{1fa1d}\u6868\u760e\ufd07\uf602'});
+try {
+renderPassEncoder0.setBlendConstant({ r: -520.1, g: -820.2, b: 230.9, a: -880.1, });
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup2);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u0f3b\u1731\u0d9e',
+  entries: [
+    {
+      binding: 3004,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 424, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 186,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let buffer3 = device0.createBuffer({
+  label: '\uca8e\ued5e\u{1f774}\u3596\u4e10\u3854',
+  size: 295459,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\udb6b\u0e9c\u0e3e\u04b1\u505c'});
+let commandBuffer8 = commandEncoder18.finish();
+try {
+computePassEncoder4.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -351.5, g: 250.2, b: -361.3, a: -458.7, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(35, 1, 20, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(368);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline14);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let imageBitmap3 = await createImageBitmap(img0);
+let textureView17 = texture3.createView({label: '\u{1fc6a}\u35f1\u010f\u098a', aspect: 'all', format: 'r32uint', baseMipLevel: 1});
+try {
+renderPassEncoder0.beginOcclusionQuery(947);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4, renderBundle0, renderBundle0, renderBundle10, renderBundle4, renderBundle3, renderBundle3, renderBundle2]);
+} catch {}
+let textureView18 = texture7.createView({label: '\u04fc\u90e7', format: 'r32uint'});
+let sampler6 = device0.createSampler({
+  label: '\u{1fcc0}\u00d9\u{1ffb4}\u{1f607}\u0a5c\u{1f94f}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 80.47,
+  lodMaxClamp: 89.55,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 149.2, g: 449.4, b: 553.0, a: 623.8, });
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup7, new Uint32Array(3092), 1235, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder10.pushDebugGroup('\u{1f60d}');
+} catch {}
+let pipeline17 = await device0.createRenderPipelineAsync({
+  label: '\u{1f7c7}\u0aa0\u050a\u0791\u05ca\u{1f9b1}\u1265\u{1fd76}\u6950',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm8x2', offset: 4954, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 2812, shaderLocation: 9},
+          {format: 'sint8x4', offset: 4104, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 820, shaderLocation: 10},
+          {format: 'sint32x3', offset: 3424, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 3196, shaderLocation: 2},
+          {format: 'sint32x2', offset: 3956, shaderLocation: 5},
+          {format: 'sint8x2', offset: 102, shaderLocation: 13},
+          {format: 'float32x2', offset: 312, shaderLocation: 6},
+          {format: 'uint16x2', offset: 2524, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 1952, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 14572,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 4308, shaderLocation: 12},
+          {format: 'float32x4', offset: 856, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 5360, attributes: []},
+      {
+        arrayStride: 3020,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 72, shaderLocation: 3}],
+      },
+      {arrayStride: 768, attributes: []},
+      {
+        arrayStride: 16196,
+        attributes: [
+          {format: 'float32x2', offset: 2028, shaderLocation: 14},
+          {format: 'float32x4', offset: 3016, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView19 = texture4.createView({label: '\u9c2f\u{1f92d}\u01fc', baseMipLevel: 4, arrayLayerCount: 1});
+try {
+renderPassEncoder0.beginOcclusionQuery(2399);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 990.2, g: 7.475, b: 380.5, a: 934.5, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(965);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 21_768_554 */
+{offset: 786, bytesPerRow: 1108, rowsPerImage: 94}, {width: 215, height: 0, depthOrArrayLayers: 210});
+} catch {}
+let textureView20 = texture6.createView({
+  label: '\u0470\u{1fdf2}\u{1fdcf}\uaa97\u{1f77a}\u4609\u0234\uadea\u6ff7\u{1f8f7}',
+  baseArrayLayer: 120,
+  arrayLayerCount: 294,
+});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder1.setBindGroup(5, bindGroup7);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 374_198 */
+{offset: 619, bytesPerRow: 255, rowsPerImage: 81}, {width: 1, height: 8, depthOrArrayLayers: 19});
+} catch {}
+let pipeline18 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let imageBitmap4 = await createImageBitmap(offscreenCanvas4);
+let textureView21 = texture1.createView({label: '\u00ea\u2130\u011d\u{1f605}\u383b', baseMipLevel: 7, baseArrayLayer: 103, arrayLayerCount: 53});
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(196);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 4,
+  origin: {x: 17, y: 0, z: 66},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(64)), /* required buffer size: 696_655 */
+{offset: 107, bytesPerRow: 216, rowsPerImage: 104}, {width: 41, height: 1, depthOrArrayLayers: 32});
+} catch {}
+let pipeline19 = await device0.createRenderPipelineAsync({
+  label: '\u{1fcdc}\u16f8\u14a1\uab93\ud44c\u{1fdc4}',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+});
+let gpuCanvasContext3 = offscreenCanvas4.getContext('webgpu');
+let offscreenCanvas5 = new OffscreenCanvas(817, 843);
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\uf328\uc8c9\u03d7\u8e2e\u32d6\u{1f915}\u09c9\u0a5b\u{1fed2}\ub230\udbfb',
+  entries: [
+    {
+      binding: 832,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 3176,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1950,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandBuffer9 = commandEncoder13.finish({label: '\uac18\u0977\u0016\u{1fe8a}\u6a44\u00b9\u6615'});
+let textureView22 = texture6.createView({
+  label: '\ue253\u{1f953}\u5fa5\u0efa\u05b3\u1f71\ue431\u03ea\ub718\u7f4c',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  baseArrayLayer: 359,
+});
+let computePassEncoder10 = commandEncoder8.beginComputePass({label: '\uc0dd\ue6d2\u0934\u0287\u062d\uca9a\u6c80\uedeb\u024a\u7d7a\u43ad'});
+try {
+renderPassEncoder0.beginOcclusionQuery(2565);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -603.5, g: 462.0, b: -48.34, a: 879.1, });
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(5, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline6);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u{1fef1}\u{1f79d}\u663a\u06d1\u6d2f',
+  entries: [
+    {binding: 3479, visibility: 0, sampler: { type: 'comparison' }},
+    {
+      binding: 2527,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let textureView23 = texture3.createView({label: '\u{1fd94}\u775f\u0b5a\ud271\u059a\u649b', dimension: '3d', baseMipLevel: 2});
+let renderBundle13 = renderBundleEncoder0.finish({label: '\u{1fdfe}\ud435\u5419\u97c3\u408d\u4564'});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(63, 1, 4, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8897, undefined, 0);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas5.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\u13e3\u{1f604}\uee6a\u0e81\u1d31',
+  code: `@group(0) @binding(2477)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(72) f0: vec4<u32>,
+  @location(0) f1: vec3<f32>,
+  @location(63) f2: i32,
+  @location(59) f3: vec2<f32>,
+  @location(27) f4: u32,
+  @location(31) f5: vec4<f16>,
+  @builtin(front_facing) f6: bool,
+  @location(2) f7: vec4<f16>,
+  @location(6) f8: vec4<f32>,
+  @location(48) f9: vec3<i32>,
+  @location(65) f10: vec3<u32>,
+  @location(7) f11: vec3<i32>,
+  @location(1) f12: vec2<f32>,
+  @location(38) f13: vec2<f32>,
+  @location(28) f14: vec2<u32>,
+  @location(58) f15: i32,
+  @location(61) f16: vec4<u32>,
+  @location(8) f17: i32,
+  @location(60) f18: u32,
+  @location(13) f19: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(0) f1: u32
+}
+
+@fragment
+fn fragment0(a0: S3, @location(42) a1: vec3<f32>, @location(34) a2: vec2<u32>, @location(39) a3: vec4<u32>, @location(69) a4: vec3<u32>, @builtin(position) a5: vec4<f32>, @builtin(sample_mask) a6: u32, @builtin(sample_index) a7: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(58) f27: i32,
+  @location(38) f28: vec2<f32>,
+  @location(65) f29: vec3<u32>,
+  @location(39) f30: vec4<u32>,
+  @location(6) f31: vec4<f32>,
+  @location(60) f32: u32,
+  @location(0) f33: vec3<f32>,
+  @location(13) f34: vec3<f16>,
+  @location(7) f35: vec3<i32>,
+  @location(31) f36: vec4<f16>,
+  @location(1) f37: vec2<f32>,
+  @location(34) f38: vec2<u32>,
+  @location(48) f39: vec3<i32>,
+  @location(42) f40: vec3<f32>,
+  @location(2) f41: vec4<f16>,
+  @builtin(position) f42: vec4<f32>,
+  @location(61) f43: vec4<u32>,
+  @location(27) f44: u32,
+  @location(28) f45: vec2<u32>,
+  @location(8) f46: i32,
+  @location(69) f47: vec3<u32>,
+  @location(59) f48: vec2<f32>,
+  @location(63) f49: i32,
+  @location(72) f50: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec3<f16>, @location(0) a1: vec2<f16>, @location(12) a2: i32, @location(9) a3: vec3<i32>, @location(8) a4: i32, @location(5) a5: vec3<i32>, @location(13) a6: vec2<u32>, @builtin(vertex_index) a7: u32, @location(3) a8: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let commandBuffer10 = commandEncoder19.finish({});
+let textureView24 = texture0.createView({label: '\u1f70\ubd77\ud40c', dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 228});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -944.0, g: -779.2, b: 262.6, a: 768.2, });
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(9, 311);
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u{1fe8f}\u{1fd7d}\u75ca\u0ecc\u{1f962}',
+  entries: [
+    {
+      binding: 853,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 1373,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 3027,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder20 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({
+  label: '\udb9d\ub735\u{1f8df}\u9e10\u0009\u6441\u{1fabd}\u3949\u536e\u011f',
+  type: 'occlusion',
+  count: 1521,
+});
+let texture9 = device0.createTexture({
+  label: '\u0bf8\u021d\ufd2b\u0677\ue4c6\u5f16\u724a',
+  size: {width: 30, height: 96, depthOrArrayLayers: 929},
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView25 = texture1.createView({dimension: '2d-array', baseMipLevel: 7, baseArrayLayer: 76, arrayLayerCount: 233});
+let computePassEncoder11 = commandEncoder20.beginComputePass({label: '\ud47b\u3e6c\u01c0\uac19\u5808\u03b0\ua553\u3657'});
+let renderBundle14 = renderBundleEncoder7.finish({});
+try {
+renderPassEncoder0.setVertexBuffer(4015, undefined);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup6, new Uint32Array(4534), 1807, 0);
+} catch {}
+let imageBitmap5 = await createImageBitmap(canvas2);
+let imageData4 = new ImageData(116, 100);
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1494});
+let textureView26 = texture7.createView({label: '\u1420\u{1fc7d}\u87fa\uf201\ub7a0\u0e0b\u5e1e\u0bd8', aspect: 'all'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u{1fd88}\u{1fb80}\ueb3a\ua14c\u4886\u818d',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: -439.9, g: 367.9, b: -850.6, a: -568.2, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(81.43, 0.9818, 0.09494, 0.00974, 0.3995, 0.9745);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6508, undefined, 1255649032, 1644377350);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8, commandBuffer2]);
+} catch {}
+let pipeline20 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise5;
+} catch {}
+document.body.prepend(video1);
+let bindGroupLayout9 = device0.createBindGroupLayout({entries: []});
+let textureView27 = texture9.createView({dimension: '2d', baseMipLevel: 6, baseArrayLayer: 98});
+try {
+renderPassEncoder0.setStencilReference(3266);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline14);
+} catch {}
+offscreenCanvas1.height = 851;
+let commandEncoder21 = device0.createCommandEncoder({label: '\ueb57\u67e1\u0a41\ufa91\u5c50\ud1a2\ub110'});
+let textureView28 = texture3.createView({baseMipLevel: 2});
+let renderPassEncoder1 = commandEncoder21.beginRenderPass({
+  label: '\u3b1b\u5f4c',
+  colorAttachments: [{view: textureView23, depthSlice: 319, loadOp: 'load', storeOp: 'discard'}, {
+  view: textureView28,
+  depthSlice: 192,
+  clearValue: { r: 303.4, g: -147.1, b: 976.4, a: -961.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 625695890,
+});
+try {
+renderPassEncoder0.setScissorRect(56, 1, 11, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(5, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+let renderBundle15 = renderBundleEncoder11.finish({label: '\u0d56\u{1f6f4}\ubdeb\u05c9\u05fc'});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+let pipeline21 = device0.createComputePipeline({
+  label: '\u30a6\u083f',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img1);
+let querySet6 = device0.createQuerySet({label: '\u8e68\uca57', type: 'occlusion', count: 538});
+let texture10 = device0.createTexture({
+  label: '\udd5e\uce30\ub386',
+  size: [60],
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle16 = renderBundleEncoder9.finish({label: '\u15c4\ue7a4\u{1fcc7}\u9087\u042b\u72ae\u91be\u1201\ucd99\u{1f619}\u04c0'});
+let externalTexture11 = device0.importExternalTexture({label: '\u7aec\u0fbb\u0a03\u56e4\u07f5\u07a7\u0bf9', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.beginOcclusionQuery(870);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(1.605, 0.9158, 75.06, 0.00666, 0.7938, 0.9449);
+} catch {}
+let buffer4 = device0.createBuffer({label: '\ub46f\u{1f8ca}', size: 288664, usage: GPUBufferUsage.STORAGE});
+let textureView29 = texture3.createView({format: 'r32uint', baseMipLevel: 2, arrayLayerCount: 1});
+let renderBundle17 = renderBundleEncoder9.finish();
+try {
+computePassEncoder3.setBindGroup(4, bindGroup0, new Uint32Array(8374), 4178, 0);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3332);
+} catch {}
+try {
+renderPassEncoder0.setViewport(18.81, 0.09637, 65.13, 0.3124, 0.8231, 0.9780);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 7564 widthInBlocks: 1891 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18308 */
+  offset: 10744,
+  buffer: buffer3,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 917, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1891, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u5751\u0c21\u357b\u1dec\ud5db\u232f\u207b\u{1febd}\u5fbd\u0f1a\u19ab',
+  colorFormats: ['r32uint', 'r32uint'],
+});
+let sampler7 = device0.createSampler({
+  label: '\ua868\u77a1\uf850\ua12e\ua929\u0105\u0a4e\uf78b\u{1ff36}\u9072',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.70,
+  lodMaxClamp: 99.82,
+  compare: 'less-equal',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let bindGroupLayout10 = pipeline12.getBindGroupLayout(0);
+let buffer5 = device0.createBuffer({size: 290602, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet7 = device0.createQuerySet({label: '\u098b\ucda1', type: 'occlusion', count: 2781});
+let renderPassEncoder2 = commandEncoder20.beginRenderPass({
+  label: '\u{1fd60}\u233a\u05b1\u{1f8ae}',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 290,
+  clearValue: { r: -367.1, g: -898.0, b: -333.3, a: 744.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView13,
+  depthSlice: 87,
+  clearValue: { r: -154.2, g: 831.4, b: 597.5, a: 816.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 330885983,
+});
+let sampler8 = device0.createSampler({
+  label: '\u3f90\u099e\u05c9\u3f87',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.42,
+  lodMaxClamp: 71.13,
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setViewport(6.201, 0.1203, 80.66, 0.08662, 0.1583, 0.8769);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(9958, undefined, 3112194478, 216448601);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup7, new Uint32Array(3612), 3438, 0);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(331, 886);
+try {
+offscreenCanvas7.getContext('webgl2');
+} catch {}
+let buffer6 = device0.createBuffer({label: '\u042e\u060f', size: 235958, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let texture11 = device0.createTexture({
+  label: '\u2d41\u9430\u0485\u{1fbb1}\uc727\uf388\u2a2d\u086b',
+  size: {width: 1920, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(5409), 3512, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(5, bindGroup7);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(462048, 40960);
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 159, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer0), /* required buffer size: 789 */
+{offset: 789, rowsPerImage: 108}, {width: 616, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+  label: '\ub4d3\u8297\u47fd\u0d56\u{1ff8e}\u21df',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let img2 = await imageWithData(39, 196, '#5b61f397', '#ccc21185');
+let bindGroup10 = device0.createBindGroup({
+  label: '\ueb03\ud267\uc307\u0907\u{1fcc0}\u4e1d\u0a04\uefe3\u03c4\u0be7',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let querySet8 = device0.createQuerySet({label: '\u0205\u08d1\ub7eb', type: 'occlusion', count: 1061});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({label: '\uf6ac\u{1fcad}\uefff', colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true});
+let renderBundle18 = renderBundleEncoder14.finish({});
+let sampler9 = device0.createSampler({
+  label: '\u62da\u463f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.96,
+  lodMaxClamp: 81.29,
+  compare: 'greater',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup10);
+} catch {}
+let pipeline24 = await device0.createComputePipelineAsync({
+  label: '\u3c01\u{1fff9}\u03c7\u{1fe0d}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+gc();
+try {
+computePassEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle15, renderBundle18, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 648.2, g: -119.9, b: -530.9, a: -141.0, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(5.056, 0.6367, 9.851, 0.3054, 0.09629, 0.6391);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup0);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let offscreenCanvas8 = new OffscreenCanvas(350, 77);
+let commandEncoder22 = device0.createCommandEncoder({});
+let renderPassEncoder3 = commandEncoder22.beginRenderPass({
+  label: '\u37c5\u431b\u{1f691}\u4015',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 165,
+  clearValue: { r: -919.3, g: 115.0, b: 648.0, a: 746.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView28, depthSlice: 333, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 1136761990,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u098a\u{1f90a}\u97d4\u00f3\uc115\u047d\u17ca\u8965',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(3321);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle11, renderBundle15, renderBundle9, renderBundle4, renderBundle4, renderBundle14, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -38.60, g: 701.2, b: 611.2, a: -120.3, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(20, 0, 28, 1);
+} catch {}
+try {
+renderBundleEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(178_659), /* required buffer size: 178_659 */
+{offset: 575, bytesPerRow: 208, rowsPerImage: 210}, {width: 9, height: 17, depthOrArrayLayers: 5});
+} catch {}
+try {
+adapter1.label = '\u6905\u2392\u04a2\ub832\u8d82\u{1f6dd}\u051a\u052a\u0be9\u4b36\u{1fa20}';
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u94f5\u0c95\ue664',
+  code: `@group(6) @binding(2198)
+var<storage, read_write> type1: array<u32>;
+@group(4) @binding(2477)
+var<storage, read_write> type2: array<u32>;
+@group(6) @binding(55)
+var<storage, read_write> n0: array<u32>;
+@group(2) @binding(2198)
+var<storage, read_write> local0: array<u32>;
+@group(3) @binding(2477)
+var<storage, read_write> local1: array<u32>;
+@group(5) @binding(3374)
+var<storage, read_write> parameter1: array<u32>;
+@group(5) @binding(3796)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(40) f0: vec2<i32>,
+  @builtin(front_facing) f1: bool,
+  @builtin(sample_index) f2: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(5) f1: i32,
+  @location(1) f2: vec4<u32>,
+  @location(4) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(a0: S5, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(9) f0: vec2<i32>
+}
+struct VertexOutput0 {
+  @builtin(position) f51: vec4<f32>,
+  @location(40) f52: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f16>, @location(12) a1: vec3<i32>, @location(8) a2: vec4<u32>, @location(3) a3: vec2<u32>, @location(2) a4: i32, @location(6) a5: u32, @location(7) a6: vec2<i32>, @location(1) a7: vec4<u32>, @location(13) a8: vec4<f32>, a9: S4, @location(4) a10: vec2<f16>, @location(14) a11: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer7 = device0.createBuffer({
+  label: '\u{1fdc4}\u{1f8b8}\u00b4\u0698\u0eda\u01ab\uf1a7\u1008\u04ef\u07e8\u{1f9c7}',
+  size: 37817,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let commandEncoder23 = device0.createCommandEncoder({label: '\u{1fbd3}\u0bf6\u0ee9\ub6f3\u0e98\u0bf6\u2efd\u018e\u024d\u{1f6e9}\u0fce'});
+let texture12 = device0.createTexture({
+  size: {width: 2802},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle19 = renderBundleEncoder2.finish({label: '\u7114\u08e2\ueaab\ubfdd\u9034\u0315\u0f72'});
+try {
+computePassEncoder10.setBindGroup(6, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle19, renderBundle5, renderBundle1, renderBundle8, renderBundle17, renderBundle12, renderBundle5, renderBundle19, renderBundle8, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(3268);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer2, 115188);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+adapter1.label = '\u0efb\u0c73\uf056\u01fb\u{1fbfa}\ue003';
+} catch {}
+let texture13 = device0.createTexture({
+  label: '\u0da6\ue9d6\u59d7\u92c1\u1528\u{1fa4b}\u87e2\u2f35\uffc1',
+  size: {width: 1920, height: 1, depthOrArrayLayers: 129},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['r32uint', 'r32uint'], sampleCount: 1});
+let sampler10 = device0.createSampler({
+  label: '\u00fb\u70d0\u7a90\u73f9\u0a5e',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.84,
+  lodMaxClamp: 61.92,
+});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup1, new Uint32Array(7557), 5390, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(38.74, 0.7168, 11.35, 0.1327, 0.3438, 0.7958);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer0, 421_702_213);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer4, 309_750_000);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer2, 22820, 40036);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder23.insertDebugMarker('\u{1fdfe}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let commandEncoder24 = device0.createCommandEncoder({label: '\u02f7\ubc24\ufc95\u0bfc\uc312'});
+let textureView30 = texture12.createView({label: '\u{1fd07}\ua87f\u05a4\u6322', aspect: 'all'});
+try {
+commandEncoder24.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline25 = await device0.createRenderPipelineAsync({
+  label: '\uc9bb\ufc85\ue01f\u8764\u06a7',
+  layout: pipelineLayout1,
+  multisample: {mask: 0xee47ce88},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'r32uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8084,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 408, shaderLocation: 5},
+          {format: 'float16x2', offset: 648, shaderLocation: 13},
+          {format: 'sint32x2', offset: 1176, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 520, shaderLocation: 9},
+          {format: 'uint32x4', offset: 304, shaderLocation: 8},
+          {format: 'sint16x2', offset: 5168, shaderLocation: 12},
+          {format: 'sint32x2', offset: 3564, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 5604,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 80, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 408, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 580,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 70, shaderLocation: 14}],
+      },
+      {arrayStride: 7828, attributes: []},
+      {
+        arrayStride: 1216,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 148, shaderLocation: 3}, {format: 'uint8x4', offset: 72, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup11 = device0.createBindGroup({
+  label: '\u6ff3\u0e09\u82a9\u{1f9dd}\u04c1\u0054\u13a4\u4a21\ue598\u{1fab9}\u{1fd24}',
+  layout: bindGroupLayout0,
+  entries: [
+    {binding: 2198, resource: sampler0},
+    {binding: 1303, resource: externalTexture10},
+    {binding: 55, resource: sampler0},
+  ],
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 3124});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u6116\u13e2\u08f0\ud324\u{1fb40}\u8696\u{1ff25}\uc643\u0009',
+  colorFormats: ['r32uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let renderBundle20 = renderBundleEncoder17.finish({label: '\ua203\u9d9d'});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6939, undefined, 12065150, 1831184513);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let commandEncoder25 = device0.createCommandEncoder({label: '\u5f14\ub938\u0f8b'});
+let textureView31 = texture7.createView({label: '\ud308\u889f\u7827\u2023'});
+let renderPassEncoder4 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView14,
+  depthSlice: 158,
+  clearValue: { r: 88.96, g: -467.6, b: 317.3, a: -830.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView23, depthSlice: 117, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 995124527,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({label: '\u0678\uaf0c\u229d\u{1f73a}\u0ea6', colorFormats: ['r32uint', 'r32uint']});
+try {
+renderPassEncoder3.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(568);
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange(0, 43948);
+try {
+commandEncoder24.clearBuffer(buffer0, 527972);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let gpuCanvasContext6 = canvas4.getContext('webgpu');
+let canvas5 = document.createElement('canvas');
+let textureView32 = texture11.createView({label: '\uaeaa\u0b58\u27d0\u834f\ufe5e', dimension: '2d', mipLevelCount: 1});
+let sampler11 = device0.createSampler({
+  label: '\u{1f994}\u088e\uf26f\u0e0a\u0bb9\uff95\u0853\u891f\u21c5\u7344\u{1f94f}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 67.66,
+  lodMaxClamp: 88.41,
+});
+try {
+renderPassEncoder4.setBindGroup(5, bindGroup11);
+} catch {}
+try {
+renderPassEncoder3.setViewport(46.81, 0.7616, 19.50, 0.1596, 0.1404, 0.7030);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer4, 855_457_431);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 733_846_933);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(6, bindGroup8);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+querySet8.destroy();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline26 = device0.createComputePipeline({
+  label: '\u06cf\u{1fc22}\u262f',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+try {
+window.someLabel = externalTexture10.label;
+} catch {}
+let textureView33 = texture4.createView({baseMipLevel: 2, mipLevelCount: 4});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3687);
+} catch {}
+try {
+renderPassEncoder3.draw(20, 5, 130_270_744, 380_455_539);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(880, undefined, 0);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 33},
+  aspect: 'all',
+}, new ArrayBuffer(15_565_723), /* required buffer size: 15_565_723 */
+{offset: 65, bytesPerRow: 6045, rowsPerImage: 143}, {width: 1457, height: 1, depthOrArrayLayers: 19});
+} catch {}
+let video3 = await videoWithData();
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u9d69\u064b',
+  entries: [
+    {
+      binding: 1338,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 1513, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 3168});
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(19);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(35, 1, 6, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(28);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(82, 9, 805_746_952, 141_834_471, 105_020_914);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 1_794_095_933);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(6, bindGroup8, new Uint32Array(5775), 5233, 0);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 5_870 */
+{offset: 846, rowsPerImage: 280}, {width: 1256, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  label: '\u4b0d\u99b1\u3ed8\u2174\u0416\u20b7\u05e4\u0faf\u8a85\u3055',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1272,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 380, shaderLocation: 2},
+          {format: 'uint32x3', offset: 376, shaderLocation: 7},
+          {format: 'uint32', offset: 12, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 524, shaderLocation: 0},
+          {format: 'sint8x2', offset: 98, shaderLocation: 13},
+          {format: 'sint16x2', offset: 816, shaderLocation: 15},
+          {format: 'sint32x2', offset: 804, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 124, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 176, shaderLocation: 6},
+          {format: 'float32', offset: 960, shaderLocation: 10},
+          {format: 'float32x4', offset: 92, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 132, shaderLocation: 9},
+          {format: 'float16x4', offset: 12, shaderLocation: 8},
+          {format: 'uint8x2', offset: 108, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 172, shaderLocation: 4},
+          {format: 'sint16x4', offset: 64, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+});
+let renderPassEncoder5 = commandEncoder6.beginRenderPass({
+  label: '\ud90c\u7acd\u05c8\u6519\u199c\udd35\u10c1\u{1fb97}\u{1fede}',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 234,
+  clearValue: { r: -746.5, g: 306.6, b: 823.4, a: -32.77, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {view: textureView29, depthSlice: 31, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 687052000,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle12, renderBundle11, renderBundle13, renderBundle18, renderBundle13, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 690.5, g: -234.4, b: 703.4, a: 768.9, });
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(3821);
+} catch {}
+try {
+renderPassEncoder1.draw(24, 1, 751_703_563);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 576_261_491);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer1, 74736, buffer2, 41180, 7660);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 287 */
+{offset: 287, rowsPerImage: 42}, {width: 799, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline28 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xbabe03fc},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 652,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 44, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 212, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 108,
+        attributes: [
+          {format: 'snorm16x4', offset: 40, shaderLocation: 4},
+          {format: 'sint32x4', offset: 0, shaderLocation: 2},
+          {format: 'uint32', offset: 32, shaderLocation: 1},
+          {format: 'uint32x4', offset: 0, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 23012,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 2844, shaderLocation: 5},
+          {format: 'uint8x4', offset: 2308, shaderLocation: 3},
+          {format: 'uint32x4', offset: 4284, shaderLocation: 14},
+          {format: 'sint8x2', offset: 4936, shaderLocation: 12},
+          {format: 'uint8x4', offset: 3900, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x4', offset: 4180, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+  await promise6;
+} catch {}
+gc();
+try {
+adapter1.label = '\ua52e\ue93f\u1f05\u0cdc\u0202\u046e';
+} catch {}
+let computePassEncoder12 = commandEncoder24.beginComputePass({label: '\u0af4\ubdd1\u{1fc6b}\uf057\u0438\u1137'});
+let sampler12 = device0.createSampler({
+  label: '\u05b2\u5250\ud1d3\u6fd7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.26,
+  lodMaxClamp: 47.12,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle13, renderBundle16, renderBundle3, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(547);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer0, 480_193_698);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(5, bindGroup10, new Uint32Array(7076), 3468, 0);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 0, 26176);
+} catch {}
+try {
+commandEncoder25.insertDebugMarker('\u{1f789}');
+} catch {}
+let querySet11 = device0.createQuerySet({label: '\u{1ff67}\uc093', type: 'occlusion', count: 2053});
+let commandBuffer11 = commandEncoder25.finish({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({label: '\u1b8e\u0205\u{1ffc9}\ua8a5', colorFormats: ['r32uint', 'r32uint'], stencilReadOnly: true});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(3169);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(14, 1, 60, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(34.60, 0.1996, 5.251, 0.6251, 0.4249, 0.8222);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 1_428_873_083);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline19);
+} catch {}
+let pipeline29 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 460764796,
+    stencilWriteMask: 3752607508,
+    depthBiasSlopeScale: 786.2009159301084,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 592,
+        attributes: [
+          {format: 'unorm8x2', offset: 200, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 324, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 40, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 3004,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 704, shaderLocation: 12}],
+      },
+      {arrayStride: 6864, attributes: []},
+      {
+        arrayStride: 656,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 104, shaderLocation: 14},
+          {format: 'sint16x4', offset: 224, shaderLocation: 15},
+          {format: 'sint8x4', offset: 384, shaderLocation: 1},
+          {format: 'uint32', offset: 160, shaderLocation: 7},
+          {format: 'sint32x4', offset: 140, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 356, shaderLocation: 9},
+          {format: 'float32', offset: 0, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 2},
+          {format: 'uint16x4', offset: 108, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 114, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 2932, attributes: [{format: 'sint32', offset: 436, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'none', unclippedDepth: true},
+});
+let img3 = await imageWithData(98, 194, '#7fdd9684', '#ba2d70d3');
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u2ad5\u0ea9\u229b\u{1faf0}\u0088\u0823',
+  entries: [
+    {binding: 3765, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 2930, visibility: 0, externalTexture: {}},
+    {
+      binding: 3769,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let pipelineLayout4 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout11, bindGroupLayout11, bindGroupLayout5, bindGroupLayout12, bindGroupLayout10],
+});
+let commandEncoder26 = device0.createCommandEncoder({});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup10, new Uint32Array(2598), 1514, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(66.97, 0.2844, 9.789, 0.4575, 0.9488, 0.9831);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(26, 178, 60_468_357, 168_152_862, 312_012_464);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(874, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 0, y: 2, z: 39},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 9_101_575 */
+{offset: 538, bytesPerRow: 83, rowsPerImage: 131}, {width: 1, height: 5, depthOrArrayLayers: 838});
+} catch {}
+let promise8 = device0.createRenderPipelineAsync({
+  label: '\u7519\u008c\u{1faab}\u2775\u312b',
+  layout: pipelineLayout4,
+  multisample: {mask: 0xb41b08b9},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 1245190339,
+    depthBias: -67603646,
+    depthBiasClamp: 563.3656104168565,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11880,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 1604, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 3044,
+        attributes: [
+          {format: 'sint32x4', offset: 96, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3336,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 988, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u0d6e\u9876\u0c5f\u0884\uf780\u31db\u0317\u01ee'});
+try {
+renderPassEncoder5.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(6, bindGroup8, new Uint32Array(6093), 5483, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(84, 38, 815_192_498, 414_252_692);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2_427 */
+{offset: 923}, {width: 376, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({label: '\u0ac1\u845f\u0165\uc0b5\ua78d\u6305\u0fac'});
+let texture14 = device0.createTexture({
+  label: '\u8e4a\u87c8\u5c50\u{1f7e3}\ucb4a',
+  size: [1401, 1, 1794],
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let textureView34 = texture10.createView({});
+let renderPassEncoder6 = commandEncoder28.beginRenderPass({
+  label: '\u{1ff0a}\u3c77\u7656\u0460\u6fae\u0a77\ue3ac\u0d9f\u{1fa54}',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 112,
+  clearValue: { r: -761.7, g: -774.3, b: 269.7, a: 326.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView23,
+  depthSlice: 44,
+  clearValue: { r: 894.8, g: 883.4, b: -75.80, a: -56.22, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 507917553,
+});
+let renderBundle21 = renderBundleEncoder15.finish({label: '\u0bc5\u{1ffed}\u0153\ud377\u{1f9c4}\ubbf4\ue477\ua4ea'});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -655.3, g: -895.7, b: -451.4, a: -642.5, });
+} catch {}
+try {
+renderPassEncoder5.draw(49, 398, 507_202_656, 1_572_367_926);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(222, 161, 373_033_512);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder18.draw(204, 187);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline27);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let pipeline30 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    depthBias: 1076488394,
+    depthBiasClamp: 65.37742851517311,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4428,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 4, shaderLocation: 13},
+          {format: 'sint32x2', offset: 1952, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 8164,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 188, shaderLocation: 0}],
+      },
+      {arrayStride: 4104, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7384,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 1472, shaderLocation: 4},
+          {format: 'sint32', offset: 1336, shaderLocation: 5},
+          {format: 'sint32x2', offset: 280, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 14420,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 1444, shaderLocation: 3}],
+      },
+      {
+        arrayStride: 6560,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x4', offset: 1688, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back', unclippedDepth: true},
+});
+let shaderModule5 = device0.createShaderModule({
+  label: '\u4f3c\u3f8e\u{1ffe3}\u4f57\ubb28\u6d1f',
+  code: `@group(4) @binding(3769)
+var<storage, read_write> parameter3: array<u32>;
+@group(3) @binding(186)
+var<storage, read_write> n1: array<u32>;
+@group(1) @binding(1338)
+var<storage, read_write> type3: array<u32>;
+@group(3) @binding(424)
+var<storage, read_write> function0: array<u32>;
+@group(4) @binding(2930)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(1513)
+var<storage, read_write> function1: array<u32>;
+@group(2) @binding(1338)
+var<storage, read_write> parameter4: array<u32>;
+@group(4) @binding(3765)
+var<storage, read_write> type4: array<u32>;
+@group(5) @binding(2477)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(6, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(14) f0: i32,
+  @location(25) f1: vec2<f32>,
+  @builtin(sample_mask) f2: u32,
+  @location(62) f3: vec4<i32>,
+  @location(43) f4: vec4<u32>,
+  @location(71) f5: vec3<f32>,
+  @location(28) f6: vec4<f32>,
+  @location(16) f7: u32,
+  @location(60) f8: i32,
+  @location(35) f9: vec3<f32>,
+  @location(54) f10: vec3<i32>,
+  @location(58) f11: vec2<u32>,
+  @location(47) f12: f16,
+  @location(66) f13: vec4<f16>,
+  @location(55) f14: u32,
+  @location(74) f15: vec3<i32>,
+  @location(72) f16: f16,
+  @builtin(front_facing) f17: bool
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(3) f1: vec4<f32>,
+  @location(0) f2: vec4<u32>,
+  @location(1) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(61) a1: vec2<f32>, @location(13) a2: vec4<i32>, @location(9) a3: vec3<i32>, @location(19) a4: f16, @builtin(position) a5: vec4<f32>, @location(17) a6: vec2<f16>, a7: S7, @location(31) a8: vec2<u32>, @location(70) a9: vec2<f32>, @location(20) a10: vec4<i32>, @location(57) a11: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(4) f0: vec3<u32>,
+  @location(0) f1: vec2<f16>,
+  @location(15) f2: u32,
+  @location(11) f3: i32,
+  @location(5) f4: vec4<u32>,
+  @location(14) f5: f32,
+  @location(13) f6: vec4<f32>,
+  @location(12) f7: vec4<i32>,
+  @location(8) f8: f16,
+  @location(2) f9: vec4<i32>,
+  @location(6) f10: vec4<u32>,
+  @location(1) f11: i32
+}
+struct VertexOutput0 {
+  @location(66) f53: vec4<f16>,
+  @location(20) f54: vec4<i32>,
+  @location(61) f55: vec2<f32>,
+  @location(72) f56: f16,
+  @location(14) f57: i32,
+  @location(58) f58: vec2<u32>,
+  @location(55) f59: u32,
+  @location(25) f60: vec2<f32>,
+  @location(74) f61: vec3<i32>,
+  @builtin(position) f62: vec4<f32>,
+  @location(54) f63: vec3<i32>,
+  @location(71) f64: vec3<f32>,
+  @location(13) f65: vec4<i32>,
+  @location(31) f66: vec2<u32>,
+  @location(57) f67: vec2<i32>,
+  @location(60) f68: i32,
+  @location(9) f69: vec3<i32>,
+  @location(17) f70: vec2<f16>,
+  @location(19) f71: f16,
+  @location(28) f72: vec4<f32>,
+  @location(62) f73: vec4<i32>,
+  @location(47) f74: f16,
+  @location(70) f75: vec2<f32>,
+  @location(35) f76: vec3<f32>,
+  @location(16) f77: u32,
+  @location(43) f78: vec4<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(7) a1: u32, @location(10) a2: vec2<u32>, @location(9) a3: vec4<i32>, @location(3) a4: vec2<f32>, a5: S6, @builtin(vertex_index) a6: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u5519\u4281\u5d42\u{1ff17}\u0f55\u{1fd99}\u0955\u51f8\ud77f\u6cef\u02cf',
+  entries: [
+    {
+      binding: 1019,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 673,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 1151,
+      visibility: 0,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView35 = texture8.createView({label: '\u{1f9c8}\u5e10\u{1fb3b}\u{1f74a}\u{1ff9d}'});
+let computePassEncoder13 = commandEncoder26.beginComputePass({});
+let renderPassEncoder7 = commandEncoder27.beginRenderPass({
+  label: '\u067f\ubeea\u0976\ua609\u9f8e\u0423\u4136',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 53,
+  clearValue: { r: -941.4, g: -373.2, b: 40.92, a: -19.99, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView23,
+  depthSlice: 330,
+  clearValue: { r: -372.1, g: -190.2, b: 598.9, a: 663.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 253657421,
+});
+let renderBundle22 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder12.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(58, 6, 432_615_844, 156_773_284);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageBitmap4);
+let shaderModule6 = device0.createShaderModule({
+  label: '\u0d00\u01a5\u2dcd\u8f50\u{1fe06}\ud7a4\u07db\uf562\u0d39',
+  code: `@group(0) @binding(2198)
+var<storage, read_write> parameter5: array<u32>;
+@group(0) @binding(55)
+var<storage, read_write> n2: array<u32>;
+@group(0) @binding(1303)
+var<storage, read_write> function2: array<u32>;
+@group(1) @binding(2477)
+var<storage, read_write> parameter6: array<u32>;
+
+@compute @workgroup_size(2, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(0) f1: u32
+}
+
+@fragment
+fn fragment0(@location(9) a0: f16, @location(1) a1: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(34) f79: vec2<f32>,
+  @location(63) f80: vec4<f16>,
+  @location(9) f81: f16,
+  @location(18) f82: vec4<u32>,
+  @location(6) f83: vec2<f16>,
+  @location(57) f84: i32,
+  @location(1) f85: f32,
+  @location(70) f86: vec3<i32>,
+  @location(67) f87: vec2<f32>,
+  @location(28) f88: u32,
+  @location(33) f89: f32,
+  @location(11) f90: u32,
+  @builtin(position) f91: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView36 = texture11.createView({label: '\u0f45\u6970\u2d3d\u1b2c\u01be\u1e9b\u{1fcbe}', format: 'r32uint', baseMipLevel: 1});
+let renderBundle23 = renderBundleEncoder3.finish();
+let sampler13 = device0.createSampler({
+  label: '\u0690\u0e8f\u7519\u0a4d\u0524\u0092',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.51,
+  maxAnisotropy: 10,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let buffer8 = device0.createBuffer({
+  label: '\u{1f9c3}\u87fc\u21ec\u0a81\u0d2e\u7001\u9894\u{1f6c2}',
+  size: 104793,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture15 = device0.createTexture({
+  label: '\ue970\u5ff8\ub8e0\u02d5\u2095\u34a9\u0e79',
+  size: [960, 1, 1770],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let textureView37 = texture14.createView({format: 'r32uint', baseMipLevel: 4});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u{1fcaa}\ub1db\u6f04\u{1fa29}\u5078\u{1f60e}\u97c9\u41dc',
+  colorFormats: ['r32uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder7.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setViewport(41.14, 0.08038, 42.31, 0.7994, 0.7359, 0.7395);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5977, undefined, 4228627037, 57922496);
+} catch {}
+try {
+renderBundleEncoder18.draw(49, 399, 59_170_524, 532_993_821);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(9065, undefined, 0, 1522064475);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let sampler14 = device0.createSampler({
+  label: '\ue66d\u0f50',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.35,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder3.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+let textureView38 = texture13.createView({label: '\u00e4\uefd9\u7fae\u54be\u05b7'});
+try {
+renderPassEncoder4.beginOcclusionQuery(342);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1524);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3407, undefined, 0, 2157223525);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+let gpuCanvasContext7 = canvas5.getContext('webgpu');
+let commandEncoder29 = device0.createCommandEncoder();
+let textureView39 = texture14.createView({baseMipLevel: 5, mipLevelCount: 2});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup10, new Uint32Array(9471), 3471, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer5, 72140, buffer0, 456564, 24480);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet10, 2731, 381, buffer8, 62720);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let querySet12 = device0.createQuerySet({label: '\u74c6\u3b06\u5f97\u0c74\uc231', type: 'occlusion', count: 3116});
+let commandBuffer12 = commandEncoder29.finish({label: '\ub629\u{1f864}\u{1f654}\ud8a7\u{1febf}\u8ffd\u7ba5\u{1fd7d}\u059e\u034e'});
+let textureView40 = texture4.createView({label: '\u0edc\u0d80\u0843\u0305\u{1ffe7}', mipLevelCount: 1});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(3415);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline27);
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+  label: '\u{1f885}\u{1fb71}\u693e\u49e8\u2a73\ufa1b\ua43a',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1320,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 0, shaderLocation: 5}],
+      },
+      {
+        arrayStride: 15312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 5020, shaderLocation: 12},
+          {format: 'uint8x2', offset: 3564, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 2056,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x2', offset: 676, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 32, shaderLocation: 13},
+          {format: 'uint32', offset: 36, shaderLocation: 3},
+          {format: 'sint8x2', offset: 288, shaderLocation: 2},
+          {format: 'uint32x2', offset: 336, shaderLocation: 14},
+          {format: 'sint32', offset: 212, shaderLocation: 7},
+          {format: 'sint32', offset: 12, shaderLocation: 9},
+          {format: 'uint16x4', offset: 828, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 2380, stepMode: 'instance', attributes: []},
+      {arrayStride: 2084, stepMode: 'vertex', attributes: []},
+      {arrayStride: 16580, stepMode: 'instance', attributes: []},
+      {arrayStride: 2840, stepMode: 'vertex', attributes: []},
+      {arrayStride: 6276, attributes: []},
+      {
+        arrayStride: 3296,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 340, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame3 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1fe4f}\u{1fca2}\u{1f78d}\u{1fdae}\u03ab\u09f3\u0dde'});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 1156});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\uece4\ub8de\u0e25\u36a8\u0802\u0151\ua71f\u14c3\u0903\u2eb7\ud8cc',
+  colorFormats: ['r32uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder13.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet7, 1136, 831, buffer8, 89856);
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+  label: '\ubda3\ud85f\ua251\ua545\u09ee\u4a7a\ufd34\u010d\u052d',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise7;
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+externalTexture1.label = '\u5fcd\u00aa\uc2e1\u3633\ub3ec\uf629\u2398\u01b6';
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+try {
+renderPassEncoder6.setBindGroup(6, bindGroup8);
+} catch {}
+try {
+renderPassEncoder0.setViewport(69.90, 0.8466, 6.281, 0.1223, 0.4506, 0.7662);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer6, 200192, buffer0, 216428, 29568);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline33 = device0.createComputePipeline({
+  label: '\u0360\u{1f96b}\u{1ff4d}\u0d20\u53b5\u{1fcb2}\ua024\u7000',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder32 = device0.createCommandEncoder();
+let texture16 = device0.createTexture({
+  label: '\u93d2\u{1fb12}\u{1fbc9}\u{1f79e}\u723f\u{1fc11}\u{1f787}\u9ff1',
+  size: {width: 30, height: 96, depthOrArrayLayers: 47},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder14 = commandEncoder31.beginComputePass({});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 276.4, g: -174.6, b: 263.1, a: -730.7, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(19.59, 0.1252, 40.51, 0.3826, 0.1908, 0.3670);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer3, 274584, buffer0, 521580, 252);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet6, 335, 36, buffer8, 87040);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas8.getContext('webgpu');
+let bindGroup12 = device0.createBindGroup({
+  label: '\u77c8\ub1d6\ud970\u9c44\u{1fb00}\u785f',
+  layout: bindGroupLayout1,
+  entries: [{binding: 2477, resource: externalTexture0}],
+});
+let querySet14 = device0.createQuerySet({label: '\u{1fae2}\u{1fba1}\u0b71\u{1fce6}', type: 'occlusion', count: 1580});
+let textureView41 = texture16.createView({
+  label: '\u0916\u{1fb56}\u857c\u45e8\u{1fe8e}\ud42d\u09be\ue10f\u{1f849}\uef8c\uce1b',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer1, 12268, buffer0, 112916, 74008);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 337, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'all',
+},
+{width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(querySet2, 231, 1275, buffer8, 56832);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let videoFrame4 = new VideoFrame(img1, {timestamp: 0});
+let textureView42 = texture15.createView({baseMipLevel: 4, mipLevelCount: 3, baseArrayLayer: 0});
+let sampler15 = device0.createSampler({
+  label: '\uc556\u5080\u07f2',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.86,
+  lodMaxClamp: 94.51,
+  compare: 'less',
+  maxAnisotropy: 19,
+});
+let externalTexture12 = device0.importExternalTexture({label: '\u540f\u{1fe46}\u073f', source: videoFrame1, colorSpace: 'srgb'});
+let arrayBuffer3 = buffer2.getMappedRange(43952, 43416);
+try {
+computePassEncoder1.insertDebugMarker('\u6124');
+} catch {}
+let gpuCanvasContext9 = canvas3.getContext('webgpu');
+let imageBitmap7 = await createImageBitmap(videoFrame1);
+let videoFrame5 = videoFrame0.clone();
+let commandEncoder33 = device0.createCommandEncoder({label: '\uccdf\u0789\u5b75\u09ac\u69a3\u0106\u0a59\u{1faf9}\uba71\u{1f744}\u0655'});
+let renderPassEncoder8 = commandEncoder32.beginRenderPass({
+  label: '\u02db\u5d54\u{1fb3a}\ucb46\ua7c8\u0952\ua1a1\u0b64',
+  colorAttachments: [{
+  view: textureView14,
+  depthSlice: 132,
+  clearValue: { r: -797.6, g: 62.46, b: -821.9, a: 824.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView23, depthSlice: 251, loadOp: 'load', storeOp: 'store'}],
+});
+try {
+computePassEncoder13.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet7, 1448, 1297, buffer8, 92672);
+} catch {}
+let videoFrame6 = new VideoFrame(canvas0, {timestamp: 0});
+let externalTexture13 = device0.importExternalTexture({label: '\u5edc\u{1fe16}\u{1fd21}\u0dc4\u0cfd', source: videoFrame5, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.beginOcclusionQuery(188);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1377, undefined, 0, 677744374);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 346, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(querySet8, 1056, 0, buffer8, 54784);
+} catch {}
+let promise9 = device0.createRenderPipelineAsync({
+  label: '\udb4f\ufec9\u02d9',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 3221563266,
+    stencilWriteMask: 1878133937,
+    depthBias: 849478166,
+    depthBiasSlopeScale: 142.49562287773466,
+  },
+  vertex: {module: shaderModule6, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'none'},
+});
+let texture17 = device0.createTexture({
+  label: '\u8be6\u{1faaa}\u0867\u{1fd05}',
+  size: [700, 1, 679],
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let textureView43 = texture3.createView({label: '\uc1d6\u623f\u2429', baseMipLevel: 2});
+let renderPassEncoder9 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView14,
+  depthSlice: 191,
+  clearValue: { r: -211.2, g: 322.3, b: 633.9, a: -201.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView28,
+  depthSlice: 354,
+  clearValue: { r: -774.4, g: 817.7, b: 124.4, a: 192.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet8,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\ue35e\u{1fbb8}\u{1fa6b}\u{1ffa1}\u01f6',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let renderBundle24 = renderBundleEncoder14.finish({label: '\u010f\u0c1e\u{1fac7}\ue21d\u0140\u{1fdc5}'});
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -215.5, g: 620.1, b: 579.3, a: -553.7, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(14.93, 0.1233, 10.84, 0.5885, 0.7186, 0.8875);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup4);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let imageBitmap8 = await createImageBitmap(imageBitmap7);
+let externalTexture14 = device0.importExternalTexture({label: '\u0705\u05f3\u17db\u{1fd28}\uec45\ud1af', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder9.executeBundles([renderBundle23, renderBundle10, renderBundle6, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(2, 1, 47, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6060, undefined);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(479, undefined);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer2, 146648);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  label: '\u0133\u9dd2\u0de8\u3f73\u762b\u{1f971}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 2477, resource: externalTexture5}],
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\u06cf\ub179\u{1fed4}\u0926\u{1f924}\u{1fec5}'});
+let computePassEncoder15 = commandEncoder33.beginComputePass({label: '\u0db0\u7168\u{1fae3}\u{1f7d9}\u03e6'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u0cf3\u018e\ufc6a\uf7bb\ua1f7\u0e3a\u048d\uc896\u4756\ufa97\u3d72',
+  colorFormats: ['r32uint', 'r32uint'],
+});
+let renderBundle25 = renderBundleEncoder10.finish({label: '\u03a6\u{1f623}'});
+let externalTexture15 = device0.importExternalTexture({label: '\u0ddb\u31ef\u038d\u9417\u7013\u8a3e\ua7ba\u0acb\u12ed\ufe64\u0aa9', source: video2});
+try {
+computePassEncoder12.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(545);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(25, 1, 14, 0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(80.97, 0.1533, 4.593, 0.8466, 0.1969, 0.7522);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer5, 261160, buffer2, 118204, 22932);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+canvas1.height = 1850;
+let textureView44 = texture0.createView({
+  label: '\u700a\u2aed\u153c\u6460\u{1f949}\u0930\u33e6\u{1f602}\u{1ffb8}\u00e8',
+  baseMipLevel: 3,
+  baseArrayLayer: 891,
+  arrayLayerCount: 34,
+});
+let computePassEncoder16 = commandEncoder34.beginComputePass();
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup2, new Uint32Array(2524), 1315, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(36);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(952);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline17);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 1285});
+let textureView45 = texture4.createView({label: '\ucb78\u8661\u0f3e', dimension: '3d', baseMipLevel: 1, mipLevelCount: 4});
+try {
+renderPassEncoder0.setStencilReference(2423);
+} catch {}
+try {
+renderPassEncoder7.setViewport(32.41, 0.6132, 31.59, 0.3714, 0.2898, 0.3509);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline25);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet5, 1018, 437, buffer8, 47360);
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync({
+  label: '\u01bf\ubf27',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let commandEncoder36 = device0.createCommandEncoder({label: '\u{1f76e}\u{1f6f0}\uf210\u268c\u0fb1\u1b1c'});
+let texture18 = device0.createTexture({
+  label: '\u09a5\ud787\u7db6\u{1f82c}\u{1f868}\u0be1\u329c\u{1fc83}\u0e3e',
+  size: {width: 350},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView46 = texture14.createView({label: '\ue5ec\ue35a\u7038\u0c8f\u{1fa5a}\ub5d2\u5655\u748c\u17b6', baseMipLevel: 2, mipLevelCount: 3});
+let computePassEncoder17 = commandEncoder35.beginComputePass();
+let renderPassEncoder10 = commandEncoder36.beginRenderPass({
+  label: '\u0ca6\u0bcf',
+  colorAttachments: [{view: textureView32, loadOp: 'load', storeOp: 'store'}, {
+  view: textureView38,
+  depthSlice: 80,
+  clearValue: { r: 679.5, g: -526.0, b: 378.2, a: 166.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 135941786,
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['r32uint', 'r32uint']});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder7.draw(2, 102, 10_148_319, 3_160_539_127);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer3, 251140, buffer0, 276140, 33440);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 309, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet12, 1229, 1769, buffer8, 17664);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\uae54\ud8f6',
+  entries: [{binding: 3154, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u0086\u9c8e\u0fe2',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture16 = device0.importExternalTexture({label: '\u6fc7\u5a00\u7827\u{1f809}\u4bc2\u0dc7', source: videoFrame6, colorSpace: 'srgb'});
+try {
+computePassEncoder13.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(3614);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder6.draw(240, 2, 362_478_507);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 0, y: 16, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 4, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let img4 = await imageWithData(27, 66, '#64020410', '#9ebe6d20');
+try {
+canvas6.getContext('2d');
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder();
+let sampler16 = device0.createSampler({
+  label: '\u10ff\u5515\ue826\uf8e0\u0c0a\u5b24',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.209,
+  lodMaxClamp: 8.852,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(427);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer7, 369_241_747);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer4, 1_125_280_363);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer1, 85592, buffer2, 182752, 9084);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 3, y: 61, z: 8},
+  aspect: 'all',
+},
+{width: 0, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 47},
+  aspect: 'all',
+}, new ArrayBuffer(4_216_765), /* required buffer size: 4_216_765 */
+{offset: 613, bytesPerRow: 96, rowsPerImage: 93}, {width: 6, height: 23, depthOrArrayLayers: 473});
+} catch {}
+let pipeline35 = await device0.createComputePipelineAsync({
+  label: '\ucb6c\u9d05\u0e8f\u55ec\ub7c4\u{1f88d}\u2c2c\u{1f651}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas9 = new OffscreenCanvas(1005, 517);
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\uacd2\u8d04\u1099\u14d0\u{1fd9d}\u0109',
+  entries: [{binding: 410, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let querySet16 = device0.createQuerySet({label: '\u62c0\u0590\u2f68', type: 'occlusion', count: 2679});
+let textureView47 = texture8.createView({label: '\u05c0\u9e0d\u5571\u{1f753}\uf08a\u{1fcae}\u032b\u65db\u5c16', format: 'r32uint'});
+let computePassEncoder18 = commandEncoder37.beginComputePass({label: '\ua886\u9270\ub2e2\u20f4\ube49\u{1fcfb}\u{1f70e}\uc247\u086e'});
+let renderBundle26 = renderBundleEncoder13.finish();
+let sampler17 = device0.createSampler({
+  label: '\u24b7\u{1f727}\u07e0',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.85,
+  lodMaxClamp: 92.76,
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'srgb'});
+try {
+renderPassEncoder8.setScissorRect(29, 0, 40, 1);
+} catch {}
+try {
+renderPassEncoder7.draw(110, 88, 231_239_772, 645_399_566);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer6, 16_526_390);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer8, 380_579_016);
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker('\u0cb9');
+} catch {}
+try {
+renderBundleEncoder21.insertDebugMarker('\u77f9');
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let video4 = await videoWithData();
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u7b32\u{1fca5}\u06e1\u{1f866}\u5d03\uc82e\u4cc7',
+  bindGroupLayouts: [bindGroupLayout14, bindGroupLayout10, bindGroupLayout4, bindGroupLayout4, bindGroupLayout13, bindGroupLayout5, bindGroupLayout1],
+});
+let buffer9 = device0.createBuffer({label: '\u94d7\u7f9b\u972c', size: 219594, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder38 = device0.createCommandEncoder({label: '\uf76d\u0965\ub2f4\u{1f92e}\u0086\uffd3\u150f'});
+let renderBundle27 = renderBundleEncoder21.finish({label: '\ua36d\u{1fd0b}\u{1fdc6}\u0722\u32c2\u0307\u{1ff3d}\u032a\u0815\ue78d\u09af'});
+try {
+computePassEncoder3.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(3195);
+} catch {}
+try {
+renderPassEncoder7.draw(104, 331);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 243_539_523);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer7, 1_367_289_288);
+} catch {}
+try {
+renderBundleEncoder6.draw(78, 84, 167_834_799, 397_563_250);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(267, 440, 91_743_732, -2_047_491_183, 2_031_029_253);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 3284 widthInBlocks: 821 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26660 */
+  offset: 26660,
+  buffer: buffer6,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 821, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+gc();
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 2041});
+let renderBundle28 = renderBundleEncoder1.finish({label: '\u6e6c\u{1fd84}\u7a06\u9ced\u052f\u0440\u078d\u{1fe05}'});
+let externalTexture18 = device0.importExternalTexture({label: '\u{1fa50}\u3b72\uef7a\u562f\u0ff5\u03d6\u{1f998}\u02dd\u88d1', source: video2});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(94);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 639.2, g: 32.40, b: 333.7, a: -679.4, });
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(2797);
+} catch {}
+try {
+renderPassEncoder7.draw(365, 127, 745_973_870);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer5, 3_067_266_434);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3286, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(125);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7116, undefined, 713891264, 2147508844);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2_623_858 */
+{offset: 383, bytesPerRow: 611, rowsPerImage: 53}, {width: 113, height: 1, depthOrArrayLayers: 82});
+} catch {}
+let pipeline36 = await device0.createRenderPipelineAsync({
+  label: '\u0b33\u1682\u88ea\u5d5b\u686e\ubc3c\u0543\u0749\u2ef8\u08a7\ufa04',
+  layout: pipelineLayout5,
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 1554347706,
+    stencilWriteMask: 2798836161,
+    depthBias: -498781972,
+    depthBiasSlopeScale: 362.921424968548,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 536, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint32x3', offset: 8152, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 3004, shaderLocation: 6},
+          {format: 'sint32x3', offset: 1996, shaderLocation: 13},
+          {format: 'uint32', offset: 200, shaderLocation: 12},
+          {format: 'sint32x2', offset: 5156, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 104, shaderLocation: 4},
+          {format: 'float32', offset: 2904, shaderLocation: 11},
+          {format: 'float32x4', offset: 328, shaderLocation: 0},
+          {format: 'float32', offset: 432, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 10900,
+        attributes: [
+          {format: 'float16x2', offset: 1600, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 956, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 1736, shaderLocation: 10},
+          {format: 'sint32', offset: 1300, shaderLocation: 1},
+          {format: 'float16x4', offset: 580, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 2468,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 224, shaderLocation: 7}],
+      },
+      {arrayStride: 1092, stepMode: 'instance', attributes: []},
+      {arrayStride: 252, attributes: []},
+      {arrayStride: 2448, attributes: []},
+      {arrayStride: 2252, stepMode: 'instance', attributes: []},
+      {arrayStride: 1772, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1968, attributes: [{format: 'sint16x2', offset: 676, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let imageData5 = new ImageData(248, 212);
+let commandEncoder39 = device0.createCommandEncoder({label: '\uc2c5\u5201\uff5a\u{1faa8}\u0874\u0dff\u{1f703}'});
+let textureView48 = texture16.createView({label: '\uc893\u04e8\u{1f8c6}\u{1ffc2}\u23b8\uf80f\ud1bd\u{1f937}'});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.39,
+  lodMaxClamp: 99.05,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle16, renderBundle27, renderBundle13, renderBundle16, renderBundle22, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(3463);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer8, 2_862_283);
+} catch {}
+let promise11 = buffer7.mapAsync(GPUMapMode.READ, 0, 27220);
+try {
+commandEncoder8.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync({
+  label: '\u0a23\ue918\uec68\u{1fdde}\u5029\u1c9d\u6263\ue8f4\u6873',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let pipeline38 = device0.createRenderPipeline({
+  label: '\u0b4d\u{1f718}\ub786\u6fd8\u5ceb\u12b0\ue125\u0eb5',
+  layout: pipelineLayout5,
+  multisample: {count: 4},
+  vertex: {module: shaderModule6, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+let gpuCanvasContext10 = offscreenCanvas9.getContext('webgpu');
+video3.width = 178;
+try {
+device0.label = '\u002a\u1ffa';
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\u3710\u020b\u0110\u6c74\u4a87',
+  entries: [
+    {
+      binding: 3647,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder40 = device0.createCommandEncoder();
+let commandBuffer13 = commandEncoder8.finish({label: '\u29a6\u0b89\u0f95\u0887\u{1fa1a}\u4926\u4b8d\ub25c'});
+let texture19 = device0.createTexture({
+  label: '\u5a22\u0efe\ubd7c\u227f\ued6c\u822f\u4da4\u0a1a\u3916\u150c\u5f73',
+  size: {width: 1401, height: 1, depthOrArrayLayers: 1210},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let renderPassEncoder11 = commandEncoder38.beginRenderPass({
+  label: '\u8783\u{1fd4b}\u285f',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 294,
+  clearValue: { r: -136.8, g: -928.4, b: 235.9, a: -826.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView13,
+  depthSlice: 366,
+  clearValue: { r: -415.5, g: 594.1, b: 381.3, a: 136.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u{1f865}\u5784\u6bf6\uf68e\ue0b7\u0f5e\u{1f960}\u24a9\u902f\uc521\ub676',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: false,
+});
+try {
+computePassEncoder16.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup7, new Uint32Array(5268), 4508, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle25, renderBundle21, renderBundle8, renderBundle17, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(39, 0, 48, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(9700, undefined, 3526195911, 126944455);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer6, 128312, buffer2, 85908, 39452);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18676 */
+  offset: 18676,
+  rowsPerImage: 134,
+  buffer: buffer3,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet15, 1117, 151, buffer8, 34560);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer3), /* required buffer size: 419 */
+{offset: 419}, {width: 329, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u{1fe00}\u09f7\u0c76\u6782\u8c74',
+  layout: bindGroupLayout12,
+  entries: [
+    {binding: 3765, resource: sampler17},
+    {binding: 3769, resource: sampler0},
+    {binding: 2930, resource: externalTexture18},
+  ],
+});
+let sampler19 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'clamp-to-edge', lodMinClamp: 38.39, lodMaxClamp: 79.01});
+try {
+renderPassEncoder7.drawIndexed(118);
+} catch {}
+let arrayBuffer4 = buffer0.getMappedRange(503008, 21880);
+let commandEncoder41 = device0.createCommandEncoder({label: '\u0677\u08ea\u{1fd48}\ub0b5\u12dc\u80ec'});
+let externalTexture19 = device0.importExternalTexture({label: '\u{1f6e7}\u0a34\u02b4\u83b2', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(2817);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle12, renderBundle17, renderBundle27, renderBundle26, renderBundle20, renderBundle8, renderBundle7, renderBundle28, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(79, 0, 4, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(57.37, 0.6126, 18.12, 0.1507, 0.2967, 0.3950);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(319);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer4, 566_615_373);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer7, 2_907_963_095);
+} catch {}
+try {
+texture19.destroy();
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 88, y: 0, z: 76},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 160, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 483, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline39 = await device0.createComputePipelineAsync({
+  label: '\u77cd\u2286\u0a4c\u{1f6ae}\u{1f7eb}\u89a5\u059c\u82f9\u0bae',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u{1fe39}\u0db5\u0269\u8383\u{1fd78}\ue4fd\u{1f7bc}\u54bd\u0f68\u730f\u{1f9f8}'});
+let textureView49 = texture9.createView({
+  label: '\u{1fc19}\udbc1',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 713,
+  arrayLayerCount: 1,
+});
+let computePassEncoder19 = commandEncoder42.beginComputePass({});
+let renderPassEncoder12 = commandEncoder40.beginRenderPass({
+  label: '\u{1fd44}\u9f57\ud938\u0ad6\u0e3e\u0449\u85ef\u9a1c\u{1ff91}\u05c5\uf07c',
+  colorAttachments: [{
+  view: textureView14,
+  depthSlice: 385,
+  clearValue: { r: 656.1, g: 346.7, b: -272.1, a: 178.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView28, depthSlice: 169, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet6,
+});
+let renderBundle29 = renderBundleEncoder24.finish({label: '\u0a2c\ufa5f\u{1f670}\uc511'});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame2});
+try {
+renderPassEncoder8.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(651);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer0, 227444);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet3, 46, 354, buffer8, 96000);
+} catch {}
+try {
+computePassEncoder8.insertDebugMarker('\u0b52');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 286},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 13_271_920 */
+{offset: 760, bytesPerRow: 610, rowsPerImage: 294}, {width: 110, height: 0, depthOrArrayLayers: 75});
+} catch {}
+let pipeline40 = await device0.createComputePipelineAsync({
+  label: '\ufee2\u4f71\u2040\ua788\u14e4\u0054\u24e9\u01d7\u4836\u9b94\u79af',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let canvas7 = document.createElement('canvas');
+let computePassEncoder20 = commandEncoder41.beginComputePass({label: '\u0993\u{1fa16}\u86b5\u6b66'});
+try {
+renderPassEncoder6.setBlendConstant({ r: -699.7, g: 258.7, b: 318.6, a: -403.3, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(102, 333);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\u04c6');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\uc9dc\ub938\u7ee8\u{1f783}\u{1fe5f}\u04d3',
+  layout: bindGroupLayout15,
+  entries: [{binding: 410, resource: externalTexture4}],
+});
+let commandEncoder43 = device0.createCommandEncoder({label: '\uae3e\u765b\u75bd\uabcd\u{1f8df}\u096b\u0a24\u{1fece}\u91de'});
+let querySet18 = device0.createQuerySet({label: '\u7542\u{1f614}\u65ba\u2118\u36d5\u9404\uf594\u088d', type: 'occlusion', count: 11});
+let textureView50 = texture6.createView({
+  label: '\u040d\u6cd2\u{1f826}\u99c0\u0bf8\u9135\u67f3\u25c9\u{1fff9}',
+  dimension: '2d',
+  baseArrayLayer: 44,
+});
+let computePassEncoder21 = commandEncoder43.beginComputePass({});
+let renderPassEncoder13 = commandEncoder39.beginRenderPass({
+  label: '\u06d2\u5c52\u{1f7af}\u{1fb24}\u0893\u055d\u6fe2\uae02\uc5d9\ufa60\u0b74',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 47,
+  clearValue: { r: 607.6, g: 652.4, b: 116.1, a: 993.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView43,
+  depthSlice: 347,
+  clearValue: { r: 80.04, g: -166.2, b: -826.5, a: -382.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 939034612,
+});
+let renderBundle30 = renderBundleEncoder2.finish({label: '\ua34e\u9695\ua6c7\u74e1\u53df\u{1fb1e}\u46aa\uc420\u4a55\u{1fbd4}'});
+let sampler20 = device0.createSampler({
+  label: '\u0333\u64f0\u{1fb6a}\u329d\ub643\u{1fee7}\u13a9\u89a3\u{1fa5b}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 12.51,
+  lodMaxClamp: 56.85,
+});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 474.0, g: -694.8, b: -366.6, a: -217.6, });
+} catch {}
+try {
+renderPassEncoder7.setViewport(0.6770, 0.05549, 46.08, 0.8085, 0.1106, 0.8987);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(9, 94, 300_086_453, 1_118_602_461, 1_316_078_685);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7791, undefined, 0, 297939317);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11, commandBuffer7, commandBuffer13]);
+} catch {}
+let pipeline41 = await device0.createComputePipelineAsync({
+  label: '\u0a5b\u{1fa7d}\u3fbd\udcfe\u{1fe0b}\u3c42\u7cf7\u6d3e',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({entries: []});
+let textureView51 = texture19.createView({label: '\u30a3\ub11f', baseMipLevel: 6, mipLevelCount: 2});
+let renderBundle31 = renderBundleEncoder1.finish();
+let sampler21 = device0.createSampler({
+  label: '\u08da\uc32d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.29,
+  compare: 'less-equal',
+});
+let pipeline42 = device0.createComputePipeline({
+  label: '\u02be\u7f84\ufb90\ucdbd\u0e2b',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline43 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 3805811225,
+    depthBias: -1483349935,
+    depthBiasSlopeScale: 20.011148723474037,
+  },
+  vertex: {module: shaderModule6, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let querySet19 = device0.createQuerySet({label: '\u6705\udf09\u218f\u58e3\ua0b1\ub8dd\u84cd\u{1fb57}', type: 'occlusion', count: 4016});
+let renderBundle32 = renderBundleEncoder17.finish({label: '\u{1fa60}\u233c'});
+try {
+renderPassEncoder1.setScissorRect(61, 1, 9, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(38.47, 0.3920, 16.41, 0.05854, 0.5583, 0.6475);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(17);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline17);
+} catch {}
+let arrayBuffer5 = buffer2.getMappedRange(165408, 23720);
+let pipeline44 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let renderBundle33 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(441);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle15, renderBundle17, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(60, 0, 20, 1);
+} catch {}
+try {
+renderPassEncoder13.setViewport(12.07, 0.1669, 10.89, 0.7476, 0.8359, 0.9904);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(42, 153, 1_354_231_470);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline31);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet14, 964, 68, buffer8, 11520);
+} catch {}
+try {
+renderPassEncoder9.pushDebugGroup('\u{1faf6}');
+} catch {}
+try {
+  await promise10;
+} catch {}
+let imageBitmap9 = await createImageBitmap(video1);
+let commandBuffer14 = commandEncoder2.finish();
+let texture20 = device0.createTexture({
+  label: '\u{1fc20}\ue795\ub431\u07d4\u{1f7ba}\u049e\u4c6d\u15d7\u3b06\u{1f9cb}',
+  size: [700, 1, 67],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView52 = texture7.createView({label: '\u3411\u09fb', dimension: '1d'});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u{1f86b}\u08b4\u05e5\ub707\ue434\u26c3\u967f\u{1f687}\u8604\u18f8',
+  colorFormats: ['r32uint', 'r32uint'],
+  sampleCount: 1,
+});
+let sampler22 = device0.createSampler({
+  label: '\u{1fc6d}\u73d9\u088c\ueea1\u0ab5\uf232\u{1f91f}\uad1c\u00d0\uf348',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.43,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup10, new Uint32Array(6274), 3074, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer5, 215_216_565);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline17);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({label: '\u6820\u{1fe6b}\u0d64\u{1f7cc}'});
+let commandBuffer15 = commandEncoder44.finish({label: '\u0c17\uc6e3\u0136\u2254\u0efc\u7af0\u7ed1'});
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(30, 1, 13, 0);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(2798);
+} catch {}
+try {
+renderPassEncoder6.setViewport(70.01, 0.1993, 8.026, 0.7741, 0.3728, 0.8803);
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u228b\u78e2\u0e5b'});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(6, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(16, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(122, 210, 151_996_948, 810_406_174);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer2, 67_501_030);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer5, 13348, buffer0, 390396, 11692);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let pipeline45 = device0.createRenderPipeline({
+  label: '\u{1ff6f}\ue387\u508e\u4bef\ua1f3',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x59b3ffe9},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3188, attributes: []},
+      {
+        arrayStride: 4924,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 760, shaderLocation: 4},
+          {format: 'sint32x2', offset: 440, shaderLocation: 14},
+          {format: 'float32x2', offset: 236, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 7684,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 344, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw'},
+});
+gc();
+let imageData6 = new ImageData(168, 244);
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({label: '\u077a\ua6c8\u{1fd92}', colorFormats: ['r32uint', 'r32uint']});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(20, 0, 64, 1);
+} catch {}
+try {
+renderPassEncoder7.draw(34);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer9, 213100, buffer0, 413172, 2788);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 157, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet7, 2101, 246, buffer8, 44288);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(442, 973);
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+let textureView53 = texture1.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 53, arrayLayerCount: 1});
+let renderPassEncoder14 = commandEncoder45.beginRenderPass({
+  label: '\u0932\u8c01',
+  colorAttachments: [{
+  view: textureView14,
+  depthSlice: 203,
+  clearValue: { r: -835.9, g: 336.2, b: -224.9, a: -18.07, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView29, depthSlice: 44, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 49435682,
+});
+let renderBundle34 = renderBundleEncoder29.finish({label: '\u0005\u{1f8f0}\ud604\u6a06\u0050\u0758\u4ea8'});
+let sampler23 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 3.268,
+  maxAnisotropy: 1,
+});
+let externalTexture21 = device0.importExternalTexture({source: video4, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setVertexBuffer(7754, undefined, 35615915);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(730, undefined, 1697206960);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4212, new Float32Array(18006));
+} catch {}
+try {
+  await promise12;
+} catch {}
+document.body.prepend(canvas7);
+let imageData7 = new ImageData(28, 160);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let textureView54 = texture11.createView({label: '\ub5fe\u2e47\u6bd4\u050f', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+renderPassEncoder7.setBindGroup(5, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle20, renderBundle12, renderBundle3, renderBundle18, renderBundle34, renderBundle17]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(24, 1, 8, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(43);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(310, 396, 636_307_163);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer4, 1_117_610_141);
+} catch {}
+try {
+renderBundleEncoder4.draw(42, 293);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline14);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder9.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 25_151 */
+{offset: 571, bytesPerRow: 80, rowsPerImage: 150}, {width: 5, height: 8, depthOrArrayLayers: 3});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(330, 993);
+let bindGroup16 = device0.createBindGroup({
+  label: '\u1dc8\u2b91\uc641\uc3ff\u0304\ud08d\uf4f2',
+  layout: bindGroupLayout15,
+  entries: [{binding: 410, resource: externalTexture0}],
+});
+let textureView55 = texture1.createView({
+  label: '\u05fd\u1d2e\u0c0a\u6cd5\u03be\u31e8\u{1fcf1}\u7bba\u{1f7b9}',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  baseArrayLayer: 218,
+});
+let externalTexture22 = device0.importExternalTexture({label: '\u856f\u2415\u{1fae5}\u{1fddd}\u926f', source: video0});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder12.beginOcclusionQuery(56);
+} catch {}
+try {
+renderPassEncoder11.setViewport(37.29, 0.05321, 14.89, 0.6510, 0.6373, 0.7931);
+} catch {}
+try {
+renderBundleEncoder4.draw(56, 9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 53004, new Int16Array(13203), 9227);
+} catch {}
+let pipeline46 = device0.createComputePipeline({
+  label: '\u74bc\ubcb0\u0715\u2d94\u8fac\u50c6\u5f72\u{1fb34}\ud62a',
+  layout: 'auto',
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline47 = device0.createRenderPipeline({
+  label: '\u0d6a\u0330\u03f9\udbcc',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'always', failOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilWriteMask: 2983651177,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 11556, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1072, attributes: [{format: 'sint32x3', offset: 64, shaderLocation: 8}]},
+      {
+        arrayStride: 3244,
+        attributes: [
+          {format: 'uint8x4', offset: 36, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 640, shaderLocation: 3},
+          {format: 'sint8x4', offset: 1184, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 852, shaderLocation: 0},
+          {format: 'sint8x4', offset: 1872, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 2764,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 264, shaderLocation: 4},
+          {format: 'sint16x2', offset: 596, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+let gpuCanvasContext11 = offscreenCanvas11.getContext('webgpu');
+let videoFrame7 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let commandEncoder46 = device0.createCommandEncoder({label: '\u0370\u0822\u8b3a\u110c\u{1fb54}\u4a72\ufadb\u{1fb96}'});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 411});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u0d7b\u78cf\u{1fb08}\u0ef2\u5c34\u05da\u{1f957}\u7177\uce64',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let sampler24 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.52,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder4.draw(21, 201, 250_556_643, 312_233_688);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(130, 115);
+} catch {}
+let arrayBuffer6 = buffer5.getMappedRange(14944, 10888);
+let videoFrame8 = new VideoFrame(img1, {timestamp: 0});
+let buffer10 = device0.createBuffer({
+  label: '\u{1fbf6}\u0ca9\u243a\u5b59\u5640\u0ed9\u033d\u{1fdae}',
+  size: 202627,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder47 = device0.createCommandEncoder({label: '\ua2a9\u9c68\u84dd'});
+let texture21 = device0.createTexture({
+  label: '\u2a26\u{1f925}\u{1f84c}\uaa0e\ue7f9\u{1fb84}\u11f7',
+  size: [120, 384, 1949],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let renderPassEncoder15 = commandEncoder46.beginRenderPass({
+  label: '\u8e77\u0b82\u4019\ua19c\ub225\ufe9c\u4d6a\u963a',
+  colorAttachments: [{
+  view: textureView14,
+  depthSlice: 193,
+  clearValue: { r: -302.5, g: -192.5, b: -992.6, a: -941.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView13,
+  depthSlice: 302,
+  clearValue: { r: 809.2, g: -457.7, b: 678.3, a: 751.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet20,
+  maxDrawCount: 1091420177,
+});
+let renderBundle35 = renderBundleEncoder13.finish({label: '\u845d\u795d'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(4, bindGroup4, new Uint32Array(2373), 1312, 0);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -195.4, g: -175.8, b: 81.01, a: -962.4, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(550, 1, 713, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(139, 82);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(351, 114, 607_902_871, 35_813_132, 393_338_043);
+} catch {}
+try {
+renderBundleEncoder4.draw(48, 67, 215_138_152, 241_187_667);
+} catch {}
+let promise13 = buffer0.mapAsync(GPUMapMode.READ, 48688);
+try {
+commandEncoder47.resolveQuerySet(querySet0, 657, 144, buffer8, 20224);
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u682f\u44c5\u0a75\u056f\uadcc\uac7e',
+  entries: [
+    {binding: 40, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 1501, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let querySet21 = device0.createQuerySet({
+  label: '\u{1f9ae}\u00c9\uc27d\ua501\u1994\u{1fd50}\uf13d\u41c7\ua324\u0659\u5348',
+  type: 'occlusion',
+  count: 2925,
+});
+let renderBundle36 = renderBundleEncoder7.finish({label: '\u5d0c\ubc46\u4b6f\u6214\u0d27\u2612\u{1f891}'});
+let sampler25 = device0.createSampler({
+  label: '\u0a5c\u045f\u0e82\u{1f918}\ub34b\u{1fd6b}\u0e68',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 43.00,
+  lodMaxClamp: 87.35,
+  compare: 'equal',
+});
+try {
+computePassEncoder14.setPipeline(pipeline42);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 492.2, g: 503.7, b: 572.1, a: 446.4, });
+} catch {}
+try {
+renderBundleEncoder4.draw(56);
+} catch {}
+try {
+texture14.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 215, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 26_800_377 */
+{offset: 869, bytesPerRow: 2232, rowsPerImage: 174}, {width: 529, height: 1, depthOrArrayLayers: 70});
+} catch {}
+let promise14 = device0.createComputePipelineAsync({
+  label: '\u0f74\ucbdc\u6e31\u0120\u0315\u403c\u0867\u{1f7f3}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+gc();
+let shaderModule7 = device0.createShaderModule({
+  label: '\u{1fe25}\u{1f9b2}',
+  code: `@group(4) @binding(673)
+var<storage, read_write> type5: array<u32>;
+@group(5) @binding(3004)
+var<storage, read_write> parameter7: array<u32>;
+@group(4) @binding(1151)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(3796)
+var<storage, read_write> parameter8: array<u32>;
+@group(5) @binding(186)
+var<storage, read_write> n3: array<u32>;
+@group(1) @binding(2477)
+var<storage, read_write> local3: array<u32>;
+@group(4) @binding(1019)
+var<storage, read_write> type6: array<u32>;
+@group(6) @binding(2477)
+var<storage, read_write> global1: array<u32>;
+@group(3) @binding(3796)
+var<storage, read_write> global2: array<u32>;
+@group(5) @binding(424)
+var<storage, read_write> global3: array<u32>;
+@group(3) @binding(3374)
+var<storage, read_write> parameter9: array<u32>;
+
+@compute @workgroup_size(3, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: f32,
+  @location(0) f1: u32,
+  @builtin(sample_mask) f2: u32,
+  @location(1) f3: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(1) f0: f16,
+  @location(2) f1: vec3<f16>,
+  @location(6) f2: vec2<f16>,
+  @location(12) f3: vec3<f32>,
+  @location(14) f4: u32,
+  @location(11) f5: vec2<u32>,
+  @location(13) f6: vec4<u32>,
+  @location(9) f7: vec3<f16>,
+  @location(3) f8: f32,
+  @location(15) f9: vec3<u32>,
+  @location(4) f10: i32
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<f16>, @location(8) a1: vec4<u32>, @location(0) a2: u32, a3: S8, @location(5) a4: f16, @location(10) a5: i32, @builtin(vertex_index) a6: u32, @builtin(instance_index) a7: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder49 = device0.createCommandEncoder();
+try {
+computePassEncoder12.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7713, undefined, 0);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet5, 394, 845, buffer8, 51968);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let buffer11 = device0.createBuffer({label: '\u05fa\u91b9\u3115\u6601\u{1ff00}\u3ef1', size: 159679, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder50 = device0.createCommandEncoder();
+let querySet22 = device0.createQuerySet({label: '\u09e8\u0f76\u9a2d\u78e1', type: 'occlusion', count: 2558});
+let texture22 = device0.createTexture({
+  label: '\ud485\ue4ad\u20cf\u7e80\u046e\u{1f673}\u07e1\u0df0\u0f11',
+  size: {width: 1920},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView56 = texture15.createView({label: '\u1182\u4a6c\u202a\u05ad\u316f\u0671', aspect: 'all', baseMipLevel: 6});
+let renderPassEncoder16 = commandEncoder5.beginRenderPass({
+  label: '\u{1fabf}\u3eaa\ueaf2\u8763\u0029\ud0c4\u{1ffbc}\uf982\u{1fb7b}',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 161,
+  clearValue: { r: 89.33, g: 525.5, b: -113.5, a: 795.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView28,
+  depthSlice: 14,
+  clearValue: { r: 304.4, g: 526.2, b: -402.5, a: 103.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 795706827,
+});
+try {
+renderPassEncoder9.setScissorRect(85, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(495, 29, 430_391_709, -2_023_829_245, 174_312_482);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(24);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6954, undefined, 3680864689, 39034145);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 463, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1906, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 1, y: 2, z: 1},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer6), /* required buffer size: 41_529 */
+{offset: 603, bytesPerRow: 259, rowsPerImage: 51}, {width: 1, height: 6, depthOrArrayLayers: 4});
+} catch {}
+let pipeline48 = await promise9;
+video4.height = 149;
+let pipelineLayout6 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout15, bindGroupLayout4, bindGroupLayout11, bindGroupLayout7, bindGroupLayout11],
+});
+let textureView57 = texture14.createView({baseMipLevel: 5});
+let externalTexture23 = device0.importExternalTexture({label: '\u0967\ub171\u02db', source: video2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setVertexBuffer(4358, undefined);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline27);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 496 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15196 */
+  offset: 15196,
+  buffer: buffer3,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 124, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline49 = await promise8;
+let renderPassEncoder17 = commandEncoder50.beginRenderPass({
+  label: '\uf70f\u7c08\u0915\u{1fe85}\uc524\u6fcb\ub8f3\u751d',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 156,
+  clearValue: { r: 620.7, g: 957.1, b: -793.5, a: -76.50, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {view: textureView43, depthSlice: 343, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 1077976180,
+});
+let externalTexture24 = device0.importExternalTexture({label: '\u2e95\u{1fc24}', source: video2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(546);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(94, 1, 446, 0);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup12, new Uint32Array(51), 14, 0);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(66_700), /* required buffer size: 66_700 */
+{offset: 172, bytesPerRow: 252, rowsPerImage: 132}, {width: 36, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let pipeline50 = device0.createRenderPipeline({
+  label: '\u{1feef}\ue850\u1e3a\ua31e',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xa3b67d7a},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'always', failOp: 'zero', depthFailOp: 'decrement-wrap'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-wrap',
+    },
+    stencilReadMask: 2827681266,
+    stencilWriteMask: 1697463802,
+    depthBias: -462687772,
+    depthBiasSlopeScale: 372.5515013090153,
+    depthBiasClamp: 407.5727936087835,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15764,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 1916, shaderLocation: 1},
+          {format: 'sint32', offset: 84, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 8704, shaderLocation: 4},
+          {format: 'sint32x3', offset: 2440, shaderLocation: 9},
+          {format: 'sint32x2', offset: 1152, shaderLocation: 7},
+          {format: 'float32x4', offset: 4200, shaderLocation: 13},
+          {format: 'sint32x2', offset: 160, shaderLocation: 12},
+          {format: 'uint32x3', offset: 200, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 17392,
+        attributes: [
+          {format: 'uint8x2', offset: 8014, shaderLocation: 14},
+          {format: 'uint32', offset: 3080, shaderLocation: 6},
+          {format: 'uint8x2', offset: 9782, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 14224, stepMode: 'instance', attributes: []},
+      {arrayStride: 6712, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10228,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 172, shaderLocation: 5}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+device0.destroy();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img5 = await imageWithData(206, 152, '#c738eae1', '#75f2f8ac');
+let video5 = await videoWithData();
+let gpuCanvasContext12 = canvas8.getContext('webgpu');
+let shaderModule8 = device0.createShaderModule({
+  label: '\u02c0\ub9f9\u0375\u0439\uf320\u2439\u77df\u82be',
+  code: `@group(0) @binding(1303)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(2198)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(55)
+var<storage, read_write> local4: array<u32>;
+@group(1) @binding(2477)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(1) f1: vec3<u32>,
+  @location(2) f2: vec3<f32>,
+  @location(3) f3: vec3<f32>,
+  @location(7) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(12) f0: vec3<i32>,
+  @location(3) f1: vec2<u32>,
+  @location(14) f2: i32,
+  @location(9) f3: f32,
+  @location(5) f4: u32,
+  @location(11) f5: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: f16, @location(1) a1: f32, a2: S9, @location(4) a3: vec4<f16>, @location(7) a4: vec4<f32>, @location(0) a5: vec4<u32>, @location(10) a6: vec3<f32>, @location(15) a7: vec2<u32>, @location(2) a8: vec4<f32>, @location(6) a9: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let buffer12 = device0.createBuffer({
+  label: '\u6cba\u{1fd26}\u{1fe23}\u7999',
+  size: 147291,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder51 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({
+  label: '\u{1f88c}\u{1fd21}\u9205\uf606\u6e33\u07c0\u07bd\uaa91\u8f1a\u{1f9fe}\u0305',
+  type: 'occlusion',
+  count: 1624,
+});
+let renderPassEncoder18 = commandEncoder47.beginRenderPass({
+  label: '\uf7b4\u{1fbd8}\u7b6a\u514f\u06a4\u0cbf\u25ea\u70f6\u5f4d',
+  colorAttachments: [{
+  view: textureView43,
+  depthSlice: 172,
+  clearValue: { r: 917.3, g: 994.3, b: 243.6, a: 763.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView29,
+  depthSlice: 208,
+  clearValue: { r: -662.6, g: 181.0, b: -336.4, a: -150.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 829227304,
+});
+let sampler26 = device0.createSampler({
+  label: '\u03c8\ua8c3\u6b50\u1084\u03c0\u{1fc41}\u027b',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 31.75,
+  lodMaxClamp: 38.96,
+});
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle6, renderBundle33, renderBundle11, renderBundle21, renderBundle5, renderBundle22, renderBundle8, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer0, 718_954_273);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer12, 351_539_465);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 124752, 21684);
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  label: '\uc7a5\u894d\u{1feca}\u3c93\u3428\u35e6\u29df\ue5a9\u3432\uaae6',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13676,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 4356, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 1628, shaderLocation: 3},
+          {format: 'sint16x4', offset: 8840, shaderLocation: 12},
+          {format: 'sint16x4', offset: 132, shaderLocation: 5},
+          {format: 'sint32x3', offset: 3252, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 292,
+        attributes: [
+          {format: 'uint32x4', offset: 12, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 1440, attributes: [{format: 'unorm8x4', offset: 40, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+renderBundleEncoder18.label = '\u06af\u{1f620}\u0a9c\ud89a\u{1fe42}\u03b8\u0778\u0046';
+} catch {}
+document.body.prepend(video3);
+try {
+texture18.label = '\u4c31\u0dff\u0088\u0f93\u0f72';
+} catch {}
+offscreenCanvas2.height = 319;
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+  await promise13;
+} catch {}
+gc();
+let videoFrame9 = new VideoFrame(img1, {timestamp: 0});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let imageData8 = new ImageData(160, 156);
+let video6 = await videoWithData();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+video0.width = 77;
+gc();
+let img6 = await imageWithData(285, 200, '#e9cf085c', '#b9d65c8b');
+let videoFrame10 = videoFrame0.clone();
+let offscreenCanvas12 = new OffscreenCanvas(764, 929);
+let imageData9 = new ImageData(212, 116);
+try {
+adapter1.label = '\u{1fe4e}\ua21c\u{1ff2a}\u2026\u0a8f\u{1f727}\u06f9\u0095\u{1f8e0}\u{1f7d2}\u0adc';
+} catch {}
+document.body.prepend(canvas4);
+let canvas9 = document.createElement('canvas');
+let gpuCanvasContext13 = canvas9.getContext('webgpu');
+canvas3.width = 7;
+let canvas10 = document.createElement('canvas');
+offscreenCanvas1.width = 677;
+let offscreenCanvas13 = new OffscreenCanvas(531, 478);
+try {
+canvas10.getContext('webgl');
+} catch {}
+document.body.prepend(img0);
+try {
+window.someLabel = bindGroupLayout2.label;
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+offscreenCanvas13.getContext('webgpu');
+} catch {}
+document.body.prepend(canvas7);
+canvas4.height = 1731;
+let offscreenCanvas14 = new OffscreenCanvas(686, 860);
+let imageData10 = new ImageData(152, 84);
+let img7 = await imageWithData(109, 283, '#63ec5b37', '#76863b1e');
+let imageBitmap10 = await createImageBitmap(video4);
+let bindGroupLayout19 = device0.createBindGroupLayout({entries: []});
+let textureView58 = texture7.createView({label: '\ud6bf\u0145'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\ub5f3\ufe00\u0286\u{1fee7}\u7d1e',
+  colorFormats: ['r32uint', 'r32uint'],
+  stencilReadOnly: false,
+});
+try {
+renderPassEncoder17.beginOcclusionQuery(764);
+} catch {}
+try {
+renderPassEncoder7.draw(64, 89, 1_768_267_676, 132_585_739);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4295, undefined, 327922182, 2953244259);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(118, 519, 41_916_488, 174_117_613, 852_784_136);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(8004, undefined);
+} catch {}
+let pipeline52 = device0.createComputePipeline({
+  label: '\u4ebc\u20c6\u7c11\u385e\u2e92',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline53 = device0.createRenderPipeline({
+  label: '\u{1f877}\u0112\u9697\u1a05\u{1f7f4}\uaad1\u{1f7e0}\uf208',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 3560280289,
+    depthBiasSlopeScale: 672.6687743205991,
+    depthBiasClamp: 782.9512575476951,
+  },
+  vertex: {module: shaderModule6, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+video5.height = 179;
+try {
+offscreenCanvas14.getContext('bitmaprenderer');
+} catch {}
+let imageBitmap11 = await createImageBitmap(canvas4);
+let videoFrame11 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let offscreenCanvas15 = new OffscreenCanvas(611, 488);
+let img8 = await imageWithData(175, 245, '#643b77c5', '#fb96d9b8');
+document.body.prepend(img7);
+let canvas11 = document.createElement('canvas');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageBitmap12 = await createImageBitmap(canvas1);
+let videoFrame12 = new VideoFrame(img8, {timestamp: 0});
+let gpuCanvasContext14 = offscreenCanvas15.getContext('webgpu');
+offscreenCanvas7.height = 265;
+let gpuCanvasContext15 = offscreenCanvas12.getContext('webgpu');
+let promise15 = adapter0.requestAdapterInfo();
+try {
+adapter0.label = '\u3ad8\u02a3\u526a\u{1f754}\u0c78\u{1fc32}';
+} catch {}
+document.body.prepend(video2);
+try {
+  await promise15;
+} catch {}
+try {
+externalTexture3.label = '\u0a29\u{1fa31}\u0f9b\u0c56\uf647\u03e3\u0d6b';
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let gpuCanvasContext16 = canvas11.getContext('webgpu');
+let offscreenCanvas16 = new OffscreenCanvas(664, 757);
+let offscreenCanvas17 = new OffscreenCanvas(217, 111);
+let offscreenCanvas18 = new OffscreenCanvas(573, 850);
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let imageData11 = new ImageData(112, 136);
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas16.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let canvas12 = document.createElement('canvas');
+video5.width = 146;
+let textureView59 = texture11.createView({
+  label: '\u{1fc71}\u515b\u{1f851}\u3d17\ua54a\u{1f931}\u{1f98c}\u3e0c\u{1ffed}\u43b4',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let sampler27 = device0.createSampler({
+  label: '\ua349\ub654\ua64a\u0d70\u06d8',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 91.61,
+  lodMaxClamp: 97.06,
+  compare: 'less',
+});
+let externalTexture25 = device0.importExternalTexture({source: video6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder9.setStencilReference(2719);
+} catch {}
+try {
+renderPassEncoder7.draw(15, 87, 833_399_427, 945_363_368);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(120, 22, 297_341_053, -1_383_866_748, 120_901_272);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer6, 1_604_325_891);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(85, 50);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2680, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 174, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer2);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let device1 = await adapter1.requestDevice({
+  label: '\u0891\u{1fca3}\u03e0\u11bc',
+  defaultQueue: {label: '\ua4b5\u1d69\u4be6\u{1ffd5}\uea0e\u1686\u{1f843}\u0ce9\ub83f\u04af'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxVertexAttributes: 27,
+    maxVertexBufferArrayStride: 10071,
+    maxStorageTexturesPerShaderStage: 12,
+    maxStorageBuffersPerShaderStage: 19,
+    maxDynamicStorageBuffersPerPipelineLayout: 6972,
+    maxDynamicUniformBuffersPerPipelineLayout: 8585,
+    maxBindingsPerBindGroup: 5262,
+    maxTextureArrayLayers: 1332,
+    maxTextureDimension1D: 15751,
+    maxTextureDimension2D: 16107,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 180050035,
+    maxStorageBufferBindingSize: 221049690,
+    maxUniformBuffersPerShaderStage: 19,
+    maxSampledTexturesPerShaderStage: 33,
+    maxInterStageShaderVariables: 48,
+    maxInterStageShaderComponents: 100,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+let commandEncoder52 = device1.createCommandEncoder({});
+let computePassEncoder22 = commandEncoder52.beginComputePass({label: '\ua631\u1434\u833f\u01fc\u0d97\u{1fffc}\u0d10\u96b9\u532c\u{1fd79}'});
+let sampler28 = device1.createSampler({
+  label: '\u0d54\u9ba9\u1f98\u0da0',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 81.06,
+});
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+document.body.prepend(canvas7);
+gc();
+let computePassEncoder23 = commandEncoder52.beginComputePass({label: '\ue859\u{1fe07}\ud9b0\u3956\uc31e\u2f69\u{1f604}\ucb28\u2637\u{1fabc}'});
+document.body.prepend(img5);
+let bindGroupLayout20 = device1.createBindGroupLayout({label: '\u5381\u{1fbe1}', entries: []});
+let commandEncoder53 = device1.createCommandEncoder({label: '\u074d\u1541\u{1f8da}\u2ee5\u7e74\u1190'});
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({colorFormats: ['r16float', 'rg32float', 'rgba32float'], stencilReadOnly: true});
+let sampler29 = device1.createSampler({
+  label: '\u7f59\u7d97',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.69,
+  lodMaxClamp: 63.23,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder23.insertDebugMarker('\u{1f72b}');
+} catch {}
+gc();
+let commandEncoder54 = device1.createCommandEncoder({label: '\u3b8c\ubada\u0265\u60db\uff35\u9fc9'});
+let computePassEncoder24 = commandEncoder54.beginComputePass({label: '\u{1fa00}\u00ac\u{1f756}'});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  label: '\u0cf9\u3387\u6148\u0b91\u00b1\u{1ff11}\u2e7b',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle37 = renderBundleEncoder33.finish({label: '\ubcba\u4c5d\ua690\ufe6d\u5c16'});
+try {
+renderBundleEncoder32.setVertexBuffer(9324, undefined, 0, 144936190);
+} catch {}
+let pipelineLayout7 = device1.createPipelineLayout({label: '\u55c9\u29a6', bindGroupLayouts: [bindGroupLayout20, bindGroupLayout20, bindGroupLayout20]});
+let querySet24 = device1.createQuerySet({label: '\u{1fda7}\uf629\u0e0e\ue0bc\u0580', type: 'occlusion', count: 2167});
+let computePassEncoder25 = commandEncoder53.beginComputePass({label: '\u{1f861}\u06f3\u016e\ua1f1\u{1fd78}\u0650'});
+let renderBundle38 = renderBundleEncoder32.finish({label: '\u3f1b\u0b0a\u68d1\u65a5\u0838\u8c2e'});
+try {
+adapter1.label = '\u343a\ue33a\uf6ad\u0bab\u6f6c';
+} catch {}
+try {
+pipeline47.label = '\u04a8\u3f50\u08a0\u{1ffce}\uc1bc';
+} catch {}
+let video7 = await videoWithData();
+let imageData12 = new ImageData(204, 240);
+let bindGroup17 = device1.createBindGroup({label: '\u048d\u{1fce4}\u{1f6c9}\u58f6\u{1fd4c}\ue62e', layout: bindGroupLayout20, entries: []});
+let commandEncoder55 = device1.createCommandEncoder({});
+let computePassEncoder26 = commandEncoder55.beginComputePass({label: '\u{1f6d5}\u{1f8f6}\u{1fec9}\u{1fb48}\u073f\u6007'});
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+gc();
+let querySet25 = device1.createQuerySet({label: '\u11a2\u69b4\u3bd8\u0099\u0f90\uaca2\u0a6e\u{1fe1f}\u0cde', type: 'occlusion', count: 1020});
+let texture23 = device1.createTexture({
+  label: '\u{1fb37}\u48e6\u{1fa97}\u5acf\u845d\u0b29\u3b74\u81f1\u{1fc5f}\u8758',
+  size: {width: 48, height: 64, depthOrArrayLayers: 2},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float'],
+});
+let externalTexture26 = device1.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+let video8 = await videoWithData();
+let texture24 = device1.createTexture({
+  label: '\ue895\u{1f792}',
+  size: {width: 48, height: 64, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let textureView60 = texture24.createView({format: 'rgba32float'});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise16 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext18 = offscreenCanvas18.getContext('webgpu');
+let renderBundleEncoder34 = device1.createRenderBundleEncoder({
+  label: '\u{1f639}\u{1f895}\ud2a2\u73e4',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+try {
+  await promise16;
+} catch {}
+document.body.prepend(img4);
+let buffer13 = device1.createBuffer({
+  label: '\uf14e\u08eb\u42ec\u01f8\uc91f',
+  size: 63900,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture25 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder35 = device1.createRenderBundleEncoder({colorFormats: ['r16float', 'rg32float', 'rgba32float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+buffer13.unmap();
+} catch {}
+let bindGroupLayout21 = device1.createBindGroupLayout({
+  label: '\u2202\ua16d\u2202\u3f0b\u0164\u5b58\u8e0c',
+  entries: [
+    {
+      binding: 4560,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let bindGroup18 = device1.createBindGroup({label: '\u{1f7ea}\ube3c', layout: bindGroupLayout20, entries: []});
+let buffer14 = device1.createBuffer({
+  label: '\ub264\u43b6\u{1f743}\uc146\ufa5a\u0922\u9ca7\u6fa2\u8b7e',
+  size: 71490,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let renderBundle39 = renderBundleEncoder34.finish({label: '\u{1fd5f}\uf800\u452a\uc036\u0333\uc1c4\u6651'});
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let img9 = await imageWithData(127, 220, '#793563f4', '#29d0c64e');
+let commandEncoder56 = device1.createCommandEncoder({label: '\uae46\u0f48\u97d4\u02e3\u6aa2\u27f7\u{1f95b}\u47f5'});
+let commandBuffer16 = commandEncoder56.finish({label: '\ue371\u{1fcca}'});
+let renderBundle40 = renderBundleEncoder34.finish({label: '\ub6f2\u049c\u079d\u054a\u{1fdde}\u1a96\u56db\ubd76\u23b6\u0c4b\ua4a3'});
+let sampler30 = device1.createSampler({
+  label: '\u7414\u9bed\u8376\ub821\u05a5\u55bd\u{1f71e}\u0dd2\u0b04',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.31,
+  lodMaxClamp: 78.85,
+});
+let externalTexture27 = device1.importExternalTexture({label: '\u1a01\u0830', source: videoFrame12, colorSpace: 'srgb'});
+try {
+renderBundleEncoder35.setVertexBuffer(0, buffer14, 0, 21981);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 4860, new Float32Array(25807), 14767, 720);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 18, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(175), /* required buffer size: 175 */
+{offset: 175, bytesPerRow: 624}, {width: 37, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let texture26 = device1.createTexture({
+  label: '\u376f\u3af9\ub725\u92f0\u1355\u504d\u00ad\ubcda\u0c6d\u0497\u068f',
+  size: [4900, 6, 38],
+  mipLevelCount: 3,
+  format: 'astc-10x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder35.setVertexBuffer(0, buffer14, 0, 46078);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 207_578 */
+{offset: 66, bytesPerRow: 552, rowsPerImage: 332}, {width: 32, height: 44, depthOrArrayLayers: 2});
+} catch {}
+let video9 = await videoWithData();
+let commandEncoder57 = device1.createCommandEncoder({});
+try {
+commandEncoder57.copyBufferToBuffer(buffer13, 52324, buffer14, 37192, 3160);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 220, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 840, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer14, 15040, 42956);
+dissociateBuffer(device1, buffer14);
+} catch {}
+let gpuCanvasContext19 = canvas12.getContext('webgpu');
+offscreenCanvas16.width = 416;
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(97, 786);
+let video10 = await videoWithData();
+try {
+offscreenCanvas17.getContext('webgl2');
+} catch {}
+let commandEncoder58 = device1.createCommandEncoder({label: '\u5825\u{1f745}\uc363\u552f\ufe76\u6f8c'});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder({label: '\u0c40\u0d51', colorFormats: ['r16float', 'rg32float', 'rgba32float']});
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 704 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8304 */
+  offset: 2480,
+  bytesPerRow: 1024,
+  buffer: buffer13,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 6, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer13);
+} catch {}
+let bindGroup19 = device1.createBindGroup({
+  label: '\u01ba\u0637\u038a\u{1fe74}\u{1fb8a}\u0103\u825a\u18eb',
+  layout: bindGroupLayout20,
+  entries: [],
+});
+let commandEncoder59 = device1.createCommandEncoder();
+let textureView61 = texture26.createView({format: 'astc-10x6-unorm-srgb', baseArrayLayer: 10, arrayLayerCount: 11});
+let renderBundle41 = renderBundleEncoder32.finish({});
+offscreenCanvas11.height = 696;
+let commandEncoder60 = device1.createCommandEncoder();
+try {
+renderBundleEncoder36.setBindGroup(6, bindGroup18, []);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5792 widthInBlocks: 362 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 27568 */
+  offset: 21776,
+  buffer: buffer14,
+}, {width: 3620, height: 6, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer14, 22116, 47936);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 8},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 18_746_855 */
+{offset: 535, bytesPerRow: 7559, rowsPerImage: 248}, {width: 4540, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img9);
+try {
+offscreenCanvas19.getContext('webgl');
+} catch {}
+let commandEncoder61 = device1.createCommandEncoder({label: '\u59f2\u{1f8a8}\u0e2d'});
+let querySet26 = device1.createQuerySet({label: '\ua0dd\u{1fa44}\u{1fd03}\u7744\u{1f959}', type: 'occlusion', count: 3125});
+let textureView62 = texture26.createView({label: '\u6a99\u024a\u0634\u028b\uf2bb', baseMipLevel: 2, baseArrayLayer: 12, arrayLayerCount: 11});
+let externalTexture28 = device1.importExternalTexture({label: '\u9b88\u0211\u{1f84c}\u19cd\u3c93', source: video6});
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup19, new Uint32Array(7559), 3140, 0);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(4, buffer14, 0, 1240);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(buffer13, 41904, buffer14, 59184, 2876);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 220, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 250, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2530, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 90_224 */
+{offset: 132, bytesPerRow: 582, rowsPerImage: 96}, {width: 29, height: 59, depthOrArrayLayers: 2});
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(1, 831);
+let video11 = await videoWithData();
+let imageData13 = new ImageData(8, 172);
+let commandEncoder62 = device1.createCommandEncoder();
+let renderBundle42 = renderBundleEncoder32.finish();
+try {
+commandEncoder60.clearBuffer(buffer14, 33332, 27736);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 9240, new Float32Array(2610), 683, 256);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(138_119), /* required buffer size: 138_119 */
+{offset: 839, bytesPerRow: 330, rowsPerImage: 104}, {width: 160, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let commandEncoder63 = device1.createCommandEncoder({label: '\u07aa\ub85b\u59e5\u142a\u0a2b\uc6be\u96eb'});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({
+  label: '\u1201\u25c3\u{1f9d0}\u2a6c\u{1f6f5}\u{1fd1b}\u6ffc\u07e5\ub49f',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler31 = device1.createSampler({
+  label: '\u{1f8b0}\u348d\ub922\u09d1\u{1fa0e}\u{1f6f9}\u0f26\u269d\ub05d',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 98.38,
+});
+let externalTexture29 = device1.importExternalTexture({label: '\u8f36\u{1ff78}\u4b86\u5f5e', source: video10, colorSpace: 'srgb'});
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 9352 */
+  offset: 9352,
+  bytesPerRow: 0,
+  buffer: buffer13,
+}, {
+  texture: texture23,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandBuffer17 = commandEncoder62.finish({label: '\u95cc\u09b2\u036a\u08f5\u092d\u{1ffe6}\u9913\u8978'});
+let textureView63 = texture25.createView({label: '\u492e\u0e41\u{1fec9}\u1368\u0e65\u6034', dimension: '2d-array'});
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({
+  label: '\u9ce0\u1218\uf0dc\uc07c\u6c2b\u0757\ue09b',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+try {
+commandEncoder57.copyBufferToBuffer(buffer13, 15552, buffer14, 9256, 32336);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 32, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 12, y: 51 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas13 = document.createElement('canvas');
+let bindGroup20 = device1.createBindGroup({layout: bindGroupLayout20, entries: []});
+let commandEncoder64 = device1.createCommandEncoder({label: '\u151e\u0d12\u{1f821}\u04b9\u05fb\u{1f653}\u17c9\u4a4e\u774e'});
+let texture27 = device1.createTexture({
+  size: [48, 64, 363],
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let computePassEncoder27 = commandEncoder64.beginComputePass({});
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup20, new Uint32Array(4194), 429, 0);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(2, buffer14, 68420, 2382);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 192 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 15184 */
+  offset: 15184,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 23, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 30},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 12, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup21 = device1.createBindGroup({label: '\uab73\u05a3\u4e34', layout: bindGroupLayout20, entries: []});
+let commandEncoder65 = device1.createCommandEncoder();
+let textureView64 = texture23.createView({
+  label: '\u0637\u{1f88b}\ua9ce\u00ff\u{1fb0c}\u{1feee}\u5d63\u0ed4\u28d6',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder28 = commandEncoder59.beginComputePass({label: '\u06ab\u59ff\ud3a6\u04d2\u{1f651}\u{1f784}\uf669'});
+let externalTexture30 = device1.importExternalTexture({
+  label: '\u{1f76a}\u4170\u0cc6\u{1f9f0}\u{1fc64}\u09ac\u{1f70b}\uafa3\u0ad6\u{1fe6b}\u0d36',
+  source: videoFrame4,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup17, new Uint32Array(1897), 1551, 0);
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 560, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 110, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 100, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 24, new Int16Array(10646), 1475, 2056);
+} catch {}
+let gpuCanvasContext20 = canvas13.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img10 = await imageWithData(184, 115, '#bbd3040a', '#23dfcc4f');
+let commandBuffer18 = commandEncoder43.finish({label: '\uf4e3\u{1f915}\u08e2\u{1fb6d}\u{1feb6}\u0520\ue0a2\u0776\u9964\uf3a0\u27c9'});
+let textureView65 = texture13.createView({label: '\u{1fb58}\u{1f66a}\u{1ff0f}\ubc86\ud04c\ub9aa\u{1ffa5}\ued39\ueabf'});
+let computePassEncoder29 = commandEncoder51.beginComputePass({label: '\ub3fc\u7ca7\u{1f9ea}\uac29'});
+let sampler32 = device0.createSampler({
+  label: '\uc41f\ua275\uf558\u0c5b\u{1fdea}\u98cf\u0980\uf98a\u49b7\u{1fc55}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 84.25,
+});
+try {
+renderPassEncoder15.beginOcclusionQuery(351);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 332.3, g: -243.2, b: 239.4, a: -596.9, });
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(504);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(9215, undefined, 3304507808, 577345578);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(186, 37);
+} catch {}
+let arrayBuffer7 = buffer7.getMappedRange(0, 8956);
+try {
+commandEncoder49.copyBufferToBuffer(buffer12, 70548, buffer2, 54772, 61276);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet5, 630, 386, buffer8, 52992);
+} catch {}
+let pipeline54 = await promise14;
+let bindGroupLayout22 = device0.createBindGroupLayout({label: '\u10f4\u8507\u{1fe50}\u0007\u154d\u440d\u0a14\u7f36\ud335\u0917', entries: []});
+let commandEncoder66 = device0.createCommandEncoder({});
+let computePassEncoder30 = commandEncoder66.beginComputePass({label: '\u{1fb14}\u512c\ue637'});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(296);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.draw(512, 205, 809_028_603, 502_033_991);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(28, 1, 339_847_982, 247_715_911, 603_782_551);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup3, new Uint32Array(6096), 5706, 0);
+} catch {}
+let pipeline55 = device0.createRenderPipeline({
+  label: '\u6190\uafa9\u0248\u510a\uac5d\u2e37\uda53\u22cd\u00ea\u3a3b',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0xffffffff},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'replace'},
+    stencilReadMask: 3731237750,
+    stencilWriteMask: 1290530142,
+    depthBiasSlopeScale: 981.6271425645816,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13776,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 2760, shaderLocation: 13},
+          {format: 'sint8x4', offset: 2604, shaderLocation: 5},
+          {format: 'sint8x4', offset: 972, shaderLocation: 8},
+          {format: 'sint16x2', offset: 132, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 1848, shaderLocation: 4},
+          {format: 'sint32x4', offset: 276, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 6932, stepMode: 'instance', attributes: []},
+      {arrayStride: 1884, attributes: []},
+      {
+        arrayStride: 6600,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 684, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 948, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let img11 = await imageWithData(193, 92, '#a7ce70bb', '#f000d7da');
+try {
+adapter1.label = '\uc3de\u8805\uf74e\ua9cf\u0b46\u452b\u005b\uc100';
+} catch {}
+try {
+offscreenCanvas20.getContext('webgl');
+} catch {}
+let textureView66 = texture27.createView({
+  label: '\u2b5b\u183a\u5149\uf50b\u{1f796}',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'rgba32float',
+  baseMipLevel: 2,
+  baseArrayLayer: 92,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup21, new Uint32Array(87), 43, 0);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 1, y: 2, z: 120},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 3, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 19708, new BigUint64Array(33457), 29116, 1420);
+} catch {}
+let querySet27 = device1.createQuerySet({
+  label: '\uf9ee\ufe90\u8ce7\u{1fc8a}\udf47\u{1fabc}\u{1f757}\u05c8\u488f\u9ca5',
+  type: 'occlusion',
+  count: 2836,
+});
+let renderBundleEncoder39 = device1.createRenderBundleEncoder({
+  label: '\u5197\u9004\u01e8\ub1a3\u059a\u0330\uf583',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle43 = renderBundleEncoder37.finish({label: '\udb77\u{1f9a2}\u6600\u23db\u726b'});
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 307},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 12, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer14, 53928, 11192);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+renderBundleEncoder36.insertDebugMarker('\u9bd6');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = textureView7.label;
+} catch {}
+let texture28 = device0.createTexture({
+  size: {width: 1401, height: 1, depthOrArrayLayers: 33},
+  mipLevelCount: 9,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let renderPassEncoder19 = commandEncoder48.beginRenderPass({
+  label: '\uf51a\u4d57',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 130,
+  clearValue: { r: -664.7, g: -0.2159, b: 796.2, a: 610.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView28,
+  depthSlice: 21,
+  clearValue: { r: 447.7, g: -190.2, b: -931.9, a: 56.77, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet22,
+  maxDrawCount: 95674692,
+});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({label: '\u776c\u0379', colorFormats: ['r32uint', 'r32uint'], depthReadOnly: true});
+try {
+computePassEncoder2.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(4, bindGroup14, new Uint32Array(4515), 3363, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(27, 43, 7_958_559, 69_658_929);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer9, 1_247_355_618);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer5, 825_728_200);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(194);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(9630, undefined, 1778203637, 1858591802);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet0, 655, 84, buffer8, 7680);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9, commandBuffer18, commandBuffer14]);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandEncoder67 = device1.createCommandEncoder();
+let textureView67 = texture27.createView({
+  label: '\u{1f6f4}\u0620\u05ed\ue9d0\u{1ff7b}\ub016\uec8c\u6b9c\u{1ffc2}\u07a2\u05cb',
+  aspect: 'all',
+  format: 'rgba32float',
+  mipLevelCount: 1,
+  baseArrayLayer: 62,
+  arrayLayerCount: 58,
+});
+let renderBundle44 = renderBundleEncoder33.finish({label: '\u0ebc\u70c0'});
+let offscreenCanvas21 = new OffscreenCanvas(54, 22);
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 20, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 520, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(509, 999);
+let promise17 = adapter0.requestAdapterInfo();
+try {
+window.someLabel = computePassEncoder28.label;
+} catch {}
+let commandEncoder68 = device1.createCommandEncoder({label: '\u37d1\u0733'});
+let textureView68 = texture26.createView({
+  label: '\u0e3d\uca19\u037b\u{1fcc9}\u01a1\u{1fb1a}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 30,
+});
+let renderBundleEncoder41 = device1.createRenderBundleEncoder({label: '\u0bd2\u{1fa71}', colorFormats: ['r16float', 'rg32float', 'rgba32float']});
+let renderBundle45 = renderBundleEncoder35.finish({label: '\u0e23\u{1ffef}\u{1f723}\udc3d\u{1f875}\uc71a\ua85b\u64a5\ua926'});
+try {
+renderBundleEncoder39.setBindGroup(6, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer14, 5552, 10077);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 310, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 720, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder68.clearBuffer(buffer14, 29896, 9932);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: img9,
+  origin: { x: 60, y: 13 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let imageData14 = new ImageData(172, 108);
+let commandEncoder69 = device1.createCommandEncoder({});
+try {
+computePassEncoder28.setBindGroup(7, bindGroup20, new Uint32Array(6953), 2525, 0);
+} catch {}
+let bindGroup22 = device1.createBindGroup({layout: bindGroupLayout20, entries: []});
+let pipelineLayout8 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout21]});
+try {
+computePassEncoder27.setBindGroup(6, bindGroup21, new Uint32Array(2233), 2193, 0);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 50, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 970, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder38.insertDebugMarker('\u06c8');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 400, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 15_856_116 */
+{offset: 964, bytesPerRow: 1642, rowsPerImage: 284}, {width: 990, height: 0, depthOrArrayLayers: 35});
+} catch {}
+let imageData15 = new ImageData(192, 32);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let imageData16 = new ImageData(52, 76);
+let bindGroupLayout23 = device1.createBindGroupLayout({
+  label: '\u030f\uda70\u089d\u4419\u{1f6ed}\u062f',
+  entries: [
+    {binding: 127, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 2104,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 2064,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let buffer15 = device1.createBuffer({
+  label: '\u07c5\ub6a2\u0e92\uee2e\u93a7\u199c\u0efb\u{1fcec}',
+  size: 133852,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let querySet28 = device1.createQuerySet({
+  label: '\u{1fcd7}\u8e22\uc61c\u67b6\u{1f808}\u{1f77a}\u07d7\u0ce0\u3201\u0756\u2ca5',
+  type: 'occlusion',
+  count: 3316,
+});
+let textureView69 = texture25.createView({label: '\u{1f6cf}\u7133\u2174\u{1fd21}\u0579\u3abe\u59a6', dimension: '2d'});
+let sampler33 = device1.createSampler({
+  label: '\u0aba\u0982\u4dc2\u0fca\u9bf5\u2d1d\u09f1\ucc80\u08f0\u{1fa9c}\uee2b',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.63,
+  lodMaxClamp: 56.31,
+});
+try {
+commandEncoder57.copyBufferToBuffer(buffer15, 53244, buffer14, 13004, 41004);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3840 */
+  offset: 3312,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 3, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 12260, new BigUint64Array(9159), 1289, 1604);
+} catch {}
+let shaderModule9 = device1.createShaderModule({
+  label: '\u{1fb01}\ubfdc',
+  code: `
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(6) f1: vec2<i32>,
+  @location(0) f2: vec3<f32>,
+  @location(1) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(21) f0: vec3<f32>,
+  @location(14) f1: vec4<i32>,
+  @location(25) f2: i32,
+  @location(1) f3: vec4<u32>,
+  @location(18) f4: vec3<i32>,
+  @location(5) f5: i32,
+  @location(24) f6: f32,
+  @location(26) f7: vec2<i32>,
+  @location(2) f8: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec2<f16>, @location(19) a1: vec4<f16>, @builtin(vertex_index) a2: u32, @location(10) a3: vec2<f32>, @location(7) a4: vec3<u32>, @builtin(instance_index) a5: u32, @location(22) a6: vec4<f32>, @location(16) a7: vec3<i32>, @location(23) a8: vec4<f16>, @location(6) a9: vec2<u32>, @location(15) a10: vec2<i32>, @location(8) a11: vec3<u32>, a12: S10, @location(4) a13: vec3<u32>, @location(13) a14: f16, @location(20) a15: vec2<u32>, @location(0) a16: vec3<f32>, @location(11) a17: vec3<f32>, @location(9) a18: f32, @location(3) a19: vec4<f16>, @location(12) a20: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet29 = device1.createQuerySet({label: '\udf57\u9104\u{1fa7b}\u{1fb0d}\ufb88\u4b6e', type: 'occlusion', count: 4025});
+let textureView70 = texture25.createView({mipLevelCount: 1});
+let externalTexture31 = device1.importExternalTexture({source: video11, colorSpace: 'display-p3'});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup22, new Uint32Array(3396), 1374, 0);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer14, 7864, 60068);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let img12 = await imageWithData(148, 284, '#7f5ef012', '#09e991e6');
+let promise18 = adapter1.requestAdapterInfo();
+let commandEncoder70 = device1.createCommandEncoder();
+let textureView71 = texture26.createView({
+  label: '\u0604\u6233\u{1fff5}\u053d\u6790\u0634\uc527\u08a0\u7df5\ubad3',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 22,
+});
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({
+  label: '\u462d\u09bf\ub55e\u38d0\u55cd\u0927\u{1fe2d}\u780c',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let externalTexture32 = device1.importExternalTexture({label: '\u7113\u0aab', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder41.setBindGroup(1, bindGroup17, new Uint32Array(9946), 7914, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(1, buffer14, 0, 25602);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 160, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 910, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video7);
+offscreenCanvas13.height = 1885;
+let gpuCanvasContext21 = offscreenCanvas22.getContext('webgpu');
+let texture29 = device1.createTexture({
+  label: '\u{1ffc7}\u459d\u8f31\u96dc\ucc82\u083d',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let textureView72 = texture27.createView({
+  label: '\u5c44\u6883\u{1fa34}\u{1fd8b}\ua362\u4558\uf8fb\u5f44\u0df8\u33d1',
+  mipLevelCount: 2,
+  baseArrayLayer: 360,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup17, new Uint32Array(6849), 2159, 0);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup22);
+} catch {}
+let arrayBuffer8 = buffer15.getMappedRange(0, 48960);
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer16]);
+} catch {}
+let pipeline56 = device1.createRenderPipeline({
+  label: '\u0e75\u0e92\u074b\ud19d\u0942',
+  layout: pipelineLayout7,
+  multisample: {mask: 0xffffffff},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg32float'}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'keep'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'increment-clamp'},
+    stencilWriteMask: 4177364808,
+    depthBias: -8250838,
+    depthBiasSlopeScale: 588.7527919271602,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3536,
+        attributes: [
+          {format: 'float16x4', offset: 708, shaderLocation: 23},
+          {format: 'uint32x2', offset: 1528, shaderLocation: 2},
+          {format: 'sint32', offset: 488, shaderLocation: 18},
+          {format: 'uint16x2', offset: 460, shaderLocation: 20},
+          {format: 'sint32x3', offset: 1296, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 22},
+          {format: 'uint16x2', offset: 644, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 904, shaderLocation: 0},
+          {format: 'uint8x4', offset: 0, shaderLocation: 12},
+          {format: 'uint32x2', offset: 216, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 340, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 112, shaderLocation: 24},
+          {format: 'sint8x4', offset: 132, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 1872,
+        attributes: [
+          {format: 'snorm16x4', offset: 896, shaderLocation: 3},
+          {format: 'sint32x2', offset: 312, shaderLocation: 25},
+          {format: 'sint32x3', offset: 1024, shaderLocation: 16},
+          {format: 'float32x4', offset: 72, shaderLocation: 19},
+          {format: 'uint8x4', offset: 772, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 296, shaderLocation: 10},
+          {format: 'sint16x2', offset: 212, shaderLocation: 15},
+          {format: 'uint32x2', offset: 200, shaderLocation: 6},
+          {format: 'float32', offset: 120, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 304, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 5288,
+        attributes: [
+          {format: 'uint32x4', offset: 480, shaderLocation: 1},
+          {format: 'sint32', offset: 2176, shaderLocation: 26},
+          {format: 'float16x4', offset: 832, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 1652, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+});
+let img13 = await imageWithData(41, 98, '#8fb25774', '#31f735aa');
+let commandEncoder71 = device1.createCommandEncoder();
+let renderBundle46 = renderBundleEncoder32.finish({label: '\u98e4\u{1ffa2}\u6afb\u{1faac}'});
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(0, buffer14, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 5888, new Float32Array(28019), 383, 2368);
+} catch {}
+let gpuCanvasContext22 = offscreenCanvas21.getContext('webgpu');
+let imageData17 = new ImageData(120, 192);
+try {
+adapter0.label = '\u0cff\u02fa\u065e';
+} catch {}
+let videoFrame13 = new VideoFrame(offscreenCanvas10, {timestamp: 0});
+let bindGroupLayout24 = device1.createBindGroupLayout({
+  label: '\u0cc1\u{1fb2f}\u84c5\u5176\u8c39\u0eb6\u{1f67c}\uaed1',
+  entries: [
+    {
+      binding: 3642,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer16 = device1.createBuffer({size: 32597, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder72 = device1.createCommandEncoder({label: '\u4401\u{1fe73}'});
+let querySet30 = device1.createQuerySet({type: 'occlusion', count: 3452});
+let textureView73 = texture27.createView({
+  label: '\ub455\u{1ff5a}\u4a82\uca71\u6345\u6923\u0f35\u0314',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 14,
+});
+let sampler34 = device1.createSampler({
+  label: '\u0095\u{1fa1f}\u9bc3\u0397',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 95.56,
+});
+try {
+commandEncoder71.copyBufferToBuffer(buffer13, 17168, buffer14, 53048, 6768);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 9564, new Int16Array(25553), 23554, 320);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(56)), /* required buffer size: 109_815 */
+{offset: 871, bytesPerRow: 400, rowsPerImage: 236}, {width: 9, height: 37, depthOrArrayLayers: 2});
+} catch {}
+video0.height = 28;
+let imageBitmap13 = await createImageBitmap(canvas8);
+let commandEncoder73 = device1.createCommandEncoder({label: '\u0355\ud909\ub95b\u3ba9\uaae2\u0c1b\ue9d2\uf39a\u{1f8aa}'});
+let texture30 = device1.createTexture({
+  label: '\u8ada\u{1f6e6}\u2b60\u0bd0\u54cf',
+  size: {width: 48, height: 64, depthOrArrayLayers: 2},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let sampler35 = device1.createSampler({
+  label: '\uae48\u{1fdb4}\u0901\u07ce\u{1fe5a}\u01a1\u{1fdef}\u0f3c\u2d55\u0bed',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 69.77,
+  lodMaxClamp: 97.71,
+});
+try {
+renderBundleEncoder42.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(6, bindGroup20, new Uint32Array(6077), 2338, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(0, buffer14, 0);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer13, 8232, buffer14, 59252, 6080);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 560, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2370, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet25, 252, 217, buffer16, 2304);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 14880, new Int16Array(61156), 5919, 7024);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 23, y: 150 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline57 = device1.createRenderPipeline({
+  label: '\u08e2\u993e\u{1fee3}',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'rg32float', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1088,
+        attributes: [
+          {format: 'float16x4', offset: 8, shaderLocation: 3},
+          {format: 'float32x4', offset: 172, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 24},
+          {format: 'sint16x2', offset: 112, shaderLocation: 18},
+          {format: 'sint32x3', offset: 36, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 11},
+          {format: 'uint16x2', offset: 284, shaderLocation: 12},
+          {format: 'float32x2', offset: 220, shaderLocation: 23},
+          {format: 'sint8x2', offset: 2, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 88, shaderLocation: 9},
+          {format: 'sint32', offset: 96, shaderLocation: 15},
+          {format: 'uint32x3', offset: 0, shaderLocation: 2},
+          {format: 'uint32x3', offset: 508, shaderLocation: 4},
+          {format: 'float32x2', offset: 232, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 74, shaderLocation: 0},
+          {format: 'uint32x4', offset: 32, shaderLocation: 7},
+          {format: 'sint8x4', offset: 32, shaderLocation: 26},
+          {format: 'unorm16x4', offset: 244, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 104, shaderLocation: 19},
+          {format: 'uint16x4', offset: 308, shaderLocation: 6},
+          {format: 'uint32', offset: 40, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 1098, shaderLocation: 8},
+          {format: 'sint32x3', offset: 2524, shaderLocation: 25},
+          {format: 'sint32x2', offset: 2580, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 288,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 2, shaderLocation: 22},
+          {format: 'float32x2', offset: 4, shaderLocation: 13},
+          {format: 'uint16x2', offset: 80, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+sampler2.label = '\u{1fcb6}\u02a9\u491c\uc18c\u{1f892}\ued84\u{1fccc}\u7717\ud3a4';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img14 = await imageWithData(294, 169, '#24ed9223', '#4a57ceb0');
+let commandBuffer19 = commandEncoder69.finish({});
+let textureView74 = texture27.createView({
+  label: '\u0149\u{1fe35}\uc754\ue1dd\u{1fc82}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 153,
+  arrayLayerCount: 171,
+});
+let renderBundle47 = renderBundleEncoder36.finish({});
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 167},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 2, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 17, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder74 = device1.createCommandEncoder();
+let renderBundleEncoder43 = device1.createRenderBundleEncoder({
+  label: '\u0a8e\ud1e4\u{1f712}\u4942\u6d6a\u0dfb\u{1f862}\u{1f945}\u0ee0\u{1f8da}\ufbba',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+});
+try {
+renderBundleEncoder41.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer15, 73044, buffer16, 22980, 5604);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer16, 30648, 316);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let commandEncoder75 = device1.createCommandEncoder({label: '\u{1fc45}\ua5ed\u{1fb13}\uca81'});
+let computePassEncoder31 = commandEncoder73.beginComputePass({label: '\u760c\u4c4b\udce4'});
+try {
+renderBundleEncoder42.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(7, buffer14, 0, 33615);
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(buffer15, 88648, buffer16, 8852, 19032);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+let pipeline58 = device1.createRenderPipeline({
+  label: '\u{1fdac}\u426f\ucc4d\u{1fa4f}\u{1f78a}\uf4e0\u{1f8e2}',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rg32float'}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 164,
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 9},
+          {format: 'float32x2', offset: 4, shaderLocation: 19},
+          {format: 'float32x3', offset: 68, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 60, shaderLocation: 24},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 11},
+          {format: 'float32x4', offset: 0, shaderLocation: 22},
+          {format: 'sint8x2', offset: 30, shaderLocation: 18},
+          {format: 'uint32x2', offset: 20, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 21},
+          {format: 'sint32x2', offset: 8, shaderLocation: 16},
+          {format: 'uint32x2', offset: 56, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x3', offset: 852, shaderLocation: 14},
+          {format: 'sint32x4', offset: 1692, shaderLocation: 26},
+          {format: 'sint16x4', offset: 1004, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 2940, shaderLocation: 0},
+          {format: 'float16x4', offset: 2796, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 2908, shaderLocation: 17},
+          {format: 'uint32x4', offset: 116, shaderLocation: 12},
+          {format: 'sint16x2', offset: 264, shaderLocation: 5},
+          {format: 'float16x4', offset: 900, shaderLocation: 10},
+          {format: 'uint16x2', offset: 148, shaderLocation: 2},
+          {format: 'uint8x2', offset: 628, shaderLocation: 6},
+          {format: 'float32', offset: 1272, shaderLocation: 23},
+          {format: 'sint8x2', offset: 2632, shaderLocation: 25},
+          {format: 'uint32x3', offset: 1548, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 188, attributes: [{format: 'uint32x4', offset: 4, shaderLocation: 20}]},
+    ],
+  },
+});
+offscreenCanvas10.width = 864;
+try {
+  await promise17;
+} catch {}
+let videoFrame14 = new VideoFrame(videoFrame13, {timestamp: 0});
+let externalTexture33 = device1.importExternalTexture({label: '\u02ed\u568b\u0001', source: videoFrame5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder39.setBindGroup(0, bindGroup19, new Uint32Array(4563), 4262, 0);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 4, y: 6, z: 23},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 31, height: 28, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext20.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 4908, new Float32Array(6806), 3423, 364);
+} catch {}
+let pipeline59 = await device1.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x620cb8a5},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.BLUE}, {format: 'rg32float', writeMask: 0}, {format: 'rgba32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 3124399654,
+    stencilWriteMask: 2479830251,
+    depthBias: -487212981,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 284,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x4', offset: 12, shaderLocation: 16},
+          {format: 'sint32x2', offset: 76, shaderLocation: 26},
+          {format: 'float32x3', offset: 8, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 120, shaderLocation: 13},
+          {format: 'uint16x2', offset: 36, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 9},
+          {format: 'uint32x4', offset: 72, shaderLocation: 2},
+          {format: 'uint16x4', offset: 28, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 23},
+          {format: 'sint16x2', offset: 8, shaderLocation: 5},
+          {format: 'uint32x2', offset: 108, shaderLocation: 6},
+          {format: 'float32', offset: 40, shaderLocation: 24},
+          {format: 'uint16x4', offset: 32, shaderLocation: 8},
+          {format: 'float32x4', offset: 44, shaderLocation: 0},
+          {format: 'uint8x2', offset: 138, shaderLocation: 4},
+          {format: 'float32', offset: 0, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 2228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 312, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 528, shaderLocation: 11},
+          {format: 'float32x2', offset: 76, shaderLocation: 22},
+          {format: 'sint16x4', offset: 440, shaderLocation: 18},
+          {format: 'float32x3', offset: 36, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 1532,
+        attributes: [
+          {format: 'uint8x2', offset: 28, shaderLocation: 1},
+          {format: 'sint8x2', offset: 458, shaderLocation: 25},
+          {format: 'float32x2', offset: 728, shaderLocation: 19},
+          {format: 'sint32', offset: 188, shaderLocation: 14},
+          {format: 'sint32x3', offset: 620, shaderLocation: 15},
+          {format: 'uint8x4', offset: 16, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let bindGroup23 = device1.createBindGroup({layout: bindGroupLayout20, entries: []});
+let renderBundle48 = renderBundleEncoder39.finish({label: '\uc251\u067f'});
+let sampler36 = device1.createSampler({
+  label: '\uedf8\u{1fc0d}\u0810\uf272\u00fa\u03d9\u8921\ubc84\u0727\udf85\ubf2d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.537,
+  lodMaxClamp: 85.13,
+});
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17832 */
+  offset: 17832,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 16, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+computePassEncoder27.insertDebugMarker('\u6c9c');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 196 */
+{offset: 196}, {width: 61, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = device1.createComputePipeline({
+  label: '\uce43\u{1fa0a}\u1d06\uce74\u1d13\u7a0e\u4d5a\u04ed\u0057',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule10 = device1.createShaderModule({
+  label: '\u87f5\ub3f4\u{1ff3b}',
+  code: `@group(3) @binding(4560)
+var<storage, read_write> parameter11: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>,
+  @location(3) f1: vec3<i32>,
+  @location(1) f2: vec2<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(5) f4: vec2<u32>,
+  @location(2) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @builtin(vertex_index) f0: u32,
+  @location(10) f1: i32,
+  @location(0) f2: vec2<f32>,
+  @location(24) f3: vec4<f32>,
+  @location(18) f4: vec4<u32>,
+  @location(12) f5: vec2<u32>,
+  @location(4) f6: vec4<i32>,
+  @location(11) f7: vec3<u32>,
+  @location(17) f8: vec2<i32>,
+  @builtin(instance_index) f9: u32,
+  @location(16) f10: vec2<u32>,
+  @location(6) f11: vec2<f32>,
+  @location(15) f12: f32,
+  @location(1) f13: vec4<f32>,
+  @location(2) f14: vec3<i32>,
+  @location(22) f15: vec4<i32>,
+  @location(13) f16: f32,
+  @location(14) f17: vec2<i32>,
+  @location(23) f18: vec3<i32>,
+  @location(19) f19: vec3<u32>,
+  @location(26) f20: vec2<u32>,
+  @location(25) f21: vec3<f16>,
+  @location(5) f22: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec3<f16>, @location(3) a1: vec2<i32>, @location(8) a2: vec2<u32>, @location(7) a3: vec4<f16>, a4: S11, @location(20) a5: f16, @location(9) a6: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet31 = device1.createQuerySet({type: 'occlusion', count: 2286});
+let texture31 = device1.createTexture({
+  label: '\u4493\u245d\u0983\u0f94\u90a8\u9cb2\u{1fc68}\u9679\uf379',
+  size: {width: 12},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let renderBundleEncoder44 = device1.createRenderBundleEncoder({colorFormats: ['r16float', 'rg32float', 'rgba32float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup17, []);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7656 */
+  offset: 7656,
+  buffer: buffer13,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 1650, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 120, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 620, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet29, 3675, 167, buffer16, 0);
+} catch {}
+let computePassEncoder32 = commandEncoder65.beginComputePass({label: '\u6b83\u08f2\ue9af\u{1fa6f}\u0782'});
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({
+  label: '\u{1f689}\u059e\u01e3\u0518\ua33b',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+let externalTexture34 = device1.importExternalTexture({label: '\u{1f9a5}\u0206\u5241\u04d7\u{1fc70}\u93e9\uace9', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder27.setBindGroup(6, bindGroup18);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer13, 14808, buffer16, 20276, 2360);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 10134 */
+  offset: 10134,
+  buffer: buffer13,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet28, 985, 2323, buffer16, 11520);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 9300, new Float32Array(41547), 26373, 3072);
+} catch {}
+let promise19 = adapter0.requestAdapterInfo();
+let textureView75 = texture26.createView({label: '\u0b42\u6fca', dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 20});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({
+  label: '\u{1f87a}\u0af6\ua09c',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder58.clearBuffer(buffer14, 52940, 7348);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet24, 1839, 26, buffer16, 28672);
+} catch {}
+document.body.prepend(video8);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas14 = document.createElement('canvas');
+let renderPassEncoder20 = commandEncoder49.beginRenderPass({
+  label: '\ub589\ub9ef\u0a5b\ucdd8\u16a2\u{1fa83}\u9709\u3058\u5917',
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 274,
+  clearValue: { r: -532.1, g: 268.7, b: -745.8, a: -437.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {view: textureView23, depthSlice: 368, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 1181123285,
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup2, new Uint32Array(9209), 1109, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -104.7, g: 945.7, b: -905.2, a: 431.1, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(50, 1, 35, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(315, 663);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup13, new Uint32Array(8952), 7356, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(521, 128, 222_174_663, 1_100_629_809);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(84, 272, 409_279_839, -1_420_462_941, 268_122_521);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let pipeline61 = await device0.createComputePipelineAsync({
+  label: '\u{1fd80}\uaa80\u2537\ue5a3',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+canvas7.width = 428;
+let querySet32 = device1.createQuerySet({label: '\u063d\u0551\ud2e6\u0f5b\u0cf6\u018b\uf795', type: 'occlusion', count: 705});
+let textureView76 = texture27.createView({
+  label: '\uf141\u{1fb9d}\ubaf5\u8cee\u0239\u0723\u0e33\ud04e\u018d\u160f',
+  dimension: '2d',
+  format: 'rgba32float',
+  baseMipLevel: 2,
+  baseArrayLayer: 27,
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder41.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(4, buffer14, 14928, 52929);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder75.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12710 */
+  offset: 12710,
+  buffer: buffer14,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder75.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 690, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 530, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 100, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: img10,
+  origin: { x: 10, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 11, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let img15 = await imageWithData(87, 227, '#77073d48', '#90b70cf8');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageData18 = new ImageData(180, 152);
+try {
+renderBundleEncoder43.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(5, buffer14, 41324, 12914);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 129},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 6, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 5, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 148, new DataView(new ArrayBuffer(33062)), 11310, 1240);
+} catch {}
+let promise21 = device1.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}}});
+let img16 = await imageWithData(93, 57, '#01fefa42', '#f35def53');
+let commandEncoder76 = device1.createCommandEncoder({label: '\u6c1e\ue0b6\u776a\u9089\u7989\u0509\uf8ed'});
+let renderBundleEncoder47 = device1.createRenderBundleEncoder({
+  label: '\udc45\u{1f864}\u064b\u83d7\u0eca\u{1f7a3}',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder70.clearBuffer(buffer14, 11264, 23300);
+dissociateBuffer(device1, buffer14);
+} catch {}
+let canvas15 = document.createElement('canvas');
+try {
+  await promise19;
+} catch {}
+let video12 = await videoWithData();
+let canvas16 = document.createElement('canvas');
+let buffer17 = device1.createBuffer({
+  label: '\ueeaa\ub0a8\uda24\u{1fbf6}\u0769\u13a0\u7748\ua649\ua005',
+  size: 44044,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder77 = device1.createCommandEncoder({});
+let textureView77 = texture29.createView({label: '\u7728\u8812\u33fe\u{1fa00}\u392b', mipLevelCount: 1});
+let computePassEncoder33 = commandEncoder63.beginComputePass({label: '\u82a4\u07e1\u{1f69c}\u0221\u05a9'});
+let renderBundle49 = renderBundleEncoder39.finish({label: '\u0b58\u0869\u6219\ucf46\u06a8\u0ac1'});
+try {
+renderBundleEncoder38.setVertexBuffer(1, buffer14);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+canvas16.getContext('webgpu');
+} catch {}
+let gpuCanvasContext23 = canvas15.getContext('webgpu');
+document.body.prepend(video6);
+offscreenCanvas12.width = 457;
+let gpuCanvasContext24 = canvas14.getContext('webgpu');
+let texture32 = device1.createTexture({
+  label: '\uad79\u045d\u0a62\u0c5f\u18ce\u57b6\u5da5\ud468\u53dd\u{1fa5f}',
+  size: {width: 12, height: 16, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView78 = texture24.createView({label: '\u{1fd66}\u36f3\u2d2b\u9bd5\u{1f621}', arrayLayerCount: 1});
+let renderBundleEncoder48 = device1.createRenderBundleEncoder({
+  label: '\uf37c\u{1f706}\u0c75\u{1fc50}\ua7c2\u{1f6d3}\u9a02\u07e3\u{1f692}',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  sampleCount: 1,
+});
+let externalTexture35 = device1.importExternalTexture({label: '\u{1fd94}\u8e9e\u087d\u{1fdd2}\ucc51', source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup20, new Uint32Array(7199), 2591, 0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline60);
+} catch {}
+try {
+commandEncoder75.resolveQuerySet(querySet27, 968, 102, buffer16, 28928);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise22 = adapter1.requestAdapterInfo();
+let commandEncoder78 = device1.createCommandEncoder({});
+let renderBundle50 = renderBundleEncoder39.finish({label: '\ub5cf\u2df1\uaf6c\u47cd\uc52b\u{1fc3e}\u{1fc35}\uf5ca\ua8ce\u{1fcb3}\u8a81'});
+try {
+renderBundleEncoder44.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer13, 45584, buffer14, 24132, 12400);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 10752 */
+  offset: 8912,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(27_980), /* required buffer size: 27_980 */
+{offset: 440, bytesPerRow: 660}, {width: 30, height: 42, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline62 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg32float', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 4294967295,
+    depthBiasClamp: 625.7539227667406,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 780,
+        attributes: [
+          {format: 'float16x4', offset: 100, shaderLocation: 0},
+          {format: 'float16x2', offset: 280, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 36, shaderLocation: 9},
+          {format: 'sint32', offset: 132, shaderLocation: 25},
+          {format: 'sint32x4', offset: 212, shaderLocation: 16},
+          {format: 'sint8x2', offset: 164, shaderLocation: 15},
+          {format: 'uint32x4', offset: 92, shaderLocation: 20},
+          {format: 'float32x2', offset: 60, shaderLocation: 17},
+          {format: 'uint32x3', offset: 20, shaderLocation: 4},
+          {format: 'uint32x2', offset: 148, shaderLocation: 8},
+          {format: 'uint32', offset: 80, shaderLocation: 1},
+          {format: 'float32x4', offset: 40, shaderLocation: 22},
+          {format: 'unorm16x2', offset: 152, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1512, shaderLocation: 23},
+          {format: 'float32', offset: 864, shaderLocation: 11},
+          {format: 'float32x4', offset: 764, shaderLocation: 3},
+          {format: 'sint8x4', offset: 276, shaderLocation: 18},
+          {format: 'uint32x2', offset: 224, shaderLocation: 7},
+          {format: 'uint16x4', offset: 260, shaderLocation: 2},
+          {format: 'uint32x2', offset: 1668, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 24},
+          {format: 'sint32x4', offset: 2960, shaderLocation: 14},
+          {format: 'sint16x4', offset: 484, shaderLocation: 26},
+        ],
+      },
+      {
+        arrayStride: 112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 28, shaderLocation: 13},
+          {format: 'sint8x2', offset: 2, shaderLocation: 5},
+          {format: 'uint32x2', offset: 20, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 92, attributes: [{format: 'unorm8x2', offset: 8, shaderLocation: 19}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+video12.height = 197;
+let bindGroup24 = device1.createBindGroup({label: '\u5ee1\u0b4c\u{1fe5c}\u0c40\u90e8\u0af7', layout: bindGroupLayout20, entries: []});
+let buffer18 = device1.createBuffer({
+  label: '\u010d\u3fba\u{1ff21}\ue925\u0929\u{1fa75}\u{1f952}\u699e\u7c4c',
+  size: 53842,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder79 = device1.createCommandEncoder({});
+let renderBundleEncoder49 = device1.createRenderBundleEncoder({
+  label: '\ue748\ua7a9\u8409\u6f94\u7ed5\u0747\ub20e\ua539\uc2fa\u0cc6',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 8, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet27, 2752, 20, buffer16, 12032);
+} catch {}
+let promise23 = device1.createRenderPipelineAsync({
+  label: '\u1a08\uac33\u0515\ua1f0\u1f5b\uec5e\ua0f2\u{1fa98}\u6c05\u0cf1\u{1f692}',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 725014256,
+    stencilWriteMask: 4153977728,
+    depthBias: 0,
+    depthBiasSlopeScale: 865.7734239464902,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 796,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 36, shaderLocation: 6},
+          {format: 'float32x3', offset: 288, shaderLocation: 21},
+          {format: 'uint8x4', offset: 248, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 50, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 174, shaderLocation: 22},
+          {format: 'uint16x4', offset: 236, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 120, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 88, shaderLocation: 17},
+          {format: 'uint8x2', offset: 26, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 132, shaderLocation: 19},
+          {format: 'sint32x3', offset: 32, shaderLocation: 5},
+          {format: 'uint32', offset: 176, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 244, shaderLocation: 23},
+          {format: 'sint32x3', offset: 12, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 7252,
+        attributes: [
+          {format: 'float32x4', offset: 112, shaderLocation: 11},
+          {format: 'sint16x4', offset: 484, shaderLocation: 16},
+          {format: 'uint32', offset: 696, shaderLocation: 7},
+          {format: 'sint8x4', offset: 1800, shaderLocation: 15},
+          {format: 'sint16x4', offset: 540, shaderLocation: 18},
+          {format: 'float32', offset: 620, shaderLocation: 24},
+          {format: 'uint32x2', offset: 748, shaderLocation: 4},
+          {format: 'sint32x2', offset: 396, shaderLocation: 14},
+          {format: 'sint32x4', offset: 208, shaderLocation: 26},
+          {format: 'uint32x3', offset: 1772, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 104, shaderLocation: 3},
+          {format: 'float32x2', offset: 2376, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 332, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let querySet33 = device1.createQuerySet({label: '\u713d\u52d7\uff7c\ue3ed\u96e9\u489b\u8608', type: 'occlusion', count: 1561});
+let textureView79 = texture30.createView({dimension: '3d', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundle51 = renderBundleEncoder34.finish();
+try {
+commandEncoder71.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 18 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 10650 */
+  offset: 10650,
+  buffer: buffer16,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet30, 3384, 64, buffer16, 3328);
+} catch {}
+let bindGroupLayout25 = device1.createBindGroupLayout({
+  label: '\u27a6\u8b2c\u07dc\u{1f99c}\uef2d\u01d2\u{1f6a1}\u{1fa5f}\u02c1',
+  entries: [
+    {
+      binding: 265,
+      visibility: 0,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 3584,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 3814,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroupLayout26 = pipeline57.getBindGroupLayout(2);
+let textureView80 = texture26.createView({
+  label: '\ubc53\u0e72\u0203\u{1f81a}\uee29\u066d\u426a\u11ab\u0e46',
+  format: 'astc-10x6-unorm-srgb',
+  mipLevelCount: 2,
+  baseArrayLayer: 27,
+  arrayLayerCount: 10,
+});
+let externalTexture36 = device1.importExternalTexture({label: '\u009e\u822a\ubf7e\u9e35\u2b75', source: video9, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder46.setBindGroup(4, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(6, buffer14, 0, 61988);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer8), /* required buffer size: 999 */
+{offset: 999, bytesPerRow: 367}, {width: 10, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+let offscreenCanvas23 = new OffscreenCanvas(1023, 347);
+let video13 = await videoWithData();
+let imageBitmap14 = await createImageBitmap(canvas8);
+let commandEncoder80 = device1.createCommandEncoder({label: '\u4cd9\u7342\uf8c0\uc4da'});
+try {
+computePassEncoder23.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(0, buffer14, 0);
+} catch {}
+let promise25 = device1.createRenderPipelineAsync({
+  label: '\u{1f6f8}\u5099',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 690177861,
+    stencilWriteMask: 473858048,
+    depthBiasSlopeScale: 236.94186887132736,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3832,
+        attributes: [
+          {format: 'sint32x2', offset: 152, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 616, shaderLocation: 24},
+          {format: 'float16x2', offset: 1504, shaderLocation: 9},
+          {format: 'sint16x2', offset: 532, shaderLocation: 3},
+          {format: 'sint32x2', offset: 2840, shaderLocation: 4},
+          {format: 'float32', offset: 524, shaderLocation: 25},
+          {format: 'sint32', offset: 756, shaderLocation: 23},
+          {format: 'uint32x2', offset: 412, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 604, shaderLocation: 5},
+          {format: 'uint32x2', offset: 2224, shaderLocation: 18},
+          {format: 'sint8x2', offset: 180, shaderLocation: 17},
+          {format: 'uint32x4', offset: 2252, shaderLocation: 26},
+          {format: 'sint8x2', offset: 1066, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 492, shaderLocation: 7},
+          {format: 'sint16x4', offset: 1856, shaderLocation: 14},
+          {format: 'float32x3', offset: 96, shaderLocation: 20},
+          {format: 'sint8x2', offset: 430, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 1392, shaderLocation: 15},
+          {format: 'uint32', offset: 516, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 56, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 532, shaderLocation: 13},
+          {format: 'float32x2', offset: 524, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 516,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 48, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 764,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x4', offset: 40, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 116, shaderLocation: 0},
+          {format: 'uint8x4', offset: 0, shaderLocation: 16},
+          {format: 'uint32x2', offset: 76, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+document.body.prepend(img5);
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u0e54\u0344';
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let videoFrame15 = new VideoFrame(video7, {timestamp: 0});
+let textureView81 = texture24.createView({label: '\uaef2\u1281\u03d4\u0379\u4af0\u0d90\u01a1\u837b\u43cf\u0dba\u04c5'});
+let sampler37 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.70,
+  lodMaxClamp: 56.30,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder27.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(4, bindGroup20, new Uint32Array(3523), 911, 0);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(6, buffer14);
+} catch {}
+try {
+buffer15.destroy();
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer18, 9748, buffer14, 62968, 6928);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 11328 */
+  offset: 11328,
+  bytesPerRow: 256,
+  buffer: buffer14,
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer14);
+} catch {}
+let textureView82 = texture24.createView({label: '\udbf2\u0112', mipLevelCount: 1});
+let renderBundleEncoder50 = device1.createRenderBundleEncoder({colorFormats: ['r16float', 'rg32float', 'rgba32float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder47.setBindGroup(5, bindGroup19);
+} catch {}
+try {
+commandEncoder79.copyBufferToBuffer(buffer18, 7836, buffer14, 44940, 19892);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder71.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 18 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7286 */
+  offset: 7286,
+  bytesPerRow: 512,
+  buffer: buffer16,
+}, {width: 9, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+let promise26 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 23, y: 1725 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise22;
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let renderBundleEncoder51 = device1.createRenderBundleEncoder({
+  label: '\u{1fde9}\ub88e\u{1f842}\u{1fd98}\u3417\u083f\u{1fb48}\u095a',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder51.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(2, buffer14, 63500);
+} catch {}
+let imageData19 = new ImageData(216, 120);
+try {
+computePassEncoder25.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer15, 47888, buffer14, 37552, 4512);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder71.insertDebugMarker('\u{1fad2}');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 84 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap15 = await createImageBitmap(canvas0);
+try {
+  await promise26;
+} catch {}
+try {
+window.someLabel = textureView28.label;
+} catch {}
+document.body.prepend(canvas1);
+let video14 = await videoWithData();
+let commandEncoder81 = device1.createCommandEncoder({label: '\u{1fd12}\ue33c\u0853\u{1f78d}\u0cc5\u0416\u5e08'});
+let textureView83 = texture30.createView({mipLevelCount: 5});
+try {
+renderBundleEncoder47.setPipeline(pipeline58);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 520, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2080, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(438), /* required buffer size: 438 */
+{offset: 438, bytesPerRow: 315}, {width: 12, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 80, y: 5 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise27 = device1.createComputePipelineAsync({
+  label: '\u08ea\ub663\u6d4b\ub174\uef8c',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline63 = device1.createRenderPipeline({
+  label: '\u{1fbb6}\u{1fbaa}\u8cee\uf5c2',
+  layout: pipelineLayout7,
+  multisample: {mask: 0x20d08988},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 2394419495,
+    stencilWriteMask: 1786971638,
+    depthBias: -830556487,
+    depthBiasSlopeScale: -54.755334536915065,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 552, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 5028,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 952, shaderLocation: 26},
+          {format: 'unorm8x2', offset: 174, shaderLocation: 17},
+          {format: 'uint32x2', offset: 248, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 576, shaderLocation: 19},
+          {format: 'uint32x4', offset: 336, shaderLocation: 20},
+          {format: 'float32', offset: 644, shaderLocation: 22},
+          {format: 'uint16x2', offset: 388, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 932, shaderLocation: 0},
+          {format: 'sint32x3', offset: 468, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 492, shaderLocation: 13},
+          {format: 'uint32x2', offset: 112, shaderLocation: 2},
+          {format: 'sint16x2', offset: 220, shaderLocation: 15},
+          {format: 'sint32', offset: 616, shaderLocation: 18},
+          {format: 'sint16x2', offset: 732, shaderLocation: 14},
+          {format: 'sint32', offset: 704, shaderLocation: 25},
+          {format: 'float32x4', offset: 340, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 21},
+          {format: 'float16x2', offset: 900, shaderLocation: 3},
+          {format: 'uint32x3', offset: 1224, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 496, shaderLocation: 24},
+          {format: 'sint32x3', offset: 252, shaderLocation: 16},
+          {format: 'float16x2', offset: 1320, shaderLocation: 9},
+          {format: 'float32x3', offset: 704, shaderLocation: 23},
+          {format: 'uint32x4', offset: 40, shaderLocation: 12},
+          {format: 'uint32x2', offset: 992, shaderLocation: 7},
+          {format: 'uint16x2', offset: 2244, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 5528, attributes: []},
+      {
+        arrayStride: 1788,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 684, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', unclippedDepth: true},
+});
+let img17 = await imageWithData(94, 167, '#2e15e1b6', '#4168b0d5');
+let bindGroup25 = device1.createBindGroup({label: '\u0af3\ub604\u0aa1\u009d\ud210\u6d4c', layout: bindGroupLayout20, entries: []});
+let commandEncoder82 = device1.createCommandEncoder({});
+let commandBuffer20 = commandEncoder80.finish();
+let texture33 = device1.createTexture({
+  label: '\u{1fc37}\uedb1\u389a\u11ed\ubfa4\u{1f832}\ued37\u{1fcbe}\u{1fd46}\u70f4',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let textureView84 = texture30.createView({baseMipLevel: 3, mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder79.beginComputePass({label: '\uc12d\u45dd\ub683\u9a3c\uec7b\u52b4'});
+let sampler38 = device1.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 63.22,
+  lodMaxClamp: 88.93,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer14, 70264, 16);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 6, y: 29 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise24;
+} catch {}
+let renderBundle52 = renderBundleEncoder49.finish();
+try {
+renderBundleEncoder51.setPipeline(pipeline57);
+} catch {}
+try {
+commandEncoder82.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 15232 */
+  offset: 12560,
+  bytesPerRow: 256,
+  buffer: buffer14,
+}, {width: 7, height: 11, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 17136, new BigUint64Array(38728), 16618, 144);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(5_497), /* required buffer size: 5_497 */
+{offset: 261, bytesPerRow: 187}, {width: 0, height: 29, depthOrArrayLayers: 1});
+} catch {}
+let imageData20 = new ImageData(48, 20);
+document.body.prepend(img11);
+try {
+window.someLabel = computePassEncoder27.label;
+} catch {}
+let renderBundle53 = renderBundleEncoder38.finish({label: '\uf825\u7721\u008b\u051f\u0130\u0c09\u0950\ud409\u0d69\u{1f9a3}\u6566'});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup20, new Uint32Array(3714), 76, 0);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(3, buffer14, 0, 34473);
+} catch {}
+let textureView85 = texture32.createView({label: '\uc4aa\u0e5a\ued65', baseMipLevel: 1});
+try {
+computePassEncoder33.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(1, buffer14, 0, 22072);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 64, depthOrArrayLayers: 2}
+*/
+{
+  source: canvas9,
+  origin: { x: 132, y: 9 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 14, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder83 = device1.createCommandEncoder({label: '\ucd0d\u6bd9\u1733\u0312\u07a4\u0124\u1905'});
+let commandBuffer21 = commandEncoder68.finish({});
+let texture34 = device1.createTexture({
+  label: '\uc480\ub9be\uf685\uabb6\ub215\u1b6c\ue192\u4010\u{1fd81}',
+  size: {width: 24, height: 32, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder35 = commandEncoder60.beginComputePass({label: '\u1b86\u00f2\u{1fada}\u065d'});
+let renderBundleEncoder52 = device1.createRenderBundleEncoder({
+  label: '\u6239\u2ebc\u09c1\u9c6f\u{1ffa3}\u96c2',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle54 = renderBundleEncoder32.finish({label: '\u6049\u{1fcff}\uda9a'});
+try {
+renderBundleEncoder44.setBindGroup(4, bindGroup22, new Uint32Array(3777), 540, 0);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer14, 65112, 3996);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet25, 154, 75, buffer16, 12544);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 180, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(10_071_081), /* required buffer size: 10_071_081 */
+{offset: 111, bytesPerRow: 3689, rowsPerImage: 195}, {width: 2180, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let textureView86 = texture27.createView({baseMipLevel: 2, baseArrayLayer: 116, arrayLayerCount: 40});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({
+  label: '\u09d2\u98bb\ud3fd\u0f70\u4e2b\u{1f6f5}\u08cd\ucd71\u4285\u9595',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 14524 */
+  offset: 14524,
+  buffer: buffer13,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 5, y: 29, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline64 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  multisample: {mask: 0x1fca5541},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 48,
+        attributes: [
+          {format: 'float32x4', offset: 4, shaderLocation: 19},
+          {format: 'sint16x2', offset: 8, shaderLocation: 14},
+          {format: 'sint32x4', offset: 0, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 17},
+          {format: 'uint8x2', offset: 6, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 11},
+          {format: 'uint32x2', offset: 0, shaderLocation: 8},
+          {format: 'uint8x2', offset: 12, shaderLocation: 4},
+          {format: 'uint8x2', offset: 2, shaderLocation: 12},
+          {format: 'float16x2', offset: 4, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 24},
+          {format: 'uint8x2', offset: 6, shaderLocation: 7},
+          {format: 'uint16x2', offset: 0, shaderLocation: 20},
+          {format: 'float16x2', offset: 8, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 3856, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 200,
+        attributes: [
+          {format: 'float32x3', offset: 24, shaderLocation: 23},
+          {format: 'uint8x2', offset: 26, shaderLocation: 2},
+          {format: 'sint8x2', offset: 36, shaderLocation: 15},
+          {format: 'sint32', offset: 12, shaderLocation: 5},
+          {format: 'sint8x2', offset: 6, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 70, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm16x4', offset: 2484, shaderLocation: 21},
+          {format: 'sint32x2', offset: 3436, shaderLocation: 25},
+          {format: 'uint32x3', offset: 304, shaderLocation: 1},
+          {format: 'float32x2', offset: 2592, shaderLocation: 3},
+          {format: 'sint32x4', offset: 488, shaderLocation: 26},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'unorm8x4', offset: 412, shaderLocation: 22}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas24 = new OffscreenCanvas(248, 271);
+let texture35 = device1.createTexture({
+  label: '\u06f3\u4d39\u9525\uce28\ube68\uf361\uf5d6',
+  size: [12, 16, 437],
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder33.setBindGroup(4, bindGroup20);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 448 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 78944 */
+  offset: 8352,
+  bytesPerRow: 512,
+  rowsPerImage: 111,
+  buffer: buffer15,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 2, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 27, depthOrArrayLayers: 2});
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer16, 13260, 5236);
+dissociateBuffer(device1, buffer16);
+} catch {}
+gc();
+let bindGroup26 = device1.createBindGroup({label: '\uec37\u{1f653}\u7344\u0020\u0718\u{1fd82}', layout: bindGroupLayout20, entries: []});
+let textureView87 = texture26.createView({
+  label: '\u{1f9ee}\u076f\u42cc\u00d1\ua41a\u097c\u0ca2\u6b4a\u8156\uf27f\u39f8',
+  aspect: 'all',
+  baseMipLevel: 1,
+  baseArrayLayer: 26,
+  arrayLayerCount: 1,
+});
+let computePassEncoder36 = commandEncoder61.beginComputePass({label: '\u70d2\u056b\u515b\u2f01\ub034\u0703\u{1f925}\u25fb'});
+let renderBundle55 = renderBundleEncoder34.finish({});
+try {
+computePassEncoder27.setBindGroup(7, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(3, bindGroup20, new Uint32Array(781), 26, 0);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 14, y: 3 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline65 = device1.createRenderPipeline({
+  label: '\u{1fcf4}\uee51\ufe1a\u48d1\ue782\u76d0',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1724,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 160, shaderLocation: 22},
+          {format: 'snorm16x4', offset: 708, shaderLocation: 13},
+          {format: 'sint32x4', offset: 204, shaderLocation: 16},
+          {format: 'sint32', offset: 240, shaderLocation: 5},
+          {format: 'uint32x4', offset: 76, shaderLocation: 7},
+          {format: 'float16x4', offset: 120, shaderLocation: 21},
+          {format: 'sint16x2', offset: 944, shaderLocation: 26},
+          {format: 'sint8x2', offset: 254, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 158, shaderLocation: 3},
+          {format: 'uint32x4', offset: 172, shaderLocation: 4},
+          {format: 'float16x2', offset: 380, shaderLocation: 19},
+          {format: 'uint8x2', offset: 1362, shaderLocation: 12},
+          {format: 'uint32', offset: 296, shaderLocation: 20},
+          {format: 'float32x2', offset: 700, shaderLocation: 17},
+          {format: 'uint8x4', offset: 1032, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32x4', offset: 196, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 1064, shaderLocation: 24},
+          {format: 'unorm8x2', offset: 1140, shaderLocation: 10},
+          {format: 'float32x3', offset: 1232, shaderLocation: 9},
+          {format: 'float16x2', offset: 420, shaderLocation: 11},
+          {format: 'sint8x2', offset: 174, shaderLocation: 25},
+          {format: 'uint8x4', offset: 1124, shaderLocation: 6},
+          {format: 'sint8x4', offset: 232, shaderLocation: 18},
+          {format: 'float16x4', offset: 2512, shaderLocation: 0},
+          {format: 'uint8x4', offset: 568, shaderLocation: 1},
+          {format: 'uint32x4', offset: 1460, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 2044, shaderLocation: 23},
+        ],
+      },
+    ],
+  },
+});
+let gpuCanvasContext25 = offscreenCanvas24.getContext('webgpu');
+gc();
+let imageData21 = new ImageData(60, 28);
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let texture36 = device1.createTexture({
+  size: {width: 96, height: 128, depthOrArrayLayers: 1264},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView88 = texture36.createView({baseMipLevel: 1, baseArrayLayer: 1049, arrayLayerCount: 114});
+let sampler39 = device1.createSampler({
+  label: '\u9324\u0776\u{1fb74}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 52.68,
+  lodMaxClamp: 56.92,
+});
+try {
+computePassEncoder32.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(1, buffer14);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+commandEncoder75.resolveQuerySet(querySet29, 3373, 188, buffer16, 23040);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 412, new Float32Array(35967), 21915, 36);
+} catch {}
+document.body.prepend(img11);
+gc();
+let canvas17 = document.createElement('canvas');
+let promise28 = adapter0.requestAdapterInfo();
+let canvas18 = document.createElement('canvas');
+let textureView89 = texture30.createView({label: '\ud1d8\u2ea3\u0d0f\u2b86\u3ddd', dimension: '3d', aspect: 'all', baseMipLevel: 4});
+let renderBundle56 = renderBundleEncoder48.finish({label: '\u{1fae7}\u0deb\ub408\uf79a\ucacf\u0747'});
+try {
+computePassEncoder27.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(1, buffer14);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 61},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 48, height: 31, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 139},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(48)), /* required buffer size: 965_130 */
+{offset: 330, bytesPerRow: 40, rowsPerImage: 134}, {width: 0, height: 1, depthOrArrayLayers: 181});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 227, y: 690 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder84 = device1.createCommandEncoder({label: '\uf5eb\uc42b\u9515\u185e\u36c2'});
+let textureView90 = texture33.createView({});
+let computePassEncoder37 = commandEncoder75.beginComputePass({label: '\u0417\u0586\u859f\u074d'});
+let pipeline66 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0xf0dd8a80},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-wrap',
+    },
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 1049171832,
+    stencilWriteMask: 699058241,
+    depthBias: 156379345,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 164,
+        attributes: [
+          {format: 'uint16x4', offset: 12, shaderLocation: 12},
+          {format: 'sint32x3', offset: 0, shaderLocation: 5},
+          {format: 'float32x4', offset: 0, shaderLocation: 9},
+          {format: 'uint32', offset: 44, shaderLocation: 8},
+          {format: 'sint32x4', offset: 24, shaderLocation: 15},
+          {format: 'uint8x2', offset: 44, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 4460,
+        attributes: [
+          {format: 'sint16x4', offset: 512, shaderLocation: 26},
+          {format: 'uint32x4', offset: 292, shaderLocation: 7},
+          {format: 'sint32x4', offset: 1912, shaderLocation: 14},
+          {format: 'float32x3', offset: 1032, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 24, shaderLocation: 19},
+          {format: 'float16x2', offset: 32, shaderLocation: 0},
+          {format: 'float32x3', offset: 36, shaderLocation: 21},
+          {format: 'sint8x2', offset: 12, shaderLocation: 16},
+          {format: 'uint8x2', offset: 62, shaderLocation: 1},
+          {format: 'sint32x4', offset: 16, shaderLocation: 25},
+          {format: 'float32x4', offset: 8, shaderLocation: 13},
+          {format: 'float16x2', offset: 4, shaderLocation: 24},
+          {format: 'float32x4', offset: 80, shaderLocation: 22},
+          {format: 'float16x2', offset: 16, shaderLocation: 3},
+          {format: 'sint32', offset: 92, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 1556,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 100, shaderLocation: 17}],
+      },
+      {arrayStride: 808, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 420,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 192, shaderLocation: 4},
+          {format: 'uint16x4', offset: 8, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 2440, attributes: []},
+      {
+        arrayStride: 1368,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 188, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 56, shaderLocation: 10},
+          {format: 'uint32', offset: 68, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let gpuCanvasContext26 = canvas17.getContext('webgpu');
+let img18 = await imageWithData(220, 4, '#bb8f6485', '#d47213cc');
+let gpuCanvasContext27 = canvas18.getContext('webgpu');
+gc();
+try {
+  await promise28;
+} catch {}
+let video15 = await videoWithData();
+let commandEncoder85 = device1.createCommandEncoder();
+try {
+renderBundleEncoder50.setVertexBuffer(6, buffer14);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer13, 14548, buffer14, 20996, 20164);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder81.clearBuffer(buffer14, 40212, 12504);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 1120, new Float32Array(36371), 35073, 148);
+} catch {}
+let pipeline67 = await promise23;
+let shaderModule11 = device1.createShaderModule({
+  code: `
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec3<f32>,
+  @location(1) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(7) f0: vec3<f32>,
+  @location(23) f1: vec3<i32>,
+  @location(6) f2: vec4<f32>,
+  @location(8) f3: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: u32, @location(21) a1: vec3<f16>, @location(9) a2: vec4<f32>, @location(0) a3: vec4<f16>, @location(25) a4: i32, a5: S12, @location(19) a6: vec3<i32>, @location(14) a7: vec4<f16>, @location(15) a8: vec4<u32>, @location(3) a9: u32, @location(16) a10: vec4<u32>, @location(4) a11: vec3<f16>, @location(18) a12: vec3<f16>, @location(12) a13: vec2<i32>, @location(5) a14: f32, @location(1) a15: vec2<f32>, @builtin(instance_index) a16: u32, @location(20) a17: vec4<f32>, @location(22) a18: vec4<i32>, @location(13) a19: vec2<u32>, @location(11) a20: vec2<u32>, @location(26) a21: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView91 = texture32.createView({label: '\u8457\u{1fddb}\u5cfe\uedd6\u0e5e', baseMipLevel: 1});
+try {
+renderBundleEncoder42.setVertexBuffer(2, buffer14, 66364, 2263);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer5), /* required buffer size: 349 */
+{offset: 86, bytesPerRow: 77, rowsPerImage: 216}, {width: 2, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline68 = await promise25;
+offscreenCanvas8.height = 1189;
+let externalTexture37 = device1.importExternalTexture({
+  label: '\u46a0\u31a0\u0193\u0f6f\u6594\u69ef\u81d7\u0d24\u1975\u0f12',
+  source: videoFrame11,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder46.setVertexBuffer(5, buffer14);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1120 */
+  offset: 1120,
+  bytesPerRow: 0,
+  rowsPerImage: 27,
+  buffer: buffer15,
+}, {
+  texture: texture35,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 28},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 179});
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 286 */
+{offset: 286, bytesPerRow: 199, rowsPerImage: 92}, {width: 5, height: 61, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(265, 265);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(920, 587);
+let videoFrame16 = new VideoFrame(video3, {timestamp: 0});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+let canvas19 = document.createElement('canvas');
+let buffer19 = device1.createBuffer({
+  label: '\uee5b\u2d02\u{1fb71}\ud6ed',
+  size: 446468,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder86 = device1.createCommandEncoder({label: '\u82ff\uf1f7\ub1b2\u05ba\u07ef\u{1fe76}'});
+let textureView92 = texture30.createView({
+  label: '\u0bb3\u{1fe27}\u05f7\u6458\u08fb\u{1fb60}\u{1f805}',
+  format: 'r16float',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let sampler40 = device1.createSampler({
+  label: '\u036d\ua98b\u341d\u856f\ub858\u6ea8\u09db\u6b07\ua24a\uada3',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.92,
+  lodMaxClamp: 54.16,
+});
+try {
+renderBundleEncoder47.setBindGroup(7, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(7, buffer14, 57612, 9224);
+} catch {}
+try {
+commandEncoder82.clearBuffer(buffer16, 25488, 4036);
+dissociateBuffer(device1, buffer16);
+} catch {}
+let textureView93 = texture25.createView({
+  label: '\u25b9\u7221\u{1fb11}\uc4e8\u0901\u403b\uee94\u{1f991}\uceee\u084d\ua055',
+  dimension: '2d-array',
+});
+let externalTexture38 = device1.importExternalTexture({
+  label: '\u5a39\u88c0\u{1feb9}\u3a45\u{1ff9d}\u749e\u{1f90b}',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder23.setBindGroup(5, bindGroup25, new Uint32Array(2444), 211, 0);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12518 */
+  offset: 12518,
+  buffer: buffer18,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas11,
+  origin: { x: 3, y: 5 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline69 = await device1.createComputePipelineAsync({
+  label: '\u82b3\u13a0\u{1fe18}\ucb06\ud98e\u09a6\u{1f8c2}\u{1f8f3}\u0988',
+  layout: 'auto',
+  compute: {module: shaderModule11, entryPoint: 'compute0'},
+});
+let videoFrame17 = new VideoFrame(videoFrame7, {timestamp: 0});
+let commandBuffer22 = commandEncoder76.finish({label: '\u0e63\udfd5\u07bb\u252f\u{1faed}'});
+let textureView94 = texture26.createView({
+  label: '\u{1ff4d}\u1413\u{1fdf8}\u{1fb4b}\u{1f684}\u01cb\u{1f896}',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 7,
+  arrayLayerCount: 22,
+});
+let sampler41 = device1.createSampler({
+  label: '\uc669\u011c\u0dff\u9995\u0efa\u60af\u07a8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.47,
+  maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder43.setVertexBuffer(5, buffer14, 0);
+} catch {}
+let pipeline70 = await device1.createComputePipelineAsync({
+  label: '\uc650\u02d8\u394a\u0a0d\uea3c',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+let pipeline71 = device1.createRenderPipeline({
+  label: '\ufefc\u0006\u{1ff10}\u73fb\u527d\ubba1\u04b6\uc110\u2475\u{1fd1f}\uee11',
+  layout: pipelineLayout7,
+  multisample: {mask: 0x57a115de},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: 0,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1232,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 196, shaderLocation: 16},
+          {format: 'sint16x4', offset: 200, shaderLocation: 22},
+          {format: 'unorm10-10-10-2', offset: 92, shaderLocation: 1},
+          {format: 'float32x3', offset: 60, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 9},
+          {format: 'float32', offset: 56, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm8x2', offset: 2594, shaderLocation: 26},
+          {format: 'sint32x3', offset: 2188, shaderLocation: 12},
+          {format: 'sint8x4', offset: 1936, shaderLocation: 25},
+          {format: 'sint8x4', offset: 44, shaderLocation: 19},
+          {format: 'sint8x4', offset: 256, shaderLocation: 23},
+          {format: 'float16x4', offset: 784, shaderLocation: 14},
+          {format: 'float32x2', offset: 2036, shaderLocation: 0},
+          {format: 'uint16x2', offset: 2124, shaderLocation: 3},
+          {format: 'sint8x2', offset: 542, shaderLocation: 8},
+          {format: 'uint8x4', offset: 1952, shaderLocation: 2},
+          {format: 'uint8x4', offset: 412, shaderLocation: 15},
+          {format: 'uint32', offset: 1236, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 3308, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 4216, shaderLocation: 20},
+          {format: 'unorm16x4', offset: 688, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 1784, shaderLocation: 5},
+          {format: 'uint16x2', offset: 1704, shaderLocation: 11},
+          {format: 'float32', offset: 748, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw'},
+});
+canvas1.height = 64;
+let querySet34 = device1.createQuerySet({label: '\uf074\u08aa\u{1f78e}\ubf9c\u0336\u04b4', type: 'occlusion', count: 2992});
+let computePassEncoder38 = commandEncoder78.beginComputePass({label: '\ua699\uf013\u2518\ub52e\u{1fc1d}\u7866\u0438\u639c\ub50a\u0abe\ua0d6'});
+try {
+device1.queue.writeBuffer(buffer14, 13392, new Float32Array(47464), 39456, 552);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: img14,
+  origin: { x: 5, y: 19 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+bindGroupLayout5.label = '\u4808\ub2cf\ude96\u8e18\u{1f821}';
+} catch {}
+let promise29 = adapter1.requestAdapterInfo();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let buffer20 = device1.createBuffer({
+  label: '\u3a6e\u0eea\u{1f8a2}\u2c22\ubfdf\u2b39\u4bde\u7473\u044e',
+  size: 246342,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+let textureView95 = texture32.createView({
+  label: '\u0ec8\ubb3d\u{1fb11}\u{1fcdf}\u2ae2\uf56b\u0268\u7fc2',
+  dimension: '3d',
+  aspect: 'all',
+  baseMipLevel: 1,
+});
+try {
+computePassEncoder35.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(5, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(6, buffer19, 191844, 2420);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 844 */
+{offset: 844}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext28 = offscreenCanvas25.getContext('webgpu');
+let texture37 = device1.createTexture({
+  label: '\u0e21\u0b51\u3832\u{1f618}\u8d79\u02ed',
+  size: [12, 16, 1],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView96 = texture34.createView({dimension: '2d-array', baseMipLevel: 2});
+let renderPassEncoder21 = commandEncoder77.beginRenderPass({
+  label: '\u5362\u2446\uf372\u{1f8ba}',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -875.5, g: -242.6, b: -29.62, a: -661.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 185.2, g: 416.2, b: -245.1, a: 293.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: -419.6, g: 6.351, b: 404.5, a: 72.42, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet26,
+});
+let renderBundleEncoder54 = device1.createRenderBundleEncoder({colorFormats: ['r16float', 'rg32float', 'rgba32float'], stencilReadOnly: true});
+try {
+renderPassEncoder21.beginOcclusionQuery(2327);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(0, 8, 3, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer19, 'uint16', 347616, 78678);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(7, buffer19, 432288, 5981);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas26.getContext('webgpu');
+try {
+  await promise29;
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(602, 916);
+let commandBuffer23 = commandEncoder57.finish({label: '\u61e1\u{1f926}\uf0f2\u3724\u0643\u0bc8\u{1fcaf}\u1e01\u049b\u0a1b\u32cc'});
+let texture38 = device1.createTexture({
+  label: '\uef8f\u02d8\u9661\u{1f9a8}\u06c8\uad82',
+  size: [24, 32, 272],
+  mipLevelCount: 6,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float', 'rg32float', 'rg32float'],
+});
+try {
+computePassEncoder32.setBindGroup(7, bindGroup25);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(2912);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer19, 0, 36261);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer15, 24880, buffer16, 8976, 12164);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet28, 1114, 1062, buffer16, 13056);
+} catch {}
+let imageData22 = new ImageData(48, 64);
+try {
+window.someLabel = pipelineLayout0.label;
+} catch {}
+let querySet35 = device1.createQuerySet({label: '\ufda3\u{1ff18}\u0bde\udc8f', type: 'occlusion', count: 3566});
+let texture39 = device1.createTexture({
+  label: '\u{1f671}\u0e58\u094b\uda60\uba72',
+  size: {width: 24, height: 32, depthOrArrayLayers: 966},
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle57 = renderBundleEncoder37.finish({label: '\uc4ac\u0e0b\u{1fa4e}\uea51\u{1ff09}\u{1fcaa}\u{1f6a5}\u18e1'});
+try {
+renderPassEncoder21.executeBundles([renderBundle37, renderBundle38, renderBundle42, renderBundle38, renderBundle42, renderBundle54, renderBundle41, renderBundle51, renderBundle49]);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 944.4, g: -404.5, b: 670.6, a: 807.6, });
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer19, 'uint32', 368088);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer19, 'uint32', 357000, 50425);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 5248, new BigUint64Array(7034), 6560, 8);
+} catch {}
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame18 = new VideoFrame(img15, {timestamp: 0});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup25, new Uint32Array(5383), 1040, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline69);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(193, undefined, 487156238, 2428804549);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(6, bindGroup19, new Uint32Array(9967), 2224, 0);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(6, buffer19, 395072, 520);
+} catch {}
+let arrayBuffer9 = buffer19.getMappedRange(0, 218028);
+try {
+gpuCanvasContext28.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+let videoFrame19 = new VideoFrame(imageBitmap11, {timestamp: 0});
+try {
+offscreenCanvas27.getContext('webgl');
+} catch {}
+let gpuCanvasContext30 = canvas19.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+video8.width = 14;
+let img19 = await imageWithData(146, 120, '#6f2eb482', '#b18f2cac');
+let textureView97 = texture33.createView({label: '\u0d74\u{1f77c}\u41b5\u{1f94d}\u1096\u{1fd40}\ua1b8\u01e1\u05e8', baseMipLevel: 0});
+let renderBundle58 = renderBundleEncoder38.finish({label: '\u270c\ua603\ue1b6\u8b42\u0747\u03b5\u2db8\uc3a1'});
+let externalTexture39 = device1.importExternalTexture({source: video9, colorSpace: 'display-p3'});
+try {
+renderPassEncoder21.setScissorRect(4, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder21.setViewport(0.1082, 0.2110, 1.203, 4.548, 0.5356, 0.5707);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer19, 'uint32', 203088, 49092);
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+let imageBitmap16 = await createImageBitmap(video11);
+let textureView98 = texture23.createView({
+  label: '\u4b83\u7310\ucb7a\u01c3\u{1fc56}\u5128\ub389\u7249\udba4\u0b7b\u{1fa34}',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+});
+try {
+renderPassEncoder21.setBlendConstant({ r: 146.3, g: -843.4, b: -227.3, a: 137.9, });
+} catch {}
+try {
+renderPassEncoder21.setViewport(4.604, 3.285, 0.7884, 1.615, 0.5962, 0.7377);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer14, 1308, 46884);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(7, buffer19, 183104);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture38,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 22},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4256 */
+  offset: 4256,
+  bytesPerRow: 0,
+  rowsPerImage: 2,
+  buffer: buffer16,
+}, {width: 0, height: 0, depthOrArrayLayers: 35});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer16, 9952, 784);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet27, 683, 402, buffer16, 15360);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 8892, new Float32Array(35404), 24146, 3176);
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let imageBitmap17 = await createImageBitmap(canvas19);
+let commandEncoder87 = device1.createCommandEncoder({label: '\u{1fc38}\u{1faec}\u67ee\u2504\ua826'});
+let texture40 = device1.createTexture({
+  label: '\u57b1\u199c\u{1fd63}\u{1fb1c}\u{1f90d}\uf87c\uadb8\uc666\u{1f8e2}\u0785\u00d4',
+  size: {width: 24, height: 32, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let renderPassEncoder22 = commandEncoder86.beginRenderPass({
+  label: '\ua47d\u{1fa02}\u0273\u7815\u{1fa45}\u0325\u{1fb91}\u659b\ueaf1\u0fd5\u{1fe73}',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 104.1, g: 890.3, b: -391.4, a: 60.53, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -441.4, g: -818.1, b: -698.4, a: -198.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView85,
+  depthSlice: 0,
+  clearValue: { r: 850.3, g: 67.45, b: -578.8, a: 909.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 537894017,
+});
+let renderBundleEncoder55 = device1.createRenderBundleEncoder({label: '\u018a\u5f03\u007b', colorFormats: ['r16float', 'rg32float', 'rgba32float']});
+let externalTexture40 = device1.importExternalTexture({
+  label: '\u0bd2\u{1f92e}\u{1f8c7}\u0d59\u48fd\u{1fdbe}\u232a\u{1ffcd}\uf197\u7ca5',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder31.setPipeline(pipeline70);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(1613);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -143.6, g: 877.3, b: 248.2, a: 824.2, });
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(7, buffer14, 54828, 12741);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer18, 40692, buffer17, 12588, 12240);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 23984, new Float32Array(35866), 23721, 192);
+} catch {}
+let bindGroupLayout27 = device1.createBindGroupLayout({
+  label: '\u026c\ufa6a\u0e31\u024e\u162e\u{1ff3e}',
+  entries: [{binding: 154, visibility: 0, sampler: { type: 'comparison' }}],
+});
+let renderBundle59 = renderBundleEncoder37.finish({});
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer19, 330972, 34220);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(7, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(3, buffer14, 41532, 6516);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 150, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3510, height: 6, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer17, 3180);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 64, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 97, y: 233 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let querySet36 = device1.createQuerySet({
+  label: '\u{1f737}\u0768\u7c1f\u76be\u{1fbb0}\u9f53\u01b9\u7005\u41d9\u0e6b\u0dc2',
+  type: 'occlusion',
+  count: 59,
+});
+let texture41 = device1.createTexture({
+  label: '\udeb3\u{1ff27}\u0e6b',
+  size: [2448, 6, 1255],
+  mipLevelCount: 6,
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-6x6-unorm', 'astc-6x6-unorm-srgb'],
+});
+let textureView99 = texture23.createView({label: '\u5878\u038e\u1a84\u8070\u{1f9f2}\u{1ffad}\u4105\u0917\u030d', baseMipLevel: 3});
+try {
+renderPassEncoder21.setScissorRect(4, 7, 0, 1);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer14, 0, 29715);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder55.setIndexBuffer(buffer19, 'uint16', 58692, 93984);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(61, undefined, 3138734876, 802329056);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer16, 17360, 7656);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 13092, new BigUint64Array(48831), 32243, 176);
+} catch {}
+document.body.prepend(video8);
+let commandEncoder88 = device1.createCommandEncoder({label: '\u0938\ucd08\u{1fc10}'});
+let commandBuffer24 = commandEncoder81.finish({label: '\u350d\u076b\ub3e8\u6c11\u2e44\u2e2b\u{1fe86}\u{1fee3}\uc62f\u{1f83a}'});
+let texture42 = device1.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder39 = commandEncoder71.beginComputePass({});
+let renderBundle60 = renderBundleEncoder43.finish({label: '\u00bf\u048f\u0809\ua06b\ua14d\u{1faa3}\u26dc'});
+try {
+computePassEncoder26.setPipeline(pipeline60);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(701);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle41]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer19, 'uint16', 376830, 39008);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline71);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(0, buffer14);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline71);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 1, y: 14 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView100 = texture40.createView({
+  label: '\u040b\udd68\udd7a\u{1fdeb}\u01d6\u001a\ub5e1\u090d\uaf1f',
+  aspect: 'all',
+  format: 'rgba32float',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+let renderBundle61 = renderBundleEncoder32.finish();
+let sampler42 = device1.createSampler({
+  label: '\u09f6\u0cd6\uf022\u79e7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.21,
+  lodMaxClamp: 32.18,
+});
+let externalTexture41 = device1.importExternalTexture({
+  label: '\u1318\u719e\u18f5\u38e4\u8e2a\u5645\ucb9f\u9a0a\u4b6c',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder38.setPipeline(pipeline60);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle55, renderBundle51, renderBundle44, renderBundle47, renderBundle55, renderBundle57]);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: 578.6, g: -879.6, b: -331.5, a: 830.1, });
+} catch {}
+try {
+renderPassEncoder22.setViewport(1.520, 6.971, 0.1316, 0.2794, 0.1431, 0.5109);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer19, 'uint16', 341968, 29973);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 1, y: 133 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 2, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture20.label;
+} catch {}
+let texture43 = device1.createTexture({
+  label: '\ud756\u06d6\ub1fb\u{1fbae}\u3d3b\u{1fb65}\ue2d4\u{1f9bd}\u174c\u0f32',
+  size: {width: 96, height: 128, depthOrArrayLayers: 675},
+  mipLevelCount: 5,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float', 'rg32float'],
+});
+let textureView101 = texture24.createView({label: '\u05dc\uf4d3\u{1fe19}\u68d0\u060d\u039e\u3b1d'});
+let renderBundle62 = renderBundleEncoder52.finish({label: '\u0712\u76b8\uda8e\u{1fb06}\u2b57\u9974\u0d1f\u3aa1\u4855\u4a34\u7907'});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer19);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder83.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas25,
+  origin: { x: 6, y: 68 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+document.body.prepend(canvas12);
+let commandEncoder89 = device1.createCommandEncoder({label: '\uf0d5\u1a9f\u7424\u01b0\u02eb\u029a'});
+let texture44 = device1.createTexture({
+  label: '\ucc0f\u0ef0\u0289\u7a13\u{1fec2}\u0328\ud800\ud8c5\u{1fcb0}\u4d7a\uef65',
+  size: {width: 96, height: 128, depthOrArrayLayers: 4},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let textureView102 = texture30.createView({label: '\u1a50\u{1fc3c}', baseMipLevel: 3, baseArrayLayer: 0});
+let computePassEncoder40 = commandEncoder72.beginComputePass({label: '\u9bbd\u1eb5'});
+try {
+renderPassEncoder22.setViewport(3.767, 1.811, 1.170, 0.1713, 0.9540, 0.9906);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(6, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline65);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(buffer18, 42700, buffer17, 7456, 2244);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline72 = await device1.createComputePipelineAsync({
+  label: '\u0f6b\u89a8\u0d57\u074e\ub115\uc8e7\u{1f7d5}\u993d\u0765\u6eff',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+let texture45 = device1.createTexture({
+  size: {width: 24, height: 32, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let textureView103 = texture35.createView({
+  label: '\u{1f60f}\ue695\ucf8d\u0f29\u7229\u4f57\u0c1d\ub833\u0b69\ua187\ud666',
+  baseMipLevel: 3,
+  baseArrayLayer: 248,
+  arrayLayerCount: 124,
+});
+let computePassEncoder41 = commandEncoder74.beginComputePass({label: '\u0895\u0102\ubb73\u6cd8\u090c'});
+try {
+renderPassEncoder22.executeBundles([renderBundle38, renderBundle58, renderBundle39, renderBundle61, renderBundle60, renderBundle51]);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup19, new Uint32Array(753), 589, 0);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline57);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet33, 1037, 203, buffer16, 20992);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 126, y: 1 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline73 = await device1.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}}});
+let canvas20 = document.createElement('canvas');
+let video16 = await videoWithData();
+let videoFrame20 = new VideoFrame(video16, {timestamp: 0});
+let videoFrame21 = new VideoFrame(img3, {timestamp: 0});
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({
+  label: '\u9c21\u58aa\uf724\u16d8\u0a51\u7d77\uc6bb\u{1f884}\u6911\u{1fec9}\u09b5',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(5, 4, 0, 3);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer14, 0, 19468);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(5, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(5, bindGroup17, new Uint32Array(7599), 5927, 0);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline57);
+} catch {}
+try {
+commandEncoder70.copyBufferToBuffer(buffer13, 11360, buffer17, 36612, 2716);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer17);
+} catch {}
+document.body.prepend(video13);
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\u0e37\u9e5d',
+  entries: [
+    {
+      binding: 5075,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet37 = device1.createQuerySet({label: '\u55ec\u00f5\u{1f950}\u6712', type: 'occlusion', count: 267});
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({
+  label: '\uf012\u9f00\ud467\u9c52\uf9ab\uf111\u07ce\ub488\u5f7f\uf1f8\udc46',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  sampleCount: 1,
+});
+let externalTexture42 = device1.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder21.setBlendConstant({ r: -538.2, g: -243.4, b: 747.6, a: 597.2, });
+} catch {}
+try {
+renderPassEncoder22.setViewport(1.082, 6.505, 4.900, 1.076, 0.7842, 0.8734);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer19, 'uint32', 158300, 205797);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 17648 */
+  offset: 17648,
+  rowsPerImage: 10,
+  buffer: buffer13,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet32, 234, 210, buffer16, 29184);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 11, y: 41 },
+  flipY: true,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline74 = await device1.createComputePipelineAsync({
+  label: '\u004b\u8030\u670a\u{1fe9f}\u{1f9b7}\u823d\u6d25\u9f88\u{1f73a}',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let pipeline75 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 2091224619,
+    stencilWriteMask: 1385521120,
+    depthBiasSlopeScale: 765.2776802719122,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3548,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 796, shaderLocation: 0},
+          {format: 'uint32x3', offset: 1252, shaderLocation: 6},
+          {format: 'uint8x4', offset: 332, shaderLocation: 4},
+          {format: 'uint32', offset: 608, shaderLocation: 1},
+          {format: 'sint32x2', offset: 68, shaderLocation: 25},
+          {format: 'uint16x2', offset: 420, shaderLocation: 7},
+          {format: 'sint32', offset: 48, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 96, shaderLocation: 11},
+          {format: 'sint32x3', offset: 780, shaderLocation: 14},
+          {format: 'float32x2', offset: 548, shaderLocation: 19},
+          {format: 'sint16x4', offset: 872, shaderLocation: 18},
+          {format: 'uint32', offset: 156, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 200, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 188, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 244, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 954, shaderLocation: 24},
+          {format: 'snorm16x2', offset: 516, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 56,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 0, shaderLocation: 26},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 3},
+          {format: 'uint32x4', offset: 12, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 23},
+          {format: 'sint16x2', offset: 0, shaderLocation: 5},
+          {format: 'sint32', offset: 0, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 608,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 36, shaderLocation: 20}],
+      },
+      {arrayStride: 1712, attributes: [{format: 'float32', offset: 208, shaderLocation: 17}]},
+      {arrayStride: 468, attributes: []},
+      {arrayStride: 4200, attributes: []},
+      {arrayStride: 1472, attributes: [{format: 'uint32x2', offset: 532, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'none'},
+});
+let shaderModule12 = device0.createShaderModule({
+  label: '\udd2b\u387b\uc19e\u2498\ue511\u0e4c',
+  code: `@group(1) @binding(1513)
+var<storage, read_write> n5: array<u32>;
+@group(4) @binding(2930)
+var<storage, read_write> n6: array<u32>;
+@group(4) @binding(3769)
+var<storage, read_write> field4: array<u32>;
+@group(0) @binding(1338)
+var<storage, read_write> field5: array<u32>;
+@group(2) @binding(1513)
+var<storage, read_write> type7: array<u32>;
+@group(5) @binding(2477)
+var<storage, read_write> field6: array<u32>;
+@group(4) @binding(3765)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(1513)
+var<storage, read_write> type8: array<u32>;
+@group(2) @binding(1338)
+var<storage, read_write> parameter12: array<u32>;
+@group(3) @binding(3004)
+var<storage, read_write> function3: array<u32>;
+@group(1) @binding(1338)
+var<storage, read_write> n8: array<u32>;
+@group(3) @binding(424)
+var<storage, read_write> local5: array<u32>;
+@group(3) @binding(186)
+var<storage, read_write> n9: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec2<u32>,
+  @location(1) f2: vec2<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(32) f92: vec3<f16>,
+  @builtin(position) f93: vec4<f32>,
+  @location(38) f94: vec3<i32>,
+  @location(37) f95: f32,
+  @location(43) f96: vec4<u32>,
+  @location(11) f97: f16,
+  @location(6) f98: vec3<u32>,
+  @location(45) f99: vec2<f32>,
+  @location(12) f100: i32,
+  @location(70) f101: vec4<i32>,
+  @location(17) f102: u32,
+  @location(65) f103: vec2<u32>,
+  @location(54) f104: vec2<i32>,
+  @location(20) f105: f16,
+  @location(39) f106: vec3<i32>,
+  @location(4) f107: f16,
+  @location(30) f108: vec3<f16>,
+  @location(67) f109: vec4<u32>,
+  @location(23) f110: i32,
+  @location(48) f111: f16,
+  @location(63) f112: i32,
+  @location(28) f113: vec4<i32>,
+  @location(46) f114: vec4<f32>,
+  @location(19) f115: u32,
+  @location(51) f116: f32,
+  @location(29) f117: vec4<f32>,
+  @location(10) f118: f32,
+  @location(25) f119: vec3<i32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout29 = pipeline20.getBindGroupLayout(0);
+let renderBundle63 = renderBundleEncoder21.finish({label: '\ubf61\u09b6'});
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer7, 432_054_140);
+} catch {}
+try {
+renderBundleEncoder4.draw(344, 31, 2_575_846_158, 1_639_314_788);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline51);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+let pipeline76 = device0.createRenderPipeline({
+  label: '\u96bf\u2dd6\u0a63\u0b10\u75a6\u464f\ue4d2\u58b1\u0095\u9b4f\u{1fd32}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap'},
+    stencilReadMask: 75792146,
+    stencilWriteMask: 4270536176,
+    depthBiasSlopeScale: 0.26705943938102905,
+    depthBiasClamp: 17.069680735132238,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 312, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 1024, shaderLocation: 8},
+          {format: 'uint16x2', offset: 12620, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 2304, shaderLocation: 3},
+          {format: 'sint32x3', offset: 4420, shaderLocation: 9},
+          {format: 'sint16x2', offset: 3204, shaderLocation: 12},
+          {format: 'sint16x4', offset: 9508, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 10432, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 3086, shaderLocation: 14},
+          {format: 'uint16x4', offset: 584, shaderLocation: 6},
+          {format: 'uint32x3', offset: 3940, shaderLocation: 10},
+          {format: 'float16x2', offset: 11036, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32x4', offset: 2544, shaderLocation: 11},
+          {format: 'uint32x3', offset: 2224, shaderLocation: 5},
+          {format: 'uint32x4', offset: 3840, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 5280,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x4', offset: 440, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+canvas9.height = 260;
+let bindGroup27 = device1.createBindGroup({label: '\ucab4\u7de8\u05bd\ufb55\u{1facb}\uf6ca', layout: bindGroupLayout26, entries: []});
+let buffer21 = device1.createBuffer({
+  label: '\u{1f736}\u0e64\u0bd9\u0627\u3a97',
+  size: 66896,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let textureView104 = texture43.createView({baseMipLevel: 4, baseArrayLayer: 541, arrayLayerCount: 78});
+let renderPassEncoder23 = commandEncoder85.beginRenderPass({
+  label: '\u060b\uc528\u{1ff36}\u0a05\u{1f815}\udb73\u{1f628}\u32c3\u0d0e\u9944',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 66.44, g: 97.22, b: 891.2, a: 498.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 194.5, g: 431.7, b: 840.3, a: -48.17, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: 619.1, g: -107.1, b: -990.8, a: 894.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet32,
+  maxDrawCount: 161070436,
+});
+let renderBundleEncoder58 = device1.createRenderBundleEncoder({
+  label: '\ua704\u{1f99b}\u{1feb2}\u{1f794}\u028f\u4d6e\u06f7\u{1f8c5}\ufc79',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(3, 0, 0, 7);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(326);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder83.copyBufferToTexture({
+  /* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 67328 */
+  offset: 67328,
+  bytesPerRow: 256,
+  rowsPerImage: 243,
+  buffer: buffer15,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 9, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer14, 69756, 700);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet25, 209, 150, buffer21, 45056);
+} catch {}
+let pipeline77 = device1.createRenderPipeline({
+  label: '\u{1fa91}\u02f5\u66ce\u232a\uc70a\u{1f7bb}\u2970',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 731875351,
+    stencilWriteMask: 2216179971,
+    depthBiasSlopeScale: 233.95447549688583,
+    depthBiasClamp: 57.65716784568926,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 804,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 104, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 28, shaderLocation: 1},
+          {format: 'uint16x4', offset: 4, shaderLocation: 11},
+          {format: 'uint32x3', offset: 76, shaderLocation: 3},
+          {format: 'float16x4', offset: 368, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 28, shaderLocation: 4},
+          {format: 'uint32x4', offset: 48, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 60, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 0},
+          {format: 'float32x4', offset: 36, shaderLocation: 6},
+          {format: 'sint32x2', offset: 24, shaderLocation: 12},
+          {format: 'uint32x2', offset: 248, shaderLocation: 16},
+          {format: 'sint8x2', offset: 218, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 112, shaderLocation: 26},
+          {format: 'sint16x4', offset: 68, shaderLocation: 19},
+          {format: 'uint8x4', offset: 536, shaderLocation: 2},
+          {format: 'uint32x2', offset: 408, shaderLocation: 15},
+          {format: 'float16x2', offset: 52, shaderLocation: 21},
+          {format: 'sint32x4', offset: 140, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 776,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 128, shaderLocation: 8},
+          {format: 'sint8x2', offset: 152, shaderLocation: 22},
+          {format: 'float16x2', offset: 60, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 20, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 2004, attributes: []},
+      {
+        arrayStride: 276,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 56, shaderLocation: 18}],
+      },
+    ],
+  },
+});
+let imageBitmap18 = await createImageBitmap(video13);
+let gpuCanvasContext31 = canvas20.getContext('webgpu');
+let adapter2 = await navigator.gpu.requestAdapter({});
+let imageData23 = new ImageData(100, 184);
+let bindGroup28 = device1.createBindGroup({
+  label: '\u8821\u24f8\u09f9\u016d\u4df2\u24de\u{1f851}\u{1ff9f}\uf66d\u9ff4',
+  layout: bindGroupLayout20,
+  entries: [],
+});
+let textureView105 = texture36.createView({label: '\u04f7\u0b2e', dimension: '2d', aspect: 'all', baseMipLevel: 0, baseArrayLayer: 647});
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({label: '\u9194\u1b0e', colorFormats: ['r16float', 'rg32float', 'rgba32float'], depthReadOnly: true});
+try {
+computePassEncoder24.setPipeline(pipeline70);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer14, 0, 71085);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16132 */
+  offset: 6316,
+  bytesPerRow: 512,
+  buffer: buffer18,
+}, {
+  texture: texture44,
+  mipLevel: 2,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 20, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer18);
+} catch {}
+let canvas21 = document.createElement('canvas');
+let imageBitmap19 = await createImageBitmap(offscreenCanvas1);
+let videoFrame22 = new VideoFrame(video16, {timestamp: 0});
+let textureView106 = texture43.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 33});
+let renderPassEncoder24 = commandEncoder87.beginRenderPass({
+  label: '\u8d17\u1028\u{1ff56}\ud33e\ufd39\u{1fd07}\ud695\u986b\u13f3',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -344.8, g: 409.7, b: 357.2, a: 668.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 532.9, g: -714.3, b: 552.9, a: -186.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView95,
+  depthSlice: 0,
+  clearValue: { r: 808.1, g: 304.6, b: 879.4, a: -647.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet35,
+  maxDrawCount: 146168777,
+});
+let renderBundle64 = renderBundleEncoder56.finish({label: '\uf279\udc03\u018f\u8502\u{1f6d9}'});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(3113);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline71);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer14, 62128, 6331);
+} catch {}
+let promise31 = device1.queue.onSubmittedWorkDone();
+let pipeline78 = await device1.createRenderPipelineAsync({
+  label: '\u{1fa90}\u133a\u{1f78e}\u{1fdcf}\u0c46\u03b7\u005e\u01d4',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {format: 'rg32float'}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilWriteMask: 1422050415,
+    depthBias: -269290765,
+    depthBiasSlopeScale: 847.595920351803,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1300, attributes: []},
+      {
+        arrayStride: 4480,
+        attributes: [
+          {format: 'unorm16x2', offset: 540, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 1346, shaderLocation: 10},
+          {format: 'sint16x4', offset: 252, shaderLocation: 16},
+          {format: 'float16x4', offset: 128, shaderLocation: 17},
+          {format: 'uint32x3', offset: 232, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 196, shaderLocation: 24},
+          {format: 'sint8x4', offset: 340, shaderLocation: 15},
+          {format: 'uint16x2', offset: 1984, shaderLocation: 12},
+          {format: 'sint8x2', offset: 288, shaderLocation: 5},
+          {format: 'uint16x2', offset: 364, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 520, shaderLocation: 11},
+          {format: 'uint16x2', offset: 60, shaderLocation: 20},
+          {format: 'sint8x4', offset: 888, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 272, shaderLocation: 13},
+          {format: 'uint8x2', offset: 342, shaderLocation: 4},
+          {format: 'float32', offset: 396, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 594, shaderLocation: 19},
+          {format: 'unorm16x2', offset: 3212, shaderLocation: 23},
+          {format: 'sint32x2', offset: 292, shaderLocation: 18},
+          {format: 'uint16x4', offset: 580, shaderLocation: 2},
+          {format: 'float32x2', offset: 36, shaderLocation: 21},
+          {format: 'uint32x4', offset: 44, shaderLocation: 6},
+          {format: 'float32x2', offset: 788, shaderLocation: 22},
+          {format: 'uint32x3', offset: 1340, shaderLocation: 7},
+          {format: 'sint32', offset: 396, shaderLocation: 25},
+          {format: 'float32x3', offset: 420, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 1420, attributes: []},
+      {arrayStride: 0, attributes: [{format: 'sint32x2', offset: 1772, shaderLocation: 26}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroupLayout30 = device1.createBindGroupLayout({label: '\uc527\u04f7\u18bf\u{1fe03}\u07f3\u0273', entries: []});
+let textureView107 = texture25.createView({label: '\ub22c\uf95d\ue5be', baseMipLevel: 0});
+let sampler43 = device1.createSampler({
+  label: '\u{1f934}\u0d97\u09cb\u7bbe',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.05,
+  lodMaxClamp: 99.20,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder21.setBlendConstant({ r: 56.48, g: -719.1, b: -705.2, a: 873.4, });
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(5, bindGroup24, new Uint32Array(7747), 1214, 0);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(7, buffer19, 362232, 81334);
+} catch {}
+try {
+commandEncoder82.resolveQuerySet(querySet36, 27, 22, buffer21, 8192);
+} catch {}
+try {
+device1.queue.submit([commandBuffer23, commandBuffer20, commandBuffer22, commandBuffer21]);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandBuffer25 = commandEncoder82.finish({});
+let texture46 = device1.createTexture({
+  label: '\u3784\u8e87\uc584\u4b06\u0bf6\u363f',
+  size: [96],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView108 = texture41.createView({
+  label: '\ucdf9\u6b63\u{1fe41}\u0302\u{1fba8}\u78cf\u13ab\u92ce\u0bb7\u{1fd68}\u01d7',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 1014,
+});
+let computePassEncoder42 = commandEncoder70.beginComputePass({label: '\u67ea\uc502\u{1f613}\u6e0d\u0c0c'});
+let renderPassEncoder25 = commandEncoder84.beginRenderPass({
+  label: '\u{1f8ba}\u7f6a\u0d07\u257a\u8df3\u{1fbac}',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 963.1, g: -381.1, b: 976.0, a: 589.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {view: textureView64, depthSlice: 0, loadOp: 'load', storeOp: 'store'}, {
+  view: textureView95,
+  depthSlice: 0,
+  clearValue: { r: -978.5, g: 471.1, b: -8.242, a: 722.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet27,
+  maxDrawCount: 355449621,
+});
+try {
+computePassEncoder40.setPipeline(pipeline60);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup26, new Uint32Array(952), 64, 0);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 867.7, g: 407.8, b: -392.4, a: 109.8, });
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(2, 1, 3, 3);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline71);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer14);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(4, buffer14, 57304);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(buffer15, 66888, buffer14, 31900, 8208);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1244 */
+  offset: 1244,
+  bytesPerRow: 256,
+  buffer: buffer18,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer18);
+} catch {}
+let pipeline79 = await promise21;
+let offscreenCanvas28 = new OffscreenCanvas(260, 638);
+let img20 = await imageWithData(211, 90, '#8691b2bf', '#627d1f8d');
+try {
+adapter0.label = '\u113f\uf541\u3b7a\u{1fbc6}\u228f\uc83b\u{1f835}\u0f79';
+} catch {}
+try {
+canvas21.getContext('bitmaprenderer');
+} catch {}
+let bindGroup29 = device1.createBindGroup({layout: bindGroupLayout26, entries: []});
+let commandEncoder90 = device1.createCommandEncoder({label: '\u0bed\u01e5\u0ba2\ub3f1\u08f9\u{1f8cb}\uc261\u0b9d\uf625\u6f44'});
+let renderPassEncoder26 = commandEncoder67.beginRenderPass({
+  label: '\ub5e5\ud4f4\u01ce\u04d6\u0d6b\u7a4d\u{1f82e}\u06e7\u{1f604}',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 309.9, g: -312.1, b: 716.9, a: 450.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -723.4, g: -564.1, b: 376.3, a: 301.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: 281.5, g: -667.7, b: 132.4, a: 197.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet31,
+});
+let externalTexture43 = device1.importExternalTexture({label: '\uea10\u0a30\u{1f81a}\ub9cf\u01ac\u0cf0', source: video2});
+try {
+computePassEncoder32.setPipeline(pipeline70);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(96, 31, 151_532_172, 502_002_938, 865_348_528);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer16, 331_603_126);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup27, new Uint32Array(2819), 28, 0);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline71);
+} catch {}
+let commandEncoder91 = device1.createCommandEncoder({label: '\u{1f683}\u03a6\u0462\u{1f69a}\u5572\u220c\u068c\ua869\u{1fd03}'});
+let renderBundle65 = renderBundleEncoder43.finish();
+try {
+computePassEncoder38.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: -575.6, g: -662.9, b: 835.7, a: -899.6, });
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer19, 'uint16', 231768, 27327);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer19, 160996);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 136},
+  aspect: 'all',
+}, new ArrayBuffer(6_021_499), /* required buffer size: 6_021_499 */
+{offset: 453, bytesPerRow: 883, rowsPerImage: 194}, {width: 94, height: 29, depthOrArrayLayers: 36});
+} catch {}
+let querySet38 = device1.createQuerySet({
+  label: '\u{1fb10}\u{1f912}\u8a36\u6ac8\u5bd0\u{1f8b0}\u04b6\u8e2e\u228d\udf67\u0012',
+  type: 'occlusion',
+  count: 1048,
+});
+let computePassEncoder43 = commandEncoder88.beginComputePass({label: '\ud469\u0444\u0523\u05da\u0769\u0ab5\u{1f6b4}\u{1ffc5}'});
+let renderPassEncoder27 = commandEncoder75.beginRenderPass({
+  label: '\u0d1b\u42d7\u0067\u0d3f',
+  colorAttachments: [{view: textureView96, loadOp: 'clear', storeOp: 'discard'}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 891.1, g: 635.2, b: -450.1, a: 721.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: -305.8, g: 429.7, b: -22.67, a: 291.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet25,
+  maxDrawCount: 1048803690,
+});
+try {
+computePassEncoder32.setPipeline(pipeline73);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(4, 0, 0, 5);
+} catch {}
+try {
+renderPassEncoder24.setViewport(0.4304, 3.323, 4.027, 3.354, 0.8560, 0.9521);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer18, 134_942_074);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer19);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline64);
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet27, 958, 1718, buffer16, 5120);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 814 */
+{offset: 814, bytesPerRow: 548}, {width: 36, height: 34, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(291, 472);
+let imageData24 = new ImageData(12, 180);
+let querySet39 = device1.createQuerySet({type: 'occlusion', count: 3454});
+let textureView109 = texture41.createView({
+  label: '\u5a89\u{1fc82}\u4eb1\u019a\u{1f7eb}\u0f0d\u{1ff07}\u{1fbeb}\ub760',
+  format: 'astc-6x6-unorm',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 635,
+  arrayLayerCount: 559,
+});
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline71);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer19);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer19, 'uint16', 24438, 193997);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(4155, undefined, 0, 1804278373);
+} catch {}
+let promise32 = device1.popErrorScope();
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder90.insertDebugMarker('\ua582');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer17, 876, new Float32Array(43420), 25518, 872);
+} catch {}
+let renderPassEncoder28 = commandEncoder83.beginRenderPass({
+  label: '\u8066\u{1ffb6}\u011b\u987e\u{1f6c0}\u0ea6\ud3d1\u0357',
+  colorAttachments: [{view: textureView96, loadOp: 'clear', storeOp: 'store'}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -32.96, g: 71.20, b: 766.5, a: -849.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: -723.2, g: 132.3, b: -312.4, a: -922.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 330820248,
+});
+let renderBundleEncoder60 = device1.createRenderBundleEncoder({
+  label: '\u2086\ucfe9\ue3e1\u402e\ub708\ue194',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+});
+try {
+computePassEncoder33.setBindGroup(4, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder26.setViewport(5.599, 0.9763, 0.3380, 5.819, 0.00388, 0.3295);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(59, 191);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20844 */
+  offset: 20844,
+  bytesPerRow: 256,
+  rowsPerImage: 211,
+  buffer: buffer15,
+}, {
+  texture: texture44,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 11, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer15);
+} catch {}
+let pipeline80 = device1.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32float'}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', depthFailOp: 'replace'},
+    stencilReadMask: 457959939,
+    stencilWriteMask: 412690138,
+    depthBias: 332619557,
+    depthBiasSlopeScale: 857.8270138843837,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1120,
+        attributes: [
+          {format: 'float16x2', offset: 148, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 260, shaderLocation: 5},
+          {format: 'float16x2', offset: 120, shaderLocation: 0},
+          {format: 'uint32', offset: 36, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 21},
+          {format: 'uint8x4', offset: 96, shaderLocation: 26},
+          {format: 'sint32', offset: 16, shaderLocation: 22},
+          {format: 'sint32', offset: 80, shaderLocation: 17},
+          {format: 'float32', offset: 308, shaderLocation: 1},
+          {format: 'sint32x3', offset: 60, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 592,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 20, shaderLocation: 25},
+          {format: 'sint8x2', offset: 72, shaderLocation: 3},
+          {format: 'float32', offset: 16, shaderLocation: 20},
+          {format: 'float32x4', offset: 36, shaderLocation: 9},
+          {format: 'uint32x4', offset: 4, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 72, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 128, shaderLocation: 13},
+          {format: 'uint16x2', offset: 44, shaderLocation: 8},
+          {format: 'sint32x3', offset: 28, shaderLocation: 10},
+          {format: 'uint32', offset: 60, shaderLocation: 12},
+          {format: 'uint32', offset: 40, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 4080,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 2816, shaderLocation: 4},
+          {format: 'uint8x2', offset: 938, shaderLocation: 16},
+          {format: 'sint32x2', offset: 328, shaderLocation: 2},
+          {format: 'sint8x2', offset: 400, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 188,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 36, shaderLocation: 24}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 72, attributes: [{format: 'unorm8x2', offset: 6, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+canvas12.width = 2556;
+let gpuCanvasContext32 = offscreenCanvas28.getContext('webgpu');
+let videoFrame23 = new VideoFrame(imageBitmap16, {timestamp: 0});
+try {
+offscreenCanvas29.getContext('bitmaprenderer');
+} catch {}
+video13.height = 114;
+let canvas22 = document.createElement('canvas');
+try {
+  await promise32;
+} catch {}
+let bindGroupLayout31 = device1.createBindGroupLayout({
+  label: '\uc0e8\ue748\u1459',
+  entries: [
+    {
+      binding: 2229,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 643,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let textureView110 = texture44.createView({label: '\u{1fc42}\u0cd9\u9048\u7f11\u{1f76a}\u00f8\u402d\ucf5f', baseMipLevel: 3});
+let renderBundleEncoder61 = device1.createRenderBundleEncoder({
+  label: '\u{1fb3b}\u{1f7bc}\u09f6\ub94c\u09cf\u2e94\u1879\u{1ff75}',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle66 = renderBundleEncoder45.finish({});
+try {
+renderPassEncoder24.setBindGroup(6, bindGroup17, new Uint32Array(3555), 1794, 0);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(3585);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer19, 640_234_466);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(6, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder57.setPipeline(pipeline64);
+} catch {}
+try {
+commandEncoder90.clearBuffer(buffer21, 4028, 16860);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer17, 30000, new Int16Array(44349), 24629, 184);
+} catch {}
+let promise33 = device1.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg32float', writeMask: GPUColorWrite.GREEN}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 3309942368,
+    stencilWriteMask: 3117408413,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 924,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x4', offset: 288, shaderLocation: 16},
+          {format: 'uint32', offset: 296, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 240, shaderLocation: 6},
+          {format: 'float16x4', offset: 0, shaderLocation: 20},
+          {format: 'uint32', offset: 108, shaderLocation: 2},
+          {format: 'sint32x4', offset: 108, shaderLocation: 12},
+          {format: 'sint8x4', offset: 44, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 160, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 36, shaderLocation: 18},
+          {format: 'sint32x3', offset: 256, shaderLocation: 8},
+          {format: 'sint8x4', offset: 24, shaderLocation: 19},
+          {format: 'uint8x2', offset: 392, shaderLocation: 11},
+          {format: 'uint8x4', offset: 24, shaderLocation: 3},
+          {format: 'sint8x4', offset: 276, shaderLocation: 23},
+          {format: 'snorm16x2', offset: 60, shaderLocation: 7},
+          {format: 'float32x3', offset: 72, shaderLocation: 4},
+          {format: 'float16x2', offset: 8, shaderLocation: 26},
+          {format: 'sint16x4', offset: 80, shaderLocation: 25},
+          {format: 'snorm8x2', offset: 274, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 1364, attributes: [{format: 'uint32', offset: 24, shaderLocation: 15}]},
+      {arrayStride: 736, attributes: [{format: 'unorm16x2', offset: 0, shaderLocation: 0}]},
+      {arrayStride: 80, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4116,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 552, shaderLocation: 14}],
+      },
+      {
+        arrayStride: 420,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 52, shaderLocation: 5}],
+      },
+      {arrayStride: 8612, stepMode: 'instance', attributes: []},
+      {arrayStride: 952, attributes: [{format: 'float16x4', offset: 244, shaderLocation: 21}]},
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(581, 809);
+gc();
+let imageBitmap20 = await createImageBitmap(imageBitmap9);
+let bindGroup30 = device1.createBindGroup({layout: bindGroupLayout20, entries: []});
+let commandEncoder92 = device1.createCommandEncoder({label: '\u{1f8ac}\uf743\u{1f70c}\udb31\u10a3'});
+let textureView111 = texture40.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder44 = commandEncoder91.beginComputePass({label: '\u2661\u3029\u00b2\u{1faa2}\u9052\ua502\u09d5'});
+let sampler44 = device1.createSampler({
+  label: '\u0ea0\u015b\u36b5\u481d',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.96,
+  lodMaxClamp: 82.17,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder21.setStencilReference(336);
+} catch {}
+try {
+renderPassEncoder21.draw(66, 130, 380_818_081);
+} catch {}
+let pipeline81 = await promise27;
+let pipeline82 = device1.createRenderPipeline({
+  label: '\u0a11\ue21a\u0149\u134b',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'rg32float'}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2212,
+        attributes: [
+          {format: 'sint32x4', offset: 928, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 988, shaderLocation: 13},
+          {format: 'sint16x4', offset: 64, shaderLocation: 2},
+          {format: 'sint16x4', offset: 916, shaderLocation: 22},
+          {format: 'float32', offset: 584, shaderLocation: 24},
+          {format: 'sint32x3', offset: 36, shaderLocation: 10},
+          {format: 'float32x3', offset: 700, shaderLocation: 6},
+          {format: 'uint32x4', offset: 484, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 116, shaderLocation: 9},
+          {format: 'sint32', offset: 1004, shaderLocation: 23},
+          {format: 'float32x2', offset: 268, shaderLocation: 1},
+          {format: 'float32x3', offset: 248, shaderLocation: 5},
+          {format: 'uint32x4', offset: 460, shaderLocation: 26},
+          {format: 'unorm16x2', offset: 96, shaderLocation: 0},
+          {format: 'uint32', offset: 36, shaderLocation: 8},
+          {format: 'uint16x2', offset: 1784, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 1084, shaderLocation: 21},
+          {format: 'uint32x3', offset: 1128, shaderLocation: 19},
+          {format: 'sint16x4', offset: 5108, shaderLocation: 3},
+          {format: 'float16x2', offset: 716, shaderLocation: 7},
+          {format: 'float32x2', offset: 7488, shaderLocation: 25},
+          {format: 'sint32x3', offset: 216, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 716, shaderLocation: 15},
+          {format: 'uint8x2', offset: 1096, shaderLocation: 18},
+          {format: 'uint8x2', offset: 426, shaderLocation: 12},
+          {format: 'sint32x4', offset: 1724, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 780, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+try {
+canvas22.getContext('2d');
+} catch {}
+try {
+window.someLabel = externalTexture25.label;
+} catch {}
+let videoFrame24 = new VideoFrame(img7, {timestamp: 0});
+try {
+computePassEncoder25.setPipeline(pipeline74);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(253);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer15, 2_533_272_826);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(4, buffer19, 160824);
+} catch {}
+try {
+  await buffer17.mapAsync(GPUMapMode.READ, 13176);
+} catch {}
+try {
+commandEncoder90.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4628 */
+  offset: 4628,
+  rowsPerImage: 141,
+  buffer: buffer16,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 3, y: 23, z: 49},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(8)), /* required buffer size: 3_869_106 */
+{offset: 314, bytesPerRow: 432, rowsPerImage: 96}, {width: 29, height: 28, depthOrArrayLayers: 94});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas30.getContext('webgl2');
+} catch {}
+let commandEncoder93 = device1.createCommandEncoder({label: '\u00e1\u02d4\u735f\u0091\u3139'});
+let textureView112 = texture42.createView({});
+let computePassEncoder45 = commandEncoder89.beginComputePass({});
+let renderBundleEncoder62 = device1.createRenderBundleEncoder({
+  label: '\u{1f611}\u{1fc5a}\u0ab1\u{1fa7a}',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+let externalTexture44 = device1.importExternalTexture({
+  label: '\ub78e\u0830\u3c7b\u6aea\u0213\u37c5\u{1f809}\u9af5\u5822',
+  source: videoFrame9,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder26.setBindGroup(4, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: 559.4, g: -55.82, b: -37.23, a: -532.0, });
+} catch {}
+try {
+renderPassEncoder21.draw(70);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(79);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer17, 694_465_029);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup20, []);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(3, buffer19, 401568, 9526);
+} catch {}
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14800 */
+  offset: 13200,
+  bytesPerRow: 256,
+  buffer: buffer15,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 7, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet24, 1401, 542, buffer21, 57600);
+} catch {}
+try {
+renderPassEncoder28.insertDebugMarker('\ue3a6');
+} catch {}
+let pipeline83 = device1.createComputePipeline({
+  label: '\u2719\uf86e\u{1f8fd}\u0042\u{1f9c0}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img21 = await imageWithData(297, 279, '#17ca094f', '#247049de');
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let videoFrame25 = new VideoFrame(imageBitmap8, {timestamp: 0});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\u{1f891}\u{1f7b3}\ue056\uf3ce\u0acc\u60e3\u09c6\uebeb\u0769\ufe0d',
+  colorFormats: ['r32uint', 'r32uint'],
+  depthReadOnly: true,
+});
+let sampler45 = device0.createSampler({
+  label: '\udeca\u{1f8ca}\u{1fe07}\u171e\u{1fbf0}\u053b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.43,
+  lodMaxClamp: 88.14,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(455, 106);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer0, 1_040_485_409);
+} catch {}
+try {
+renderBundleEncoder4.draw(57, 0, 858_019_211, 265_116_326);
+} catch {}
+try {
+renderBundleEncoder4.drawIndexed(165, 118, 935_877_776, 235_199_179);
+} catch {}
+let pipeline84 = await device0.createRenderPipelineAsync({
+  label: '\u9be6\ud06f\u05b3\u48f1\u0216\u71b8\u08ff\u6749',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x19a393bf},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap'},
+    stencilWriteMask: 1327713840,
+    depthBiasSlopeScale: 532.7174568025637,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1728,
+        attributes: [
+          {format: 'sint8x4', offset: 96, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 196, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32', offset: 1420, shaderLocation: 14},
+          {format: 'uint32x2', offset: 40, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup31 = device1.createBindGroup({layout: bindGroupLayout27, entries: [{binding: 154, resource: sampler38}]});
+let commandBuffer26 = commandEncoder93.finish({label: '\ub7ac\uf78f\u9862'});
+let computePassEncoder46 = commandEncoder92.beginComputePass();
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(951);
+} catch {}
+try {
+renderPassEncoder21.draw(137, 376, 11_918_998, 374_586_730);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer21, 130_756_475);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer16, 249_832_639);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 7, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise34 = device1.createComputePipelineAsync({
+  label: '\u0779\uac13\u82c7\u0f3d\uf24e\ud8f8\u1464\u{1fff0}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas31 = new OffscreenCanvas(460, 115);
+let videoFrame26 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+offscreenCanvas31.getContext('webgl2');
+} catch {}
+let bindGroupLayout32 = device1.createBindGroupLayout({
+  label: '\u{1f837}\u5b94',
+  entries: [
+    {
+      binding: 5204,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let renderPassEncoder29 = commandEncoder90.beginRenderPass({
+  label: '\u{1f67f}\u89af\u8253\u455f\ub2a3\uaf03\u54c4\ud691\u1f39',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -309.0, g: -511.2, b: -341.6, a: 178.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 989.9, g: 101.2, b: -980.9, a: -512.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView85,
+  depthSlice: 0,
+  clearValue: { r: 151.8, g: -437.0, b: -440.6, a: 244.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 422390210,
+});
+let renderBundle67 = renderBundleEncoder58.finish({label: '\u0d0b\u075c\u5ec7\u0fd5\u5111\u093c\uc463\u1dbe\u{1f734}\ua0fd\u021c'});
+try {
+computePassEncoder28.setPipeline(pipeline72);
+} catch {}
+try {
+renderPassEncoder21.draw(67, 40);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(60);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer19, 0, 54483);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(2, buffer19, 360552, 17999);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let arrayBuffer10 = buffer21.getMappedRange(0, 58240);
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 43856 */
+  offset: 41296,
+  bytesPerRow: 256,
+  buffer: buffer14,
+}, {width: 0, height: 11, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer14);
+} catch {}
+let textureView113 = texture46.createView({label: '\u016f\u0179', baseArrayLayer: 0});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline70);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle54, renderBundle44, renderBundle57, renderBundle59, renderBundle38]);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(190, 103, 1_918_072_137, 291_335_729, 456_339_229);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(5, buffer19, 135012, 164850);
+} catch {}
+try {
+texture43.destroy();
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet35, 1321, 929, buffer21, 16640);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(660, 166);
+let buffer22 = device1.createBuffer({
+  label: '\u{1f72b}\u54b2\u87ac\u{1f73e}',
+  size: 410352,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView114 = texture42.createView({label: '\u0af6\u0121', mipLevelCount: 1});
+let computePassEncoder47 = commandEncoder58.beginComputePass({});
+let externalTexture45 = device1.importExternalTexture({label: '\u867e\u030c\ub8f8\u0511\u3e6a', source: video9, colorSpace: 'display-p3'});
+try {
+computePassEncoder38.setPipeline(pipeline60);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(2056);
+} catch {}
+try {
+renderPassEncoder21.draw(71, 39, 6_720_098, 355_284_668);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer17, 88_121_255);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer19, 'uint32', 172876);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(1, buffer14, 3120);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise35 = device1.createComputePipelineAsync({
+  label: '\u0bbc\u2d9a\uea11\u7169\ub398\u0e38\udc52',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let pipeline85 = device1.createRenderPipeline({
+  label: '\uef98\ud49e\u0803\u48e4\u{1fa34}\u{1f7f6}\uc644\uf6ad\u77f2\u02a4',
+  layout: pipelineLayout8,
+  multisample: {},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.RED}, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'always', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 821903960,
+    stencilWriteMask: 3066526633,
+    depthBias: -1301225456,
+    depthBiasSlopeScale: 917.141590913657,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 292, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 164, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 4856, shaderLocation: 5},
+          {format: 'float16x2', offset: 712, shaderLocation: 1},
+          {format: 'sint32', offset: 4240, shaderLocation: 10},
+          {format: 'sint16x4', offset: 3824, shaderLocation: 2},
+          {format: 'sint32x4', offset: 976, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 2312, shaderLocation: 15},
+          {format: 'uint16x4', offset: 2132, shaderLocation: 26},
+          {format: 'float32x2', offset: 132, shaderLocation: 21},
+          {format: 'float16x2', offset: 1444, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 1196, shaderLocation: 13},
+          {format: 'uint32x2', offset: 60, shaderLocation: 18},
+          {format: 'uint16x4', offset: 1596, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 2696, shaderLocation: 6},
+          {format: 'sint32', offset: 4960, shaderLocation: 23},
+          {format: 'sint32x3', offset: 2816, shaderLocation: 17},
+          {format: 'sint32x4', offset: 1020, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 2036, shaderLocation: 25},
+          {format: 'snorm16x2', offset: 1128, shaderLocation: 24},
+          {format: 'unorm16x2', offset: 3800, shaderLocation: 9},
+          {format: 'uint32x2', offset: 1216, shaderLocation: 12},
+          {format: 'uint32x2', offset: 520, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x2', offset: 218, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 100, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 7128,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 900, shaderLocation: 16}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 496, shaderLocation: 22}],
+      },
+    ],
+  },
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas23 = document.createElement('canvas');
+let bindGroup32 = device1.createBindGroup({layout: bindGroupLayout32, entries: [{binding: 5204, resource: sampler40}]});
+let querySet40 = device1.createQuerySet({
+  label: '\u{1ff64}\u{1f7c1}\uc268\u{1fc38}\ucfb6\u23f6\u3227\u{1f808}\u00ad\u7a3b',
+  type: 'occlusion',
+  count: 621,
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup19, new Uint32Array(5806), 1658, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(957);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: 243.0, g: -711.1, b: 171.4, a: 273.5, });
+} catch {}
+try {
+renderPassEncoder21.draw(253, 117, 21_624_427, 478_220_382);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(206, 53, 1_011_477_963, -1_897_958_039);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer19, 0, 46097);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(5, bindGroup23, []);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer23 = device1.createBuffer({label: '\u{1f6e1}\u5386', size: 53565, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder94 = device1.createCommandEncoder({label: '\u0c3e\u75f9\uac41\uf5cf\u00df\ue71f\uc78b\u178b'});
+let querySet41 = device1.createQuerySet({label: '\ub27d\u8432\u0505\u{1fcfe}', type: 'occlusion', count: 118});
+let textureView115 = texture39.createView({
+  label: '\u087a\u{1fa8e}\u0d02\u01f1\u924c\u7deb\u{1fce4}\u0fb9\u99c6\u7919\uac4c',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 518,
+});
+let renderPassEncoder30 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 691.7, g: -857.0, b: 537.3, a: 532.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -544.1, g: 26.53, b: -114.8, a: -354.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: -51.08, g: -959.3, b: -865.3, a: 253.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet29,
+  maxDrawCount: 395415513,
+});
+let renderBundle68 = renderBundleEncoder47.finish({label: '\u0453\u1df4\ud08f\u0741\u99e4\u507f\u8d9d\ubcb7\uf517\u43a2\u0599'});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(751);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer14, 686_988_487);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 5476, new BigUint64Array(59323), 54678, 512);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 3_161 */
+{offset: 408, bytesPerRow: 297}, {width: 5, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+offscreenCanvas32.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder95 = device1.createCommandEncoder({label: '\u6383\u4922\u535e\ub93d\u2e7f\u8718\u18e5\u{1fcee}'});
+let commandBuffer27 = commandEncoder95.finish();
+let renderBundle69 = renderBundleEncoder35.finish();
+let sampler46 = device1.createSampler({
+  label: '\u6c21\u0900\u885b',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 62.24,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup28, new Uint32Array(267), 183, 0);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: -261.5, g: -624.9, b: 680.9, a: -933.6, });
+} catch {}
+try {
+renderPassEncoder28.setViewport(0.2700, 6.307, 0.02962, 0.5153, 0.6391, 0.8260);
+} catch {}
+try {
+renderPassEncoder21.draw(203, 202, 361_322_457);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer19, 'uint16', 389690, 1999);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline65);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 13296, new DataView(new ArrayBuffer(46781)), 41901, 1796);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(1910);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.draw(404, 236, 978_149_937, 1_043_353_685);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer21, 1_846_305_667);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(5, buffer19, 42092, 94514);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 576, new DataView(new ArrayBuffer(56038)), 7769, 6192);
+} catch {}
+document.body.prepend(video4);
+offscreenCanvas32.height = 434;
+let commandEncoder96 = device1.createCommandEncoder({label: '\u0b00\u3f26\u6d2d\ue8b9\uc7b6\u087f\u03d3'});
+let commandBuffer28 = commandEncoder96.finish({label: '\u{1fe85}\u13c0\u1f2e\u{1f757}\u2548\u2c77\u0a3d\u03fa\u{1ff91}'});
+let renderBundleEncoder64 = device1.createRenderBundleEncoder({
+  label: '\u1d84\u{1fa15}\u0ded\u0d81\uec0c\u44e1\u{1fe9a}\u582d\udf0b',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+let renderBundle70 = renderBundleEncoder54.finish({label: '\u{1fe94}\u2ac3\u{1fa13}\u0808\u040f\u7ee4\u{1fb0f}\u3af4\u9007'});
+try {
+computePassEncoder24.setPipeline(pipeline81);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -633.1, g: 822.8, b: 124.9, a: 55.35, });
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(1, 6, 0, 1);
+} catch {}
+try {
+renderPassEncoder21.draw(51, 273, 139_306_889, 997_617_682);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer19, 'uint16', 439632, 2362);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 6136, new Float32Array(41402), 37636, 8);
+} catch {}
+let pipeline86 = device1.createComputePipeline({
+  label: '\ub68c\u{1faec}\u{1fe84}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let textureView116 = texture36.createView({label: '\u814d\u6fb5\ufb28\u2c8a\u{1f893}', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 997});
+let externalTexture46 = device1.importExternalTexture({label: '\u71a1\u{1f72b}\u495b\u8c91\u004d\ue255', source: video5, colorSpace: 'display-p3'});
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: 380.6, g: 720.6, b: 641.2, a: -638.5, });
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(5, bindGroup28, new Uint32Array(3578), 482, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 23908, new BigUint64Array(37617), 35117, 80);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 64, depthOrArrayLayers: 1264}
+*/
+{
+  source: imageBitmap17,
+  origin: { x: 164, y: 14 },
+  flipY: false,
+}, {
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 3, y: 4, z: 89},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 35, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext33 = canvas23.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise31;
+} catch {}
+offscreenCanvas5.height = 3026;
+document.body.prepend(canvas13);
+let offscreenCanvas33 = new OffscreenCanvas(390, 600);
+let gpuCanvasContext34 = offscreenCanvas33.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame27 = new VideoFrame(video6, {timestamp: 0});
+document.body.prepend(img8);
+let commandEncoder97 = device1.createCommandEncoder({label: '\u3c2f\ufffe\u05cf\u2102\u3033'});
+let querySet42 = device1.createQuerySet({label: '\u0fd2\u3232\u50e2', type: 'occlusion', count: 669});
+let textureView117 = texture24.createView({label: '\u0b3e\u0d16\u9973\u399c\u90e1\u007c\u{1fa1d}', dimension: '3d'});
+let computePassEncoder48 = commandEncoder97.beginComputePass({label: '\u{1fdd2}\u0cc5\u009a\u83bc\ub104'});
+let externalTexture47 = device1.importExternalTexture({label: '\u0b44\u{1fa73}\u1ce7\u{1fe80}\u0be3', source: video0, colorSpace: 'srgb'});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(429);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: -712.6, g: 280.3, b: -229.9, a: 95.50, });
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(2221);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 278},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(32)), /* required buffer size: 16_114_683 */
+{offset: 431, bytesPerRow: 5093, rowsPerImage: 226}, {width: 1848, height: 0, depthOrArrayLayers: 15});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+canvas4.width = 1135;
+let offscreenCanvas34 = new OffscreenCanvas(581, 30);
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+offscreenCanvas2.width = 240;
+let imageBitmap21 = await createImageBitmap(img8);
+let imageData25 = new ImageData(68, 244);
+document.body.prepend(video11);
+try {
+offscreenCanvas34.getContext('2d');
+} catch {}
+let commandEncoder98 = device1.createCommandEncoder();
+let renderBundle71 = renderBundleEncoder38.finish({});
+try {
+renderPassEncoder22.executeBundles([renderBundle47, renderBundle42, renderBundle39, renderBundle39, renderBundle71, renderBundle56, renderBundle57]);
+} catch {}
+try {
+renderPassEncoder21.draw(32);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(5, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(5, bindGroup19, new Uint32Array(6031), 741, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 517 */
+{offset: 517}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas28,
+  origin: { x: 153, y: 17 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline87 = await promise35;
+document.body.prepend(canvas22);
+video0.width = 119;
+let img22 = await imageWithData(284, 135, '#d4bba11f', '#99d6817c');
+canvas13.width = 1191;
+let videoFrame28 = new VideoFrame(videoFrame18, {timestamp: 0});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let computePassEncoder49 = commandEncoder98.beginComputePass({label: '\u{1fa05}\u{1fbee}\u84a8\u8056\u0160\u021e\u28cd'});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup31, new Uint32Array(8232), 2292, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(678);
+} catch {}
+try {
+renderPassEncoder26.setViewport(5.776, 2.568, 0.1846, 4.279, 0.4967, 0.8829);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer21, 788_020_517);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(5, bindGroup31);
+} catch {}
+let textureView118 = texture25.createView({label: '\u80bf\u8197\u0e0d\u0186\u0005\ub1cd', dimension: '2d-array', baseMipLevel: 0});
+let renderBundleEncoder65 = device1.createRenderBundleEncoder({colorFormats: ['r16float', 'rg32float', 'rgba32float'], depthReadOnly: true, stencilReadOnly: false});
+let renderBundle72 = renderBundleEncoder34.finish({label: '\u0166\u4ead\u3acf\u071d\u1e2a'});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(5, 5, 1, 1);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(62, 151, 691_364_753, 243_953_537, 385_548_604);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 2080, new BigUint64Array(53056), 41263, 56);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 32, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 22, y: 4 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup33 = device1.createBindGroup({label: '\u{1fa8c}\u{1f87d}', layout: bindGroupLayout20, entries: []});
+let textureView119 = texture32.createView({label: '\u0b9f\ua38a\u0414\u0ab5\u03bd\u5ae9', baseMipLevel: 1});
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({
+  label: '\u4ac8\uf9f5\ue02f\u8191\uc339\u61ed\u{1fa66}',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+});
+let renderBundle73 = renderBundleEncoder33.finish();
+let externalTexture48 = device1.importExternalTexture({
+  label: '\uce7c\u{1fb12}\u{1f84c}\u0116\uc65f\u601b\u0b47\u28c8\u6800',
+  source: videoFrame27,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder21.draw(63);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(657);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer21, 993_534_108);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer19, 0, 362499);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(2, buffer19, 0, 254809);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer11 = buffer19.getMappedRange(344664, 79836);
+try {
+renderBundleEncoder46.insertDebugMarker('\ue3b5');
+} catch {}
+try {
+device1.queue.submit([commandBuffer17]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 2156, new BigUint64Array(2674), 487, 88);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: img15,
+  origin: { x: 25, y: 8 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline88 = device1.createRenderPipeline({
+  label: '\uab35\u0cf4\u344d\u0c61\u8ed2\u{1f94c}',
+  layout: 'auto',
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rg32float', writeMask: 0}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'keep'},
+    stencilReadMask: 4125211046,
+    stencilWriteMask: 3638400563,
+    depthBiasClamp: 411.28875984916095,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2144,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 196, shaderLocation: 10},
+          {format: 'sint16x4', offset: 196, shaderLocation: 15},
+          {format: 'uint32x3', offset: 72, shaderLocation: 20},
+          {format: 'sint32x4', offset: 172, shaderLocation: 26},
+          {format: 'float32x4', offset: 348, shaderLocation: 24},
+          {format: 'unorm10-10-10-2', offset: 52, shaderLocation: 23},
+          {format: 'sint8x4', offset: 344, shaderLocation: 18},
+          {format: 'uint8x2', offset: 1046, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 14, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 21},
+          {format: 'sint8x2', offset: 240, shaderLocation: 25},
+          {format: 'float32x3', offset: 84, shaderLocation: 22},
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 13},
+          {format: 'sint32x2', offset: 412, shaderLocation: 16},
+          {format: 'float16x4', offset: 508, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 772, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 44,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 4, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 0},
+          {format: 'uint32x3', offset: 4, shaderLocation: 4},
+          {format: 'uint8x2', offset: 20, shaderLocation: 8},
+          {format: 'uint32x4', offset: 0, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 1628,
+        attributes: [
+          {format: 'uint32x3', offset: 72, shaderLocation: 12},
+          {format: 'uint32x4', offset: 76, shaderLocation: 7},
+          {format: 'sint32x4', offset: 96, shaderLocation: 5},
+          {format: 'float32x3', offset: 436, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 772,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x2', offset: 36, shaderLocation: 2},
+          {format: 'sint16x4', offset: 76, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder99 = device1.createCommandEncoder();
+let textureView120 = texture45.createView({label: '\u0d5c\u0e4e\u0e6d\u278b\u6595\u{1ff58}\u0a24\u{1fb77}', baseMipLevel: 2});
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({
+  label: '\u0c25\u2a2a\u{1f76a}\u6afb\u0836\u98db\u{1fb24}\u4b8b\ue397',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(12, 26, 124_520_474, 1_130_405_226, 1_071_973_832);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(7, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(5, buffer14, 70092, 1327);
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 30},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 3472, new DataView(new ArrayBuffer(45540)), 1011, 10208);
+} catch {}
+let pipeline89 = await device1.createComputePipelineAsync({layout: pipelineLayout8, compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}}});
+let bindGroup34 = device1.createBindGroup({
+  label: '\u8276\u775e\u2880\u0cce\ue2b6\u{1fefa}\uda89\u{1f6bb}\u0141\u7d99\u8bd6',
+  layout: bindGroupLayout26,
+  entries: [],
+});
+try {
+renderPassEncoder21.setBindGroup(6, bindGroup18);
+} catch {}
+try {
+renderPassEncoder24.setViewport(3.610, 0.3314, 0.1326, 7.085, 0.3986, 0.6571);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer16, 3_191_240_246);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(0, bindGroup26);
+} catch {}
+let arrayBuffer12 = buffer21.getMappedRange(59600, 5584);
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 150, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 990, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer14, 25400, 15664);
+dissociateBuffer(device1, buffer14);
+} catch {}
+let commandEncoder100 = device1.createCommandEncoder({label: '\u87e8\u5346\u0ec6\ud7db\u7cc3\u{1fa4a}\ud4dd\u6bd5\u0c2f'});
+try {
+renderPassEncoder26.setStencilReference(2062);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(0, buffer19, 232808, 165373);
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer14, 66704, 1336);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder99.resolveQuerySet(querySet37, 111, 138, buffer23, 512);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 4084, new Int16Array(62371), 38561, 6764);
+} catch {}
+let pipeline90 = await promise34;
+let commandEncoder101 = device1.createCommandEncoder({label: '\u5ec4\u{1f902}\uf2d0\u5de6'});
+let texture47 = device1.createTexture({
+  label: '\uf77c\u{1fc4f}\u539d\u0100\u8996\ub7a4\u838a',
+  size: {width: 24},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView121 = texture40.createView({baseMipLevel: 1});
+let computePassEncoder50 = commandEncoder100.beginComputePass();
+let renderPassEncoder31 = commandEncoder101.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -193.9, g: -688.4, b: 633.5, a: -996.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -798.1, g: -285.0, b: -905.7, a: 295.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {view: textureView95, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet40,
+  maxDrawCount: 124094035,
+});
+let sampler47 = device1.createSampler({
+  label: '\u0fec\u016a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 83.33,
+});
+let externalTexture49 = device1.importExternalTexture({source: videoFrame22, colorSpace: 'srgb'});
+try {
+renderPassEncoder21.drawIndirect(buffer13, 3_530_940_434);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer23, 'uint16', 15126, 14105);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(6, bindGroup29, new Uint32Array(6903), 4556, 0);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(225, undefined, 0);
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer14, 12892, 4452);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 696 */
+{offset: 696}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline91 = device1.createRenderPipeline({
+  layout: pipelineLayout7,
+  multisample: {mask: 0x143872c6},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'always', failOp: 'invert', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 60388748,
+    depthBiasSlopeScale: 972.8563616738224,
+    depthBiasClamp: 6.776282150329607,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1212,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 312, shaderLocation: 9},
+          {format: 'uint32x3', offset: 36, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 5},
+          {format: 'sint32x3', offset: 308, shaderLocation: 19},
+          {format: 'uint32x4', offset: 420, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 524, shaderLocation: 7},
+          {format: 'uint8x2', offset: 198, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 132, shaderLocation: 0},
+          {format: 'sint32x4', offset: 176, shaderLocation: 22},
+          {format: 'float32', offset: 200, shaderLocation: 20},
+          {format: 'sint32x3', offset: 636, shaderLocation: 23},
+          {format: 'uint16x4', offset: 20, shaderLocation: 15},
+          {format: 'sint16x4', offset: 64, shaderLocation: 12},
+          {format: 'float32x2', offset: 164, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 486, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 168, shaderLocation: 18},
+          {format: 'sint8x2', offset: 92, shaderLocation: 25},
+          {format: 'uint8x4', offset: 28, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 264, stepMode: 'instance', attributes: []},
+      {arrayStride: 1104, attributes: []},
+      {
+        arrayStride: 616,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 412, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 108, shaderLocation: 1},
+          {format: 'sint16x4', offset: 16, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 26},
+          {format: 'uint8x2', offset: 390, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+pseudoSubmit(device1);
+let sampler48 = device1.createSampler({
+  label: '\u6c57\u3e88\u{1ffd0}\u{1fcd9}\u19e6\u2a4d\ud866\u0e0d\u09ff\ude16',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.76,
+  lodMaxClamp: 44.79,
+});
+let externalTexture50 = device1.importExternalTexture({label: '\u297c\u8b89\u{1f9f6}\u09c5\u4e8a\u6f5f\u2708\u{1f9b6}', source: videoFrame19});
+try {
+computePassEncoder36.setPipeline(pipeline90);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(6, bindGroup20);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(2, 0, 4, 4);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer15, 35_208_880);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(0, buffer14, 0, 48195);
+} catch {}
+try {
+renderBundleEncoder59.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(0, buffer19, 0, 156510);
+} catch {}
+try {
+commandEncoder99.resolveQuerySet(querySet37, 66, 166, buffer23, 41216);
+} catch {}
+let pipeline92 = device1.createComputePipeline({
+  label: '\u349c\u{1f6a2}\uf397\u91bf\u0ded\u{1f890}\u001b\u00a0',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise30;
+} catch {}
+gc();
+let textureView122 = texture29.createView({label: '\u{1fd0f}\u2538\u2a97\ue05a\u{1ff2d}'});
+let sampler49 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.48,
+});
+try {
+renderPassEncoder22.setScissorRect(2, 7, 0, 1);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(119, 39);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer19, 1_498_100_021);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer21, 473_411_775);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(6, buffer19);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer22, 324984, buffer14, 14208, 56548);
+dissociateBuffer(device1, buffer22);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 180 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 906 */
+  offset: 906,
+  buffer: buffer18,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 90, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+commandEncoder99.insertDebugMarker('\uc760');
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas35 = new OffscreenCanvas(427, 172);
+let textureView123 = texture46.createView({label: '\u7412\u0f3c\u2983'});
+let sampler50 = device1.createSampler({
+  label: '\u0fe1\u5a2d\ufc0b\u{1fcc0}\u1117\u7c0f\u3e73\u050c\ud990\u90f7\uf9fa',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 66.06,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder30.setViewport(2.587, 6.726, 3.372, 0.7530, 0.1446, 0.5480);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer23, 1_655_328_614);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer19, 'uint32', 315832, 14112);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline71);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2272 */
+  offset: 2272,
+  bytesPerRow: 0,
+  rowsPerImage: 104,
+  buffer: buffer22,
+}, {
+  texture: texture39,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 23},
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 654});
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder99.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12930 */
+  offset: 12930,
+  bytesPerRow: 256,
+  buffer: buffer16,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.submit([commandBuffer25]);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let videoFrame29 = new VideoFrame(offscreenCanvas31, {timestamp: 0});
+let bindGroup35 = device1.createBindGroup({label: '\u0ddb\u{1fe74}\ud13f', layout: bindGroupLayout20, entries: []});
+let commandEncoder102 = device1.createCommandEncoder({label: '\u{1fde3}\u{1ffe0}\uc886\u0d41\u{1f8b7}'});
+let querySet43 = device1.createQuerySet({type: 'occlusion', count: 3713});
+let computePassEncoder51 = commandEncoder99.beginComputePass();
+let renderPassEncoder32 = commandEncoder102.beginRenderPass({
+  label: '\u{1f89f}\u30c4\u3aa0',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -732.5, g: 296.2, b: -857.3, a: -889.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 465.4, g: -780.3, b: 301.6, a: 659.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView95,
+  depthSlice: 0,
+  clearValue: { r: -158.6, g: 232.1, b: -835.4, a: 263.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder21.draw(534, 251);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(227, 102, 121_285_077, 184_617_772, 792_366_281);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(4, bindGroup26);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 4,
+  origin: {x: 18, y: 0, z: 45},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 11_067_875 */
+{offset: 637, bytesPerRow: 73, rowsPerImage: 221}, {width: 24, height: 0, depthOrArrayLayers: 687});
+} catch {}
+let pipeline93 = device1.createComputePipeline({
+  label: '\ubc97\u80d8\u0feb\ue291\u{1febc}\ua52d\u03e5',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline94 = device1.createRenderPipeline({
+  label: '\u07a8\u0888\ud35a\u0c58\u{1f848}\u711a\udccc\u{1f7f5}\u16ee',
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0x95274cee},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg32float'}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2032,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 24, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 552, shaderLocation: 6},
+          {format: 'uint32x2', offset: 264, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 1232,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x3', offset: 48, shaderLocation: 14},
+          {format: 'uint32x4', offset: 40, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 196, shaderLocation: 20},
+          {format: 'sint32x3', offset: 20, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 940, shaderLocation: 7},
+          {format: 'float16x2', offset: 292, shaderLocation: 26},
+          {format: 'uint32x4', offset: 792, shaderLocation: 15},
+          {format: 'sint16x4', offset: 532, shaderLocation: 22},
+          {format: 'sint16x2', offset: 136, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 122, shaderLocation: 21},
+          {format: 'sint32', offset: 56, shaderLocation: 25},
+          {format: 'unorm10-10-10-2', offset: 588, shaderLocation: 18},
+          {format: 'sint32x3', offset: 356, shaderLocation: 12},
+          {format: 'uint32x2', offset: 164, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 2688,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 160, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 292, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 2300,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 28, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 256, shaderLocation: 5},
+          {format: 'sint16x4', offset: 792, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 116, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+let bindGroupLayout33 = device1.createBindGroupLayout({
+  label: '\u05e2\uf80d\ufa92\u{1f6aa}\uaf74\ud4b9\u2d34\u4d41',
+  entries: [
+    {
+      binding: 4361,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 134995801, hasDynamicOffset: false },
+    },
+    {
+      binding: 4285,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder103 = device1.createCommandEncoder({label: '\u{1ff7b}\u5abe\u{1f861}\u{1fd23}\u663a\u3de6\u53a9\uabb1\u6fdf\u81ac\u0921'});
+let textureView124 = texture45.createView({
+  label: '\u085e\ub159\u{1fff7}\uc8a1\u432a\u{1f681}\u{1fb78}\u{1fdd7}\u{1f7da}\u{1f78d}\u0df8',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderPassEncoder33 = commandEncoder103.beginRenderPass({
+  label: '\u{1f80e}\uadd2\u3d61\ua7c9\u{1fd9a}\u07f1\u5a78\u0e7b\u07c1',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 294.5, g: 37.52, b: -888.6, a: 779.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -530.8, g: 229.1, b: -825.7, a: -296.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: -25.02, g: -315.8, b: -27.40, a: -960.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 1189589563,
+});
+let renderBundleEncoder68 = device1.createRenderBundleEncoder({
+  label: '\u841c\u1d11\ud36a\uded1',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder21.draw(322, 50, 1_849_610_297);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer20, 790_255_676);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer14, 4_294_967_295);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer19, 199744, 190689);
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas35.getContext('webgpu');
+let device2 = await adapter3.requestDevice({
+  label: '\u01ed\u{1fcd0}\u1d21\u98cb\ucd87',
+  defaultQueue: {label: '\u35d9\u1601\ub3d9\u3799\u{1fa97}\u0958\u1122\u45f9'},
+});
+let imageBitmap22 = await createImageBitmap(canvas3);
+let commandEncoder104 = device1.createCommandEncoder();
+let renderPassEncoder34 = commandEncoder104.beginRenderPass({
+  label: '\u9e7b\u04a1\u9679\u72ea\u2ae9\u{1f937}\u1969\u01bc',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -856.4, g: 135.5, b: -37.22, a: -635.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 431.0, g: 253.9, b: -272.2, a: -418.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {view: textureView85, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 852776544,
+});
+try {
+computePassEncoder34.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder21.setViewport(4.649, 2.646, 0.1698, 4.256, 0.08900, 0.6456);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer22, 1_291_064_173);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer23, 'uint16');
+} catch {}
+try {
+querySet32.destroy();
+} catch {}
+let arrayBuffer13 = buffer17.getMappedRange(36280, 616);
+try {
+device1.queue.writeBuffer(buffer14, 5604, new Float32Array(36012), 2622, 572);
+} catch {}
+let imageBitmap23 = await createImageBitmap(imageData5);
+let buffer24 = device2.createBuffer({size: 208288, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder69 = device2.createRenderBundleEncoder({
+  label: '\u0175\u7cb8\uedc5\ud88e\uf651\uc324\u0dbd',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+});
+let sampler51 = device2.createSampler({
+  label: '\u7618\u{1f733}\u673c\u{1fe22}\u0c3f',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 61.58,
+  lodMaxClamp: 61.98,
+  compare: 'greater-equal',
+});
+let externalTexture51 = device2.importExternalTexture({label: '\u0f14\uc723\u8551\u96a2\ue675', source: videoFrame26, colorSpace: 'srgb'});
+let promise36 = device2.queue.onSubmittedWorkDone();
+try {
+  await promise36;
+} catch {}
+let buffer25 = device2.createBuffer({
+  label: '\u{1fc34}\u065a\u1b2e\u0063\u{1f92b}\u990f',
+  size: 186076,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder105 = device2.createCommandEncoder({label: '\ub9af\u0484\uf7d5\u1f49\u{1f862}\u{1fc97}\u6a1b'});
+let texture48 = device2.createTexture({
+  label: '\u{1ff1e}\u{1fa90}\ucd2a\u{1fbb3}\u0bc7\u61df\u0d03\u9bf1',
+  size: {width: 14, height: 8, depthOrArrayLayers: 30},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let computePassEncoder52 = commandEncoder105.beginComputePass({label: '\u32ac\u5d38\u0958\u64e1\u{1f720}\ua021'});
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `@group(0) @binding(3765)
+var<storage, read_write> n10: array<u32>;
+@group(3) @binding(1338)
+var<storage, read_write> global4: array<u32>;
+@group(5) @binding(1513)
+var<storage, read_write> type9: array<u32>;
+@group(5) @binding(1338)
+var<storage, read_write> n11: array<u32>;
+@group(3) @binding(1513)
+var<storage, read_write> type10: array<u32>;
+@group(0) @binding(3769)
+var<storage, read_write> type11: array<u32>;
+@group(4) @binding(3479)
+var<storage, read_write> type12: array<u32>;
+@group(0) @binding(2930)
+var<storage, read_write> n12: array<u32>;
+@group(2) @binding(3796)
+var<storage, read_write> n13: array<u32>;
+@group(4) @binding(2527)
+var<storage, read_write> n14: array<u32>;
+@group(1) @binding(410)
+var<storage, read_write> n15: array<u32>;
+@group(4) @binding(76)
+var<storage, read_write> type13: array<u32>;
+@group(2) @binding(3374)
+var<storage, read_write> type14: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(1) f1: vec3<u32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(14) f0: vec4<u32>,
+  @location(13) f1: vec2<i32>,
+  @location(10) f2: vec4<u32>,
+  @location(9) f3: vec3<u32>,
+  @location(12) f4: vec4<i32>,
+  @location(8) f5: vec2<f32>,
+  @location(6) f6: vec4<u32>,
+  @location(3) f7: vec3<u32>,
+  @location(2) f8: f32,
+  @location(11) f9: vec4<f16>,
+  @location(7) f10: f32,
+  @location(0) f11: vec3<f32>,
+  @location(4) f12: vec3<f32>,
+  @builtin(vertex_index) f13: u32
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(5) a1: vec2<i32>, @location(1) a2: vec2<f16>, a3: S13, @builtin(instance_index) a4: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderPassEncoder35 = commandEncoder41.beginRenderPass({
+  label: '\u0019\u846c\u{1f678}\uc5e9\u01f5\uc673',
+  colorAttachments: [{
+  view: textureView28,
+  depthSlice: 382,
+  clearValue: { r: 992.7, g: -586.5, b: 579.7, a: -69.71, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView29,
+  depthSlice: 37,
+  clearValue: { r: -522.9, g: -552.6, b: -317.3, a: 464.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 1153471148,
+});
+let renderBundleEncoder70 = device0.createRenderBundleEncoder({
+  label: '\ud859\u02d2\u4c41\u5a08\u{1fd28}\u{1fd9d}',
+  colorFormats: ['r32uint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let sampler52 = device0.createSampler({
+  label: '\uaae2\u2cad\u0a0c\u9bb8\u058a\u02bc\u0767\u{1fc27}\u{1f8d4}\u{1fa1b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 51.34,
+  lodMaxClamp: 75.93,
+});
+let externalTexture52 = device0.importExternalTexture({source: videoFrame15, colorSpace: 'srgb'});
+try {
+renderPassEncoder1.beginOcclusionQuery(694);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(54, 0, 29, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer1, 544_043_693);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer7, 903_927_485);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(4, bindGroup12, new Uint32Array(2494), 2434, 0);
+} catch {}
+try {
+renderBundleEncoder4.draw(69, 165);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(708, undefined, 0, 3421477834);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 5,
+  origin: {x: 0, y: 1, z: 4},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer8), /* required buffer size: 484_703 */
+{offset: 571, bytesPerRow: 41, rowsPerImage: 227}, {width: 1, height: 5, depthOrArrayLayers: 53});
+} catch {}
+let promise37 = device0.createComputePipelineAsync({
+  label: '\u{1fe94}\u66da',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let pipeline95 = await device0.createRenderPipelineAsync({
+  label: '\ubd7a\u03c7\u2644\u00a4\u345f\u0317',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x4b24837f},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let imageBitmap24 = await createImageBitmap(offscreenCanvas2);
+let device3 = await adapter2.requestDevice({label: '\u1474\u6f30\uedd4\u0145\u00e2\u03aa\ubb52\u06fc\u{1feb0}'});
+let video17 = await videoWithData();
+let commandEncoder106 = device2.createCommandEncoder();
+let querySet44 = device2.createQuerySet({label: '\uca9f\u463c\u0ef3\u{1fc44}', type: 'occlusion', count: 3343});
+let textureView125 = texture48.createView({label: '\uff7c\u0f54', mipLevelCount: 1});
+let arrayBuffer14 = buffer25.getMappedRange(0, 174132);
+try {
+commandEncoder106.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 47140 */
+  offset: 13091,
+  bytesPerRow: 256,
+  rowsPerImage: 44,
+  buffer: buffer24,
+}, {
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 2, depthOrArrayLayers: 4});
+dissociateBuffer(device2, buffer24);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer11), /* required buffer size: 455_199 */
+{offset: 259, bytesPerRow: 119, rowsPerImage: 273}, {width: 3, height: 2, depthOrArrayLayers: 15});
+} catch {}
+try {
+window.someLabel = sampler51.label;
+} catch {}
+let commandEncoder107 = device2.createCommandEncoder({label: '\u0e41\u4088\u{1f986}\u29e9'});
+let texture49 = device2.createTexture({
+  label: '\u0b1e\u256c\ua70c\u99e0\u022c\u2465\u{1f8f6}\ub416\u525f\u5b61\u186a',
+  size: {width: 14, height: 8, depthOrArrayLayers: 202},
+  mipLevelCount: 3,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture53 = device2.importExternalTexture({label: '\ud6df\uc8a5\u0d88\u{1f60a}\u65a2\ue85d', source: videoFrame13, colorSpace: 'display-p3'});
+try {
+buffer25.unmap();
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(buffer24, 170600, buffer25, 152720, 16724);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+commandEncoder106.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 35 */
+  offset: 35,
+  bytesPerRow: 0,
+  rowsPerImage: 149,
+  buffer: buffer24,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 20});
+dissociateBuffer(device2, buffer24);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer25);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(763), /* required buffer size: 763 */
+{offset: 762, bytesPerRow: 274}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let textureView126 = texture39.createView({label: '\u0775\u011f\ubdb7\u0c1b', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 300});
+try {
+renderPassEncoder21.drawIndexed(48, 22, 252_701_305, 284_655_854, 250_605_928);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer21, 759_962_783);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder65.setPipeline(pipeline58);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 96, height: 128, depthOrArrayLayers: 1264}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 126, y: 108 },
+  flipY: true,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 9, y: 12, z: 801},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img23 = await imageWithData(130, 183, '#3b5c2aa5', '#97d73774');
+let texture50 = device3.createTexture({
+  label: '\u0a48\u6d06',
+  size: [190, 320, 46],
+  mipLevelCount: 9,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder71 = device3.createRenderBundleEncoder({
+  label: '\u4b97\u07d4\u5445\u017c\u801e\u960c\u1c19',
+  colorFormats: ['r32uint', undefined, 'rg8uint', 'rg32float', 'rgba8uint', 'rg16uint'],
+  depthReadOnly: true,
+});
+let sampler53 = device3.createSampler({
+  label: '\u{1fbb4}\u0771\ucca6\u084c\u4a00\u0595\ubb8e\u5cf7',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.01,
+  lodMaxClamp: 79.30,
+});
+let querySet45 = device3.createQuerySet({type: 'occlusion', count: 1004});
+let texture51 = device3.createTexture({
+  label: '\u7913\u95c5\u{1fbe6}\ue383\u441a\u60c2\u{1ff26}\ua285\ub785\u{1fb9a}',
+  size: {width: 380, height: 640, depthOrArrayLayers: 43},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg32float', 'rg32float'],
+});
+let externalTexture54 = device3.importExternalTexture({label: '\u2a92\u{1fe24}\u{1fdd5}\ub625\u{1f7b1}\u0f88', source: videoFrame20, colorSpace: 'srgb'});
+try {
+gpuCanvasContext10.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup36 = device1.createBindGroup({label: '\u0e86\ua16d\u{1f9ea}\u03b8\uc5b8\uad2a\u059e', layout: bindGroupLayout30, entries: []});
+let commandEncoder108 = device1.createCommandEncoder({label: '\u0a58\uac0a\u4fdc\uf81a\u0714\u4544\u{1f9c0}\u69d9\u3372\u{1f884}'});
+let texture52 = device1.createTexture({
+  label: '\ue18c\u017e\u815a\u{1fb33}\ua70a\u0ccd\u{1fdda}\u7d60',
+  size: {width: 12, height: 16, depthOrArrayLayers: 791},
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let externalTexture55 = device1.importExternalTexture({label: '\u2dd8\ucd01\ue86a\u8a86\u{1fde7}\u8177\uf7ac\ua537', source: video6, colorSpace: 'srgb'});
+try {
+renderPassEncoder33.setBlendConstant({ r: -520.6, g: -666.5, b: 617.0, a: 230.1, });
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline82);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(0, buffer19, 0);
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(buffer15, 105292, buffer16, 26772, 404);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17054 */
+  offset: 17054,
+  buffer: buffer22,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer22);
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder108.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+try {
+commandEncoder108.resolveQuerySet(querySet40, 317, 300, buffer22, 89600);
+} catch {}
+let computePassEncoder53 = commandEncoder107.beginComputePass({label: '\ubdb7\u{1f717}\u0e32\u054f\u2d71\u{1fb50}\u24a1\u8572'});
+let renderBundle74 = renderBundleEncoder69.finish();
+try {
+commandEncoder106.copyBufferToBuffer(buffer24, 161288, buffer25, 13064, 30140);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder109 = device2.createCommandEncoder({label: '\u30f7\uc9df'});
+let querySet46 = device2.createQuerySet({label: '\u{1f756}\u0135', type: 'occlusion', count: 513});
+let texture53 = device2.createTexture({
+  label: '\u{1fa00}\u{1ff5e}',
+  size: {width: 14, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let textureView127 = texture48.createView({mipLevelCount: 2});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\u5407\u987c\u98de\u951e\u823e',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle75 = renderBundleEncoder72.finish({label: '\u01b2\u{1fd39}'});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+  await buffer24.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer25);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 2_994 */
+{offset: 703, bytesPerRow: 33, rowsPerImage: 7}, {width: 14, height: 7, depthOrArrayLayers: 10});
+} catch {}
+let img24 = await imageWithData(225, 157, '#8fb28dfa', '#d83b391c');
+let renderBundleEncoder73 = device3.createRenderBundleEncoder({
+  label: '\udecd\ub6d5',
+  colorFormats: ['r32uint', undefined, 'rg8uint', 'rg32float', 'rgba8uint', 'rg16uint'],
+  stencilReadOnly: true,
+});
+let externalTexture56 = device3.importExternalTexture({label: '\u{1f925}\u6ae7\u7f6a\uad0c\uc444\u0aa0\u35cf', source: video17, colorSpace: 'display-p3'});
+let promise38 = adapter3.requestAdapterInfo();
+let pipelineLayout9 = device1.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout28, bindGroupLayout26, bindGroupLayout31, bindGroupLayout26],
+});
+let commandEncoder110 = device1.createCommandEncoder();
+let renderBundleEncoder74 = device1.createRenderBundleEncoder({
+  label: '\ubc18\u584e\u9a25',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder31.beginOcclusionQuery(211);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer19, 'uint32', 342828, 87232);
+} catch {}
+try {
+renderBundleEncoder42.setIndexBuffer(buffer23, 'uint32', 16008);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(5, buffer19);
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 1,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 42, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas15,
+  origin: { x: 31, y: 0 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder111 = device2.createCommandEncoder();
+let renderBundle76 = renderBundleEncoder69.finish({});
+let sampler54 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 61.05,
+  lodMaxClamp: 87.06,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(77_082), /* required buffer size: 77_082 */
+{offset: 780, bytesPerRow: 157, rowsPerImage: 18}, {width: 10, height: 0, depthOrArrayLayers: 28});
+} catch {}
+let commandEncoder112 = device3.createCommandEncoder({label: '\u0f67\u6ff8\ud3c3\u{1fa6e}\u089f\u74b9\u0f86'});
+let texture54 = device3.createTexture({
+  label: '\u02df\u8345\u0893\u08ca',
+  size: [95, 160, 46],
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView128 = texture50.createView({
+  label: '\ua8df\u3bb0\u09f6\u44b8\u{1ffe8}\u{1f930}',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+  baseArrayLayer: 21,
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let renderPassEncoder36 = commandEncoder108.beginRenderPass({
+  label: '\u4716\u9664\u{1f6ca}\u0cb8\uc87e',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 101.0, g: 552.5, b: 922.7, a: -614.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 427.8, g: -531.4, b: -23.06, a: 31.51, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView95, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 1213944061,
+});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  label: '\uc44e\ubf02\u5d72\u{1f93e}\u{1f666}',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle77 = renderBundleEncoder45.finish({label: '\ude0e\u7908\ub29b\u065e\u4af1\u{1fa0b}\u{1fe1e}\u294f'});
+try {
+computePassEncoder31.setBindGroup(5, bindGroup17);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(5, bindGroup35);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline71);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet24, 1078, 269, buffer22, 232704);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 8, z: 2},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(80)), /* required buffer size: 42_677 */
+{offset: 635, bytesPerRow: 231, rowsPerImage: 1}, {width: 3, height: 0, depthOrArrayLayers: 183});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 64, depthOrArrayLayers: 1264}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 17, y: 12 },
+  flipY: true,
+}, {
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 4, y: 2, z: 67},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let pipeline96 = device1.createComputePipeline({
+  label: '\u097e\u0686\u0977\u041b\u5100\u7768\u371f\u{1f9e5}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline97 = device1.createRenderPipeline({
+  label: '\u25cb\u6335\u078e\u5840\u583a\u03fc\uba1f\ucb7f',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', depthFailOp: 'increment-clamp'},
+    stencilReadMask: 2051578362,
+    stencilWriteMask: 3264339445,
+    depthBiasClamp: 309.3044939015202,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 36, shaderLocation: 8},
+          {format: 'float32x2', offset: 332, shaderLocation: 22},
+          {format: 'uint16x4', offset: 176, shaderLocation: 7},
+          {format: 'uint16x2', offset: 188, shaderLocation: 20},
+          {format: 'sint8x4', offset: 48, shaderLocation: 15},
+          {format: 'uint16x2', offset: 588, shaderLocation: 12},
+          {format: 'float32x2', offset: 280, shaderLocation: 11},
+          {format: 'float16x2', offset: 84, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 200, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 456, shaderLocation: 3},
+          {format: 'float16x2', offset: 144, shaderLocation: 9},
+          {format: 'float32x2', offset: 88, shaderLocation: 10},
+          {format: 'float32x2', offset: 460, shaderLocation: 24},
+          {format: 'uint8x2', offset: 466, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 196, shaderLocation: 19},
+          {format: 'float32x3', offset: 20, shaderLocation: 0},
+          {format: 'sint32x3', offset: 248, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 308, shaderLocation: 2},
+          {format: 'sint32x3', offset: 4844, shaderLocation: 16},
+          {format: 'sint32x2', offset: 3512, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 2536,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 168, shaderLocation: 25}],
+      },
+      {
+        arrayStride: 3760,
+        attributes: [
+          {format: 'sint32x4', offset: 84, shaderLocation: 26},
+          {format: 'unorm8x2', offset: 632, shaderLocation: 21},
+          {format: 'uint32', offset: 88, shaderLocation: 1},
+          {format: 'sint32x3', offset: 276, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 232,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 60, shaderLocation: 23}],
+      },
+      {arrayStride: 10068, attributes: [{format: 'uint8x2', offset: 2364, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let commandEncoder113 = device1.createCommandEncoder({label: '\u{1fa48}\u{1fa74}\uc835\u0cc1\u3ee4\u6428'});
+let textureView129 = texture27.createView({
+  label: '\u{1f79e}\u0847\u05a4\u{1fc2a}\u38fb\u57a0\uee3e\u3dfb\u6f0a\u7d7c',
+  baseArrayLayer: 245,
+  arrayLayerCount: 117,
+});
+let computePassEncoder54 = commandEncoder113.beginComputePass();
+let renderPassEncoder37 = commandEncoder110.beginRenderPass({
+  label: '\ued42\u0257\u00eb\uc28a\u{1fa05}\u04c4\u0dc2\u07fe\u372c\ub3db\u{1f6ac}',
+  colorAttachments: [{view: textureView96, loadOp: 'load', storeOp: 'store'}, {view: textureView64, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}, {
+  view: textureView85,
+  depthSlice: 0,
+  clearValue: { r: 93.12, g: 574.3, b: -992.8, a: -336.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet27,
+});
+let sampler55 = device1.createSampler({
+  label: '\u0475\u1cb6\u0255',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.78,
+  lodMaxClamp: 80.51,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder26.beginOcclusionQuery(1301);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(2, 6, 1, 1);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(3488);
+} catch {}
+try {
+renderPassEncoder21.draw(264, 364, 155_921_382, 474_979_976);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(69, 419, 286_829_865, 148_799_934, 913_050_123);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer13, 109_504_722);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline65);
+} catch {}
+gc();
+let texture55 = device3.createTexture({
+  label: '\u9581\u0123\u0b8f\ub4f1\ub3ac\u4099',
+  size: [380, 640, 93],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float'],
+});
+let renderBundleEncoder76 = device3.createRenderBundleEncoder({
+  colorFormats: ['r32uint', undefined, 'rg8uint', 'rg32float', 'rgba8uint', 'rg16uint'],
+  depthReadOnly: false,
+});
+let sampler56 = device3.createSampler({
+  label: '\u0050\u{1f777}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 27.65,
+  lodMaxClamp: 73.74,
+  compare: 'greater',
+});
+try {
+device3.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 8, y: 18, z: 12},
+  aspect: 'all',
+}, new ArrayBuffer(519_501), /* required buffer size: 519_501 */
+{offset: 688, bytesPerRow: 225, rowsPerImage: 372}, {width: 47, height: 74, depthOrArrayLayers: 7});
+} catch {}
+try {
+device3.destroy();
+} catch {}
+let video18 = await videoWithData();
+let commandEncoder114 = device2.createCommandEncoder({label: '\uc9b7\u3334\ua6ea\u{1fe14}\uc8d9\uc8de\udbc1\u69ff\u2c66\u305d'});
+let externalTexture57 = device2.importExternalTexture({
+  label: '\u{1f60a}\ub3b1\uff14\u{1fd19}\u{1f817}\u19e3\ub712\u{1f791}',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let commandEncoder115 = device1.createCommandEncoder();
+let textureView130 = texture52.createView({
+  label: '\u244a\uc786\u47b3\u0a95\u36f6\uba3b\u769a\u5c8c\u0248\u4a9d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 214,
+  arrayLayerCount: 328,
+});
+let renderBundle78 = renderBundleEncoder75.finish({});
+let externalTexture58 = device1.importExternalTexture({
+  label: '\u0e11\u1bf3\uae0e\u247b\u{1ff83}\u0123\u04f2\u0b58\udc26',
+  source: videoFrame16,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder37.setBindGroup(6, bindGroup26);
+} catch {}
+try {
+renderPassEncoder34.setViewport(2.126, 6.667, 2.513, 0.02763, 0.05602, 0.4460);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer21, 4_294_967_295);
+} catch {}
+try {
+renderBundleEncoder59.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(6, buffer14);
+} catch {}
+let arrayBuffer15 = buffer19.getMappedRange(425496, 19092);
+try {
+commandEncoder115.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 94},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 51952 */
+  offset: 51952,
+  bytesPerRow: 0,
+  rowsPerImage: 193,
+  buffer: buffer14,
+}, {width: 0, height: 1, depthOrArrayLayers: 84});
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 1224, new DataView(new ArrayBuffer(55642)), 1565, 3892);
+} catch {}
+let computePassEncoder55 = commandEncoder114.beginComputePass({label: '\u097e\uc78e\ua2a5\u08ba\u98a2'});
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 8_630 */
+{offset: 340, bytesPerRow: 224, rowsPerImage: 18}, {width: 2, height: 2, depthOrArrayLayers: 3});
+} catch {}
+video17.width = 10;
+let pipelineLayout10 = device1.createPipelineLayout({label: '\ueee8\u{1ffb4}\u06e6\u0190\u0be1\u{1fa46}', bindGroupLayouts: []});
+let renderBundle79 = renderBundleEncoder53.finish({label: '\u06f7\u936a\u{1f89a}\u98bc\u1b2b\ud750\u0427'});
+let externalTexture59 = device1.importExternalTexture({
+  label: '\u{1fd94}\u9cf3\u7529\u8cfc\udf05\u0ecc\u{1fbc1}\u0087\u7cab\uee92',
+  source: videoFrame16,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle72, renderBundle56, renderBundle77, renderBundle42, renderBundle42, renderBundle49]);
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(2507);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+gc();
+let videoFrame30 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+  await promise38;
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(586, 134);
+try {
+offscreenCanvas36.getContext('webgpu');
+} catch {}
+let commandEncoder116 = device2.createCommandEncoder({label: '\u5aa7\u{1f874}\u7c17\u9a80\u8c41'});
+let texture56 = device2.createTexture({
+  label: '\uf65d\u0bc7\uf951\u0327\u{1faf5}\u867c',
+  size: [56, 32, 120],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder56 = commandEncoder116.beginComputePass({label: '\ua475\uccc0\u{1fe01}\ud7ad\u{1f622}\u07f4\ua5d3\u0988'});
+let renderBundleEncoder77 = device2.createRenderBundleEncoder({
+  label: '\u0c59\u0494\u177c\u{1fd63}\u0318',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+  depthReadOnly: true,
+});
+let sampler57 = device2.createSampler({
+  label: '\u92bf\u01fb\u063b',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 68.97,
+  lodMaxClamp: 72.78,
+});
+let sampler58 = device2.createSampler({
+  label: '\u01f4\u0b5b\uce9c\u9f1f',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 33.75,
+  lodMaxClamp: 68.13,
+});
+try {
+commandEncoder111.clearBuffer(buffer25);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let textureView131 = texture53.createView({label: '\ub5b1\uae8d\u{1f61c}', dimension: '2d', mipLevelCount: 1});
+try {
+renderBundleEncoder77.setVertexBuffer(5980, undefined, 925276833, 2971033732);
+} catch {}
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder109.copyBufferToBuffer(buffer24, 206576, buffer25, 186036, 20);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer25, 45416, new BigUint64Array(45024), 30413);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(265_380), /* required buffer size: 265_380 */
+{offset: 815, bytesPerRow: 236, rowsPerImage: 224}, {width: 9, height: 2, depthOrArrayLayers: 6});
+} catch {}
+let textureView132 = texture42.createView({label: '\u{1fbab}\u{1f9f4}\uc721\u{1f773}\u{1ff97}\u{1f7af}'});
+let renderPassEncoder38 = commandEncoder61.beginRenderPass({
+  label: '\u8018\u0a0b\u{1fd89}\uc83d\u1fd6\u3306',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -509.2, g: -528.3, b: 149.4, a: -390.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 703.2, g: 460.1, b: -207.9, a: 0.5882, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView119,
+  depthSlice: 0,
+  clearValue: { r: 227.1, g: -794.1, b: 434.4, a: -401.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 1160911270,
+});
+let externalTexture60 = device1.importExternalTexture({label: '\u{1f75d}\ua4ed\uf200\uda09\u59d3\u7759\ua4e4\u9f6c', source: videoFrame24});
+try {
+renderPassEncoder32.executeBundles([renderBundle61, renderBundle56, renderBundle54, renderBundle48, renderBundle62, renderBundle38, renderBundle43, renderBundle41, renderBundle71, renderBundle55]);
+} catch {}
+try {
+renderPassEncoder33.setViewport(5.876, 6.269, 0.04908, 0.9040, 0.7813, 0.9569);
+} catch {}
+try {
+renderPassEncoder21.draw(21, 151);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer19, 1_496_842_924);
+} catch {}
+try {
+computePassEncoder40.pushDebugGroup('\u1336');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap9,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img12);
+try {
+window.someLabel = renderBundle52.label;
+} catch {}
+let bindGroup37 = device1.createBindGroup({label: '\u026f\u4ebe\u46c8\u072a\u{1f6c5}\u8592', layout: bindGroupLayout20, entries: []});
+let buffer26 = device1.createBuffer({
+  label: '\u09a1\ucddc',
+  size: 13464,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let texture57 = device1.createTexture({
+  size: [24, 32, 1],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView133 = texture33.createView({label: '\u59cc\u05b3\u00c5\u{1f6f5}\u9371\udba5\u0bc4\uc871', dimension: '1d', mipLevelCount: 1});
+let renderBundle80 = renderBundleEncoder61.finish();
+try {
+computePassEncoder43.setPipeline(pipeline60);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer16, 662_573_322);
+} catch {}
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 532 */
+  offset: 532,
+  buffer: buffer13,
+}, {
+  texture: texture57,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder115.resolveQuerySet(querySet26, 2473, 581, buffer23, 18688);
+} catch {}
+try {
+computePassEncoder40.popDebugGroup();
+} catch {}
+let querySet47 = device1.createQuerySet({label: '\u{1fbfd}\u0b48', type: 'occlusion', count: 36});
+let commandBuffer29 = commandEncoder115.finish({});
+try {
+renderPassEncoder24.beginOcclusionQuery(1169);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(6, 8, 0, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer19, 'uint16', 149378, 14804);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(5, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(0, buffer14, 0);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData26 = new ImageData(76, 128);
+offscreenCanvas12.width = 1010;
+let offscreenCanvas37 = new OffscreenCanvas(666, 927);
+try {
+offscreenCanvas37.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let bindGroupLayout34 = device2.createBindGroupLayout({entries: []});
+let pipelineLayout11 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout34]});
+let externalTexture61 = device2.importExternalTexture({
+  label: '\u0283\u0475\u0858\u{1f949}\u{1fc7c}\u1aa7\u1470\u228d',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder105.copyBufferToBuffer(buffer24, 110176, buffer25, 72272, 55804);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer25, 40064);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 188_750 */
+{offset: 642, bytesPerRow: 87, rowsPerImage: 127}, {width: 14, height: 4, depthOrArrayLayers: 18});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder117 = device1.createCommandEncoder({});
+let textureView134 = texture29.createView({label: '\u417f\u{1f79a}\u{1f609}\uf95a'});
+let renderPassEncoder39 = commandEncoder117.beginRenderPass({
+  label: '\u022a\u{1fba9}\u028b\u0b35\u0469\u{1f958}\u02d0\u7c69\u1c9a',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 854.9, g: -841.8, b: 856.9, a: 49.65, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView64, depthSlice: 0, loadOp: 'load', storeOp: 'store'}, {view: textureView95, depthSlice: 0, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet33,
+  maxDrawCount: 310639580,
+});
+try {
+renderPassEncoder34.setBlendConstant({ r: 319.1, g: 937.6, b: 281.2, a: 431.6, });
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(1, 8, 3, 0);
+} catch {}
+try {
+renderPassEncoder38.setViewport(5.308, 1.314, 0.5940, 4.035, 0.1150, 0.1761);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(192);
+} catch {}
+try {
+renderBundleEncoder59.setIndexBuffer(buffer19, 'uint32', 162380);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(6, buffer19, 0, 302297);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 7, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let video19 = await videoWithData();
+let buffer27 = device1.createBuffer({size: 165112, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE, mappedAtCreation: true});
+let texture58 = device1.createTexture({
+  label: '\u{1fc38}\u7cc2\ue90a\u{1f94f}\u7e84\u{1fd57}',
+  size: {width: 48, height: 64, depthOrArrayLayers: 2},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView135 = texture30.createView({
+  label: '\u0e1d\uc8ce\ud498\u04c6\u91c7\u6c58\u0304\u6b27',
+  aspect: 'all',
+  baseMipLevel: 0,
+  mipLevelCount: 4,
+});
+try {
+computePassEncoder32.setPipeline(pipeline73);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.draw(82, 9, 80_281_914, 456_567_183);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(415, 32, 481_044_041, 147_084_858, 1_099_740_506);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer23, 1_097_337_829);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer19, 319_805_571);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(6, buffer14, 2396, 3897);
+} catch {}
+try {
+device1.queue.submit([commandBuffer24, commandBuffer19]);
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(927, 423);
+try {
+offscreenCanvas38.getContext('2d');
+} catch {}
+try {
+externalTexture23.label = '\u0898\uc640\ua39b\u{1f749}\u0e8d\ub71c\u{1f8c4}\ue4a5\u{1f989}';
+} catch {}
+offscreenCanvas23.width = 97;
+let canvas24 = document.createElement('canvas');
+let video20 = await videoWithData();
+gc();
+let videoFrame31 = new VideoFrame(offscreenCanvas31, {timestamp: 0});
+let textureView136 = texture48.createView({label: '\u3f9f\u0e4c\u0ea7\u551c\u0db6\ubb2f\u07ad', baseMipLevel: 2});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer25, 29268, new Float32Array(62185), 15854, 148);
+} catch {}
+let gpuCanvasContext36 = canvas24.getContext('webgpu');
+canvas5.height = 1788;
+try {
+window.someLabel = commandEncoder112.label;
+} catch {}
+let canvas25 = document.createElement('canvas');
+let videoFrame32 = new VideoFrame(canvas6, {timestamp: 0});
+let texture59 = device1.createTexture({
+  label: '\u0df9\ue43f\u4d6f\u0147\u0497\ud187\uf5f7\uc6dd\u{1faba}\ue163\u{1f8f1}',
+  size: [48, 64, 2],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView137 = texture45.createView({label: '\u0c84\u0005\u{1f6b0}', baseMipLevel: 1});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(907);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(2642);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(4, bindGroup36);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(buffer23, 'uint16', 23830);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(3, buffer19, 0, 307224);
+} catch {}
+let arrayBuffer16 = buffer19.getMappedRange(445720, 308);
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 2, y: 14 },
+  flipY: false,
+}, {
+  texture: texture37,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline98 = device1.createComputePipeline({layout: pipelineLayout9, compute: {module: shaderModule9, entryPoint: 'compute0'}});
+let gpuCanvasContext37 = canvas25.getContext('webgpu');
+let sampler59 = device1.createSampler({
+  label: '\ud8d7\uf655\u379f\u0af9\u{1fe87}\u0c30\u{1fc0a}\u08c5\u0f6f\ub83b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 97.15,
+  lodMaxClamp: 98.03,
+  compare: 'always',
+});
+try {
+renderPassEncoder21.drawIndirect(buffer15, 37_175_025);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer23, 'uint16', 42838, 6323);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(7, bindGroup21);
+} catch {}
+try {
+window.someLabel = renderBundleEncoder44.label;
+} catch {}
+let shaderModule14 = device1.createShaderModule({
+  code: `
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@location(35) a0: vec2<f32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32, @builtin(position) a3: vec4<f32>, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(6) f0: vec4<f16>,
+  @location(23) f1: vec4<i32>,
+  @location(22) f2: vec3<u32>,
+  @location(9) f3: i32
+}
+struct VertexOutput0 {
+  @location(35) f120: vec2<f32>,
+  @builtin(position) f121: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<u32>, @builtin(vertex_index) a1: u32, @location(2) a2: u32, @location(26) a3: vec4<i32>, @location(14) a4: vec4<f16>, @location(5) a5: vec2<u32>, @builtin(instance_index) a6: u32, @location(11) a7: vec2<f32>, @location(18) a8: vec2<f16>, @location(10) a9: vec2<i32>, @location(21) a10: vec2<f32>, @location(12) a11: u32, @location(7) a12: vec3<f16>, @location(1) a13: vec3<u32>, @location(0) a14: i32, @location(8) a15: vec4<f16>, @location(25) a16: i32, @location(4) a17: vec2<f32>, @location(13) a18: i32, @location(19) a19: vec3<i32>, @location(20) a20: u32, @location(24) a21: vec3<f16>, @location(17) a22: vec4<f32>, @location(3) a23: vec4<u32>, a24: S14, @location(15) a25: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder118 = device1.createCommandEncoder();
+let querySet48 = device1.createQuerySet({label: '\u03c8\ub516\ub9da\u39d7\u0842\u13ee\uc551\u71f8\u0c88\u0664', type: 'occlusion', count: 1892});
+let textureView138 = texture41.createView({dimension: '2d', baseMipLevel: 5, baseArrayLayer: 1200});
+try {
+renderPassEncoder29.setBindGroup(7, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: -458.3, g: -607.7, b: -0.7603, a: 821.9, });
+} catch {}
+try {
+renderPassEncoder37.setViewport(0.6988, 6.400, 0.01823, 1.072, 0.3874, 0.8414);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline82);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer14, 9224, 43403);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(3, buffer19, 442684, 1422);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(buffer18, 19572, buffer21, 4920, 33848);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 22620, new Float32Array(60215), 5512, 8);
+} catch {}
+let pipeline99 = device1.createComputePipeline({
+  label: '\u028e\u{1fd68}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+try {
+textureView128.label = '\u0fa1\u97d2\ubc58\u04f9\u{1ff7a}\u0c42';
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(866, 230);
+let texture60 = device2.createTexture({
+  label: '\uc56f\u{1fa3c}\u693e\ufb97',
+  size: {width: 7, height: 4, depthOrArrayLayers: 15},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let renderBundle81 = renderBundleEncoder77.finish({});
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 29176 */
+  offset: 27568,
+  bytesPerRow: 512,
+  buffer: buffer25,
+}, {width: 9, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let querySet49 = device1.createQuerySet({
+  label: '\u8d50\u59f5\u0d37\u{1f620}\u{1fefd}\u0a45\u015a\u0d5d\uf16c\u07fb\u00e0',
+  type: 'occlusion',
+  count: 1723,
+});
+let commandBuffer30 = commandEncoder118.finish();
+let textureView139 = texture59.createView({label: '\uedc9\ubec6', baseArrayLayer: 0});
+let renderBundle82 = renderBundleEncoder61.finish({label: '\u{1fafa}\u5bdd\ub887\u0307\u6777'});
+try {
+renderPassEncoder34.setBindGroup(5, bindGroup29, new Uint32Array(972), 678, 0);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: -228.8, g: -60.48, b: 724.9, a: -813.0, });
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(9, 49, 148_247_445, 626_647_770, 983_824_628);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder74.setIndexBuffer(buffer23, 'uint32', 19340, 29202);
+} catch {}
+let videoFrame33 = new VideoFrame(img24, {timestamp: 0});
+gc();
+let imageBitmap25 = await createImageBitmap(imageData9);
+let bindGroup38 = device1.createBindGroup({label: '\u0dbc\u{1fccf}\u75ac\u09d6\ua8ec', layout: bindGroupLayout20, entries: []});
+let querySet50 = device1.createQuerySet({type: 'occlusion', count: 3595});
+let renderBundleEncoder78 = device1.createRenderBundleEncoder({
+  label: '\uc5eb\u3113\uadd4\u{1fe32}\u{1ffd9}\u0eee\u99e6\u42a7\u{1fd9e}\u5eb7',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(6, bindGroup35, new Uint32Array(1846), 1569, 0);
+} catch {}
+try {
+renderPassEncoder38.beginOcclusionQuery(3258);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle68, renderBundle58, renderBundle43, renderBundle60, renderBundle54]);
+} catch {}
+try {
+renderPassEncoder32.setViewport(3.853, 6.736, 1.909, 1.252, 0.6042, 0.7449);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline57);
+} catch {}
+let canvas26 = document.createElement('canvas');
+try {
+offscreenCanvas39.getContext('webgl');
+} catch {}
+let commandEncoder119 = device2.createCommandEncoder({label: '\u{1fb82}\u71d3\u06de\ud4ed\u0116\uaf6c\ud260\u49ff'});
+let texture61 = device2.createTexture({
+  label: '\u{1f9ca}\u{1fe79}\u5e7a\u0684\u2363',
+  size: {width: 7, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32float', 'rg32float'],
+});
+let textureView140 = texture53.createView({label: '\u06aa\u63a6\u{1fe54}\u6f9e\u0aa9\ua098\u{1f6c7}\u037c\ueff1\u042a'});
+let computePassEncoder57 = commandEncoder119.beginComputePass({label: '\u2fba\u{1f78c}\u0ea0\u0279\ucc2b\u8954\u6402\u1ee6\u385a'});
+let renderBundleEncoder79 = device2.createRenderBundleEncoder({
+  label: '\u4467\u{1fcb9}\ucd4b',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+});
+try {
+commandEncoder111.copyBufferToBuffer(buffer24, 191880, buffer25, 182080, 2252);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 27},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer7), /* required buffer size: 430_526 */
+{offset: 774, bytesPerRow: 214, rowsPerImage: 222}, {width: 10, height: 11, depthOrArrayLayers: 10});
+} catch {}
+canvas15.width = 2218;
+let videoFrame34 = new VideoFrame(img6, {timestamp: 0});
+let gpuCanvasContext38 = canvas26.getContext('webgpu');
+document.body.prepend(img2);
+gc();
+try {
+texture50.label = '\uf617\u9f7c\u2978\u06a5\u57fb\u4b07\ubc68\u0acf\u6ead';
+} catch {}
+let pipelineLayout12 = device2.createPipelineLayout({
+  label: '\u0fc4\u{1fbc0}\u{1fa8d}\u{1f81f}\u8503\u{1fb82}\u{1ff2b}\u8442',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout34],
+});
+let buffer28 = device2.createBuffer({size: 18840, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let textureView141 = texture56.createView({label: '\u0b98\u840b\u88a5', baseMipLevel: 3});
+let computePassEncoder58 = commandEncoder111.beginComputePass();
+let externalTexture62 = device2.importExternalTexture({
+  label: '\ufb79\uf143\u1d92\u0379\u552b\u834f\ud53f\uf83d\u537e\u052b\ucd2f',
+  source: video10,
+  colorSpace: 'srgb',
+});
+let promise39 = device2.popErrorScope();
+let arrayBuffer17 = buffer24.getMappedRange(0, 33836);
+let promise40 = buffer25.mapAsync(GPUMapMode.READ, 0, 136728);
+try {
+renderPassEncoder38.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle44, renderBundle57, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer19, 'uint32', 349948, 3231);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline58);
+} catch {}
+let promise41 = device1.createComputePipelineAsync({
+  label: '\u{1fac8}\udfb7\ue3ca',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let img25 = await imageWithData(200, 231, '#15e1dc86', '#c99c7852');
+let commandEncoder120 = device1.createCommandEncoder({label: '\u{1fdc0}\u58cb\u{1f8a0}'});
+let texture62 = device1.createTexture({
+  label: '\u{1ffe2}\u0bbb\u040b\uc7d8\u3727\u0d38',
+  size: [24, 32, 580],
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let renderPassEncoder40 = commandEncoder120.beginRenderPass({
+  label: '\ua8e3\ua66f\u0bdc\u05f2\u1732',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 367.9, g: -964.4, b: -912.9, a: -625.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 779.7, g: 363.8, b: 941.0, a: 758.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView85,
+  depthSlice: 0,
+  clearValue: { r: -244.4, g: -164.7, b: -895.1, a: -368.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 1203710381,
+});
+let renderBundle83 = renderBundleEncoder66.finish({label: '\u0250\ud711\u0f4e\u{1f874}\u8f8b\u18cd\u0da3\ua6cf\u54a3\u37e3\u54ef'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup31, []);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setViewport(3.108, 5.177, 1.853, 1.674, 0.7370, 0.9850);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(309, 147);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer15, 213_768_413);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder78.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(2, buffer14, 7116);
+} catch {}
+try {
+device1.queue.submit([commandBuffer26]);
+} catch {}
+gc();
+try {
+gpuCanvasContext31.unconfigure();
+} catch {}
+let video21 = await videoWithData();
+offscreenCanvas38.height = 656;
+let offscreenCanvas40 = new OffscreenCanvas(507, 225);
+offscreenCanvas16.width = 243;
+gc();
+let canvas27 = document.createElement('canvas');
+let videoFrame35 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let textureView142 = texture58.createView({
+  label: '\u0603\uc886\u{1f869}\u0fe9\u{1fc54}\uecd3\u0a7e\ue32c\u{1f871}\u{1fe59}\u306b',
+  dimension: '3d',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let renderBundle84 = renderBundleEncoder57.finish();
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer16, 391_938_327);
+} catch {}
+let pipeline100 = await promise33;
+let texture63 = device1.createTexture({
+  size: {width: 48, height: 64, depthOrArrayLayers: 2},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture64 = gpuCanvasContext0.getCurrentTexture();
+let textureView143 = texture42.createView({
+  label: '\u01fe\u085f\u{1f706}\ua557\u8b14\u{1f88b}\u{1fc7a}\u2f85\udc32\u06d0\u86db',
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder31.setBindGroup(7, bindGroup26);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(107);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer21, 238_972_774);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer19, 81608, 69353);
+} catch {}
+let img26 = await imageWithData(202, 63, '#503e0d4b', '#5452357b');
+try {
+offscreenCanvas40.getContext('webgpu');
+} catch {}
+let commandEncoder121 = device1.createCommandEncoder({label: '\u{1fb2e}\uf63d\u{1ff7f}\u25d6\u{1fec2}\u1f02\u2f0d\u086d\u3239'});
+try {
+renderPassEncoder31.beginOcclusionQuery(150);
+} catch {}
+try {
+renderPassEncoder21.draw(522, 318);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(192);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer16, 8_166_893);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(7592, undefined);
+} catch {}
+try {
+commandEncoder121.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+let pipeline101 = await device1.createComputePipelineAsync({
+  label: '\u8a77\ue73d',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap26 = await createImageBitmap(img3);
+let commandEncoder122 = device1.createCommandEncoder({label: '\u91da\u19d6\ua3ef'});
+let texture65 = device1.createTexture({
+  label: '\u012e\u0e7c\u{1faac}\u6514\u049a',
+  size: {width: 96, height: 128, depthOrArrayLayers: 318},
+  mipLevelCount: 3,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(950);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer14, 0, 16651);
+} catch {}
+try {
+commandEncoder121.copyTextureToBuffer({
+  texture: texture38,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 768 */
+  offset: 768,
+  bytesPerRow: 0,
+  rowsPerImage: 296,
+  buffer: buffer16,
+}, {width: 0, height: 0, depthOrArrayLayers: 144});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder122.resolveQuerySet(querySet30, 2503, 133, buffer22, 189440);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 32, new Float32Array(29665), 5541, 1332);
+} catch {}
+let pipeline102 = device1.createComputePipeline({
+  label: '\u8647\ud12a\ub3d7\u9df1',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let bindGroup39 = device2.createBindGroup({label: '\u0738\u2d39\u2333\u{1fb79}\u0d94\u65b4', layout: bindGroupLayout34, entries: []});
+let querySet51 = device2.createQuerySet({
+  label: '\uf6bb\ud7f4\u1f42\u345c\u{1fa9a}\u{1f9d2}\ue9c9\u2292\uecb1\ue855\u96c4',
+  type: 'occlusion',
+  count: 2392,
+});
+let renderBundle85 = renderBundleEncoder69.finish({label: '\u0627\uc228\u0c2a\u07d7\u{1ff31}\ua702\u624d\u0c9d\u09cd\udfd8\u011e'});
+let sampler60 = device2.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.14,
+  lodMaxClamp: 90.27,
+});
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer29 = device2.createBuffer({label: '\u0931\u{1f908}\ue167\u055a\u2690\ua758\u5853', size: 93804, usage: GPUBufferUsage.STORAGE});
+let commandEncoder123 = device2.createCommandEncoder({label: '\u292e\u1ebb\u0d69\u{1fa26}\u{1ff99}\ufda1\u{1fa36}\u070d'});
+let textureView144 = texture49.createView({label: '\u0699\u7270\u05f1\u353a', mipLevelCount: 2, baseArrayLayer: 47, arrayLayerCount: 23});
+let sampler61 = device2.createSampler({
+  label: '\u{1fdc9}\u0fea\u0591\ueb24\u034c\udf91\u022a',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.63,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder79.setBindGroup(2, bindGroup39, []);
+} catch {}
+try {
+renderBundleEncoder79.setVertexBuffer(6363, undefined, 2351625236);
+} catch {}
+try {
+device2.queue.submit([]);
+} catch {}
+document.body.prepend(video21);
+try {
+device3.queue.label = '\u9932\u016f\u033c\ua031\ue57b\u005a\u0b08\uc8ef\u{1fcbf}\u9541';
+} catch {}
+let gpuCanvasContext39 = canvas27.getContext('webgpu');
+try {
+  await promise39;
+} catch {}
+let videoFrame36 = new VideoFrame(offscreenCanvas28, {timestamp: 0});
+let computePassEncoder59 = commandEncoder109.beginComputePass({label: '\udd58\u441c\u141f\u06d1\u1a1c\u3773\u{1f9c0}\uec92\u{1fe7d}\u{1f606}'});
+let imageBitmap27 = await createImageBitmap(imageData2);
+let querySet52 = device1.createQuerySet({label: '\u32b5\u5afc\u9565\u{1f81b}\u{1f76f}\u284d', type: 'occlusion', count: 3941});
+let textureView145 = texture32.createView({label: '\u8fac\u7c90\u0ffd\u{1f8e9}', mipLevelCount: 1});
+let externalTexture63 = device1.importExternalTexture({label: '\u182f\u0f42\ua9cd\u0a5c\u8dc1\u{1fb43}', source: videoFrame25, colorSpace: 'display-p3'});
+try {
+computePassEncoder34.setBindGroup(7, bindGroup21, new Uint32Array(5224), 899, 0);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(1380);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle71, renderBundle39, renderBundle71, renderBundle52, renderBundle69, renderBundle53]);
+} catch {}
+try {
+renderPassEncoder21.draw(13, 150, 215_895_960);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer14, 188_234_022);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer14, 0, 33333);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(4, bindGroup19, new Uint32Array(6788), 14, 0);
+} catch {}
+try {
+commandEncoder121.copyBufferToBuffer(buffer18, 48396, buffer21, 46888, 3232);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 58630 */
+  offset: 58630,
+  buffer: buffer13,
+}, {
+  texture: texture57,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder122.clearBuffer(buffer14, 69824, 928);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 3244, new BigUint64Array(26799), 23775, 300);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(0, bindGroup39, new Uint32Array(6654), 6101, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 139_773 */
+{offset: 85, bytesPerRow: 291, rowsPerImage: 120}, {width: 2, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let imageBitmap28 = await createImageBitmap(videoFrame31);
+let pipelineLayout13 = device2.createPipelineLayout({label: '\u{1fb25}\u{1ff3c}\u448b\u5baf', bindGroupLayouts: []});
+let commandEncoder124 = device2.createCommandEncoder({label: '\u15e3\u4ffb\u86f5\u0938\u231e\ua157\u{1f739}\uf4d2\u377c\ud407\u082d'});
+let commandBuffer31 = commandEncoder123.finish({label: '\u{1faf0}\ue385\u0bc3\u0eec\uf15a\u6880\u03b8\u3f88'});
+let renderBundleEncoder80 = device2.createRenderBundleEncoder({
+  label: '\u{1f9ef}\u062e\uce9a\u8384',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+  stencilReadOnly: true,
+});
+let sampler62 = device2.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.14,
+  lodMaxClamp: 77.03,
+});
+try {
+renderBundleEncoder80.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer11), /* required buffer size: 56_113 */
+{offset: 880, bytesPerRow: 235, rowsPerImage: 18}, {width: 2, height: 2, depthOrArrayLayers: 14});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let bindGroup40 = device2.createBindGroup({label: '\u0e79\u{1fbd1}\u{1fc68}', layout: bindGroupLayout34, entries: []});
+let buffer30 = device2.createBuffer({
+  label: '\u0680\udbd2\u{1fafa}\u7899\u4fb3\u01f7\u0c6d\u{1f96e}\u89d9',
+  size: 451652,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView146 = texture53.createView({
+  label: '\u{1fb63}\u034b\u{1fdb7}\u{1f937}\u90f1\ub072\u063a',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 2,
+});
+let externalTexture64 = device2.importExternalTexture({label: '\ub021\ub5c7\uf3e9\u0c28\u0d9c\u8a7f\uc3ce\u5199', source: video6, colorSpace: 'srgb'});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder79.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer24, 17464, buffer30, 255248, 18032);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 20_203 */
+{offset: 139, bytesPerRow: 33, rowsPerImage: 76}, {width: 13, height: 0, depthOrArrayLayers: 9});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+offscreenCanvas36.width = 499;
+let pipelineLayout14 = device1.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout26, bindGroupLayout27, bindGroupLayout20, bindGroupLayout30, bindGroupLayout21, bindGroupLayout20],
+});
+let commandEncoder125 = device1.createCommandEncoder({label: '\u0b15\u0268\u8280\u9be1\ua608'});
+let renderPassEncoder41 = commandEncoder122.beginRenderPass({
+  label: '\u1dbe\ua443\u18c5\uc506\u05d9\uc8c0\u7205\u0200\u{1f9da}\u0562',
+  colorAttachments: [{view: textureView96, loadOp: 'clear', storeOp: 'store'}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 249.2, g: 933.7, b: 750.4, a: 362.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView91,
+  depthSlice: 0,
+  clearValue: { r: 911.0, g: 911.3, b: 957.0, a: -562.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet40,
+  maxDrawCount: 844155374,
+});
+let externalTexture65 = device1.importExternalTexture({label: '\u{1fc1c}\u07e5\u5334\u5a21\u2017', source: video7, colorSpace: 'srgb'});
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle51, renderBundle53, renderBundle39, renderBundle45]);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(5, 1, 1, 7);
+} catch {}
+try {
+renderPassEncoder32.setViewport(3.598, 3.349, 1.052, 0.2666, 0.1758, 0.6938);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(21, 154, 1_579_408_679, 384_701_973, 171_027_241);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer18, 269_885_004);
+} catch {}
+try {
+commandEncoder121.resolveQuerySet(querySet27, 1233, 1339, buffer22, 112128);
+} catch {}
+try {
+renderBundleEncoder68.pushDebugGroup('\u{1f954}');
+} catch {}
+try {
+gpuCanvasContext30.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 43, y: 702 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup41 = device2.createBindGroup({
+  label: '\ubc4b\u{1f767}\u6e98\u14e7\u0752\ue9f9\u{1f7c3}\u{1ff10}\udb59',
+  layout: bindGroupLayout34,
+  entries: [],
+});
+let commandEncoder126 = device2.createCommandEncoder();
+let commandBuffer32 = commandEncoder126.finish({});
+let renderBundle86 = renderBundleEncoder77.finish({label: '\ue4c0\u79dc\u5768\ue2cf\u4342\u0124\u{1f644}\u{1ffe0}\u{1fd78}\u6d44\u0284'});
+try {
+renderBundleEncoder79.setVertexBuffer(7919, undefined);
+} catch {}
+let videoFrame37 = new VideoFrame(img13, {timestamp: 0});
+try {
+adapter2.label = '\u90cc\u8907\u07c8\ue6be\u07cf\u0359\u{1fb71}\ub279';
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let video22 = await videoWithData();
+let textureView147 = texture65.createView({label: '\u{1f7cb}\u0bbd\u66f2', mipLevelCount: 1, baseArrayLayer: 175, arrayLayerCount: 118});
+let sampler63 = device1.createSampler({
+  label: '\ub2fe\u{1fc28}\ub81e\u1410\u0ddc\uea03\u0362\uc5ac\u03f6',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.39,
+});
+try {
+computePassEncoder51.setBindGroup(6, bindGroup26, new Uint32Array(6622), 2834, 0);
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(1, 3, 3, 0);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(27, 67);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer26, 63_289_496);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer23, 87_838_050);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer23, 'uint32', 32976, 16926);
+} catch {}
+try {
+renderBundleEncoder74.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(4, bindGroup17, new Uint32Array(768), 218, 0);
+} catch {}
+try {
+renderBundleEncoder64.setIndexBuffer(buffer23, 'uint32');
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(1, buffer14, 0, 3048);
+} catch {}
+try {
+buffer18.destroy();
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder121.copyTextureToBuffer({
+  texture: texture57,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2356 */
+  offset: 2356,
+  rowsPerImage: 223,
+  buffer: buffer16,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 28256, new Int16Array(22745), 2834, 632);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 64, depthOrArrayLayers: 1264}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 24, y: 5 },
+  flipY: true,
+}, {
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 3, y: 4, z: 172},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 10, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let pipeline103 = device1.createComputePipeline({
+  label: '\u4143\u{1fcfa}\uf093\ue8d1',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let imageBitmap29 = await createImageBitmap(videoFrame18);
+let renderPassEncoder42 = commandEncoder121.beginRenderPass({
+  label: '\u{1f686}\u{1fd96}\u060a\u0595\u32ab\u7d64\u{1fe75}\uf7d5\u1260\ua102\u{1fe74}',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 226.5, g: -174.1, b: -967.6, a: -656.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 746.4, g: 546.9, b: 732.1, a: 841.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView85,
+  depthSlice: 0,
+  clearValue: { r: -348.2, g: -610.2, b: 634.5, a: 882.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet50,
+  maxDrawCount: 1086054530,
+});
+let sampler64 = device1.createSampler({
+  label: '\u0b01\u{1f895}\u{1fbfe}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.25,
+  lodMaxClamp: 79.55,
+});
+try {
+computePassEncoder32.setPipeline(pipeline98);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup36, []);
+} catch {}
+try {
+renderPassEncoder21.draw(178, 29, 570_421_423, 55_539_974);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer23, 304_417_802);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(5, bindGroup35, new Uint32Array(4835), 4148, 0);
+} catch {}
+try {
+commandEncoder125.copyBufferToBuffer(buffer22, 65240, buffer26, 6536, 4400);
+dissociateBuffer(device1, buffer22);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+renderPassEncoder41.pushDebugGroup('\u037e');
+} catch {}
+let pipeline104 = await device1.createComputePipelineAsync({
+  label: '\u{1fbb7}\u7ed6\u28e0\u0b8c\u0669\u6e2a\u0f2e\ud94f\u0412\u160f',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter2.label = '\u089c\ub36b\u0b5c\udb18\u04e9';
+} catch {}
+offscreenCanvas0.width = 2859;
+let commandEncoder127 = device2.createCommandEncoder({label: '\u0dcd\u0b01\u0422\u0215\u{1fa23}'});
+let renderBundleEncoder81 = device2.createRenderBundleEncoder({
+  label: '\u{1fb3d}\u684f\u0d9c\u{1ff34}\u9f7a\u{1f89f}\uc536\u{1fe64}\u8ec5\uc5c3',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder81.setBindGroup(3, bindGroup41, new Uint32Array(883), 56, 0);
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(buffer24, 182272, buffer28, 6184, 7740);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer28);
+} catch {}
+let commandEncoder128 = device1.createCommandEncoder();
+let textureView148 = texture43.createView({
+  label: '\u009b\uc187\u33c9\u0bdd\u07fe\u7ba1\u9174\u{1faa7}',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 70,
+  arrayLayerCount: 88,
+});
+let renderPassEncoder43 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -72.17, g: 394.1, b: -537.6, a: 220.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 153.7, g: 501.1, b: -681.6, a: -18.29, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView119,
+  depthSlice: 0,
+  clearValue: { r: -708.5, g: -112.9, b: -582.2, a: -794.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+});
+try {
+renderPassEncoder21.beginOcclusionQuery(2712);
+} catch {}
+try {
+renderPassEncoder22.setViewport(1.192, 4.446, 2.188, 3.364, 0.7867, 0.8506);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer26, 1_240_971_253);
+} catch {}
+try {
+renderBundleEncoder67.setIndexBuffer(buffer23, 'uint32', 51056, 1508);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(3945, undefined, 0, 1290939323);
+} catch {}
+try {
+renderPassEncoder41.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageData16);
+let imageData27 = new ImageData(132, 200);
+let imageData28 = new ImageData(92, 140);
+let commandEncoder129 = device2.createCommandEncoder({label: '\u0ebe\uf39b\u0aaa\u68a1\u3f96\u0735\u{1f804}\u{1f9fa}'});
+let querySet53 = device2.createQuerySet({type: 'occlusion', count: 1625});
+let texture66 = device2.createTexture({
+  label: '\u8635\u0d24\u01ae\uca9d\u0772',
+  size: [28],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderBundleEncoder79.setBindGroup(1, bindGroup39);
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(568, 928);
+try {
+offscreenCanvas41.getContext('webgl');
+} catch {}
+let commandEncoder130 = device1.createCommandEncoder({label: '\u{1f754}\u1757\u{1fe2f}\u0df0\u6fe9'});
+let querySet54 = device1.createQuerySet({label: '\uf8ce\u{1f6b3}\u367e\u{1fb6a}\u0bde\u7a71', type: 'occlusion', count: 101});
+let textureView149 = texture59.createView({label: '\u87b3\u0f20\u4161\u0b77\u{1f7d7}\u6fe2\uf731', arrayLayerCount: 1});
+let renderPassEncoder44 = commandEncoder128.beginRenderPass({
+  label: '\u09b2\uf0b9\u04ce\u0200\u57ac\u8baf',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -51.73, g: -551.2, b: 201.5, a: 906.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 672.4, g: 358.4, b: 460.8, a: 570.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView95,
+  depthSlice: 0,
+  clearValue: { r: -818.2, g: 15.99, b: 652.6, a: 326.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet39,
+});
+try {
+renderPassEncoder43.setBindGroup(4, bindGroup23);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(4, bindGroup32);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer22, 41840, buffer26, 5120, 2072);
+dissociateBuffer(device1, buffer22);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder130.copyTextureToBuffer({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4364 */
+  offset: 4360,
+  buffer: buffer14,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+renderBundleEncoder65.insertDebugMarker('\u{1f96d}');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas18,
+  origin: { x: 149, y: 44 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 2,
+  origin: {x: 1, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline105 = await promise41;
+try {
+  await promise40;
+} catch {}
+let video23 = await videoWithData();
+let imageBitmap31 = await createImageBitmap(imageData16);
+try {
+window.someLabel = texture53.label;
+} catch {}
+let bindGroup42 = device2.createBindGroup({label: '\ua4b3\u022e\u3529\u0cd4\u89a0\u9895\u0961\uf12c', layout: bindGroupLayout34, entries: []});
+let commandEncoder131 = device2.createCommandEncoder();
+let computePassEncoder60 = commandEncoder106.beginComputePass();
+try {
+renderBundleEncoder81.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+commandEncoder105.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 32624 */
+  offset: 32624,
+  buffer: buffer30,
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder131.clearBuffer(buffer25, 3292);
+dissociateBuffer(device2, buffer25);
+} catch {}
+let commandEncoder132 = device1.createCommandEncoder({label: '\u8c62\u00ba\u627c\u09fe\u0504\ub6f6\uf553\u4fc7\ub8ff\u080e'});
+let querySet55 = device1.createQuerySet({type: 'occlusion', count: 2406});
+let texture67 = device1.createTexture({
+  label: '\u{1fb3a}\u{1fca6}\u{1fa08}\u6238\u0ca9\u{1fece}',
+  size: [96, 128, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder45 = commandEncoder132.beginRenderPass({
+  label: '\u0431\u0bb5\uf878\udb4d\u8b9e\u{1fa88}\u{1f987}\u7fa1',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 299.1, g: 918.9, b: 647.4, a: -295.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: -809.6, g: 634.6, b: -788.1, a: 453.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView119,
+  depthSlice: 0,
+  clearValue: { r: -941.5, g: -460.4, b: 36.88, a: -424.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 247543170,
+});
+try {
+renderPassEncoder45.setBindGroup(6, bindGroup34, new Uint32Array(3130), 2486, 0);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder130.clearBuffer(buffer17);
+dissociateBuffer(device1, buffer17);
+} catch {}
+let promise42 = device1.queue.onSubmittedWorkDone();
+let pipeline106 = await device1.createRenderPipelineAsync({
+  label: '\u766c\u836d',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg32float'}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'replace'},
+    stencilWriteMask: 3297471864,
+    depthBias: -2004466368,
+    depthBiasSlopeScale: 508.36188087668916,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1068,
+        attributes: [
+          {format: 'sint32', offset: 8, shaderLocation: 22},
+          {format: 'uint16x4', offset: 0, shaderLocation: 26},
+          {format: 'sint8x4', offset: 232, shaderLocation: 23},
+          {format: 'unorm16x2', offset: 60, shaderLocation: 1},
+          {format: 'sint32x3', offset: 44, shaderLocation: 17},
+          {format: 'uint32x3', offset: 112, shaderLocation: 8},
+          {format: 'uint16x2', offset: 36, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 368, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 192, shaderLocation: 20},
+          {format: 'snorm16x4', offset: 328, shaderLocation: 9},
+          {format: 'float16x4', offset: 16, shaderLocation: 5},
+          {format: 'uint32x2', offset: 16, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 380, shaderLocation: 0},
+          {format: 'float32', offset: 256, shaderLocation: 7},
+          {format: 'uint32', offset: 204, shaderLocation: 18},
+          {format: 'float16x2', offset: 36, shaderLocation: 13},
+          {format: 'sint8x2', offset: 258, shaderLocation: 10},
+          {format: 'sint32x3', offset: 60, shaderLocation: 2},
+          {format: 'sint32x2', offset: 36, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 232, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 304, shaderLocation: 24},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 6},
+          {format: 'sint16x2', offset: 360, shaderLocation: 4},
+          {format: 'float32x2', offset: 880, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 192,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 32, shaderLocation: 14}],
+      },
+      {
+        arrayStride: 1236,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 520, shaderLocation: 11}],
+      },
+      {arrayStride: 1292, attributes: [{format: 'uint8x2', offset: 2, shaderLocation: 16}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back'},
+});
+let canvas28 = document.createElement('canvas');
+try {
+gpuCanvasContext33.unconfigure();
+} catch {}
+offscreenCanvas27.height = 1901;
+let querySet56 = device2.createQuerySet({label: '\u045d\u0efd\u3f7d\uedcc\u084a\u8710\u6274\u{1f720}\u98af', type: 'occlusion', count: 736});
+let computePassEncoder61 = commandEncoder124.beginComputePass();
+let renderBundleEncoder82 = device2.createRenderBundleEncoder({
+  label: '\u5a7b\u903e\ua8a1\u5b03\u{1f85d}\u1460\u034f\ubfc4\u0518\u062a\u2334',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle87 = renderBundleEncoder77.finish({label: '\ua53e\u{1fb9b}\u7db2\ucd60\u{1fa6f}'});
+let externalTexture66 = device2.importExternalTexture({
+  label: '\u0aba\u0f60\u8368\u{1f75d}\u4e60\u9ef7\u0b89\u8748',
+  source: video19,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder81.setBindGroup(0, bindGroup41);
+} catch {}
+let arrayBuffer18 = buffer24.getMappedRange(33840, 54812);
+let canvas29 = document.createElement('canvas');
+try {
+canvas28.getContext('webgl2');
+} catch {}
+let commandEncoder133 = device3.createCommandEncoder({label: '\u1f82\u845e\ued65\u{1fd6a}\uf4e7\u3335\u75f3\u{1fba4}'});
+let querySet57 = device3.createQuerySet({label: '\u05f9\u{1f738}\u18ee\u854b\u143e\u{1fea9}\u032f\u{1f7b9}', type: 'occlusion', count: 4090});
+let externalTexture67 = device3.importExternalTexture({label: '\u{1fe60}\ude32\u4647\ue357\u6570\u06f8\u098c', source: videoFrame18, colorSpace: 'srgb'});
+try {
+renderBundleEncoder71.setVertexBuffer(8345, undefined, 2469935848, 1211343566);
+} catch {}
+try {
+commandEncoder112.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 11, y: 8, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 19, y: 11, z: 17},
+  aspect: 'all',
+},
+{width: 29, height: 81, depthOrArrayLayers: 3});
+} catch {}
+let img27 = await imageWithData(295, 227, '#6570847d', '#1f5f5ee7');
+let videoFrame38 = new VideoFrame(video15, {timestamp: 0});
+let commandEncoder134 = device2.createCommandEncoder({label: '\u5e01\u{1fc27}\ucdf9'});
+try {
+renderBundleEncoder82.setVertexBuffer(6091, undefined);
+} catch {}
+try {
+commandEncoder127.clearBuffer(buffer28);
+dissociateBuffer(device2, buffer28);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 141388, new Int16Array(39870), 25782);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 4_612_967 */
+{offset: 270, bytesPerRow: 299, rowsPerImage: 302}, {width: 6, height: 26, depthOrArrayLayers: 52});
+} catch {}
+let gpuCanvasContext40 = canvas29.getContext('webgpu');
+let imageData29 = new ImageData(68, 132);
+let buffer31 = device1.createBuffer({
+  label: '\u{1fc01}\u13c7\u{1fd7b}\u66bb\ufaaa\u35a2\u5637\u957c',
+  size: 63069,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture68 = device1.createTexture({
+  label: '\u0c1f\u4909\u{1f614}\u5eac\u{1fd61}\u0528\u7acd\u{1fda6}\ub2f1\u7bfe\uca7f',
+  size: [12, 16, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler65 = device1.createSampler({
+  label: '\u3f80\u544e\u0b7b\u92f8',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 23.29,
+  compare: 'never',
+});
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder41.setStencilReference(3579);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer19, 225_732_145);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer13, 739_343_478);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer19, 0, 37787);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(412, undefined, 0, 1956845772);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 59},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 39, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 2, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 7, y: 26 },
+  flipY: false,
+}, {
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let videoFrame39 = new VideoFrame(offscreenCanvas35, {timestamp: 0});
+let pipelineLayout15 = device2.createPipelineLayout({label: '\ue825\u00ac', bindGroupLayouts: []});
+let commandEncoder135 = device2.createCommandEncoder({label: '\u{1fbcb}\u0222\u{1fac3}\u5269\u{1f86d}\u2cbf'});
+let texture69 = device2.createTexture({
+  label: '\u0222\u0a57\u{1f66b}\u0601\u0aa6\u048b',
+  size: {width: 7, height: 4, depthOrArrayLayers: 202},
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32float'],
+});
+let textureView150 = texture60.createView({baseMipLevel: 0});
+let renderBundleEncoder83 = device2.createRenderBundleEncoder({
+  label: '\u2e3b\ua63a\u8b59',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+});
+try {
+commandEncoder127.copyBufferToBuffer(buffer24, 142680, buffer25, 101436, 12828);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer25);
+} catch {}
+let shaderModule15 = device1.createShaderModule({
+  label: '\u6580\u8db3\u573d\u{1fde1}\u0638\u9d88',
+  code: `@group(1) @binding(154)
+var<storage, read_write> global5: array<u32>;
+@group(4) @binding(4560)
+var<storage, read_write> local6: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(22) f0: vec3<f16>,
+  @location(7) f1: vec3<f32>,
+  @location(13) f2: vec4<u32>,
+  @location(2) f3: vec4<f16>,
+  @location(1) f4: u32
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<f16>, @location(12) a1: u32, @location(6) a2: vec2<i32>, @location(14) a3: vec4<f16>, @location(17) a4: f16, @location(26) a5: f16, @location(23) a6: vec3<i32>, @location(9) a7: vec2<u32>, @builtin(vertex_index) a8: u32, @location(25) a9: f16, @location(11) a10: vec2<i32>, @location(4) a11: vec3<f32>, @location(19) a12: vec2<i32>, @location(15) a13: vec3<f16>, a14: S15, @location(8) a15: u32, @builtin(instance_index) a16: u32, @location(0) a17: vec3<f16>, @location(5) a18: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer32 = device1.createBuffer({
+  label: '\u7b96\u4b19\u{1ffdb}\u0d7d\u3d3e\u709e',
+  size: 23774,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView151 = texture62.createView({
+  label: '\u09ed\u655c\u{1f99b}\u0cbe\u8a58',
+  format: 'rgba32float',
+  baseArrayLayer: 75,
+  arrayLayerCount: 75,
+});
+let renderBundle88 = renderBundleEncoder34.finish();
+try {
+computePassEncoder50.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(4, bindGroup37);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle72, renderBundle84, renderBundle51]);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: 338.0, g: -773.2, b: 705.2, a: 787.8, });
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(37);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer19, 'uint32', 74376);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer19);
+} catch {}
+try {
+renderBundleEncoder78.setIndexBuffer(buffer19, 'uint32', 335848, 36421);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(5, buffer19);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer18, 23420, buffer21, 65576, 1304);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder130.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3184 */
+  offset: 1216,
+  bytesPerRow: 256,
+  buffer: buffer31,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer2), /* required buffer size: 556 */
+{offset: 556}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline107 = device1.createRenderPipeline({
+  label: '\u5586\u{1f7cf}\u3f10\u0ed2\u{1f677}\u88d3\ue668\u7d83\u{1ff47}\ubefd\u92b7',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float'}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-wrap',
+    },
+    depthBias: -733819323,
+    depthBiasClamp: 194.9373030329462,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1412,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 260, shaderLocation: 21},
+          {format: 'sint32', offset: 388, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 264,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 0, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 26},
+          {format: 'float32x3', offset: 12, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 36, shaderLocation: 9},
+          {format: 'sint32x3', offset: 0, shaderLocation: 12},
+          {format: 'uint16x4', offset: 4, shaderLocation: 13},
+          {format: 'float32x2', offset: 48, shaderLocation: 20},
+          {format: 'sint8x2', offset: 18, shaderLocation: 8},
+          {format: 'uint8x2', offset: 10, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 14},
+          {format: 'sint32x3', offset: 68, shaderLocation: 19},
+          {format: 'uint32x3', offset: 0, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 7},
+          {format: 'sint32x3', offset: 16, shaderLocation: 23},
+          {format: 'snorm8x4', offset: 60, shaderLocation: 4},
+          {format: 'float32', offset: 8, shaderLocation: 0},
+          {format: 'sint8x2', offset: 32, shaderLocation: 25},
+          {format: 'float32x3', offset: 4, shaderLocation: 6},
+          {format: 'uint32x3', offset: 0, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 140, shaderLocation: 1},
+          {format: 'uint16x4', offset: 36, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 24, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise42;
+} catch {}
+gc();
+let img28 = await imageWithData(92, 169, '#69618e3b', '#6b7762c3');
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(438, 263);
+let bindGroup43 = device1.createBindGroup({layout: bindGroupLayout20, entries: []});
+let pipelineLayout16 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout21, bindGroupLayout27]});
+let commandEncoder136 = device1.createCommandEncoder({label: '\u07c2\u6c4b\u{1fa32}\u0aca\uf4a3'});
+let texture70 = device1.createTexture({
+  label: '\u5447\u033c',
+  size: {width: 12, height: 16, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView152 = texture37.createView({label: '\u0698\u04d4\u{1ff4d}\ud69c'});
+let computePassEncoder62 = commandEncoder136.beginComputePass({label: '\ued26\udb7f\u{1f67e}\uc1a1\u76b5\u4ebd'});
+let externalTexture68 = device1.importExternalTexture({label: '\u06e2\u2a68\u0b16\u016a\u{1f6a9}\u945c', source: videoFrame15});
+try {
+computePassEncoder33.setPipeline(pipeline96);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(2291);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder45.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder43.setViewport(1.630, 0.5643, 1.614, 5.990, 0.3343, 0.8063);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer31, 54_688_258);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(7, buffer14, 54560, 4044);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 86, y: 2 },
+  flipY: false,
+}, {
+  texture: texture37,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas30 = document.createElement('canvas');
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\udca0\ua2f2\u{1ffd8}\u{1f771}',
+  bindGroupLayouts: [bindGroupLayout31, bindGroupLayout26, bindGroupLayout30, bindGroupLayout30, bindGroupLayout33],
+});
+let commandEncoder137 = device1.createCommandEncoder({label: '\u351b\u0d0a\u9e23\u0ba4\u0c5c'});
+let querySet58 = device1.createQuerySet({label: '\u9887\u0169\u023d\ubf9d\ub99b\u{1f938}\ub8c8', type: 'occlusion', count: 1406});
+try {
+renderPassEncoder45.setBlendConstant({ r: -959.4, g: -719.9, b: 581.2, a: -478.7, });
+} catch {}
+try {
+renderPassEncoder21.draw(4, 9, 2_790_229_265, 156_563_319);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(11, 200, 106_412_314, 396_001_538);
+} catch {}
+try {
+renderBundleEncoder74.setIndexBuffer(buffer19, 'uint16');
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer18, 15008, buffer21, 48744, 1052);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder130.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8304 */
+  offset: 4956,
+  bytesPerRow: 256,
+  buffer: buffer16,
+}, {width: 10, height: 14, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+gpuCanvasContext40.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline108 = await device1.createRenderPipelineAsync({
+  label: '\u182a\u{1fc91}\u0447\ua56d\u{1fd8b}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'zero'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32float'}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3652,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 1000, shaderLocation: 0},
+          {format: 'sint8x4', offset: 480, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 272, shaderLocation: 6},
+          {format: 'sint32x4', offset: 736, shaderLocation: 3},
+          {format: 'float32x3', offset: 16, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 360, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 232, shaderLocation: 13},
+          {format: 'uint8x2', offset: 178, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 420, shaderLocation: 7},
+          {format: 'uint32x3', offset: 28, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 2292, shaderLocation: 9},
+          {format: 'sint16x2', offset: 436, shaderLocation: 2},
+          {format: 'uint32x2', offset: 1312, shaderLocation: 19},
+          {format: 'sint8x4', offset: 848, shaderLocation: 14},
+          {format: 'sint32', offset: 880, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 56, shaderLocation: 15},
+          {format: 'uint32', offset: 856, shaderLocation: 18},
+          {format: 'sint8x4', offset: 1392, shaderLocation: 4},
+          {format: 'uint32x2', offset: 20, shaderLocation: 16},
+          {format: 'float32x3', offset: 496, shaderLocation: 21},
+          {format: 'uint16x2', offset: 920, shaderLocation: 26},
+          {format: 'sint32x3', offset: 1296, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 1892,
+        attributes: [
+          {format: 'sint32x2', offset: 132, shaderLocation: 10},
+          {format: 'float32x3', offset: 260, shaderLocation: 5},
+          {format: 'uint16x4', offset: 16, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 104, attributes: []},
+      {arrayStride: 456, stepMode: 'instance', attributes: []},
+      {arrayStride: 360, attributes: []},
+      {arrayStride: 2240, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1216,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 188, shaderLocation: 25},
+          {format: 'float32', offset: 212, shaderLocation: 24},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(img9);
+let canvas31 = document.createElement('canvas');
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  label: '\u1cc4\u6344\u{1f99f}\u5546',
+  entries: [{binding: 2563, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }}],
+});
+let texture71 = device1.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16float', 'r16float'],
+});
+let renderPassEncoder46 = commandEncoder137.beginRenderPass({
+  label: '\u0adf\u0280\uf2e6',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 158.6, g: 451.1, b: -614.9, a: 657.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView64, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}, {
+  view: textureView119,
+  depthSlice: 0,
+  clearValue: { r: 425.3, g: 209.5, b: -440.5, a: 885.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet35,
+  maxDrawCount: 1204108646,
+});
+let sampler66 = device1.createSampler({
+  label: '\u0d3b\u{1fb23}\u05ff\u0d3a\u0f8c\u5f9b\u{1f9db}\u1eac\uda9b\ub27b\u3e08',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.36,
+  lodMaxClamp: 89.25,
+  compare: 'greater',
+});
+try {
+computePassEncoder45.setPipeline(pipeline74);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(2242);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer27, 1_505_266_077);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer15, 754_583_548);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer15, 59072, buffer21, 43236, 16168);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder130.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17610 */
+  offset: 17610,
+  buffer: buffer16,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer16);
+} catch {}
+let promise43 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap16,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+adapter3.label = '\ua688\u{1fc4c}\u5401\u324e\ucf63\ub660\u34b8';
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let buffer33 = device2.createBuffer({size: 64092, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let commandEncoder138 = device2.createCommandEncoder({label: '\u3ee1\u7c40\u9567\u8456\u0d7c'});
+let textureView153 = texture61.createView({
+  label: '\u697c\u040c\uc6cb\u01f0\uc564\ua85e\u35fc\u0b5d\uea90',
+  dimension: '2d-array',
+  format: 'rg32float',
+  baseArrayLayer: 0,
+});
+let externalTexture69 = device2.importExternalTexture({
+  label: '\u{1fbd7}\u71a6\ud411\uc325\u{1f8e2}\u0c5b\u255f\u18e8\u{1fbfc}\uf3f2\u{1fb17}',
+  source: videoFrame13,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder81.setBindGroup(2, bindGroup41, new Uint32Array(5184), 388, 0);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer28);
+dissociateBuffer(device2, buffer28);
+} catch {}
+try {
+commandEncoder131.insertDebugMarker('\u0b60');
+} catch {}
+try {
+window.someLabel = externalTexture67.label;
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(925, 847);
+let shaderModule16 = device1.createShaderModule({
+  label: '\uaa09\ua3db\u1942\uf975\u5645\ua37a',
+  code: `@group(1) @binding(154)
+var<storage, read_write> local7: array<u32>;
+
+@compute @workgroup_size(3, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @location(33) f0: i32,
+  @location(10) f1: vec2<i32>,
+  @location(14) f2: vec3<f16>,
+  @location(42) f3: vec2<i32>,
+  @location(13) f4: f16,
+  @location(22) f5: u32,
+  @location(8) f6: vec4<i32>,
+  @builtin(sample_mask) f7: u32,
+  @location(28) f8: vec4<i32>,
+  @location(0) f9: vec3<f32>,
+  @location(12) f10: f32,
+  @builtin(front_facing) f11: bool,
+  @location(38) f12: vec2<u32>,
+  @location(27) f13: vec2<f16>,
+  @builtin(sample_index) f14: u32,
+  @location(32) f15: vec4<f16>,
+  @location(44) f16: vec2<f32>,
+  @location(4) f17: vec4<f32>,
+  @location(16) f18: vec3<f16>,
+  @builtin(position) f19: vec4<f32>,
+  @location(25) f20: vec3<f16>,
+  @location(9) f21: f32,
+  @location(21) f22: vec3<u32>,
+  @location(41) f23: vec3<u32>,
+  @location(5) f24: vec3<u32>,
+  @location(35) f25: i32,
+  @location(6) f26: f32,
+  @location(26) f27: vec4<f32>,
+  @location(43) f28: vec4<i32>,
+  @location(31) f29: vec2<f16>,
+  @location(19) f30: i32,
+  @location(3) f31: f16,
+  @location(11) f32: i32,
+  @location(15) f33: vec4<u32>,
+  @location(39) f34: vec4<u32>,
+  @location(18) f35: vec2<i32>,
+  @location(7) f36: vec3<u32>,
+  @location(36) f37: vec2<u32>,
+  @location(34) f38: f32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(23) a0: vec2<f32>, @location(1) a1: vec2<u32>, a2: S17) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(15) f0: vec4<f16>,
+  @location(25) f1: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(39) f122: vec4<u32>,
+  @location(14) f123: vec3<f16>,
+  @location(21) f124: vec3<u32>,
+  @location(23) f125: vec2<f32>,
+  @location(26) f126: vec4<f32>,
+  @location(1) f127: vec2<u32>,
+  @location(27) f128: vec2<f16>,
+  @location(8) f129: vec4<i32>,
+  @location(36) f130: vec2<u32>,
+  @location(32) f131: vec4<f16>,
+  @location(28) f132: vec4<i32>,
+  @location(24) f133: vec4<i32>,
+  @location(9) f134: f32,
+  @location(33) f135: i32,
+  @location(40) f136: i32,
+  @location(47) f137: vec3<i32>,
+  @location(34) f138: f32,
+  @location(38) f139: vec2<u32>,
+  @location(37) f140: vec4<u32>,
+  @location(3) f141: f16,
+  @location(43) f142: vec4<i32>,
+  @location(19) f143: i32,
+  @location(18) f144: vec2<i32>,
+  @location(42) f145: vec2<i32>,
+  @location(15) f146: vec4<u32>,
+  @location(4) f147: vec4<f32>,
+  @location(16) f148: vec3<f16>,
+  @location(31) f149: vec2<f16>,
+  @location(30) f150: f16,
+  @location(7) f151: vec3<u32>,
+  @location(35) f152: i32,
+  @location(25) f153: vec3<f16>,
+  @location(10) f154: vec2<i32>,
+  @location(22) f155: u32,
+  @location(12) f156: f32,
+  @location(13) f157: f16,
+  @location(5) f158: vec3<u32>,
+  @location(6) f159: f32,
+  @location(41) f160: vec3<u32>,
+  @location(11) f161: i32,
+  @location(44) f162: vec2<f32>,
+  @builtin(position) f163: vec4<f32>,
+  @location(0) f164: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec3<f32>, @location(23) a1: vec4<f16>, @location(14) a2: f32, @location(12) a3: vec3<i32>, @location(9) a4: i32, a5: S16, @location(1) a6: vec4<f32>, @location(5) a7: vec2<f16>, @location(19) a8: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup44 = device1.createBindGroup({
+  label: '\u{1fd8e}\uce09\u{1f6c5}',
+  layout: bindGroupLayout27,
+  entries: [{binding: 154, resource: sampler65}],
+});
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup38, new Uint32Array(6958), 4777, 0);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer13, 52696, buffer16, 14488, 10236);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder68.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 707 */
+{offset: 339, rowsPerImage: 133}, {width: 46, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise43;
+} catch {}
+let imageBitmap32 = await createImageBitmap(imageData26);
+let bindGroup45 = device1.createBindGroup({label: '\u6b0d\u0ebb', layout: bindGroupLayout20, entries: []});
+let renderPassEncoder47 = commandEncoder130.beginRenderPass({
+  label: '\u0ddf\ueb9b\uaa0f\u55dd\u26dd\ub0fc\u{1f6f0}',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 516.5, g: 356.4, b: -560.3, a: -815.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView64, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}, {
+  view: textureView95,
+  depthSlice: 0,
+  clearValue: { r: -142.7, g: -517.5, b: 525.5, a: -462.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 69723782,
+});
+let renderBundleEncoder84 = device1.createRenderBundleEncoder({
+  label: '\ud20a\u07c3\u{1fd4d}\u0d40\u3b60\ud166\u8adc\u05f0\u01b5\u7d06\u51f1',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+});
+let externalTexture70 = device1.importExternalTexture({source: videoFrame26});
+try {
+renderPassEncoder40.setBlendConstant({ r: 513.5, g: -951.8, b: 492.5, a: -876.5, });
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer32, 'uint16', 13124, 3220);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(6, bindGroup37);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame40 = new VideoFrame(offscreenCanvas6, {timestamp: 0});
+try {
+canvas30.getContext('webgpu');
+} catch {}
+let texture72 = gpuCanvasContext40.getCurrentTexture();
+let textureView154 = texture60.createView({label: '\u7ca8\uca12\uf6cf\u0703\u{1f93b}\ubb35\ub01b\u6562\u48a2\ua2a7\u03e8'});
+let computePassEncoder63 = commandEncoder127.beginComputePass({});
+let externalTexture71 = device2.importExternalTexture({label: '\uc0a0\uff7d\u1db7\uac47', source: videoFrame22, colorSpace: 'srgb'});
+try {
+renderBundleEncoder83.setVertexBuffer(5646, undefined, 0, 1127976678);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 2, y: 6, z: 35},
+  aspect: 'all',
+}, new DataView(arrayBuffer6), /* required buffer size: 267_254 */
+{offset: 414, bytesPerRow: 416, rowsPerImage: 213}, {width: 46, height: 3, depthOrArrayLayers: 4});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -846.9, g: 96.30, b: -53.09, a: -650.8, });
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(405, 378);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline57);
+} catch {}
+try {
+renderBundleEncoder50.insertDebugMarker('\u37c9');
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer29, commandBuffer27]);
+} catch {}
+let pipeline109 = await device1.createRenderPipelineAsync({
+  label: '\u6e5f\u9edf\u8bfc\u0e48\u2068\u0b54\u0f22',
+  layout: pipelineLayout17,
+  multisample: {},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 156, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 4024,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 112, shaderLocation: 6},
+          {format: 'sint32', offset: 1148, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 582, shaderLocation: 21},
+          {format: 'uint32x4', offset: 1068, shaderLocation: 19},
+          {format: 'float32x3', offset: 528, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 1204,
+        attributes: [
+          {format: 'sint16x4', offset: 220, shaderLocation: 22},
+          {format: 'unorm16x2', offset: 164, shaderLocation: 1},
+          {format: 'float32x3', offset: 204, shaderLocation: 25},
+          {format: 'sint32x2', offset: 276, shaderLocation: 10},
+          {format: 'sint16x2', offset: 448, shaderLocation: 3},
+          {format: 'uint16x2', offset: 272, shaderLocation: 8},
+          {format: 'sint16x4', offset: 0, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 1256,
+        attributes: [
+          {format: 'sint32', offset: 416, shaderLocation: 2},
+          {format: 'uint32x3', offset: 52, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 968,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 12, shaderLocation: 24},
+          {format: 'uint32x4', offset: 268, shaderLocation: 26},
+          {format: 'sint16x2', offset: 180, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 368, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 2020,
+        attributes: [
+          {format: 'unorm8x4', offset: 44, shaderLocation: 15},
+          {format: 'sint8x4', offset: 420, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 1112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 140, shaderLocation: 13},
+          {format: 'uint32x4', offset: 188, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 0, shaderLocation: 11},
+          {format: 'float16x2', offset: 376, shaderLocation: 0},
+          {format: 'uint32x4', offset: 60, shaderLocation: 16},
+          {format: 'float32x2', offset: 44, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let bindGroup46 = device2.createBindGroup({label: '\u0e17\u05db\u71a6\u5a01', layout: bindGroupLayout34, entries: []});
+let querySet59 = device2.createQuerySet({type: 'occlusion', count: 2415});
+try {
+commandEncoder131.copyBufferToBuffer(buffer24, 194248, buffer33, 13488, 10856);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer33);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5548 */
+  offset: 5548,
+  buffer: buffer24,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer24);
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let gpuCanvasContext41 = offscreenCanvas42.getContext('webgpu');
+let textureView155 = texture61.createView({label: '\u57b6\uaa9e\u{1ff97}\u0c64\ud4c2\u0697\u2c33\u{1f886}\u86b0\u3ce6'});
+let renderBundleEncoder85 = device2.createRenderBundleEncoder({
+  label: '\u{1ff19}\u7da9',
+  colorFormats: ['rg32float', 'rg32sint', 'r32float', 'r8sint', 'rg32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup40, new Uint32Array(9225), 3208, 0);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+let commandEncoder139 = device2.createCommandEncoder({});
+let querySet60 = device2.createQuerySet({type: 'occlusion', count: 3768});
+let commandBuffer33 = commandEncoder138.finish({label: '\u{1fcbf}\u092f\ubb6b\uec39'});
+let textureView156 = texture72.createView({label: '\u082c\uc092\ufa0c\u00ed\uc0c2\ua305\u0bc6\uefb9', dimension: '2d-array', mipLevelCount: 1});
+try {
+commandEncoder105.copyBufferToBuffer(buffer24, 162960, buffer33, 12368, 24824);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer33);
+} catch {}
+try {
+commandEncoder131.clearBuffer(buffer33, 35312);
+dissociateBuffer(device2, buffer33);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas34,
+  origin: { x: 62, y: 4 },
+  flipY: true,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData30 = new ImageData(172, 96);
+let shaderModule17 = device1.createShaderModule({
+  label: '\u80d8\u41e9\u0dc9\u80b0',
+  code: `@group(4) @binding(4285)
+var<storage, read_write> function4: array<u32>;
+@group(0) @binding(643)
+var<storage, read_write> field7: array<u32>;
+@group(4) @binding(4361)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec2<i32>, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(37) f165: vec4<u32>,
+  @location(24) f166: vec4<f32>,
+  @builtin(position) f167: vec4<f32>,
+  @location(41) f168: vec2<u32>,
+  @location(29) f169: vec3<f32>,
+  @location(8) f170: vec4<u32>,
+  @location(28) f171: u32,
+  @location(38) f172: f16,
+  @location(22) f173: vec4<u32>,
+  @location(32) f174: vec3<u32>,
+  @location(23) f175: i32,
+  @location(45) f176: vec2<f16>,
+  @location(47) f177: vec2<u32>,
+  @location(6) f178: vec4<f32>,
+  @location(31) f179: vec2<u32>,
+  @location(40) f180: vec4<i32>,
+  @location(4) f181: vec2<f32>,
+  @location(14) f182: vec2<i32>,
+  @location(26) f183: u32,
+  @location(27) f184: vec3<f32>,
+  @location(3) f185: vec3<i32>,
+  @location(7) f186: vec4<u32>,
+  @location(42) f187: vec2<f16>,
+  @location(39) f188: f32,
+  @location(43) f189: i32,
+  @location(21) f190: f16,
+  @location(46) f191: i32,
+  @location(25) f192: vec2<i32>,
+  @location(34) f193: vec2<u32>,
+  @location(5) f194: vec4<f16>,
+  @location(12) f195: vec2<f16>,
+  @location(19) f196: vec3<u32>,
+  @location(33) f197: vec2<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(19) a1: vec3<f16>, @location(4) a2: vec3<i32>, @location(11) a3: vec2<u32>, @location(22) a4: f16, @location(20) a5: vec4<f32>, @location(24) a6: vec2<f16>, @location(15) a7: vec4<i32>, @location(5) a8: vec2<f16>, @builtin(instance_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup47 = device1.createBindGroup({
+  label: '\u{1fb45}\u2152\u{1fa05}\ubca5\u6311',
+  layout: bindGroupLayout27,
+  entries: [{binding: 154, resource: sampler65}],
+});
+let textureView157 = texture65.createView({
+  label: '\u{1fae3}\u0b7b\u049e\u02df\uc0a7\u7637\u03d7\u9117\u14f8\u0f5e',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 123,
+});
+let sampler67 = device1.createSampler({
+  label: '\u5af1\u033a\u0a25\uf4e7\uc8df\ud9ee\udbe0\u884b\u1ceb',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 82.26,
+  lodMaxClamp: 83.20,
+});
+try {
+computePassEncoder45.setPipeline(pipeline72);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle61, renderBundle53, renderBundle77, renderBundle52, renderBundle46]);
+} catch {}
+try {
+renderPassEncoder44.setStencilReference(862);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer19, 'uint32', 394148, 4225);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline109);
+} catch {}
+let arrayBuffer19 = buffer19.getMappedRange(444920, 508);
+try {
+buffer26.unmap();
+} catch {}
+let promise44 = device1.createRenderPipelineAsync({
+  label: '\u{1f7d0}\u{1fffb}\uad7f',
+  layout: pipelineLayout7,
+  multisample: {mask: 0x8b214bc1},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba32float', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 1561714954,
+    stencilWriteMask: 2253333985,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 264,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x4', offset: 104, shaderLocation: 25},
+          {format: 'snorm16x4', offset: 20, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 14},
+          {format: 'float32x2', offset: 12, shaderLocation: 15},
+          {format: 'sint8x2', offset: 4, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 30, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 396,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 28, shaderLocation: 21},
+          {format: 'sint32x3', offset: 92, shaderLocation: 12},
+          {format: 'sint16x2', offset: 16, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 3936, attributes: [{format: 'snorm8x2', offset: 526, shaderLocation: 23}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+adapter0.label = '\uf5c7\ue2ad\u{1fc41}\u0e14\u0148\u{1fda2}\u03d8\uddc3\u3bf6\ub743\u3554';
+} catch {}
+let bindGroupLayout36 = device2.createBindGroupLayout({
+  label: '\u7eba\u5718\u{1f91d}\u388c\u{1f996}\u8b22\u787a\uffc4',
+  entries: [
+    {binding: 105, visibility: 0, externalTexture: {}},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 752,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture73 = device2.createTexture({
+  size: {width: 28},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32sint'],
+});
+let textureView158 = texture60.createView({label: '\uba06\u0104\ub877\u0ca3\u4397\u2d14', baseArrayLayer: 0});
+let sampler68 = device2.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.25,
+  lodMaxClamp: 50.37,
+  maxAnisotropy: 11,
+});
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6744 */
+  offset: 6744,
+  bytesPerRow: 0,
+  rowsPerImage: 274,
+  buffer: buffer24,
+}, {
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 7, depthOrArrayLayers: 59});
+dissociateBuffer(device2, buffer24);
+} catch {}
+try {
+device2.queue.submit([commandBuffer32, commandBuffer31]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer19), /* required buffer size: 99_551 */
+{offset: 592, bytesPerRow: 211, rowsPerImage: 67}, {width: 6, height: 0, depthOrArrayLayers: 8});
+} catch {}
+gc();
+let imageData31 = new ImageData(80, 200);
+try {
+canvas31.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let img29 = await imageWithData(184, 105, '#9d1a0cf7', '#cc7f0880');
+let imageBitmap33 = await createImageBitmap(imageData28);
+let querySet61 = device1.createQuerySet({label: '\u0dad\u{1fe0c}\u{1fe30}\u83ff\u{1fcb9}\u0fc6', type: 'occlusion', count: 3161});
+let textureView159 = texture35.createView({
+  label: '\u01c3\u{1f8c9}\u06dc\ub218\u81a0',
+  mipLevelCount: 1,
+  baseArrayLayer: 106,
+  arrayLayerCount: 191,
+});
+try {
+renderPassEncoder37.executeBundles([renderBundle42, renderBundle88]);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer21, 536_597_361);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer19, 'uint16', 177154, 139870);
+} catch {}
+try {
+renderBundleEncoder84.setPipeline(pipeline71);
+} catch {}
+let arrayBuffer20 = buffer21.getMappedRange(65184, 1652);
+let pipeline110 = device1.createComputePipeline({
+  label: '\u{1fbaf}\u{1f7e6}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas43.getContext('2d');
+} catch {}
+try {
+buffer29.label = '\udd38\u{1fb29}\u9474';
+} catch {}
+let textureView160 = texture73.createView({label: '\u0afe\u09f7'});
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 6172, new Float32Array(33445));
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(2_541_758), /* required buffer size: 2_541_758 */
+{offset: 794, bytesPerRow: 314, rowsPerImage: 202}, {width: 19, height: 13, depthOrArrayLayers: 41});
+} catch {}
+let commandEncoder140 = device1.createCommandEncoder({label: '\u{1f9c9}\u0184\u{1f9f0}\u11a8\u{1fb18}\udee9\u02e9\u03c5\u2f04\uc219\u00d5'});
+let querySet62 = device1.createQuerySet({
+  label: '\ufda6\u0b09\u0e21\u091d\u9760\u{1fd6a}\u{1fde9}\u8c37\u{1ff85}\u{1f746}\u2ed9',
+  type: 'occlusion',
+  count: 2424,
+});
+let textureView161 = texture70.createView({label: '\u08ca\u9fd3\u09bf\u8a87\u0ca6\u772c\u{1ff2b}', mipLevelCount: 2});
+let renderPassEncoder48 = commandEncoder140.beginRenderPass({
+  label: '\u0c15\uecef\u0aa5\u0669\u{1f933}\u4fcc\u427d\uaed4\u00cb\u22d6\u7b16',
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 863.7, g: -204.8, b: -421.6, a: -954.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView64,
+  depthSlice: 0,
+  clearValue: { r: 967.0, g: 802.6, b: -163.3, a: -799.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView85,
+  depthSlice: 0,
+  clearValue: { r: 693.0, g: 208.1, b: 983.7, a: 13.74, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 1200050262,
+});
+let renderBundle89 = renderBundleEncoder68.finish({label: '\uaa1f\u{1fd87}\u0b16\u6397\u0a01\u3e09\u0136\u65b4\ubd8a\u{1fb7b}'});
+try {
+renderPassEncoder21.setBlendConstant({ r: -462.5, g: -193.0, b: -108.9, a: -981.1, });
+} catch {}
+try {
+renderPassEncoder21.draw(12, 118, 151_504_937, 244_070_694);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 1764, new BigUint64Array(6675), 3451, 912);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let img30 = await imageWithData(41, 168, '#ec80c076', '#d68dbc88');
+let buffer34 = device1.createBuffer({
+  label: '\u0b29\u{1f971}\u0fc6\ufa4e\u9ec0\uf874\ucae5\u3f1e\u5b57\u57c8\u0e93',
+  size: 163305,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let querySet63 = device1.createQuerySet({type: 'occlusion', count: 2679});
+let textureView162 = texture59.createView({label: '\u413d\u0fb4\u{1fa69}\u{1fe2c}\u1014\u042c\u7b26\u{1fb99}\u{1fc54}'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup31, new Uint32Array(2949), 789, 0);
+} catch {}
+try {
+renderPassEncoder21.draw(129);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer32, 8336, 8693);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline82);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer14, 4488, new Float32Array(56471), 24612, 4520);
+} catch {}
+let commandBuffer34 = commandEncoder129.finish({label: '\u059f\u4c17\u8f69\u6531\ub528\u08b6'});
+let texture74 = gpuCanvasContext0.getCurrentTexture();
+let textureView163 = texture48.createView({
+  label: '\uce5f\u06a9\uffc5\u8db2\u{1fd38}\u58e0\u{1fe02}\uf010\u{1fc98}\u0b46\ue48a',
+  mipLevelCount: 2,
+});
+let computePassEncoder64 = commandEncoder131.beginComputePass();
+let renderBundle90 = renderBundleEncoder83.finish({});
+try {
+renderBundleEncoder82.setVertexBuffer(255, undefined, 1880187328);
+} catch {}
+gc();
+let adapter4 = await navigator.gpu.requestAdapter({});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(359, 549);
+let promise45 = adapter2.requestAdapterInfo();
+let textureView164 = texture42.createView({label: '\u{1fdf7}\u43bb\u{1f8d7}\u3568\u0830\uc566\u3f63\ua013', baseArrayLayer: 0});
+let renderBundleEncoder86 = device1.createRenderBundleEncoder({
+  label: '\u7bac\u0849\uc956',
+  colorFormats: ['r16float', 'rg32float', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle91 = renderBundleEncoder57.finish({});
+try {
+renderPassEncoder37.setViewport(4.076, 1.562, 1.497, 1.292, 0.8084, 0.9660);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer22, 769_452_112);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer19, 0, 203472);
+} catch {}
+let pipelineLayout18 = device1.createPipelineLayout({label: '\u263c\ud64e\u{1fbec}\u01f3\ua0d3\u9c7c\ubcc2', bindGroupLayouts: [bindGroupLayout21]});
+let textureView165 = texture59.createView({label: '\u0970\u7d54\u6921\u{1fe3d}\u055e\u0c30\u0f5b\u7f17\u053a\u2ae4', mipLevelCount: 1});
+try {
+renderPassEncoder21.draw(8);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(66, 23, 279_083_323, 118_431_923, 58_399_087);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer19, 866_171);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline82);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer14);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let promise46 = buffer17.mapAsync(GPUMapMode.READ, 4856, 23256);
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext42 = offscreenCanvas44.getContext('webgpu');
+try {
+  await promise45;
+} catch {}
+let canvas32 = document.createElement('canvas');
+let img31 = await imageWithData(149, 215, '#534e7755', '#e56f53fc');
+let imageData32 = new ImageData(4, 136);
+let commandEncoder141 = device2.createCommandEncoder({label: '\u6195\u6ca9\u75a6\u0a4a\u0cb7\u0f72\u{1f917}'});
+try {
+renderBundleEncoder80.setVertexBuffer(3492, undefined, 1713433447, 2518037145);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 56560, new DataView(new ArrayBuffer(60564)));
+} catch {}
+try {
+  await promise46;
+} catch {}
+let imageBitmap34 = await createImageBitmap(canvas18);
+let offscreenCanvas45 = new OffscreenCanvas(912, 701);
+offscreenCanvas27.height = 1167;
+let imageData33 = new ImageData(100, 168);
+let gpuCanvasContext43 = canvas32.getContext('webgpu');
+let commandBuffer35 = commandEncoder105.finish({});
+let textureView166 = texture53.createView({
+  label: '\u20fc\u1408\u7b44\u200a\u{1fb79}',
+  dimension: '2d-array',
+  format: 'rg32sint',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+commandEncoder106.copyBufferToBuffer(buffer24, 138696, buffer28, 12404, 5068);
+dissociateBuffer(device2, buffer24);
+dissociateBuffer(device2, buffer28);
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2008 */
+  offset: 2008,
+  buffer: buffer30,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 10, y: 39 },
+  flipY: true,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video24 = await videoWithData();
+try {
+sampler56.label = '\u{1fb70}\u{1fe5b}\u15a2\uad35\u7eec\u604f\u6476';
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let commandEncoder142 = device2.createCommandEncoder({label: '\ucfcc\u9858\u{1f915}\u0017\u0110\u018b\ua9ca\u0fd3'});
+let querySet64 = device2.createQuerySet({label: '\u9fab\u{1fe17}\ud0b8\u{1f7d5}\uce3c', type: 'occlusion', count: 1261});
+let textureView167 = texture49.createView({
+  label: '\u05b5\u666d\u{1fef4}\u1515\u0d7c\u4b1e\u447c',
+  mipLevelCount: 1,
+  baseArrayLayer: 97,
+  arrayLayerCount: 104,
+});
+let computePassEncoder65 = commandEncoder141.beginComputePass({label: '\u074b\u014f\ufd95\ubf2b\u{1fac7}\u8d88'});
+try {
+renderBundleEncoder82.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle92 = renderBundleEncoder37.finish();
+try {
+computePassEncoder42.setPipeline(pipeline98);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(6, bindGroup31);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle92, renderBundle46, renderBundle57, renderBundle92, renderBundle64, renderBundle92]);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(2570);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer34, 957_600_697);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(7, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(6, bindGroup33, new Uint32Array(9902), 7588, 0);
+} catch {}
+let arrayBuffer21 = buffer27.getMappedRange(15848);
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer7), /* required buffer size: 862 */
+{offset: 862, rowsPerImage: 73}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 32, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData15,
+  origin: { x: 93, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let canvas33 = document.createElement('canvas');
+let gpuCanvasContext44 = canvas33.getContext('webgpu');
+let bindGroupLayout37 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+try {
+renderBundleEncoder80.setBindGroup(2, bindGroup42, new Uint32Array(3296), 671, 0);
+} catch {}
+try {
+commandEncoder142.copyTextureToBuffer({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 51864 */
+  offset: 51864,
+  buffer: buffer30,
+}, {width: 22, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer30, 138180, new DataView(new ArrayBuffer(26062)), 23283, 40);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 776 */
+{offset: 776, bytesPerRow: 280}, {width: 6, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas18,
+  origin: { x: 190, y: 66 },
+  flipY: true,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout38 = device1.createBindGroupLayout({
+  label: '\u1cb6\u7f2d\u{1f6ef}\u06dc\u{1f9d1}\u0d87\ucae1\u0235\u0f89\ub18e',
+  entries: [
+    {
+      binding: 2981,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 4574,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 5113, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let renderBundle93 = renderBundleEncoder52.finish({label: '\u0589\ueb9e\ub7c2\u5317'});
+let sampler69 = device1.createSampler({
+  label: '\u04c4\u{1fde9}\u52de\u{1fc7d}\u{1f60e}\ub41a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  lodMaxClamp: 96.76,
+  compare: 'greater',
+});
+try {
+computePassEncoder27.setBindGroup(7, bindGroup27);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(3, 6, 1, 1);
+} catch {}
+try {
+renderPassEncoder21.draw(135, 335, 1_130_684_537);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(172, 433);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer23, 466_116_171);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline57);
+} catch {}
+try {
+  await buffer26.mapAsync(GPUMapMode.READ, 9600, 264);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline111 = device1.createComputePipeline({
+  label: '\u27b6\u0857\ub31f\u7a2c\u{1fac2}\u9184\u0f33\u80dc\u00f4',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+try {
+offscreenCanvas45.getContext('webgl');
+} catch {}
+let texture75 = device1.createTexture({
+  label: '\u8f50\u06d0',
+  size: [12, 16, 1],
+  mipLevelCount: 5,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+let textureView168 = texture29.createView({label: '\u5354\u853f\u2622\u719a\ubf7f\u{1f611}\u07ab\u{1fef1}', baseMipLevel: 0});
+let renderBundle94 = renderBundleEncoder58.finish({label: '\u0d47\uc9a5\udd28'});
+let sampler70 = device1.createSampler({
+  label: '\u66b8\u{1f6a1}\u670b',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.1658,
+  maxAnisotropy: 16,
+});
+let externalTexture72 = device1.importExternalTexture({
+  label: '\u16d6\u576f\u0c44\ud26b\u3718\u{1f73d}\u0d5d\u0a92',
+  source: video11,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder46.setViewport(4.959, 2.749, 0.06019, 3.440, 0.7784, 0.9751);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(119, 68, 3_868_979, 770_090_009, 2_514_812_121);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline108);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3206 */
+  offset: 3206,
+  buffer: buffer15,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 1_348 */
+{offset: 960, bytesPerRow: 38, rowsPerImage: 263}, {width: 4, height: 11, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap34,
+  origin: { x: 134, y: 21 },
+  flipY: true,
+}, {
+  texture: texture67,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext31.unconfigure();
+} catch {}
+video13.width = 101;
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -66,7 +66,7 @@ Queue::~Queue()
 
 void Queue::ensureBlitCommandEncoder()
 {
-    if (m_blitCommandEncoder)
+    if (m_blitCommandEncoder && m_blitCommandEncoder == encoderForBuffer(m_commandBuffer))
         return;
 
     auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];


### PR DESCRIPTION
#### 4349cc0db3a610f44ceefef50588b06b826dccb5
<pre>
[WebGPU] Queue may try to encode blit operations on detached encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=274289">https://bugs.webkit.org/show_bug.cgi?id=274289</a>
&lt;radar://128202303&gt;

Reviewed by Dan Glastonbury.

ensureBlitCommandEncoder needs to ensure the encoding hasn&apos;t
ended otherwise a new blit command encoder needs to be created.

Depends on <a href="https://github.com/WebKit/WebKit/pull/28680">https://github.com/WebKit/WebKit/pull/28680</a> for the test
to pass.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274289-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274289.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::ensureBlitCommandEncoder):

Canonical link: <a href="https://commits.webkit.org/279026@main">https://commits.webkit.org/279026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cef91d57f6fb836b01573f32e3830eaba066552

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2693 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/1917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57142 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2580 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45229 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49157 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11421 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->