### PR TITLE
[WebGPU] Render / compute commands should be no-ops when the command buffer will be discarded

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2133,6 +2133,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274289.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274171.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274171.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274290.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274290.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274290-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274290-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274290.html
+++ b/LayoutTests/fast/webgpu/fuzz-274290.html
@@ -1,0 +1,19049 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u0af1\u{1ff82}\u044d\u6dd6\u0256\u0a86\u06fb\u{1f6de}',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+try {
+device0.label = '\ue37c\u8cfb\uaab3';
+} catch {}
+let commandEncoder0 = device0.createCommandEncoder();
+let querySet0 = device0.createQuerySet({label: '\u0445\u{1fae7}\u04a3', type: 'occlusion', count: 1878});
+let texture0 = device0.createTexture({
+  size: {width: 1830, height: 10, depthOrArrayLayers: 153},
+  mipLevelCount: 5,
+  format: 'astc-10x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-10x10-unorm', 'astc-10x10-unorm'],
+});
+let textureView0 = texture0.createView({
+  label: '\u1a9a\u177f\u{1fae4}\u{1fe3f}',
+  dimension: '2d',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 33,
+});
+let textureView1 = texture0.createView({
+  label: '\uf1ae\u{1f88e}\u6c49\ue0ec',
+  dimension: '2d-array',
+  format: 'astc-10x10-unorm',
+  mipLevelCount: 1,
+  baseArrayLayer: 29,
+  arrayLayerCount: 72,
+});
+let sampler0 = device0.createSampler({
+  label: '\u33b4\u3bef\u{1fd2d}\u4367\u0530',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 74.42,
+  compare: 'less',
+});
+let commandBuffer0 = commandEncoder0.finish();
+let textureView2 = texture0.createView({
+  label: '\uae5c\ud0f1\ua47a\u02fa\u{1f832}\u0ae2\u02db',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 2,
+  baseArrayLayer: 68,
+  arrayLayerCount: 64,
+});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u00c6\ufb92'});
+let sampler1 = device0.createSampler({
+  label: '\ua55b\u5184\u0f6b\u{1f771}\u{1f714}\u0173\u0371',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.18,
+  lodMaxClamp: 90.48,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u2020\u0367\u{1f8ea}\u78ff\u6653\u65f6\u{1fbf2}'});
+let textureView3 = texture0.createView({
+  label: '\u8bc8\u{1fd19}\uadc1\u4593\u8908\u{1f94b}\u0096\u0bfa',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 86,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder0.setVertexBuffer(6536, undefined);
+} catch {}
+let texture1 = device0.createTexture({
+  size: {width: 1920},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\ub63b\u080e\u9651\u01bf\u9e64\u{1f774}\u{1ff88}\u0f78\uf481\ua820',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let textureView4 = texture0.createView({
+  label: '\u4a24\u0340',
+  dimension: '2d',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 125,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+let video0 = await videoWithData();
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView5 = texture0.createView({
+  label: '\u085c\uf0ee\ub3e8\u0701\uaa6b\u08bf\u3587\u6447\u{1fd89}',
+  dimension: '2d-array',
+  format: 'astc-10x10-unorm',
+  mipLevelCount: 1,
+  baseArrayLayer: 85,
+  arrayLayerCount: 22,
+});
+let renderBundle0 = renderBundleEncoder1.finish();
+let sampler2 = device0.createSampler({
+  label: '\u50bf\ud21d\u{1fcef}\u{1fddd}\u2fa1\uf62b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 45.57,
+});
+let imageBitmap0 = await createImageBitmap(video0);
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1f686}\u{1fc87}\u326a\u0826\u33cb\u2441\ue154'});
+let texture2 = device0.createTexture({
+  label: '\u0f8f\u0738\u7f43',
+  size: {width: 68, height: 2, depthOrArrayLayers: 974},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint'],
+});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u0e44\ua4c1\u{1fde5}\u{1f8f2}\u2be1\u148a\u8505'});
+let sampler3 = device0.createSampler({
+  label: '\u057b\u{1fbe6}\u{1fec1}\ufae4\u{1f916}\u3d4d\u060b\u{1f71b}\u0538\u{1fc00}',
+  addressModeV: 'mirror-repeat',
+  lodMinClamp: 33.51,
+  lodMaxClamp: 99.90,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\ud0c2\u{1f76f}\ud59a\u2cfd\u138b', source: video0, colorSpace: 'display-p3'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet1 = device0.createQuerySet({label: '\ub42f\u2e02\u6a06', type: 'occlusion', count: 3924});
+let computePassEncoder1 = commandEncoder2.beginComputePass({label: '\u28cf\u05f0\u{1fcc8}\u49a3'});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\ub3cb\u379d\ua86a\u5261\ucaa9\uc4d8\ufe31\u20f6\u89c4\u9023'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u0549\ua851\u5e2c\u{1fb1b}\u0c70\u0335'});
+let textureView6 = texture1.createView({label: '\u0328\u{1fd2c}\u{1ffce}\u0192', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 95},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 671},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 81});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img0 = await imageWithData(233, 207, '#924ed1e4', '#bbc43a5b');
+try {
+querySet0.label = '\ue1ce\u892d\u{1fda7}\u0964\u{1f9ef}';
+} catch {}
+let querySet2 = device0.createQuerySet({label: '\u9505\u6964\ue2e6\u6415\u08af\u51d4\ub104', type: 'occlusion', count: 549});
+let commandBuffer1 = commandEncoder3.finish({label: '\u{1fb1d}\uf91b'});
+let textureView7 = texture1.createView({label: '\u{1f62c}\uceb8'});
+try {
+querySet1.label = '\u02ae\u{1fada}\u{1fdf5}\u0cea\u{1fdf0}\uf715\u3566';
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  label: '\u1806\u070c\ub403',
+  size: {width: 68, height: 2, depthOrArrayLayers: 1705},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(8200, undefined, 1299722083);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 27},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 433},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 32});
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({label: '\u7d06\u{1f844}\u09ab\u{1fb02}\u2adc\u03e7\u{1fcf1}\u81bb'});
+let texture4 = device0.createTexture({
+  label: '\u10db\u0207\u096b\ucda2',
+  size: {width: 68, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView8 = texture3.createView({mipLevelCount: 1});
+let renderBundle2 = renderBundleEncoder2.finish();
+try {
+computePassEncoder2.end();
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u590a\u84eb\u882a\u{1fe4b}\u2a2f'});
+let querySet3 = device0.createQuerySet({
+  label: '\u745a\u2ea1\ub0a0\u086f\u522e\u09ab\u1172\u{1fc08}\u3fbb\u0e5c',
+  type: 'occlusion',
+  count: 2798,
+});
+let externalTexture1 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+video0.height = 1;
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  label: '\u03ed\u{1fd8b}\u7261\u0e81\u{1f936}\u052c\uf0a7\u30c1\u0e29\u01f2\u3ea8',
+  size: [34],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView9 = texture0.createView({
+  label: '\u963b\ua4c0\u{1fa01}\u{1fdd7}\u4d0f',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 72,
+});
+let externalTexture2 = device0.importExternalTexture({
+  label: '\u0c67\u{1f845}\u{1f744}\u0921\u6d2b\uab9a\u{1fdac}',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(24)), /* required buffer size: 756 */
+{offset: 756}, {width: 28, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet4 = device0.createQuerySet({label: '\uf131\u8ad4\ucaf3\u{1f91c}\uf829\u915c', type: 'occlusion', count: 2517});
+let renderBundle3 = renderBundleEncoder0.finish({label: '\ub498\u0f8d\u012a\u0c01\udb1c\u9f18\u1e35\u{1fdd0}'});
+let externalTexture3 = device0.importExternalTexture({label: '\u535a\u341f\u76cf\uc5c7\u6e28', source: video0});
+let textureView10 = texture4.createView({
+  label: '\ub3c3\u{1f8c7}\uc530\u090b\u01a2\u0244\u{1f83e}\ub938\u75e6\u6786',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle4 = renderBundleEncoder2.finish({label: '\u4c14\u4a02'});
+let textureView11 = texture0.createView({
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 94,
+  arrayLayerCount: 5,
+});
+let img1 = await imageWithData(148, 10, '#1115dc79', '#0ccde849');
+let buffer0 = device0.createBuffer({
+  label: '\u5e71\uf835\u039b\u0397\u6279\u{1fe62}\u0422',
+  size: 163455,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let computePassEncoder3 = commandEncoder8.beginComputePass({label: '\u74d6\ubd65\u69ff\u{1fc6e}\uebe0\u0818\u0433\ua752'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u0aac\u05e2\u{1fba0}\u039f\uf7fb',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(1155, undefined, 3553919765, 95701526);
+} catch {}
+try {
+  await buffer0.mapAsync(GPUMapMode.WRITE, 7992, 36304);
+} catch {}
+let imageBitmap1 = await createImageBitmap(img0);
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1fd20}\u094d\u8c4d\uedf2'});
+let querySet5 = device0.createQuerySet({
+  label: '\u36ae\u0dea\u6d61\u{1fff2}\ue260\u0efc\u0023\u24be\u{1ff2e}\u0921',
+  type: 'occlusion',
+  count: 3477,
+});
+let sampler4 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.08,
+  lodMaxClamp: 81.22,
+  compare: 'equal',
+  maxAnisotropy: 6,
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3900 */
+  offset: 3900,
+  rowsPerImage: 207,
+  buffer: buffer0,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 1650456 */
+{offset: 189, bytesPerRow: 228, rowsPerImage: 154}, {width: 3, height: 1, depthOrArrayLayers: 48});
+} catch {}
+let externalTexture4 = device0.importExternalTexture({label: '\u4cdd\u0991\ub4f3', source: video0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder3.setVertexBuffer(2123, undefined, 0);
+} catch {}
+let imageBitmap2 = await createImageBitmap(video0);
+let buffer1 = device0.createBuffer({
+  label: '\u353c\u075f\u368b\u0242\u0ccc\u0122',
+  size: 424154,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView12 = texture2.createView({baseMipLevel: 3});
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u0766\u56db\u0e7e\u99be\u0cf0'});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 359},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(72)), /* required buffer size: 766562 */
+{offset: 100, bytesPerRow: 289, rowsPerImage: 102}, {width: 34, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let commandBuffer2 = commandEncoder5.finish({label: '\u0139\u7e9f\u{1fc62}\u{1fdbe}\u0cc0\u00ea\u872a\u2dd4'});
+let texture6 = device0.createTexture({
+  size: {width: 137, height: 4, depthOrArrayLayers: 1980},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder10.clearBuffer(buffer1, 308360, 53824);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let renderBundle5 = renderBundleEncoder0.finish({label: '\ub072\u0327\u0c5d\u{1f73c}\u6845\uc648\u09b8\u1588\u08ce\u8787\u0a92'});
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11660 */
+  offset: 11644,
+  rowsPerImage: 22,
+  buffer: buffer1,
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 105},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 9499695 */
+{offset: 159, bytesPerRow: 256, rowsPerImage: 171}, {width: 9, height: 1, depthOrArrayLayers: 218});
+} catch {}
+let canvas0 = document.createElement('canvas');
+let imageBitmap3 = await createImageBitmap(imageBitmap0);
+try {
+canvas0.getContext('webgl');
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder6.finish({label: '\u{1fbf4}\u{1f6d7}\u57b4\u0d3a\u2d8e\u9f79\u0a22\ubb1e\u1a49\ud4c6\ub75d'});
+let externalTexture5 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+commandEncoder4.resolveQuerySet(querySet1, 2406, 566, buffer1, 768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 890 */
+{offset: 890, bytesPerRow: 62, rowsPerImage: 123}, {width: 27, height: 1, depthOrArrayLayers: 0});
+} catch {}
+canvas0.width = 3186;
+gc();
+let videoFrame0 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let querySet6 = device0.createQuerySet({
+  label: '\ud012\u0d4b\u9c79\u0be5\u0521\u006b\u711b\u068e\u23d0\u0f66\u{1fb51}',
+  type: 'occlusion',
+  count: 1259,
+});
+let textureView13 = texture6.createView({label: '\ub98e\ua856\u0679\u9002\udd6c\u0829', aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder5 = commandEncoder10.beginComputePass({label: '\u008e\u8be4\u048d\u0d1b\ua538\u36c7\u{1fcb9}\u637f\u0cca\ue880'});
+try {
+device0.queue.writeBuffer(buffer1, 26608, new Int16Array(27624), 12329, 704);
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\u0ac9\u0bc4\u2c26\u{1feac}\u8fda\u2c95\u{1fb43}\u7c15\u2024\u{1f993}\u0c3d', entries: []});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\ua428\u6a09\u1ce2\u1760\u3bc9\uf347\u06cc\ub351\uc741\u{1fc85}',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(298, undefined, 0, 1470325174);
+} catch {}
+try {
+texture5.destroy();
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 250020 */
+{offset: 379, bytesPerRow: 12, rowsPerImage: 293}, {width: 5, height: 1, depthOrArrayLayers: 72});
+} catch {}
+document.body.prepend(img1);
+gc();
+let pipelineLayout0 = device0.createPipelineLayout({label: '\uc005\u7b9b\u6058\u58c3\u9f29', bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0]});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u01d1\u5d00\u62b2'});
+let renderBundle6 = renderBundleEncoder1.finish({label: '\ud439\u0d3c\u0b5b\u06bc\u0d25\u0612\u0386'});
+try {
+device0.queue.writeBuffer(buffer1, 154616, new Int16Array(56154), 8098, 3432);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 81},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 290349456 */
+{offset: 304, bytesPerRow: 1028, rowsPerImage: 184}, {width: 52, height: 1, depthOrArrayLayers: 1536});
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  label: '\u{1f940}\uf62c\u0a91\u{1fd64}\u5dd0\u0ca6\u07e0\ua269\u5177',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u4b6b\u98d7\u525e\u{1fc35}\u8335\u01f4\u6ec6\ua1f6\u5d7e'});
+let commandBuffer4 = commandEncoder9.finish({});
+try {
+device0.queue.submit([commandBuffer4, commandBuffer1]);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let sampler5 = device0.createSampler({
+  label: '\u0757\u1bbc\u{1f927}\ub2f4\uf60f\u0829\u144b\u6a24\u{1f891}\u9207\u06bd',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 48.61,
+  lodMaxClamp: 75.91,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(6173, undefined);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 19},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 112},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 141});
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet4, 16, 521, buffer1, 116224);
+} catch {}
+document.body.prepend(video0);
+let commandEncoder15 = device0.createCommandEncoder({label: '\u035e\u{1f63a}\u3624'});
+let texture7 = device0.createTexture({
+  label: '\uc4da\u0f4b\u1f31',
+  size: {width: 68},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView14 = texture0.createView({
+  label: '\u{1fd04}\u091c\u541f\u81c7\u0c9d\u0a1a\ua951\u8429',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 65,
+});
+let computePassEncoder6 = commandEncoder4.beginComputePass({});
+let renderBundle7 = renderBundleEncoder3.finish({label: '\u0ddd\ub1ac'});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u2618\u2a83\u0c3b\u0560\ue0eb\u{1f7d7}\ufb83\u1229\u{1f6a8}\u{1f8a9}',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 103},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 1840203 */
+{offset: 937, bytesPerRow: 286, rowsPerImage: 109}, {width: 16, height: 0, depthOrArrayLayers: 60});
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({label: '\ucbff\u0605\ue6f1\u{1fbbb}\u813a\u050c\u5e53\u{1ffab}'});
+let querySet7 = device0.createQuerySet({
+  label: '\u0149\u0319\u{1fdec}\u5593\ubd7f\uae2d\u{1fe7f}\u{1fbbb}\u0a02\uc634\u9f04',
+  type: 'occlusion',
+  count: 2591,
+});
+let textureView15 = texture1.createView({label: '\u0d04\u0843\u{1f78e}\u{1f9f2}\u{1ffb5}\u0088\u2074\u{1f910}\u0cc5\ue0d9'});
+let computePassEncoder7 = commandEncoder11.beginComputePass({label: '\u{1f98a}\u{1f813}\u07ca\u6b0f\u0f4a\u38db'});
+let renderBundle8 = renderBundleEncoder2.finish({label: '\ued57\u434a\u915c\u04f0\u{1f778}'});
+let externalTexture7 = device0.importExternalTexture({label: '\u0124\u{1f95b}\u09ee\u00c2\u42ce', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup0, new Uint32Array(7514), 4310, 0);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer1, 121832, 162912);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandBuffer5 = commandEncoder16.finish({label: '\u4d85\ud42e\u76a9\u{1fca4}\u{1f63c}\u0608\u{1fe62}\u08de\u0d10\u09ea\u7060'});
+let externalTexture8 = device0.importExternalTexture({label: '\uad35\u5b10\ua57c\u{1ffc4}\u22a3\u{1ff6d}', source: video0});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(7490), 4103, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet6, 110, 790, buffer1, 228352);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 101572, new Int16Array(16413), 11872, 224);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 31},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(40)), /* required buffer size: 1273030 */
+{offset: 62, bytesPerRow: 130, rowsPerImage: 204}, {width: 8, height: 1, depthOrArrayLayers: 49});
+} catch {}
+gc();
+try {
+window.someLabel = buffer0.label;
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({label: '\u592f\u{1feea}\u872d\uf23c'});
+let renderBundle9 = renderBundleEncoder3.finish({});
+let sampler6 = device0.createSampler({
+  label: '\u0617\u4d6f\u1a34\u0f88\u{1fe14}\ub778\ua5bb\ua7b6\u163e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.76,
+  lodMaxClamp: 99.31,
+  compare: 'less',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(8746), 4447, 0);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer0, 95420, buffer1, 392272, 5668);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u8364\u603d\u0b2e\ueed7\u84a1\ue4a8\udc7f',
+  entries: [
+    {
+      binding: 487,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 209, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let querySet8 = device0.createQuerySet({label: '\u0549\u86b6\u0dee\u72a9\u9517\ubbb0', type: 'occlusion', count: 94});
+let textureView16 = texture7.createView({label: '\u{1f88e}\u{1feeb}\u{1f959}'});
+let computePassEncoder8 = commandEncoder15.beginComputePass({});
+let renderBundle10 = renderBundleEncoder0.finish({label: '\u009e\ue67e\u3068\u99af\u5ae6\u7501\u4ae4\ucda1\u008b\u9e89\u1394'});
+try {
+renderBundleEncoder4.setVertexBuffer(4304, undefined);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet8, 86, 5, buffer1, 378368);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 3040});
+let commandBuffer6 = commandEncoder17.finish();
+let textureView17 = texture4.createView({
+  label: '\u306a\u05b4\u{1ff67}\ue57c\u{1fbeb}\u065b\u0cdd',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  arrayLayerCount: 1,
+});
+let computePassEncoder9 = commandEncoder14.beginComputePass({});
+let renderBundle11 = renderBundleEncoder1.finish({label: '\u6531\uf1d8\u{1f6b7}\u{1f81e}\u02e1\u{1f739}\u0f35'});
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 797 */
+{offset: 797, rowsPerImage: 167}, {width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame1 = new VideoFrame(img1, {timestamp: 0});
+let bindGroup1 = device0.createBindGroup({label: '\u07f9\u0726\u{1f67a}\u0547\u{1fb13}', layout: bindGroupLayout0, entries: []});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u6c39\u{1fe4d}\ua450\ub34b\u{1ff7f}\uf947\u0374\u0f21\u{1f6a5}'});
+let textureView18 = texture2.createView({
+  label: '\u0fe8\u8d10\u895f\u{1fffc}\u540a\u05db\u{1f906}\uc81c\u69f3\u{1fd6d}\u{1f699}',
+  dimension: '3d',
+  format: 'r8sint',
+  baseMipLevel: 3,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u{1fb8d}\u9518\uc2a3\u02a4\u06e4\u55e0\u0f4d\u0a30',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler7 = device0.createSampler({
+  label: '\u{1fe40}\u7316\u0cb4\u0bca\ufea5\u{1fb37}\u{1fbb5}\u01ae\u53ce',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.48,
+  lodMaxClamp: 86.85,
+});
+try {
+commandEncoder13.copyBufferToBuffer(buffer0, 121544, buffer1, 204172, 12192);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 40872 */
+  offset: 40872,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer1, 350344, 73100);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u06ad\uf549\u0b76\ub448\ud41a\u0148\u{1fa5c}\u{1ffd8}\ufd57\u4f22\uede3',
+  entries: [
+    {binding: 463, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 926,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\uad48\u3646\uf859\uc73c\u{1f927}\u0494\u0f0e\ude67',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0],
+});
+let commandBuffer7 = commandEncoder19.finish({label: '\ua538\u{1fdf1}'});
+let textureView19 = texture4.createView({
+  label: '\u0b3f\u071d\u1138',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let sampler8 = device0.createSampler({
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.32,
+  lodMaxClamp: 59.98,
+  compare: 'never',
+});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(9148), 4918, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer0, 83868, buffer1, 25684, 71240);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u3e33\uc419\u8dc3\u{1f8cb}\u{1f736}\ubd97',
+  size: 119354,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 33},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 25555948 */
+{offset: 748, bytesPerRow: 726, rowsPerImage: 80}, {width: 31, height: 0, depthOrArrayLayers: 441});
+} catch {}
+canvas0.width = 2106;
+let textureView20 = texture3.createView({label: '\u0a76\u0a40\uebf0\u0be6\u{1febd}\u0550\u0f7a\u0d2c\ud0aa\uc63c\u0a1c', baseMipLevel: 1});
+try {
+commandEncoder13.copyBufferToBuffer(buffer0, 83280, buffer1, 38344, 452);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9736 */
+  offset: 9736,
+  rowsPerImage: 146,
+  buffer: buffer0,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer1, 281404, 102096);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder13.insertDebugMarker('\u{1fa0d}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\u3d19\ub1e6\ud05e\u0fd0'});
+let texture8 = device0.createTexture({
+  label: '\ue097\uda9b\ub97b\u{1fffb}',
+  size: {width: 68},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder10 = commandEncoder12.beginComputePass({label: '\u0a37\u082d\u91af'});
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 122 widthInBlocks: 61 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 15182 */
+  offset: 15060,
+  rowsPerImage: 9,
+  buffer: buffer0,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 61, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12960 */
+  offset: 12960,
+  rowsPerImage: 265,
+  buffer: buffer2,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let video1 = await videoWithData();
+let shaderModule0 = device0.createShaderModule({
+  label: '\ud6f1\u04b9\uc3a6\u{1fcb5}',
+  code: `@group(0) @binding(487)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(4, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<u32>,
+  @location(0) f1: vec3<u32>,
+  @location(4) f2: vec3<u32>,
+  @location(1) f3: i32,
+  @location(2) f4: vec4<i32>,
+  @location(3) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(4) a1: vec3<f16>, @location(0) a2: vec2<u32>, @location(2) a3: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout3 = device0.createBindGroupLayout({label: '\u9e96\uc8b4\u29ee\u0d79\u5bfd', entries: []});
+let texture9 = device0.createTexture({
+  label: '\uf665\u7b35\u0129\u0ed2\u{1fe5e}\ue07c\u219e',
+  size: {width: 480, height: 1, depthOrArrayLayers: 110},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+let computePassEncoder11 = commandEncoder11.beginComputePass({});
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 98 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9344 */
+  offset: 9344,
+  buffer: buffer0,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  label: '\u{1f906}\uf717\u088f\u0d0a\u3ae7\u3d10\u06e3\u03af\ub983\u0889\u{1f7ed}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 152,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 4, shaderLocation: 2}],
+      },
+      {arrayStride: 68, attributes: []},
+      {
+        arrayStride: 48,
+        attributes: [
+          {format: 'uint32x4', offset: 8, shaderLocation: 0},
+          {format: 'float16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let querySet10 = device0.createQuerySet({label: '\ub019\u{1fb1e}\u{1f70b}', type: 'occlusion', count: 2580});
+let textureView21 = texture2.createView({label: '\u0eff\ua45d\u1026\u{1fcdb}\u7d9e\u{1f75f}', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle12 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0, new Uint32Array(8065), 2672, 0);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 20568 */
+  offset: 20568,
+  buffer: buffer2,
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 93860, new BigUint64Array(29002), 3892, 10092);
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+  label: '\u59e6\u9818\u0888\u16cd\ucda3\uae8d',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'zero'},
+    stencilReadMask: 2499080538,
+    depthBiasClamp: 246.68756194490896,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 272, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 102, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 688,
+        attributes: [
+          {format: 'unorm16x2', offset: 16, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 220, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: false},
+});
+let commandEncoder21 = device0.createCommandEncoder({label: '\u{1f734}\u{1f61a}\u{1fe1a}\u03b0\u5c96\u2835\ucd61\u4671'});
+let querySet11 = device0.createQuerySet({label: '\u0ae0\u099f\u0ba0', type: 'occlusion', count: 814});
+try {
+device0.queue.writeBuffer(buffer1, 44532, new Float32Array(53384), 3965, 1952);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+externalTexture4.label = '\u{1f95d}\u698d\u13ad';
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 506,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 881, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let externalTexture9 = device0.importExternalTexture({label: '\u048c\uaf4a\u{1fd76}\u055c\ua9f8\u3168\uf077', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder4.setVertexBuffer(8428, undefined, 0, 1139257663);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer0, 128760, buffer2, 58040, 8288);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 1541341 */
+{offset: 717, bytesPerRow: 308, rowsPerImage: 122}, {width: 8, height: 1, depthOrArrayLayers: 42});
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  label: '\u{1fe87}\u051b\u63e6\u{1fa85}\u3b29\u1332\u212a\u0f03',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32sint'}, {format: 'r8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 528,
+        attributes: [
+          {format: 'uint32x3', offset: 156, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 540, stepMode: 'instance', attributes: []},
+      {arrayStride: 832, stepMode: 'instance', attributes: []},
+      {arrayStride: 584, attributes: [{format: 'unorm8x2', offset: 134, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+document.body.prepend(video1);
+let imageBitmap4 = await createImageBitmap(video1);
+try {
+window.someLabel = querySet2.label;
+} catch {}
+let bindGroup2 = device0.createBindGroup({label: '\u0299\u{1fcce}\u0bd2\u{1f82e}\uc6d1\ud419', layout: bindGroupLayout3, entries: []});
+let commandEncoder22 = device0.createCommandEncoder({});
+let textureView22 = texture6.createView({baseMipLevel: 1, mipLevelCount: 2});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let sampler9 = device0.createSampler({
+  label: '\u{1fde6}\ub5dc\u{1fe69}\ub8ef\u200b\u{1fd1f}\u0f3f\uea23\u{1fd23}\u0e9b\u0c65',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.15,
+  lodMaxClamp: 74.92,
+  maxAnisotropy: 3,
+});
+try {
+commandEncoder13.copyBufferToBuffer(buffer0, 81424, buffer1, 295044, 60944);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(72)), /* required buffer size: 789 */
+{offset: 663, rowsPerImage: 79}, {width: 63, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+  label: '\u0a64\u0254\uffd7',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x3da261d4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint'}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'always', failOp: 'keep', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 3109941963,
+    stencilWriteMask: 602270652,
+    depthBiasSlopeScale: 743.7126942296127,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 808,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 50, shaderLocation: 2},
+          {format: 'float16x2', offset: 124, shaderLocation: 4},
+          {format: 'uint32x4', offset: 484, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', cullMode: 'front'},
+});
+let canvas1 = document.createElement('canvas');
+let buffer3 = device0.createBuffer({
+  label: '\u0ac2\u{1fffb}\u0d02\uaa53\u04c5\ub1f3\u{1f989}',
+  size: 528580,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet3, 2228, 65, buffer1, 11776);
+} catch {}
+let pipeline4 = device0.createComputePipeline({
+  label: '\uac0c\u941b\u0e1a\u4ca8\u0494\u0c09\u04a0\u1330\u4d69\uc00c',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext0 = canvas1.getContext('webgpu');
+let texture10 = device0.createTexture({
+  size: [137, 4, 684],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8sint'],
+});
+let textureView23 = texture8.createView({aspect: 'all'});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer0, 139276, buffer2, 11592, 20392);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3208 */
+  offset: 3208,
+  buffer: buffer0,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline5 = device0.createComputePipeline({
+  label: '\u{1fba0}\u{1f831}\u8cd6\u6c45\u{1ffe2}\u{1ff06}\u1763\ubae3\ufc9d\u6506',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline6 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL}, {format: 'r8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 818128673,
+    stencilWriteMask: 1902341164,
+    depthBiasSlopeScale: 308.49608850718437,
+    depthBiasClamp: 804.680687815585,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 188,
+        attributes: [
+          {format: 'snorm16x4', offset: 80, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 2},
+          {format: 'uint16x2', offset: 84, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let computePassEncoder12 = commandEncoder20.beginComputePass({label: '\u02f1\u053f\u4b01\ub444'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(9279), 8230, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder22.resolveQuerySet(querySet9, 1680, 423, buffer1, 10240);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 249},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(0)), /* required buffer size: 53538546 */
+{offset: 610, bytesPerRow: 463, rowsPerImage: 155}, {width: 20, height: 3, depthOrArrayLayers: 747});
+} catch {}
+let pipeline7 = device0.createComputePipeline({
+  label: '\u{1fe70}\u{1fbde}\u{1f931}\u0c45\ubf66',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let imageData0 = new ImageData(232, 184);
+let bindGroupLayout5 = device0.createBindGroupLayout({label: '\udf33\uf562\u173a', entries: []});
+let commandEncoder23 = device0.createCommandEncoder({label: '\u0aae\ue3f8\u{1ff67}\u08bb'});
+let renderBundle13 = renderBundleEncoder4.finish({label: '\u{1fa0e}\u0d7b\ub811\u948d\ud4b4\u{1fa1f}\u0abb\u0942\u0605\uf821\u004f'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup2);
+} catch {}
+let imageData1 = new ImageData(28, 224);
+let textureView24 = texture0.createView({format: 'astc-10x10-unorm', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 53, arrayLayerCount: 79});
+let sampler10 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.85,
+  compare: 'not-equal',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet2, 217, 293, buffer1, 170752);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline8 = await device0.createRenderPipelineAsync({
+  label: '\u7e88\u0ec9\u{1f701}\u79f5\u80e0\u4441\u1643',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32sint'}, {format: 'rgba32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 472,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 116, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 240,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 48, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 160,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 24, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u{1fbb5}\u{1f770}\u52aa\ueeed\u0ee3\u{1f896}\u03cc\u0624'});
+let texture11 = device0.createTexture({
+  label: '\ud2da\u7d8d\u0f70\u04bc\u{1f739}',
+  size: [137, 4, 114],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let textureView25 = texture9.createView({
+  label: '\u459e\u0308\u08cb\ucd41\u{1f90e}\u0a48\u0d0b\u0dce\u{1fa5b}',
+  dimension: '2d',
+  baseArrayLayer: 90,
+});
+try {
+computePassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet4, 1002, 740, buffer1, 59392);
+} catch {}
+let imageBitmap5 = await createImageBitmap(img0);
+let texture12 = device0.createTexture({
+  size: [1024, 40, 223],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler11 = device0.createSampler({
+  label: '\u0660\uf360\u{1f6a6}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.28,
+  lodMaxClamp: 65.57,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder18.copyBufferToBuffer(buffer0, 144760, buffer1, 222940, 504);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 439},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 58, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 108, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 145},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(80)), /* required buffer size: 32415576 */
+{offset: 432, bytesPerRow: 354, rowsPerImage: 194}, {width: 72, height: 1, depthOrArrayLayers: 473});
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync({
+  label: '\u067a\u7efa\u60db\uff46\u60b9\uc8ae\ub47d\uf8ad',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x1ab94331},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32sint', writeMask: GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 2074061867,
+    depthBias: 382165819,
+    depthBiasClamp: 958.6180523226124,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1564,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 44, shaderLocation: 2},
+          {format: 'float32x4', offset: 816, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 580, stepMode: 'instance', attributes: []},
+      {arrayStride: 332, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 528,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 78, shaderLocation: 0}],
+      },
+    ],
+  },
+});
+let textureView26 = texture10.createView({
+  label: '\u0ebc\u6720\u05b1\u0901\u00fc\u0a53\u{1fd03}\u{1fd07}\u06c2',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet1, 536, 219, buffer1, 236544);
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u0a65\u7706\u0ea9\u{1ffc5}\u{1fd09}\uaa39\u{1f7fc}\ua04d',
+  layout: bindGroupLayout5,
+  entries: [],
+});
+let textureView27 = texture11.createView({
+  label: '\u315d\u{1fc42}\uda6a\ub5f7\ud01c\u{1f83f}\u0d90\u{1fa04}\ue9af\uc702\u101f',
+  aspect: 'all',
+  arrayLayerCount: 1,
+});
+try {
+commandEncoder23.copyBufferToBuffer(buffer0, 60820, buffer2, 56424, 37916);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let textureView28 = texture4.createView({
+  label: '\ua671\u8f99\ucba0\u60b6\ued1e\uebcb\u4917\u7049\u0b64\u{1faf7}\uf2af',
+  format: 'rgb10a2unorm',
+  baseMipLevel: 2,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u0819\u4307\u0085\u{1f734}\u024e\u0e1d',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  depthReadOnly: false,
+});
+let renderBundle14 = renderBundleEncoder8.finish();
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.63,
+  lodMaxClamp: 56.45,
+});
+try {
+renderBundleEncoder7.setIndexBuffer(buffer3, 'uint32', 108136);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 29897607 */
+{offset: 887, bytesPerRow: 985, rowsPerImage: 271}, {width: 43, height: 0, depthOrArrayLayers: 113});
+} catch {}
+let video2 = await videoWithData();
+let texture13 = device0.createTexture({
+  size: [480],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView29 = texture1.createView({label: '\u4fec\u0ddf\u0635\uf322\u5cdb\u0a42\u6317'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u1147\u04ba\u{1f8cc}\u{1f774}',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle15 = renderBundleEncoder1.finish({label: '\u{1f809}\u{1fee6}\u0552\u0558\uc73d\u0d70\u9d65\u5ef0\u0737\u{1ffca}'});
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup2);
+} catch {}
+let promise0 = device0.createRenderPipelineAsync({
+  label: '\u08a3\u{1f7fa}\u0e1b\u00c7\u089d\u0ad7\u547e\u039d',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    depthBias: -1551719305,
+    depthBiasClamp: 666.553230400478,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 56,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 0, shaderLocation: 2}, {format: 'uint32x4', offset: 4, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 120,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 28, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u754a\u6db2\u0f38\u{1fdf4}\ua25d'});
+let textureView30 = texture11.createView({label: '\u07b5\u2acc\u0e11\u92bf\uc1ee\u0068\u{1fb34}\u0e18\u0306', baseMipLevel: 0});
+let externalTexture10 = device0.importExternalTexture({label: '\uffa2\u095a\u6e9b\u0429\u{1fec1}\u{1f94f}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer3, 'uint32', 192276, 113711);
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer2, 31704, 65852);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet0, 1414, 23, buffer1, 18176);
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let imageData2 = new ImageData(128, 4);
+let buffer4 = device0.createBuffer({
+  label: '\u81fa\u{1f9e7}\u042a\u2e59\u51e7\u083e\u46f4',
+  size: 403163,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView31 = texture4.createView({label: '\u958f\u41d5', dimension: '2d-array', baseMipLevel: 3});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet5, 2977, 154, buffer1, 262656);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise1 = device0.createComputePipelineAsync({
+  label: '\u536c\u60a4\u1a27\u7028\u02f3\uf073\u08c5',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline11 = device0.createRenderPipeline({
+  label: '\u0589\u0f37\u{1f9cc}\u043d\u{1fd6c}\ud23c\u{1faa1}\u0433\u{1fbbf}\u0ef4',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x5489c77d},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba32sint'}, {format: 'r8uint'}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 84,
+        attributes: [
+          {format: 'snorm8x2', offset: 50, shaderLocation: 4},
+          {format: 'uint32x4', offset: 0, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 208, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 616,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 56, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(699, 55);
+let promise2 = adapter1.requestAdapterInfo();
+let sampler13 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.78,
+  lodMaxClamp: 72.91,
+  compare: 'less',
+  maxAnisotropy: 9,
+});
+let externalTexture11 = device0.importExternalTexture({label: '\u2ad2\u{1faf4}\u9c17\u30ee\u06fc\u0d77', source: videoFrame1});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet7, 483, 1998, buffer1, 291584);
+} catch {}
+let texture14 = device0.createTexture({
+  label: '\u0f17\u075a\u005b\u003a\u6dbf\u0758',
+  size: {width: 240, height: 1, depthOrArrayLayers: 32},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let textureView32 = texture12.createView({
+  label: '\u{1fc34}\u0396\u7995\u2c21',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 79,
+  arrayLayerCount: 59,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u{1f736}\u0b49\u4b8a',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture12 = device0.importExternalTexture({
+  label: '\u985c\u03df\u{1feb6}\u4280\ub5a7\u{1f7d0}\u{1fb6a}\u6e5f',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder6.setIndexBuffer(buffer3, 'uint16', 341428, 87119);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 17639582 */
+{offset: 414, bytesPerRow: 2126, rowsPerImage: 122}, {width: 117, height: 1, depthOrArrayLayers: 69});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline12 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+try {
+  await promise2;
+} catch {}
+let imageData3 = new ImageData(136, 164);
+let querySet12 = device0.createQuerySet({label: '\u{1fe12}\u{1f96e}\u8734\u{1f888}\u{1f79a}\u074a\u0fb8\u4b1d', type: 'occlusion', count: 1001});
+let textureView33 = texture11.createView({
+  label: '\ud6eb\u{1f900}\u0085\u0a54\u{1feb3}\u0594\u076f\u414b',
+  format: 'rgba32sint',
+  mipLevelCount: 1,
+});
+let computePassEncoder13 = commandEncoder18.beginComputePass({label: '\u0619\uccf5\u277d\u0310\ua620'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'], sampleCount: 4});
+let sampler14 = device0.createSampler({
+  label: '\u9c45\uf411\u9165\u08d7\u3363\u11d5\uf30f\udf8f\u0139\u2d3f',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 62.67,
+  lodMaxClamp: 75.02,
+});
+try {
+commandEncoder24.copyBufferToBuffer(buffer0, 87216, buffer1, 47936, 30588);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4916 */
+  offset: 4916,
+  buffer: buffer0,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 42},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 42588, new DataView(new ArrayBuffer(15078)), 2857, 2780);
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\u{1fe3a}\u7f1c\udc16\u{1f8bd}\u0dd3\u0b37',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline14 = device0.createRenderPipeline({
+  label: '\ud106\u6a47\uaae3\ucb3b',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r8sint', writeMask: 0}, {format: 'rg32sint'}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 159748990,
+    stencilWriteMask: 2747408696,
+    depthBias: 1065588359,
+    depthBiasClamp: -4.28277436757341,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2048,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 128, shaderLocation: 4},
+          {format: 'float32x4', offset: 552, shaderLocation: 2},
+          {format: 'uint32x3', offset: 808, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+externalTexture1.label = '\u{1f6f0}\u{1f88d}\ue378\u3e50\ue8b6\u0aa1\u69a5\uf3a6\u4e89\ub2d5\ude45';
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\ubc0f\u0afc\uab5c\u0e8e',
+  entries: [
+    {
+      binding: 731,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 677,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder26 = device0.createCommandEncoder();
+let texture15 = device0.createTexture({
+  label: '\u7360\ud6e2\uf9fa\u{1fed8}',
+  size: [1024, 40, 223],
+  mipLevelCount: 3,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u328f\u012c\u{1f648}\u{1f7bb}\uf7fc\u0b28\u0188\u00d6',
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(755, undefined, 3620287811, 437013012);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 186988, new Int16Array(32184), 12337, 732);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 34},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 251807094 */
+{offset: 993, bytesPerRow: 893, rowsPerImage: 248}, {width: 40, height: 2, depthOrArrayLayers: 1138});
+} catch {}
+let querySet13 = device0.createQuerySet({label: '\u1ba7\uf760\u0175\u2377\u0816\u773f', type: 'occlusion', count: 2659});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup2, new Uint32Array(2376), 1802, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 73168 */
+  offset: 73108,
+  buffer: buffer1,
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 39316, new BigUint64Array(38344), 30612, 540);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 18},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(80)), /* required buffer size: 20183098 */
+{offset: 714, bytesPerRow: 7642, rowsPerImage: 219}, {width: 469, height: 13, depthOrArrayLayers: 13});
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageData3);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let videoFrame2 = new VideoFrame(video1, {timestamp: 0});
+offscreenCanvas0.width = 576;
+let img2 = await imageWithData(67, 244, '#9ac237b2', '#9c28b20b');
+let offscreenCanvas1 = new OffscreenCanvas(387, 1000);
+let video3 = await videoWithData();
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+let img3 = await imageWithData(134, 241, '#52a169da', '#1a82d6d2');
+let imageBitmap7 = await createImageBitmap(imageBitmap6);
+gc();
+let imageData4 = new ImageData(136, 124);
+let promise3 = adapter1.requestAdapterInfo();
+try {
+  await promise3;
+} catch {}
+let video4 = await videoWithData();
+let videoFrame3 = new VideoFrame(imageBitmap1, {timestamp: 0});
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let imageBitmap8 = await createImageBitmap(img0);
+let imageData5 = new ImageData(64, 20);
+let video5 = await videoWithData();
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+document.body.prepend(img0);
+let bindGroupLayout7 = pipeline8.getBindGroupLayout(0);
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u{1ff85}\u{1fc98}\udc20\u3c74\u{1fe79}\u1d52',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout4, bindGroupLayout2, bindGroupLayout1],
+});
+let querySet14 = device0.createQuerySet({
+  label: '\u8834\u{1ff8b}\uf677\u0bba\u3cd3\u{1f9e7}\u{1f8b3}\u508b\u01cc',
+  type: 'occlusion',
+  count: 2277,
+});
+try {
+computePassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 10024, new Float32Array(55666), 9965, 4480);
+} catch {}
+let textureView34 = texture0.createView({
+  label: '\u994e\u{1f83d}\u{1f902}\uf423\udd9e\u378f\u0dd6',
+  dimension: '2d',
+  format: 'astc-10x10-unorm-srgb',
+  baseMipLevel: 3,
+  baseArrayLayer: 16,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup2, new Uint32Array(7753), 1572, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6481, undefined, 1780904957, 2115939623);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(32)), /* required buffer size: 255598 */
+{offset: 178, bytesPerRow: 215, rowsPerImage: 132}, {width: 24, height: 0, depthOrArrayLayers: 10});
+} catch {}
+let pipeline15 = await promise1;
+let offscreenCanvas2 = new OffscreenCanvas(591, 413);
+let imageData6 = new ImageData(196, 208);
+let img4 = await imageWithData(100, 262, '#4005e644', '#a3b4d19b');
+try {
+offscreenCanvas2.getContext('2d');
+} catch {}
+let videoFrame4 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+gc();
+let canvas2 = document.createElement('canvas');
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+let video6 = await videoWithData();
+gc();
+let video7 = await videoWithData();
+canvas1.width = 907;
+let offscreenCanvas3 = new OffscreenCanvas(489, 107);
+let imageData7 = new ImageData(112, 136);
+try {
+offscreenCanvas3.getContext('bitmaprenderer');
+} catch {}
+try {
+texture6.label = '\u{1ff87}\u074a\uac74\u0b99\u0fe8\uedc9';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img5 = await imageWithData(24, 43, '#780e0196', '#c8e69501');
+let imageBitmap9 = await createImageBitmap(canvas1);
+let imageBitmap10 = await createImageBitmap(imageData3);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData8 = new ImageData(120, 176);
+offscreenCanvas3.height = 395;
+let canvas3 = document.createElement('canvas');
+let img6 = await imageWithData(71, 136, '#9fc28717', '#27be8ff2');
+let commandEncoder27 = device0.createCommandEncoder({label: '\u8113\u{1f8f9}\u0611\u0a64\ud391\u4bd6\u0514\u042e\u0239'});
+let textureView35 = texture4.createView({
+  label: '\u4d1b\u{1fd82}\u0e24\udd95\u05fe\u9c6e\u{1ff59}',
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let computePassEncoder14 = commandEncoder25.beginComputePass({label: '\uef30\uce06\ufc69\u30eb\u07bc'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r8sint', 'rg32sint', 'rgba32sint', 'r8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup1, new Uint32Array(6217), 551, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas2.width = 1584;
+try {
+canvas3.getContext('webgpu');
+} catch {}
+document.body.prepend(img2);
+let video8 = await videoWithData();
+gc();
+gc();
+let imageBitmap11 = await createImageBitmap(video5);
+let canvas4 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture11.label;
+} catch {}
+canvas2.height = 2858;
+let gpuCanvasContext4 = canvas4.getContext('webgpu');
+let offscreenCanvas4 = new OffscreenCanvas(387, 381);
+let gpuCanvasContext5 = offscreenCanvas4.getContext('webgpu');
+let imageBitmap12 = await createImageBitmap(imageBitmap7);
+try {
+computePassEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(8206), 7538, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({
+  label: '\u097b\u2cd9\u02dd\u0af1\u0314\ubae7\u0c4c\u{1f661}\u{1fc9e}\u{1fbb6}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let canvas5 = document.createElement('canvas');
+let gpuCanvasContext6 = canvas5.getContext('webgpu');
+offscreenCanvas4.width = 1180;
+let img7 = await imageWithData(92, 14, '#42ae88c9', '#b8719520');
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+adapter1.label = '\u730f\u13ab\u{1fe27}\uec7d';
+} catch {}
+canvas4.width = 163;
+gc();
+let canvas6 = document.createElement('canvas');
+let imageBitmap13 = await createImageBitmap(imageBitmap12);
+let videoFrame5 = new VideoFrame(video3, {timestamp: 0});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let canvas7 = document.createElement('canvas');
+let offscreenCanvas5 = new OffscreenCanvas(834, 922);
+document.body.prepend(canvas2);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+offscreenCanvas5.getContext('2d');
+} catch {}
+let gpuCanvasContext7 = canvas7.getContext('webgpu');
+try {
+adapter0.label = '\u{1fead}\u{1fd56}\u9147\u65d7\ue381\u029a\ub29f\u03b3\u03ed\u0d73';
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+try {
+renderBundle0.label = '\ua65f\ud8eb\u{1fd85}\u28aa\u0ab0\u0ea6\u0a4e';
+} catch {}
+let imageBitmap14 = await createImageBitmap(videoFrame0);
+let gpuCanvasContext8 = canvas6.getContext('webgpu');
+let videoFrame6 = new VideoFrame(imageBitmap5, {timestamp: 0});
+document.body.prepend(img7);
+document.body.prepend(video6);
+let imageData9 = new ImageData(172, 160);
+let video9 = await videoWithData();
+let imageBitmap15 = await createImageBitmap(offscreenCanvas1);
+let device1 = await adapter2.requestDevice({
+  label: '\u6581\u5ef3\u2479\u0410',
+  defaultQueue: {label: '\u{1fa5b}\u0b1f\u9f18\u5395\u5ddb\u48fb'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 54,
+    maxVertexAttributes: 23,
+    maxVertexBufferArrayStride: 2665,
+    maxStorageTexturesPerShaderStage: 28,
+    maxStorageBuffersPerShaderStage: 29,
+    maxDynamicStorageBuffersPerPipelineLayout: 11651,
+    maxDynamicUniformBuffersPerPipelineLayout: 13431,
+    maxBindingsPerBindGroup: 7454,
+    maxTextureArrayLayers: 919,
+    maxTextureDimension1D: 8439,
+    maxTextureDimension2D: 13244,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 173085385,
+    maxUniformBuffersPerShaderStage: 29,
+    maxSampledTexturesPerShaderStage: 25,
+    maxInterStageShaderVariables: 95,
+    maxInterStageShaderComponents: 87,
+  },
+});
+let video10 = await videoWithData();
+offscreenCanvas1.height = 2653;
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+gc();
+canvas4.height = 2928;
+gc();
+let canvas8 = document.createElement('canvas');
+try {
+canvas8.getContext('webgl');
+} catch {}
+let bindGroupLayout8 = device1.createBindGroupLayout({
+  label: '\uca0d\u3380\u5c8b\u4bcc\ue181\u{1f6ae}\u{1ff9f}',
+  entries: [
+    {
+      binding: 5295,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 2853, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 4083, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+  ],
+});
+let pipelineLayout3 = device1.createPipelineLayout({
+  label: '\u0100\u3316\u{1f9a1}\u01e2\u{1fdfd}\uab90\u{1fb2a}\ufca5\u{1f7ff}\u05f9',
+  bindGroupLayouts: [bindGroupLayout8],
+});
+let imageData10 = new ImageData(252, 4);
+let querySet15 = device1.createQuerySet({
+  label: '\u{1fc10}\udf45\u{1fc07}\u{1fd7c}\uaa5f\u427b\u{1f889}\ufae7\u{1fd01}\u5789',
+  type: 'occlusion',
+  count: 3362,
+});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({
+  label: '\u0b95\u040a\u{1fb6f}\uc409\u7c26\u2fc2',
+  colorFormats: ['r32uint', 'r32sint', 'r8unorm', 'rgba16uint', 'r32uint', 'bgra8unorm', 'rgba32float'],
+  stencilReadOnly: true,
+});
+let sampler15 = device1.createSampler({
+  label: '\u0680\u0cfc\u944f',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMinClamp: 83.48,
+  lodMaxClamp: 91.44,
+});
+try {
+renderBundleEncoder14.setVertexBuffer(3716, undefined, 3403443552, 737165188);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let canvas9 = document.createElement('canvas');
+document.body.prepend(canvas6);
+let offscreenCanvas6 = new OffscreenCanvas(227, 182);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+offscreenCanvas6.width = 625;
+let canvas10 = document.createElement('canvas');
+let commandEncoder28 = device1.createCommandEncoder({});
+let videoFrame7 = new VideoFrame(img1, {timestamp: 0});
+let commandEncoder29 = device1.createCommandEncoder();
+let querySet16 = device1.createQuerySet({label: '\u09c3\u04d1\u686d\u56ad\u01db', type: 'occlusion', count: 42});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'r32sint', 'r8unorm', 'rgba16uint', 'r32uint', 'bgra8unorm', 'rgba32float'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder14.setVertexBuffer(8171, undefined, 0, 2670341314);
+} catch {}
+let gpuCanvasContext9 = canvas10.getContext('webgpu');
+let img8 = await imageWithData(9, 169, '#55d372ea', '#03285282');
+let buffer5 = device1.createBuffer({
+  label: '\ued04\u8f80\u2035\u{1f863}\ube23',
+  size: 65639,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder30 = device1.createCommandEncoder({label: '\u1d84\u6359\u0715\ub1e4'});
+let renderBundleEncoder16 = device1.createRenderBundleEncoder({
+  label: '\u58d8\u2ba0\u03ba\u{1fccd}\u0179\ua70b\u0c0e\ub44d\u{1fbb5}\u1f49\u{1f612}',
+  colorFormats: ['r32uint', 'r32sint', 'r8unorm', 'rgba16uint', 'r32uint', 'bgra8unorm', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let offscreenCanvas7 = new OffscreenCanvas(21, 131);
+let img9 = await imageWithData(186, 68, '#0b159f84', '#84fecaa6');
+let commandEncoder31 = device1.createCommandEncoder({});
+let querySet17 = device1.createQuerySet({label: '\u003d\u{1fae2}\u17a9\ue775\u422e', type: 'occlusion', count: 655});
+let shaderModule1 = device1.createShaderModule({
+  code: `@group(0) @binding(2853)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(1) f1: vec4<f32>,
+  @location(5) f2: vec4<u32>,
+  @location(2) f3: vec4<f32>,
+  @location(6) f4: vec3<f32>,
+  @location(4) f5: vec4<u32>,
+  @location(0) f6: vec4<u32>,
+  @location(7) f7: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f16>, @location(12) a1: f16, @location(22) a2: f32, @location(8) a3: vec4<f32>, @location(10) a4: vec3<f16>, @builtin(instance_index) a5: u32, @location(7) a6: vec4<f32>, @location(19) a7: vec3<f32>, @location(14) a8: vec4<i32>, @location(0) a9: vec2<u32>, @location(2) a10: f16, @location(21) a11: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer6 = device1.createBuffer({
+  label: '\u1332\u0ba6\u7ee1\u0f8b\u98be',
+  size: 90637,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+renderBundleEncoder14.setVertexBuffer(2744, undefined, 990347112);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer6, 40960, 46632);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let pipeline17 = await device1.createRenderPipelineAsync({
+  label: '\uef3a\ue386\ub643\u6a7e\u054a\u04de\u{1f698}\u{1fdcf}\ub22f\uea73',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x544f7c53},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32uint'}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-src'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 940, attributes: [{format: 'unorm10-10-10-2', offset: 104, shaderLocation: 12}]},
+      {
+        arrayStride: 556,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 248, shaderLocation: 2},
+          {format: 'float32x4', offset: 0, shaderLocation: 10},
+          {format: 'float32x3', offset: 216, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 524, shaderLocation: 5},
+          {format: 'uint8x2', offset: 70, shaderLocation: 0},
+          {format: 'float32x4', offset: 80, shaderLocation: 22},
+          {format: 'sint32x3', offset: 84, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 348, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 288,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 52, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 12, shaderLocation: 21},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let querySet18 = device1.createQuerySet({label: '\u{1f850}\u8470', type: 'occlusion', count: 1331});
+let texture16 = device1.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 810},
+  mipLevelCount: 5,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let textureView36 = texture16.createView({label: '\ufeee\u0288\ua0ec\u0633\u45f0\u2182', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 594});
+let computePassEncoder15 = commandEncoder28.beginComputePass();
+let sampler16 = device1.createSampler({
+  label: '\u0cd4\u72b1\u082e',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.55,
+  lodMaxClamp: 68.84,
+  maxAnisotropy: 13,
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer8 = commandEncoder30.finish({});
+let renderBundle16 = renderBundleEncoder15.finish({label: '\u74c3\u{1f7ac}\ud021\ub42d\u0746\u{1f79d}\u{1fc77}'});
+let externalTexture13 = device1.importExternalTexture({source: video9, colorSpace: 'srgb'});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer6, 61748, 28640);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder32 = device1.createCommandEncoder({label: '\ue0c9\ubd85\u{1f75f}\u0e1f\ub116\u0e58\u764f\u0cd1\u458c'});
+let externalTexture14 = device1.importExternalTexture({label: '\u0f51\uee2f\u5d08\u040a\u4955\u02ed\ud1b4\u9b0a', source: video1, colorSpace: 'srgb'});
+try {
+commandEncoder29.insertDebugMarker('\uf62d');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline18 = await device1.createRenderPipelineAsync({
+  label: '\u02bd\ud844\u{1fe44}\u4729',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x777d526b},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: 0}, {format: 'rgba16float', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32uint'}, {format: 'rgba8uint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 92,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 8, shaderLocation: 5},
+          {format: 'float32x3', offset: 12, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 80, attributes: [{format: 'float32x4', offset: 16, shaderLocation: 22}]},
+      {
+        arrayStride: 1224,
+        attributes: [
+          {format: 'uint32x2', offset: 172, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 12, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 276, shaderLocation: 21},
+          {format: 'float32x4', offset: 480, shaderLocation: 12},
+          {format: 'float16x2', offset: 284, shaderLocation: 19},
+          {format: 'float16x4', offset: 600, shaderLocation: 8},
+          {format: 'float32x2', offset: 104, shaderLocation: 10},
+          {format: 'sint16x2', offset: 392, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let imageData11 = new ImageData(76, 152);
+let querySet19 = device1.createQuerySet({type: 'occlusion', count: 1788});
+let pipeline19 = device1.createRenderPipeline({
+  label: '\u{1fdc1}\u7326\u0a24\u{1fb49}\u0027\u4e20\ucba8\ue9eb\u{1f677}\ud770\u2062',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32uint'}, {format: 'rgba8uint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 4003712626,
+    depthBias: 1265515594,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 1536, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 336, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 544, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 392, shaderLocation: 21},
+          {format: 'uint16x2', offset: 640, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 1156,
+        attributes: [
+          {format: 'sint16x4', offset: 16, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 480, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 430, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 992, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 86, shaderLocation: 10},
+          {format: 'float16x2', offset: 256, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder33 = device1.createCommandEncoder();
+let computePassEncoder16 = commandEncoder33.beginComputePass({label: '\u8db7\u0751\u{1fc61}\u11f0\u877b\u892c\ue6b7\u0cae'});
+let externalTexture15 = device1.importExternalTexture({label: '\u967e\u09f2\u07a5\u01e6\u78ce\u{1fd90}', source: videoFrame5, colorSpace: 'srgb'});
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img10 = await imageWithData(276, 66, '#e6624e30', '#8327f9d2');
+let canvas11 = document.createElement('canvas');
+let shaderModule2 = device1.createShaderModule({
+  label: '\u5786\u0f1f',
+  code: `@group(0) @binding(2853)
+var<storage, read_write> type1: array<u32>;
+@group(0) @binding(5295)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(23) f0: vec3<f16>,
+  @location(91) f1: vec3<f32>,
+  @location(30) f2: vec2<u32>,
+  @location(15) f3: i32,
+  @location(54) f4: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<f32>,
+  @location(6) f1: vec4<f32>,
+  @location(2) f2: f32,
+  @location(3) f3: vec4<u32>,
+  @location(0) f4: vec3<u32>,
+  @location(4) f5: vec3<u32>,
+  @location(1) f6: i32
+}
+
+@fragment
+fn fragment0(@location(78) a0: vec3<i32>, @location(0) a1: f16, @location(6) a2: i32, @builtin(sample_index) a3: u32, a4: S1, @location(11) a5: vec2<i32>, @location(40) a6: f16, @location(81) a7: vec2<u32>, @location(79) a8: vec4<u32>, @location(92) a9: vec2<f32>, @location(17) a10: vec3<u32>, @location(63) a11: vec2<f32>, @location(48) a12: vec2<u32>, @location(36) a13: i32, @location(42) a14: u32, @location(59) a15: vec2<f32>, @location(80) a16: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @builtin(vertex_index) f0: u32,
+  @location(7) f1: vec2<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(16) f3: vec4<u32>,
+  @location(14) f4: u32,
+  @location(13) f5: vec2<f32>,
+  @location(21) f6: f32,
+  @location(20) f7: vec3<f16>,
+  @location(9) f8: vec4<f32>,
+  @location(15) f9: u32
+}
+struct VertexOutput0 {
+  @location(92) f0: vec2<f32>,
+  @location(32) f1: vec3<u32>,
+  @location(81) f2: vec2<u32>,
+  @location(42) f3: u32,
+  @location(80) f4: u32,
+  @location(30) f5: vec2<u32>,
+  @location(49) f6: vec2<f16>,
+  @location(78) f7: vec3<i32>,
+  @builtin(position) f8: vec4<f32>,
+  @location(54) f9: vec2<f32>,
+  @location(6) f10: i32,
+  @location(20) f11: vec3<u32>,
+  @location(63) f12: vec2<f32>,
+  @location(59) f13: vec2<f32>,
+  @location(44) f14: vec4<u32>,
+  @location(15) f15: i32,
+  @location(13) f16: vec2<i32>,
+  @location(51) f17: f32,
+  @location(25) f18: vec2<i32>,
+  @location(2) f19: vec4<f16>,
+  @location(79) f20: vec4<u32>,
+  @location(48) f21: vec2<u32>,
+  @location(40) f22: f16,
+  @location(91) f23: vec3<f32>,
+  @location(17) f24: vec3<u32>,
+  @location(94) f25: vec2<f16>,
+  @location(0) f26: f16,
+  @location(10) f27: vec4<f32>,
+  @location(36) f28: i32,
+  @location(18) f29: vec2<u32>,
+  @location(23) f30: vec3<f16>,
+  @location(45) f31: vec3<u32>,
+  @location(11) f32: vec2<i32>,
+  @location(82) f33: vec4<u32>,
+  @location(66) f34: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec4<u32>, @location(17) a1: i32, @location(6) a2: vec2<f32>, @location(11) a3: vec2<f16>, @builtin(instance_index) a4: u32, @location(5) a5: f32, @location(10) a6: vec2<f16>, a7: S0, @location(4) a8: vec4<f32>, @location(3) a9: vec2<f32>, @location(1) a10: f32, @location(22) a11: vec4<i32>, @location(18) a12: vec3<i32>, @location(8) a13: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let computePassEncoder17 = commandEncoder31.beginComputePass({label: '\u0736\ub78e'});
+try {
+commandEncoder28.clearBuffer(buffer6, 6816, 63472);
+dissociateBuffer(device1, buffer6);
+} catch {}
+document.body.prepend(canvas9);
+let video11 = await videoWithData();
+let promise4 = adapter1.requestAdapterInfo();
+try {
+offscreenCanvas6.getContext('bitmaprenderer');
+} catch {}
+let pipelineLayout4 = device1.createPipelineLayout({
+  label: '\ud6b9\u0591\u0a48\u{1fe36}\u0ba5\u{1fd5a}\uc2ea',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout8, bindGroupLayout8, bindGroupLayout8, bindGroupLayout8],
+});
+let texture17 = device1.createTexture({
+  size: {width: 6132, height: 5, depthOrArrayLayers: 13},
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-6x5-unorm-srgb', 'astc-6x5-unorm-srgb', 'astc-6x5-unorm-srgb'],
+});
+let textureView37 = texture16.createView({baseMipLevel: 3, baseArrayLayer: 491, arrayLayerCount: 154});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 31680, new BigUint64Array(20233), 19722, 104);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 1224, y: 0, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 70316 */
+{offset: 763, bytesPerRow: 293, rowsPerImage: 79}, {width: 42, height: 5, depthOrArrayLayers: 4});
+} catch {}
+let buffer7 = device1.createBuffer({
+  label: '\u64b4\u5619',
+  size: 241233,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder34 = device1.createCommandEncoder({label: '\u9ff1\ub5e6\u{1fb6f}\u65ab'});
+let querySet20 = device1.createQuerySet({
+  label: '\ucfd4\u1c22\u7dbb\u0593\u{1fc67}\u5593\u0da3\u0dca\u0fba\u0fce\uf849',
+  type: 'occlusion',
+  count: 3621,
+});
+let texture18 = device1.createTexture({
+  label: '\u30f1\u{1f84d}\ub603\u06c6\u34f5',
+  size: [48, 1, 193],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView38 = texture16.createView({
+  label: '\u0161\u{1fe6d}\u1379',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 285,
+  arrayLayerCount: 40,
+});
+let externalTexture16 = device1.importExternalTexture({label: '\u0326\u794a\u0e7c\uf70b\ue74b\u5d3a', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder16.setVertexBuffer(3108, undefined, 2104688329, 1894907544);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+document.body.prepend(img6);
+let img11 = await imageWithData(153, 219, '#e504914b', '#980ba3f0');
+let imageBitmap16 = await createImageBitmap(video9);
+let promise5 = adapter2.requestAdapterInfo();
+let buffer8 = device1.createBuffer({size: 282552, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandBuffer9 = commandEncoder32.finish({label: '\uf031\u{1fb3f}\u0362\u0fdb\u3b82\u{1f7d1}\u01fd\u6c03\u3d17\ucad0\u{1fdbb}'});
+let textureView39 = texture16.createView({
+  label: '\u885f\u{1f9f2}\ud282\uf7a0\ub8f9',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 782,
+  arrayLayerCount: 25,
+});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({
+  label: '\uc633\u0038\u{1f911}\u08a0\ucffc\u04a9\uabcd\u05a7\u081d\uf39f',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline18);
+} catch {}
+let promise6 = device1.popErrorScope();
+try {
+  await buffer8.mapAsync(GPUMapMode.WRITE, 190200, 45728);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer7, 36548, buffer6, 50872, 33504);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer6, 71624, 1576);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 52732, new Int16Array(39695), 8075, 620);
+} catch {}
+let pipeline20 = device1.createRenderPipeline({
+  label: '\u75f7\u{1ffa9}\ucb25\u{1fc40}\uf499\u166d\u0692\u{1facc}\u0137\u{1fa96}\u10a9',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16uint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'bgra8unorm'}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 724,
+        attributes: [
+          {format: 'sint32x4', offset: 216, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 20, shaderLocation: 6},
+          {format: 'uint16x2', offset: 0, shaderLocation: 12},
+          {format: 'sint32x4', offset: 12, shaderLocation: 22},
+          {format: 'float32x3', offset: 152, shaderLocation: 21},
+          {format: 'float16x2', offset: 288, shaderLocation: 0},
+          {format: 'uint16x2', offset: 60, shaderLocation: 16},
+          {format: 'uint32x3', offset: 180, shaderLocation: 15},
+          {format: 'float16x2', offset: 16, shaderLocation: 10},
+          {format: 'float32x4', offset: 288, shaderLocation: 5},
+          {format: 'sint32x2', offset: 188, shaderLocation: 17},
+          {format: 'float16x2', offset: 208, shaderLocation: 20},
+          {format: 'sint32x4', offset: 172, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 104, shaderLocation: 1},
+          {format: 'float32', offset: 52, shaderLocation: 3},
+          {format: 'uint8x4', offset: 232, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 108, shaderLocation: 9},
+          {format: 'sint32x3', offset: 148, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 364, attributes: []},
+      {
+        arrayStride: 1780,
+        attributes: [
+          {format: 'unorm8x4', offset: 308, shaderLocation: 13},
+          {format: 'float16x4', offset: 184, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 284, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let pipelineLayout5 = device1.createPipelineLayout({label: '\u25f5\uac3e\ue980\ub3b2\u{1fb3f}\u03fa\u0c82', bindGroupLayouts: [bindGroupLayout8]});
+let commandEncoder35 = device1.createCommandEncoder({label: '\u5da2\u6a7e\ub5b7\u3c5a\u{1f622}\u{1fd7e}\u246e\u9856\u5d63'});
+let textureView40 = texture16.createView({
+  label: '\uf140\u3a2e\u0ef1\u{1ff0b}\u4d87\u2bc4\u5033\u{1f7dd}',
+  baseMipLevel: 3,
+  baseArrayLayer: 144,
+  arrayLayerCount: 20,
+});
+let computePassEncoder18 = commandEncoder35.beginComputePass({});
+let renderBundle17 = renderBundleEncoder15.finish({label: '\u0114\ud24a\u{1f6ef}\u7ca9\u853c\u{1f781}\u{1f673}\u0ff6\ue940'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline21 = device1.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule1, entryPoint: 'compute0'}});
+try {
+canvas9.getContext('webgl2');
+} catch {}
+let bindGroupLayout9 = device1.createBindGroupLayout({label: '\u9ab2\u0a0c\udaab\u04ec\u0a5c', entries: []});
+let textureView41 = texture18.createView({baseMipLevel: 3});
+try {
+renderBundleEncoder14.setPipeline(pipeline20);
+} catch {}
+let pipeline22 = device1.createRenderPipeline({
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0xf0865b9d},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 508,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 272, shaderLocation: 5},
+          {format: 'sint32x4', offset: 44, shaderLocation: 17},
+          {format: 'float32x2', offset: 244, shaderLocation: 11},
+          {format: 'float16x2', offset: 4, shaderLocation: 6},
+          {format: 'uint8x2', offset: 152, shaderLocation: 16},
+          {format: 'sint8x2', offset: 118, shaderLocation: 22},
+          {format: 'sint32x4', offset: 136, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 28, shaderLocation: 9},
+          {format: 'float32', offset: 44, shaderLocation: 1},
+          {format: 'uint32', offset: 12, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 704,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 176, shaderLocation: 0},
+          {format: 'sint32x3', offset: 240, shaderLocation: 18},
+          {format: 'uint32', offset: 28, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 372, shaderLocation: 20},
+          {format: 'uint32x2', offset: 92, shaderLocation: 14},
+          {format: 'sint32x3', offset: 76, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 188, shaderLocation: 4},
+          {format: 'float32x2', offset: 8, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 280, shaderLocation: 3},
+          {format: 'float32', offset: 428, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+});
+let texture19 = device1.createTexture({
+  size: [192, 1, 185],
+  mipLevelCount: 4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder16.setVertexBuffer(5213, undefined, 3135441660, 357971119);
+} catch {}
+try {
+commandEncoder29.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 42868 */
+  offset: 42868,
+  bytesPerRow: 0,
+  rowsPerImage: 106,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer6, 32648, 23084);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 5816, new DataView(new ArrayBuffer(55257)), 1661, 16936);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 192, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 2417057 */
+{offset: 957, bytesPerRow: 3265, rowsPerImage: 74}, {width: 1134, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+canvas11.getContext('webgpu');
+} catch {}
+let querySet21 = device1.createQuerySet({type: 'occlusion', count: 3620});
+let renderBundle18 = renderBundleEncoder16.finish({label: '\u2f49\ude82\ud059\u{1fdcf}\u20a4\u0d25'});
+let externalTexture17 = device1.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+commandEncoder34.copyBufferToBuffer(buffer7, 17724, buffer6, 18044, 57004);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let pipeline23 = device1.createRenderPipeline({
+  label: '\u4ec7\u9ef0\u{1fb49}\ub11b\u{1fa4e}\u0ab6\uf789\ue9ca\u{1fb42}\u87e5\u0522',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {format: 'r32float'}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'replace'},
+    stencilBack: {compare: 'greater-equal'},
+    stencilReadMask: 2855085725,
+    stencilWriteMask: 2524206077,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 548,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 116, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 264, shaderLocation: 8},
+          {format: 'uint32x2', offset: 300, shaderLocation: 0},
+          {format: 'sint32x3', offset: 44, shaderLocation: 14},
+          {format: 'float32', offset: 16, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 184, shaderLocation: 2},
+          {format: 'float32x2', offset: 84, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 544, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 32, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 316, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 264, attributes: [{format: 'unorm8x4', offset: 156, shaderLocation: 19}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+let commandEncoder36 = device1.createCommandEncoder({label: '\uc252\u{1fb2a}\uff97'});
+let externalTexture18 = device1.importExternalTexture({
+  label: '\u{1fa90}\u{1f862}\u49a3\u0c85\u8a77\u{1fefb}\u022d\u50f9\u{1f6a8}\u0fac',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder17.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 636, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 864, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1302, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(360, 834);
+let shaderModule3 = device1.createShaderModule({
+  label: '\ud241\u0ab5\u063f\u3112\uf06d\u024b\u3ca3\u37e5\u{1f68c}\u0636\u1f73',
+  code: `@group(2) @binding(4083)
+var<storage, read_write> function0: array<u32>;
+@group(4) @binding(4083)
+var<storage, read_write> parameter1: array<u32>;
+@group(3) @binding(5295)
+var<storage, read_write> type3: array<u32>;
+@group(4) @binding(5295)
+var<storage, read_write> local0: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(5295)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(5295)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(2853)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(2853)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(5295)
+var<storage, read_write> type5: array<u32>;
+@group(3) @binding(2853)
+var<storage, read_write> field3: array<u32>;
+@group(4) @binding(2853)
+var<storage, read_write> type6: array<u32>;
+@group(0) @binding(2853)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @location(7) f0: i32,
+  @location(62) f1: vec4<f16>,
+  @builtin(front_facing) f2: bool,
+  @location(49) f3: vec2<u32>,
+  @location(4) f4: u32,
+  @location(91) f5: u32,
+  @location(11) f6: f32,
+  @location(24) f7: vec3<f16>,
+  @location(40) f8: vec3<f32>,
+  @location(5) f9: vec2<f32>,
+  @builtin(sample_index) f10: u32,
+  @location(65) f11: vec2<u32>,
+  @location(36) f12: vec2<f16>,
+  @location(0) f13: vec3<u32>,
+  @location(38) f14: f16,
+  @builtin(position) f15: vec4<f32>,
+  @location(47) f16: vec2<f16>,
+  @location(13) f17: vec3<u32>,
+  @location(72) f18: vec4<f32>,
+  @location(83) f19: vec2<i32>,
+  @builtin(sample_mask) f20: u32,
+  @location(27) f21: vec2<f16>,
+  @location(92) f22: u32,
+  @location(33) f23: vec4<f32>,
+  @location(78) f24: vec4<i32>,
+  @location(77) f25: vec4<u32>,
+  @location(8) f26: vec3<f16>,
+  @location(3) f27: vec4<f16>,
+  @location(85) f28: u32,
+  @location(12) f29: vec3<i32>,
+  @location(9) f30: vec4<u32>,
+  @location(30) f31: vec4<f16>,
+  @location(39) f32: vec2<f16>,
+  @location(34) f33: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(2) f1: vec4<f32>,
+  @location(6) f2: vec4<f32>,
+  @location(7) f3: vec2<f32>,
+  @location(5) f4: vec4<u32>,
+  @location(0) f5: vec4<u32>,
+  @location(1) f6: vec4<f32>,
+  @location(4) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(88) a0: vec3<f16>, @location(68) a1: vec2<i32>, a2: S2, @location(81) a3: i32, @location(57) a4: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(39) f35: vec2<f16>,
+  @location(36) f36: vec2<f16>,
+  @location(88) f37: vec3<f16>,
+  @location(33) f38: vec4<f32>,
+  @location(38) f39: f16,
+  @location(12) f40: vec3<i32>,
+  @location(0) f41: vec3<u32>,
+  @location(30) f42: vec4<f16>,
+  @builtin(position) f43: vec4<f32>,
+  @location(27) f44: vec2<f16>,
+  @location(91) f45: u32,
+  @location(68) f46: vec2<i32>,
+  @location(7) f47: i32,
+  @location(81) f48: i32,
+  @location(72) f49: vec4<f32>,
+  @location(11) f50: f32,
+  @location(83) f51: vec2<i32>,
+  @location(24) f52: vec3<f16>,
+  @location(85) f53: u32,
+  @location(5) f54: vec2<f32>,
+  @location(34) f55: vec4<f16>,
+  @location(47) f56: vec2<f16>,
+  @location(92) f57: u32,
+  @location(8) f58: vec3<f16>,
+  @location(57) f59: vec4<f16>,
+  @location(4) f60: u32,
+  @location(62) f61: vec4<f16>,
+  @location(78) f62: vec4<i32>,
+  @location(40) f63: vec3<f32>,
+  @location(13) f64: vec3<u32>,
+  @location(49) f65: vec2<u32>,
+  @location(77) f66: vec4<u32>,
+  @location(3) f67: vec4<f16>,
+  @location(65) f68: vec2<u32>,
+  @location(9) f69: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec4<u32>, @location(16) a1: f16, @location(2) a2: vec4<f16>, @location(8) a3: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let querySet22 = device1.createQuerySet({label: '\u{1feb5}\u{1f90f}\uc436', type: 'occlusion', count: 3318});
+let textureView42 = texture16.createView({
+  label: '\u{1f9ba}\uc7af\u0e0a',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 696,
+  arrayLayerCount: 66,
+});
+let renderBundle19 = renderBundleEncoder17.finish({label: '\ua20e\u0697\ucb80\u4820'});
+let externalTexture19 = device1.importExternalTexture({label: '\uf7a1\u0de6\u0f9b\u{1f8f0}\u46c2', source: video1});
+try {
+renderBundleEncoder14.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 70768 */
+  offset: 13936,
+  bytesPerRow: 256,
+  rowsPerImage: 111,
+  buffer: buffer6,
+}, {width: 1, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+computePassEncoder16.insertDebugMarker('\u0cbf');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData12 = new ImageData(208, 128);
+let commandEncoder37 = device1.createCommandEncoder({label: '\u{1f854}\u0863\u4151'});
+let textureView43 = texture16.createView({
+  label: '\u8312\udb0b\u{1fdd5}\u076d',
+  aspect: 'all',
+  baseMipLevel: 4,
+  baseArrayLayer: 81,
+  arrayLayerCount: 523,
+});
+try {
+commandEncoder28.resolveQuerySet(querySet17, 208, 187, buffer5, 17152);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas7.getContext('webgpu');
+let video12 = await videoWithData();
+let textureView44 = texture18.createView({
+  label: '\u0c89\u{1f7e0}\u03fb\u8316\u4968\u2c8d\u{1f86d}',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\udfe6\u{1f9bb}\u045d\uc921\u029e\ud639\u09e5\u8fe0\uf4ff',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let externalTexture20 = device1.importExternalTexture({label: '\u{1fbe0}\u7d95\u3336\u277d', source: video12, colorSpace: 'srgb'});
+try {
+commandEncoder37.copyBufferToBuffer(buffer7, 231728, buffer6, 22868, 7492);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 336, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 324, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4614, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer6, 75184, 7872);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+offscreenCanvas8.getContext('webgpu');
+} catch {}
+let videoFrame8 = new VideoFrame(canvas10, {timestamp: 0});
+let querySet23 = device0.createQuerySet({
+  label: '\u0914\u{1fa99}\u98b2\u48a5\ubc69\u{1fa22}\ued55\uecfb\ua3dc\u0984\u0a42',
+  type: 'occlusion',
+  count: 1774,
+});
+try {
+renderBundleEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2, commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 61460, new Int16Array(4359), 3788, 240);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let canvas12 = document.createElement('canvas');
+let offscreenCanvas9 = new OffscreenCanvas(795, 411);
+let buffer9 = device1.createBuffer({size: 448780, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder38 = device1.createCommandEncoder({label: '\u2d76\u007b\u210f\ua4de\u{1ffd2}\u033e'});
+let querySet24 = device1.createQuerySet({type: 'occlusion', count: 475});
+try {
+renderBundleEncoder14.setVertexBuffer(649, undefined, 0);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer8, 77940, buffer6, 22972, 65384);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\ueeff');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 798, y: 0, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 1669532 */
+{offset: 956, bytesPerRow: 4966, rowsPerImage: 112}, {width: 1758, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let pipeline24 = device1.createComputePipeline({
+  label: '\ue7e4\u5867\udf7d\u87cf\u0ce2\ue84b\u5ce1\u081a\uddc1\u{1fc17}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise4;
+} catch {}
+let imageData13 = new ImageData(88, 176);
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({
+  label: '\u041e\ue7c0\u8f26\u{1f964}\ua893\u1f1f\u0f08',
+  colorFormats: ['r32uint', 'r32sint', 'r8unorm', 'rgba16uint', 'r32uint', 'bgra8unorm', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture21 = device1.importExternalTexture({label: '\udc42\u{1fef6}\u0380\u3a27\u0ec2', source: videoFrame4, colorSpace: 'display-p3'});
+try {
+  await promise5;
+} catch {}
+let canvas13 = document.createElement('canvas');
+let textureView45 = texture19.createView({
+  label: '\u1ac7\u{1f7a0}\ubf34\u579e\u{1f899}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 104,
+});
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 12932, new Float32Array(25137), 11385, 1008);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 522, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 1537450 */
+{offset: 659, bytesPerRow: 14099, rowsPerImage: 109}, {width: 5202, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let pipeline25 = await device1.createRenderPipelineAsync({
+  label: '\u{1fdbc}\ua6be\u03fb\u0cce',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8unorm', writeMask: 0}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst'},
+  },
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 60, attributes: [{format: 'float32x3', offset: 12, shaderLocation: 16}]},
+      {
+        arrayStride: 580,
+        attributes: [
+          {format: 'uint8x2', offset: 334, shaderLocation: 22},
+          {format: 'float32x3', offset: 288, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 2092, attributes: [{format: 'unorm16x2', offset: 228, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let img12 = await imageWithData(66, 49, '#d2d151e3', '#d1ee1cb3');
+try {
+offscreenCanvas9.getContext('webgl2');
+} catch {}
+let video13 = await videoWithData();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise7;
+} catch {}
+let img13 = await imageWithData(111, 14, '#099c382c', '#3f5ca564');
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20868 */
+  offset: 20868,
+  bytesPerRow: 0,
+  rowsPerImage: 9,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet22, 1096, 339, buffer5, 12288);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 966, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(20239536), /* required buffer size: 20239536 */
+{offset: 846, bytesPerRow: 10069, rowsPerImage: 201}, {width: 3762, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let pipeline26 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'r32sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32uint'}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 456,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 20, shaderLocation: 14},
+          {format: 'sint32x4', offset: 40, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 64, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 48, shaderLocation: 20},
+          {format: 'sint32x2', offset: 32, shaderLocation: 8},
+          {format: 'uint32x3', offset: 12, shaderLocation: 12},
+          {format: 'float32x3', offset: 84, shaderLocation: 0},
+          {format: 'float16x4', offset: 72, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 44, shaderLocation: 21},
+          {format: 'float32', offset: 12, shaderLocation: 1},
+          {format: 'sint16x2', offset: 452, shaderLocation: 7},
+          {format: 'sint8x4', offset: 84, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 126, shaderLocation: 4},
+          {format: 'float16x2', offset: 180, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 252, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 10},
+          {format: 'uint32x4', offset: 0, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 380,
+        attributes: [
+          {format: 'uint8x4', offset: 24, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 10, shaderLocation: 11},
+          {format: 'float16x4', offset: 32, shaderLocation: 5},
+          {format: 'sint32', offset: 92, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 1640, attributes: [{format: 'float16x4', offset: 40, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'front', unclippedDepth: true},
+});
+let videoFrame9 = new VideoFrame(canvas12, {timestamp: 0});
+document.body.prepend(canvas6);
+let commandEncoder39 = device1.createCommandEncoder({label: '\u0080\u0099\u028d\u1c63\u{1f918}\u963a\u0fea\u047b\u0ad4'});
+let texture20 = device1.createTexture({
+  label: '\u45ee\u5449\u024d\u{1fcaa}',
+  size: [96],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView46 = texture20.createView({label: '\ubd3a\u0da9\ud17a\u0e49\u9298'});
+try {
+computePassEncoder18.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 72604 */
+  offset: 72604,
+  rowsPerImage: 157,
+  buffer: buffer7,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet15, 2881, 316, buffer5, 10496);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let bindGroupLayout10 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3397,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 1517,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(673, undefined, 0, 2812517567);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer6, 29092, 50396);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet15, 1273, 2007, buffer5, 34560);
+} catch {}
+let gpuCanvasContext11 = canvas13.getContext('webgpu');
+let commandEncoder40 = device1.createCommandEncoder();
+let textureView47 = texture19.createView({
+  label: '\uc995\u6c85\u{1fceb}',
+  format: 'rgba16float',
+  baseMipLevel: 3,
+  baseArrayLayer: 164,
+  arrayLayerCount: 6,
+});
+let externalTexture22 = device1.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder16.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6128, undefined, 0);
+} catch {}
+let promise8 = device1.popErrorScope();
+try {
+commandEncoder40.copyBufferToBuffer(buffer8, 109344, buffer6, 83092, 5120);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 208 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10956 */
+  offset: 10956,
+  buffer: buffer7,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 52, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline27 = device1.createRenderPipeline({
+  label: '\u1434\u26d4\u0a0f\u730d',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0x58cbe398},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'constant'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x2', offset: 148, shaderLocation: 2},
+          {format: 'uint32x2', offset: 104, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 364, stepMode: 'instance', attributes: []},
+      {arrayStride: 364, stepMode: 'instance', attributes: []},
+      {arrayStride: 504, stepMode: 'instance', attributes: []},
+      {arrayStride: 60, stepMode: 'instance', attributes: []},
+      {arrayStride: 240, attributes: []},
+      {
+        arrayStride: 1032,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x4', offset: 192, shaderLocation: 16}],
+      },
+      {arrayStride: 272, attributes: []},
+      {arrayStride: 20, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 340,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 4, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: false},
+});
+let pipelineLayout6 = device1.createPipelineLayout({
+  label: '\u06a4\u0a30\u{1f6e3}\ud823',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout10, bindGroupLayout9, bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout9],
+});
+let textureView48 = texture19.createView({label: '\u{1fea5}\ufcae', baseMipLevel: 3, baseArrayLayer: 104, arrayLayerCount: 77});
+let renderBundle20 = renderBundleEncoder17.finish({label: '\u0e11\u{1f81f}\u69fc\u4b11\uc7d2\u63dd\u056a\u04e0\u8c58\u30f9'});
+let externalTexture23 = device1.importExternalTexture({label: '\u3fd2\ufa37\u4a06\u{1f90f}\u0488\u{1fa0a}\u254d', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 54112 */
+  offset: 54112,
+  rowsPerImage: 68,
+  buffer: buffer7,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4710, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandBuffer10 = commandEncoder40.finish({label: '\ub914\u0d24\u19af\u7c2e\u{1f8a9}\u00ef'});
+let textureView49 = texture18.createView({label: '\ud5f5\u0127\u{1febb}\u1f1b\u8fe0\u0397\u{1f692}\u212a\u775e\u0568\ua85b', baseMipLevel: 3});
+let renderBundle21 = renderBundleEncoder17.finish({label: '\uecd5\ub7cc\u01e0\u{1f608}\u13e0\u{1fe62}'});
+try {
+renderBundleEncoder14.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer8, 4276, buffer6, 56360, 16952);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7280 widthInBlocks: 455 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 30208 */
+  offset: 30208,
+  buffer: buffer6,
+}, {width: 2730, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 28392, new DataView(new ArrayBuffer(1355)), 947, 108);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 245 */
+{offset: 245}, {width: 31, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline28 = device1.createComputePipeline({
+  label: '\u{1ffd6}\u0386\udc44\ue4ee\u5bd8\u{1fbec}\u8ba5\u3037\u6230',
+  layout: 'auto',
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext12 = canvas12.getContext('webgpu');
+let bindGroupLayout11 = device1.createBindGroupLayout({
+  label: '\u003f\u{1fe54}\u0c14\u0e82',
+  entries: [
+    {binding: 4172, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 3263,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer10 = device1.createBuffer({
+  label: '\u0316\u{1ffde}\u9f0a\u44c0',
+  size: 109542,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder41 = device1.createCommandEncoder({label: '\u7fd3\u{1f993}\u{1f817}\u{1f691}\u{1f6cb}\uefab'});
+let computePassEncoder19 = commandEncoder28.beginComputePass({label: '\u{1f883}\u0587\u08ed\uf400\u0229'});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler17 = device1.createSampler({
+  label: '\u77eb\u29c0\u3616\ub710\ue5ab\u{1fefd}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.47,
+  lodMaxClamp: 98.56,
+});
+try {
+computePassEncoder18.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 64344 */
+  offset: 64344,
+  buffer: buffer7,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder29.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26884 */
+  offset: 15356,
+  bytesPerRow: 256,
+  rowsPerImage: 9,
+  buffer: buffer10,
+}, {width: 2, height: 1, depthOrArrayLayers: 6});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 28},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer6, 11164, 9340);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline29 = device1.createComputePipeline({
+  label: '\ue40f\u85bf\u1c86\u{1fb1e}\u{1fb20}\u9576\u0d4c\u{1f6f9}\u0d47\u5d0c\u83b1',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline30 = device1.createRenderPipeline({
+  label: '\u0a97\u0368\u{1f72c}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}, {format: 'r32float', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 639936428,
+    stencilWriteMask: 1003811495,
+    depthBias: 533426672,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: -1.0833361008630362,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 52,
+        attributes: [
+          {format: 'sint32', offset: 4, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 4, shaderLocation: 2},
+          {format: 'uint32x3', offset: 0, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 580,
+        attributes: [
+          {format: 'unorm16x4', offset: 208, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 250, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 236, shaderLocation: 7},
+          {format: 'float32x4', offset: 136, shaderLocation: 12},
+          {format: 'float32', offset: 16, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 572, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 1536, stepMode: 'instance', attributes: []},
+      {arrayStride: 84, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 160,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 104, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+gc();
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let video14 = await videoWithData();
+let commandEncoder42 = device1.createCommandEncoder({});
+let querySet25 = device1.createQuerySet({label: '\ubf95\u10c4\u{1f9ea}\ubaa6\u{1f808}\u0da1', type: 'occlusion', count: 4086});
+let commandBuffer11 = commandEncoder36.finish({label: '\u{1fad5}\u094e'});
+let sampler18 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.100,
+  lodMaxClamp: 4.818,
+  compare: 'greater-equal',
+});
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 220 widthInBlocks: 55 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6480 */
+  offset: 6260,
+  buffer: buffer7,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 55, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet17, 342, 219, buffer5, 20992);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 941 */
+{offset: 941}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(603, 481);
+let texture21 = device1.createTexture({
+  label: '\u6e84\uc336\u04f6\u3785\u0668\u{1fa92}',
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  sampleCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float'],
+});
+let computePassEncoder20 = commandEncoder41.beginComputePass({});
+let sampler19 = device1.createSampler({
+  label: '\u0465\ubb59',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.82,
+  lodMaxClamp: 39.02,
+});
+let externalTexture24 = device1.importExternalTexture({source: videoFrame9, colorSpace: 'display-p3'});
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 364 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 44396 */
+  offset: 44396,
+  bytesPerRow: 512,
+  buffer: buffer6,
+}, {width: 91, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2664, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 5, y: 1 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 6,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder43 = device1.createCommandEncoder({label: '\u93a6\u0b76\u{1f8d6}\ud333\u3de1\uf25f\u{1f83b}\u{1fbe4}'});
+let querySet26 = device1.createQuerySet({label: '\u66df\u240f\ue48a\u3eba', type: 'occlusion', count: 4071});
+let textureView50 = texture17.createView({label: '\u0d83\u021f\ue914\uc2e4\u3e6e\u25f2\ua28f', dimension: '2d', baseArrayLayer: 3});
+try {
+renderBundleEncoder20.setPipeline(pipeline25);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56444 */
+  offset: 56444,
+  buffer: buffer7,
+}, {
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer6, 78064, 1920);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+renderBundleEncoder18.insertDebugMarker('\u6a61');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 5, y: 43 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline31 = device1.createRenderPipeline({
+  label: '\u{1fb07}\u{1f8e0}\u938a\u0930\u6391',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8unorm'}, {format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'constant'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilWriteMask: 1855923758,
+    depthBias: 1241303724,
+    depthBiasSlopeScale: 149.933837064567,
+    depthBiasClamp: -84.28618179609037,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 500,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 140, shaderLocation: 22},
+          {format: 'float16x4', offset: 168, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 188, shaderLocation: 8},
+          {format: 'float32x3', offset: 16, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+offscreenCanvas10.getContext('webgl');
+} catch {}
+gc();
+let device2 = await adapter1.requestDevice({
+  label: '\u{1f897}\u7451\u{1fcfa}\u{1fbeb}\u0205\u3890\u0a61\u{1f810}\u{1fff4}\ue171\u{1fd8d}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 38,
+    maxVertexAttributes: 21,
+    maxVertexBufferArrayStride: 45731,
+    maxStorageTexturesPerShaderStage: 44,
+    maxStorageBuffersPerShaderStage: 27,
+    maxDynamicStorageBuffersPerPipelineLayout: 3360,
+    maxDynamicUniformBuffersPerPipelineLayout: 34947,
+    maxBindingsPerBindGroup: 2822,
+    maxTextureArrayLayers: 1627,
+    maxTextureDimension1D: 15227,
+    maxTextureDimension2D: 9111,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 248180403,
+    maxUniformBuffersPerShaderStage: 40,
+    maxSampledTexturesPerShaderStage: 37,
+    maxInterStageShaderVariables: 69,
+    maxInterStageShaderComponents: 73,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let querySet27 = device2.createQuerySet({label: '\u0048\uf26e\u5de5\u5d5f\ue9af', type: 'occlusion', count: 2756});
+let imageData14 = new ImageData(120, 172);
+let promise9 = adapter1.requestAdapterInfo();
+let commandEncoder44 = device2.createCommandEncoder({label: '\u4463\u{1f7a6}'});
+let querySet28 = device2.createQuerySet({label: '\u0abd\u5b4b', type: 'occlusion', count: 2781});
+let commandBuffer12 = commandEncoder44.finish({label: '\u{1f9d4}\u1694\u{1f8eb}'});
+let texture22 = device2.createTexture({
+  size: {width: 741, height: 1, depthOrArrayLayers: 1473},
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView51 = texture22.createView({
+  label: '\u92fd\u9811\u0780\u{1ffcd}\ub767',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 58,
+  arrayLayerCount: 135,
+});
+let sampler20 = device2.createSampler({
+  label: '\u40a2\u923f\u0fdc',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.90,
+  lodMaxClamp: 94.53,
+  maxAnisotropy: 5,
+});
+try {
+adapter2.label = '\u8bfd\uef16\u08c5\u2f75\u0417\ua94d\u06f6\u{1ffee}\u05ff';
+} catch {}
+let bindGroup4 = device1.createBindGroup({
+  label: '\u2b6f\u{1f735}\ufd26\u00f2\u01b7\ub3e9\u{1feae}\u7895\u6db7\ufeb4\ud5d2',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let texture23 = device1.createTexture({
+  label: '\u{1fce1}\u{1fd2f}\u03ca\u837b\u8767',
+  size: [96, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView52 = texture23.createView({
+  label: '\u{1f7f8}\u0213\u{1fab3}\u{1f9af}\u023c\u3e8f\u982c\u507a\u{1fb63}\uedd5',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder16.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline17);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer7, 224344, buffer6, 58064, 13256);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet24, 16, 142, buffer5, 1280);
+} catch {}
+let canvas14 = document.createElement('canvas');
+let img14 = await imageWithData(165, 275, '#132e6889', '#30375d90');
+let commandEncoder45 = device1.createCommandEncoder({label: '\u0329\u0f7d'});
+let textureView53 = texture18.createView({
+  label: '\ud8e3\u2157\u{1f877}\u{1ff20}\u0ce5\u{1f922}\u{1f9f1}\ua9e5\ueeeb',
+  baseMipLevel: 7,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer7, 70280, buffer10, 76480, 25336);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 348 widthInBlocks: 87 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12340 */
+  offset: 12340,
+  rowsPerImage: 108,
+  buffer: buffer7,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 87, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 24692, new BigUint64Array(2378), 135, 624);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(40)), /* required buffer size: 103 */
+{offset: 103}, {width: 95, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise10 = device1.queue.onSubmittedWorkDone();
+let canvas15 = document.createElement('canvas');
+let commandEncoder46 = device1.createCommandEncoder();
+let commandBuffer13 = commandEncoder34.finish({label: '\u016f\u04f1\u775a\uc194\u3a82'});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  label: '\u{1ff4b}\u5fc8\u89c2\ub966\ua4bf\u01f0\u0dd2\u7caa\u{1f99a}',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup4, new Uint32Array(3635), 1481, 0);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(querySet24, 265, 89, buffer5, 35584);
+} catch {}
+try {
+device1.queue.submit([commandBuffer9]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 77 */
+{offset: 77}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline32 = device1.createRenderPipeline({
+  label: '\u072a\u{1f79d}\ufa9d\ubd06\u0ba1\u00c5\u0c43\u0f58\ub965\u{1f7b1}',
+  layout: pipelineLayout6,
+  multisample: {count: 1},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'r32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 384,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 172, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 624,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 0, shaderLocation: 4},
+          {format: 'sint32x3', offset: 124, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 36, shaderLocation: 10},
+          {format: 'float32x2', offset: 56, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 68,
+        attributes: [
+          {format: 'sint32x3', offset: 0, shaderLocation: 7},
+          {format: 'sint32x2', offset: 12, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 20},
+          {format: 'float32x2', offset: 36, shaderLocation: 0},
+          {format: 'sint32', offset: 16, shaderLocation: 22},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 20, shaderLocation: 5},
+          {format: 'sint8x2', offset: 0, shaderLocation: 17},
+          {format: 'uint16x4', offset: 24, shaderLocation: 12},
+          {format: 'uint8x4', offset: 8, shaderLocation: 14},
+          {format: 'uint16x4', offset: 0, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 24, shaderLocation: 16}],
+      },
+      {arrayStride: 588, attributes: []},
+      {
+        arrayStride: 1888,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x4', offset: 20, shaderLocation: 21}],
+      },
+      {
+        arrayStride: 60,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 12, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder47 = device2.createCommandEncoder();
+let externalTexture25 = device2.importExternalTexture({label: '\u38b0\u16d9\u{1fd52}\u{1f671}\ud781\u3d49\uc2ae', source: video14, colorSpace: 'display-p3'});
+let video15 = await videoWithData();
+let querySet29 = device2.createQuerySet({
+  label: '\u0604\u0f81\u{1fbd7}\uc30a\u{1f8a9}\u6f4d\u7efe\u9118\u39e4\ua8e1\u01e4',
+  type: 'occlusion',
+  count: 2184,
+});
+let texture24 = device2.createTexture({
+  label: '\u0e0e\u6106\uc5df',
+  size: [96, 48, 1],
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+});
+let renderBundleEncoder22 = device2.createRenderBundleEncoder({
+  label: '\u04ba\ubbd4\u06ad\u01af\u591a\ua904\u4c0d\u{1fd84}\uae84\u0a00',
+  colorFormats: ['rg8sint', 'rg16float', 'rg8unorm', 'r32sint', 'rgba32uint'],
+  depthReadOnly: false,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 519 */
+{offset: 519, rowsPerImage: 287}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 227, y: 146 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder48 = device2.createCommandEncoder({label: '\u7bab\u189a\u640d'});
+let querySet30 = device2.createQuerySet({label: '\u{1fb00}\u0aa5\u07bc\u006a\u1016', type: 'occlusion', count: 798});
+let shaderModule4 = device1.createShaderModule({
+  label: '\u02dc\u0079\u{1f688}\ufe4f\u0c49\u56ff',
+  code: `@group(3) @binding(3397)
+var<storage, read_write> global2: array<u32>;
+@group(4) @binding(3397)
+var<storage, read_write> global3: array<u32>;
+@group(1) @binding(1517)
+var<storage, read_write> local1: array<u32>;
+@group(5) @binding(1517)
+var<storage, read_write> n0: array<u32>;
+@group(3) @binding(1517)
+var<storage, read_write> type7: array<u32>;
+@group(5) @binding(3397)
+var<storage, read_write> local2: array<u32>;
+@group(4) @binding(1517)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(7) f1: vec2<f32>,
+  @location(6) f2: vec2<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(2) f4: vec4<f32>,
+  @location(1) f5: vec4<f32>,
+  @location(3) f6: vec4<u32>,
+  @location(0) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(20) f0: u32,
+  @location(22) f1: vec2<i32>,
+  @location(5) f2: vec3<f16>,
+  @builtin(instance_index) f3: u32,
+  @location(18) f4: vec3<u32>,
+  @location(11) f5: vec3<u32>,
+  @location(7) f6: f16,
+  @location(16) f7: i32,
+  @location(12) f8: vec2<f32>,
+  @location(2) f9: vec3<u32>,
+  @location(13) f10: vec2<i32>,
+  @location(9) f11: f32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(0) a1: vec2<f32>, @location(15) a2: vec4<u32>, @location(21) a3: vec2<i32>, @location(8) a4: vec2<i32>, @location(19) a5: vec3<f16>, @location(14) a6: i32, @location(4) a7: vec3<i32>, @location(10) a8: f32, @location(6) a9: vec3<u32>, @location(3) a10: f32, a11: S3, @location(17) a12: i32, @location(1) a13: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder49 = device1.createCommandEncoder({});
+let texture25 = device1.createTexture({
+  label: '\u09b6\u{1f6eb}\u{1fbf7}\u0032\u2d4b\u{1fe98}\ue880\ue4f5\u4fc5',
+  size: [48],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView54 = texture16.createView({
+  label: '\u{1fcc4}\u07a5\u{1fc83}\uffc3\u{1f6b1}\u{1f6ed}\u0b6c\u0cee',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 366,
+});
+let sampler21 = device1.createSampler({
+  label: '\u04ad\u7d85\u003e\u048a\u7dda\u3511\u79e1\u042b\u{1fce4}\u0192\u2c17',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.76,
+  lodMaxClamp: 19.85,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder19.setBindGroup(4, bindGroup4, new Uint32Array(4422), 2563, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer7, 132916, buffer6, 66388, 2500);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer6, 35940, 38712);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(661), /* required buffer size: 661 */
+{offset: 661, rowsPerImage: 68}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 30, y: 96 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext13 = canvas14.getContext('webgpu');
+try {
+canvas15.getContext('webgl');
+} catch {}
+let textureView55 = texture24.createView({
+  label: '\ue655\u20c5\u{1fa97}\u0d12\ueea5',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+let computePassEncoder21 = commandEncoder48.beginComputePass({label: '\uf49d\u371b\u0259'});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let canvas16 = document.createElement('canvas');
+let imageBitmap17 = await createImageBitmap(imageData11);
+let commandEncoder50 = device2.createCommandEncoder({label: '\uf59b\u01c0\u{1f72c}\u763b\u{1f72a}\u0c5e\u386b\u09e1\ua8ce\u1030'});
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 7, y: 4, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(40)), /* required buffer size: 496 */
+{offset: 496, bytesPerRow: 265}, {width: 24, height: 13, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas3.height = 907;
+let offscreenCanvas11 = new OffscreenCanvas(672, 585);
+try {
+canvas16.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let canvas17 = document.createElement('canvas');
+let shaderModule5 = device1.createShaderModule({
+  label: '\u86ab\u072f\u0c48\u{1fdb8}',
+  code: `@group(5) @binding(1517)
+var<storage, read_write> parameter3: array<u32>;
+@group(5) @binding(3397)
+var<storage, read_write> local3: array<u32>;
+@group(4) @binding(3397)
+var<storage, read_write> type8: array<u32>;
+@group(1) @binding(1517)
+var<storage, read_write> local4: array<u32>;
+@group(3) @binding(1517)
+var<storage, read_write> function2: array<u32>;
+@group(3) @binding(3397)
+var<storage, read_write> field4: array<u32>;
+@group(4) @binding(1517)
+var<storage, read_write> n1: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(5) f1: vec4<u32>,
+  @location(0) f2: vec4<u32>,
+  @location(3) f3: vec4<u32>,
+  @location(4) f4: vec4<u32>,
+  @location(7) f5: f32,
+  @location(6) f6: vec3<f32>,
+  @location(2) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(2) f0: f16,
+  @builtin(instance_index) f1: u32,
+  @location(1) f2: u32,
+  @location(12) f3: f16,
+  @location(9) f4: f32,
+  @location(10) f5: vec3<u32>,
+  @location(7) f6: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec2<i32>, @location(20) a1: vec3<f16>, @location(21) a2: vec4<f16>, @location(15) a3: vec3<u32>, a4: S4, @location(3) a5: vec3<u32>, @location(16) a6: f16, @location(18) a7: f32, @location(4) a8: vec2<f16>, @location(17) a9: i32, @builtin(vertex_index) a10: u32, @location(5) a11: vec3<i32>, @location(13) a12: vec3<u32>, @location(14) a13: vec3<i32>, @location(8) a14: vec3<f32>, @location(22) a15: u32, @location(19) a16: vec4<f16>, @location(11) a17: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let bindGroupLayout12 = device1.createBindGroupLayout({
+  label: '\u08b6\u{1fe81}\u95fe\u086b',
+  entries: [
+    {
+      binding: 1295,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 5727,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 842103, hasDynamicOffset: true },
+    },
+    {
+      binding: 4556,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandBuffer14 = commandEncoder49.finish({label: '\u2f01\u01a6\u7219\u0d26\u6fd3'});
+let texture26 = device1.createTexture({
+  label: '\u{1f881}\ud0af\uf46e\u{1f637}\ud10a\u07e9\u{1fd15}\u033e\u0705',
+  size: {width: 192, height: 1, depthOrArrayLayers: 359},
+  mipLevelCount: 5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let textureView56 = texture21.createView({dimension: '2d-array', baseMipLevel: 2, baseArrayLayer: 0});
+let renderBundleEncoder23 = device1.createRenderBundleEncoder({
+  label: '\u482e\u93dd\u08f8\u{1ffdb}\u01de\ub802\u{1f84d}\u92e7\u{1fd0d}\u0229\ud769',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+  stencilReadOnly: true,
+});
+let sampler22 = device1.createSampler({
+  label: '\u6bef\u8164',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.41,
+  lodMaxClamp: 97.75,
+  maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+device1.queue.submit([commandBuffer8, commandBuffer11]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 726 */
+{offset: 726}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let imageData15 = new ImageData(144, 196);
+let bindGroupLayout13 = pipeline17.getBindGroupLayout(0);
+let querySet31 = device1.createQuerySet({
+  label: '\u{1fb2f}\u0cef\u993a\u7ca4\ued0a\ucff9\u856e\u7c82\u{1fb46}\ua726',
+  type: 'occlusion',
+  count: 1016,
+});
+let textureView57 = texture17.createView({
+  label: '\uc121\u0185\u0105\ueba5\u8ab9\u0d47\u5b9c',
+  dimension: '2d',
+  baseMipLevel: 0,
+  baseArrayLayer: 8,
+});
+let computePassEncoder22 = commandEncoder31.beginComputePass({label: '\u02fb\u33d9\u{1f95b}\u82a1\u8bf2\u18c4\u0ccc\uaed7'});
+try {
+computePassEncoder19.pushDebugGroup('\u2ca7');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer6, 9604, new Int16Array(21234), 336, 12372);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let imageData16 = new ImageData(148, 208);
+let commandEncoder51 = device1.createCommandEncoder({});
+let texture27 = device1.createTexture({
+  label: '\ufde8\u0c05\u{1fd56}\uafe7\u0655',
+  size: {width: 384, height: 1, depthOrArrayLayers: 111},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView58 = texture16.createView({baseMipLevel: 2, baseArrayLayer: 90, arrayLayerCount: 657});
+let renderBundle22 = renderBundleEncoder23.finish({label: '\u39b1\u0e75\ufdf6\u0411\u2db4\u6a26\u1b1d'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline24);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48628 */
+  offset: 48544,
+  rowsPerImage: 293,
+  buffer: buffer8,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer6, 29716, 23388);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let commandEncoder52 = device1.createCommandEncoder();
+let querySet32 = device1.createQuerySet({type: 'occlusion', count: 620});
+try {
+renderBundleEncoder14.setPipeline(pipeline32);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 359}
+*/
+{
+  source: img2,
+  origin: { x: 3, y: 21 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = await device1.createComputePipelineAsync({
+  label: '\u39f8\u0fba\ub33e\u{1fe65}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let commandBuffer15 = commandEncoder42.finish({label: '\uf6d3\ub608\u{1f610}\u0f5c\u3650\ue260\u6313\u0f15\u{1fd70}\u00a0\uaf91'});
+let renderBundle23 = renderBundleEncoder19.finish({label: '\u{1f9f9}\ud313\u59f4\u{1fd69}\u0c5b\u4d09\ucf5c'});
+let externalTexture26 = device1.importExternalTexture({label: '\u{1f98b}\u06f2\ua6fc\u{1ff35}\u{1ffff}', source: videoFrame4, colorSpace: 'display-p3'});
+video15.height = 6;
+let offscreenCanvas12 = new OffscreenCanvas(169, 938);
+let texture28 = device1.createTexture({
+  label: '\ueff4\udb37\u0cab\u051f',
+  size: [48, 1, 1],
+  mipLevelCount: 4,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler23 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 92.62,
+  lodMaxClamp: 95.12,
+  compare: 'not-equal',
+});
+let externalTexture27 = device1.importExternalTexture({label: '\u2571\u8db5\u4429\u9d7c\u1850\u2e35', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder20.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+  await buffer8.mapAsync(GPUMapMode.WRITE, 0, 135472);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video11,
+  origin: { x: 10, y: 4 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+try {
+device2.queue.label = '\u1b61\ud454\u{1f628}\u0ee8\u0ac9\u{1f869}\u0da0\u{1f984}\u{1fda1}\u99f2\u0a09';
+} catch {}
+let textureView59 = texture22.createView({
+  label: '\u{1ffcf}\u{1fc4a}\u2bfa',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 258,
+  arrayLayerCount: 1092,
+});
+let renderBundle24 = renderBundleEncoder22.finish({label: '\u{1f7f8}\ud564\u04d8\u944b\u9e3b\u03f2'});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+canvas17.getContext('bitmaprenderer');
+} catch {}
+let commandBuffer16 = commandEncoder47.finish();
+let textureView60 = texture22.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 6, baseArrayLayer: 31, arrayLayerCount: 1});
+let texture29 = device2.createTexture({
+  size: [741, 1, 865],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView61 = texture24.createView({label: '\ude9b\ude6b\u6071\u336f\u0166\uc853\u{1fe79}\u{1fd35}', baseMipLevel: 4, mipLevelCount: 1});
+let sampler24 = device2.createSampler({
+  label: '\uc4a7\ub3ef',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.83,
+  lodMaxClamp: 76.43,
+  compare: 'greater',
+  maxAnisotropy: 16,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 26, y: 19 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 16, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas11.getContext('2d');
+} catch {}
+let commandEncoder53 = device1.createCommandEncoder({label: '\u518c\ub6ac\ud825\u9680\u{1f81c}\ube3d\ud0d9\u04e9\u0d34\u0060'});
+let querySet33 = device1.createQuerySet({label: '\u085c\u3c2c\ua8ec\u0870\u2871', type: 'occlusion', count: 4069});
+let textureView62 = texture25.createView({label: '\u{1f916}\u0f61\ueffc\u48c4\u77e6\u{1f70b}\u00f4'});
+let renderBundle25 = renderBundleEncoder17.finish({label: '\u{1ffd5}\u6053\u0cfa\u013d\u567f\u7cec\u{1f868}\u0853'});
+let sampler25 = device1.createSampler({
+  label: '\u86cb\u0e9f\u{1fdd9}\ub668\u0c58',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 70.25,
+  lodMaxClamp: 73.54,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+let externalTexture28 = device1.importExternalTexture({label: '\u098d\u0f3b\u6ffc\ub055\u99f2\u0e0c\ub795\uaecd', source: video1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder18.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(6, bindGroup4, new Uint32Array(7160), 4456, 0);
+} catch {}
+let pipeline34 = device1.createComputePipeline({
+  label: '\ub9fd\u7225\u88a6\u{1fe71}\ucf5e\u0919\u{1fed4}\u{1f945}\u3979',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let querySet34 = device2.createQuerySet({label: '\u7e7f\u{1fc07}\u3a36\ud39b', type: 'occlusion', count: 1324});
+let textureView63 = texture24.createView({
+  label: '\u0715\u1768\u0acb\ua4eb\u8627\u8b27\u18b0\uce26\u0641\u{1ff11}',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(0)), /* required buffer size: 346 */
+{offset: 346}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img15 = await imageWithData(1, 111, '#f1bb7275', '#704dac97');
+let textureView64 = texture19.createView({
+  label: '\u3865\uf71d\u{1f729}\u8f22\ue349\uf81c',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 184,
+});
+let renderBundleEncoder24 = device1.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'rg8sint', 'rgba8uint', 'rgba8uint', 'rgba8sint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle26 = renderBundleEncoder19.finish({label: '\ub2ee\u{1f968}\u8618\u2c52\uc333\u29a5\u2bd2\u0ac3\u{1f851}\u137d'});
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(6, bindGroup4, new Uint32Array(4476), 4400, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6526, undefined, 0, 1723697995);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer10, 17596, 71024);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet16, 31, 10, buffer5, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 6, y: 39 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({});
+try {
+offscreenCanvas12.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout14 = device1.createBindGroupLayout({
+  label: '\u0d51\u0dcd\ucc65\u2af3\u0638',
+  entries: [
+    {
+      binding: 2310,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 5054,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 3964, visibility: 0, sampler: { type: 'filtering' }},
+  ],
+});
+let textureView65 = texture19.createView({
+  label: '\ua4ab\u2625\u{1f95e}\u0bad\u{1fcaa}\u{1f75a}\u35e3\u070f',
+  mipLevelCount: 2,
+  baseArrayLayer: 99,
+  arrayLayerCount: 63,
+});
+try {
+renderBundleEncoder20.setPipeline(pipeline25);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer8, 276808, buffer10, 79860, 4784);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet16, 0, 23, buffer5, 21248);
+} catch {}
+try {
+  await promise8;
+} catch {}
+document.body.prepend(video11);
+let offscreenCanvas13 = new OffscreenCanvas(454, 3);
+let bindGroupLayout15 = device1.createBindGroupLayout({
+  label: '\u0b60\u07c2\u5455\u0d65\uee09\u0954\u{1f8a0}',
+  entries: [
+    {
+      binding: 4467,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder54 = device1.createCommandEncoder({label: '\u{1fbb6}\ufa65\u08ba\ud79c\u26be\u{1f641}\u{1f604}\u0d9c\u0d26'});
+let querySet35 = device1.createQuerySet({label: '\u0413\u{1fe69}\u{1fd8f}', type: 'occlusion', count: 207});
+let texture30 = device1.createTexture({
+  size: [96, 1, 556],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({
+  label: '\u02da\u{1f94a}\u58d6\ucddd\u481c\u{1ffb9}\u036e\u0e58\u6463\u0b9c',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+  stencilReadOnly: true,
+});
+let externalTexture29 = device1.importExternalTexture({source: videoFrame4});
+let arrayBuffer0 = buffer9.getMappedRange(310488);
+try {
+computePassEncoder19.popDebugGroup();
+} catch {}
+let videoFrame10 = new VideoFrame(imageBitmap8, {timestamp: 0});
+try {
+  await promise9;
+} catch {}
+document.body.prepend(img4);
+let video16 = await videoWithData();
+let commandEncoder55 = device1.createCommandEncoder({});
+let sampler26 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 67.87,
+});
+try {
+computePassEncoder16.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer10, 83660, 14432);
+dissociateBuffer(device1, buffer10);
+} catch {}
+let commandEncoder56 = device1.createCommandEncoder({label: '\u{1f844}\u{1fbf7}\uc773\u{1fbbd}\u{1feca}\u{1ff8a}\u01f8\u{1f8e3}\u02a7\u9983'});
+let textureView66 = texture26.createView({
+  label: '\u050c\u{1fe59}\u9303\u025a\u0ef8\u{1f9be}\u9672',
+  dimension: '2d',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 262,
+});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({
+  label: '\u{1f796}\uf640\u9df7\u039d',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle27 = renderBundleEncoder20.finish({label: '\uc5f9\u8d8f\u3f20'});
+try {
+commandEncoder39.copyBufferToBuffer(buffer8, 67164, buffer10, 88632, 17692);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap14,
+  origin: { x: 3, y: 5 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture31 = device2.createTexture({
+  label: '\uca2c\ufea3\u0684\u{1fcab}\ua133\u{1f861}\u{1fc48}\uabb0\u3ded\u7a9f\u14ff',
+  size: {width: 1483, height: 1, depthOrArrayLayers: 825},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let externalTexture30 = device2.importExternalTexture({label: '\u{1fd42}\u0c8e\u0027\uc314\u0036', source: videoFrame3});
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 51, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 11, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 6, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 195, y: 45 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 3,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas18 = document.createElement('canvas');
+let bindGroup5 = device1.createBindGroup({
+  label: '\u0fc4\u0a59\u538a\u{1f60c}\u249b\u82bd\ueb9f\ubc56\u7491',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let commandEncoder57 = device1.createCommandEncoder();
+let texture32 = device1.createTexture({
+  label: '\u0142\ub26e\ub3b9\u3ad5',
+  size: [96, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({
+  label: '\u053e\u0288\ucf5f\u0f61',
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'rg8sint', 'rgba8uint', 'rgba8uint', 'rgba8sint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle28 = renderBundleEncoder18.finish();
+let commandEncoder58 = device1.createCommandEncoder({label: '\u00da\u0dfd\u{1fb08}\u0fb2\u7993\u01fe\u{1f669}'});
+let querySet36 = device1.createQuerySet({label: '\u03f6\u401f\u03ea\u859b\u0361\u038e\ua474', type: 'occlusion', count: 2295});
+try {
+computePassEncoder16.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6386, undefined, 577258464);
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.READ, 42904, 29180);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer10, 51968, 45364);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet17, 534, 99, buffer5, 13312);
+} catch {}
+let videoFrame11 = new VideoFrame(img6, {timestamp: 0});
+try {
+window.someLabel = externalTexture13.label;
+} catch {}
+let bindGroup6 = device1.createBindGroup({
+  label: '\u70e5\uc260\u5ba5\u0cc5\u5bb4\u0e7f\udd9a\u4995\u03e2\u{1fe31}',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let textureView67 = texture16.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 408});
+let renderBundleEncoder28 = device1.createRenderBundleEncoder({
+  label: '\u{1faf9}\u6b2e\ud858\u612f',
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'rg8sint', 'rgba8uint', 'rgba8uint', 'rgba8sint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 251 */
+{offset: 251}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline35 = device1.createComputePipeline({
+  label: '\u2362\ud89f\uae74\u3118\u00b5\u084e\u70bf\u4e96\u0c77',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+canvas18.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let bindGroupLayout16 = device2.createBindGroupLayout({
+  label: '\ud0fd\u0adb',
+  entries: [
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let pipelineLayout7 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout16]});
+let sampler27 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.12,
+  lodMaxClamp: 91.57,
+});
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 2,
+  origin: {x: 44, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 6851917 */
+{offset: 369, bytesPerRow: 664, rowsPerImage: 134}, {width: 99, height: 1, depthOrArrayLayers: 78});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+let offscreenCanvas14 = new OffscreenCanvas(730, 392);
+let bindGroup7 = device2.createBindGroup({
+  label: '\ub038\u05ce\ud36c\u0773\u0f80\u0ccf',
+  layout: bindGroupLayout16,
+  entries: [{binding: 34, resource: sampler27}],
+});
+try {
+texture22.destroy();
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 7, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 8, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 49 */
+{offset: 49}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 18, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 9, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule6 = device2.createShaderModule({
+  label: '\u3b09\u{1fce3}\uff22\u09f4\ud46c\u0a75\uadeb\ufe70',
+  code: `@group(0) @binding(34)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(6, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(3) f1: vec4<i32>,
+  @location(1) f2: vec3<f32>,
+  @location(2) f3: vec3<f32>,
+  @location(0) f4: vec3<i32>,
+  @location(4) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup8 = device2.createBindGroup({
+  label: '\u060e\u{1fd6b}\u0c72\u00a2\u{1feab}\u{1f9f8}\ueeeb\u814b',
+  layout: bindGroupLayout16,
+  entries: [{binding: 34, resource: sampler27}],
+});
+let buffer11 = device2.createBuffer({
+  label: '\u695e\u01b1\u8179\u50a1\u{1fb0a}\u6f57\u4c68\u1b90\u26ea\uab6a\u2f17',
+  size: 22860,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder59 = device2.createCommandEncoder();
+let computePassEncoder23 = commandEncoder48.beginComputePass({label: '\u075d\u08f7\u{1fccb}\u0d86\u{1f994}\u055b\u0b56\u{1f6de}'});
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(911), /* required buffer size: 911 */
+{offset: 911}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = device2.createComputePipeline({
+  label: '\ua694\u2fdc\u{1fe2a}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule6, entryPoint: 'compute0'},
+});
+let gpuCanvasContext15 = offscreenCanvas14.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup9 = device2.createBindGroup({
+  label: '\u{1f65b}\u{1fd73}\u0f2b\ue8ba\u{1f8e7}',
+  layout: bindGroupLayout16,
+  entries: [{binding: 34, resource: sampler27}],
+});
+let commandEncoder60 = device2.createCommandEncoder({label: '\u{1faa1}\u0d95\ufd1e\u996a\u{1f8a9}\u048d\u02c9\u0100\u194f\u16fc\u0171'});
+let textureView68 = texture29.createView({label: '\u{1fbac}\u077c', baseMipLevel: 6, mipLevelCount: 2});
+let renderBundle29 = renderBundleEncoder22.finish({label: '\u054b\uad1c\u500b\u{1fdda}\ubed5\u0535\u2c59\ucdc9\u0858\u0d65\u{1fa6f}'});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup7, new Uint32Array(5744), 3293, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 3,
+  origin: {x: 38, y: 0, z: 51},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 106627 */
+{offset: 991, bytesPerRow: 41, rowsPerImage: 112}, {width: 5, height: 1, depthOrArrayLayers: 24});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 258, y: 350 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let bindGroupLayout17 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3118,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 2458,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 972,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let querySet37 = device1.createQuerySet({label: '\u886f\u2118\u09d8\u00b6\u{1f896}\u8552', type: 'occlusion', count: 1643});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder({
+  label: '\u165d\u{1fb10}\u0c36\u0ef3\u0f69\u55ab',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder16.setBindGroup(6, bindGroup4, new Uint32Array(4689), 664, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup6, new Uint32Array(4602), 1980, 0);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer6, 22540, 59684);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.submit([commandBuffer14, commandBuffer10]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 57884, new Float32Array(63099), 19535, 2680);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 387 */
+{offset: 387}, {width: 67, height: 0, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas6.width = 1495;
+let shaderModule7 = device2.createShaderModule({
+  code: `@group(0) @binding(34)
+var<storage, read_write> local5: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(4) f1: vec4<u32>,
+  @location(3) f2: i32,
+  @location(7) f3: vec4<i32>,
+  @location(1) f4: vec2<f32>,
+  @location(2) f5: vec2<f32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: f32, @location(10) a1: vec4<f16>, @location(1) a2: u32, @location(14) a3: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup10 = device2.createBindGroup({
+  label: '\u{1fd82}\ue910\uf4bb\u{1fab0}\u0c1b\u58b5',
+  layout: bindGroupLayout16,
+  entries: [{binding: 34, resource: sampler27}],
+});
+let querySet38 = device2.createQuerySet({label: '\u0445\u098d\u958f\u{1f635}\u2622', type: 'occlusion', count: 2883});
+let texture33 = device2.createTexture({
+  size: [741, 1, 1071],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView69 = texture24.createView({
+  label: '\u{1ffff}\u0e64\ub6c2\u382c\u7eb2\u185e\u8313\u{1fe06}\u2197\u40c1\u7bc7',
+  format: 'rgba8unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+device2.queue.submit([commandBuffer12]);
+} catch {}
+let canvas19 = document.createElement('canvas');
+let imageBitmap18 = await createImageBitmap(videoFrame1);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder61 = device1.createCommandEncoder({label: '\u0b2b\u79a4'});
+let textureView70 = texture28.createView({dimension: '2d-array', baseMipLevel: 1});
+let computePassEncoder24 = commandEncoder53.beginComputePass({label: '\uec88\u0e7b\u2dda\u{1fc5f}\ufc7c\u{1f874}\ubbda\u1f03\u73fa'});
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'rg8sint', 'rgba8uint', 'rgba8uint', 'rgba8sint', 'r16uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+texture18.destroy();
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer6, 26096, 9416);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet15, 1105, 1321, buffer5, 52480);
+} catch {}
+let pipeline37 = await device1.createRenderPipelineAsync({
+  label: '\u{1fbd8}\u069d',
+  layout: pipelineLayout6,
+  multisample: {count: 1, mask: 0x89ff3725},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'zero'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'replace', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'keep', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 2058130395,
+    depthBias: 877940132,
+    depthBiasSlopeScale: 479.15772044975677,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1660, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 324,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 64, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 32, shaderLocation: 16},
+          {format: 'float32x4', offset: 52, shaderLocation: 2},
+          {format: 'uint32', offset: 320, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let device3 = await adapter3.requestDevice({
+  label: '\ue4d7\u2347\ua942\ub759\ufa9d\udf80\uef21\u0810\u0ee0\uc202\u0d0e',
+  defaultQueue: {label: '\u0c4e\u0a65\u{1f650}\u6cda\u{1f637}\u89de'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 35,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 4711,
+    maxStorageTexturesPerShaderStage: 10,
+    maxStorageBuffersPerShaderStage: 32,
+    maxDynamicStorageBuffersPerPipelineLayout: 36308,
+    maxDynamicUniformBuffersPerPipelineLayout: 42792,
+    maxBindingsPerBindGroup: 1829,
+    maxTextureArrayLayers: 1042,
+    maxTextureDimension1D: 12354,
+    maxTextureDimension2D: 14125,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 103139399,
+    maxUniformBuffersPerShaderStage: 14,
+    maxSampledTexturesPerShaderStage: 24,
+    maxInterStageShaderVariables: 62,
+    maxSamplersPerShaderStage: 17,
+  },
+});
+let video17 = await videoWithData();
+let videoFrame12 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+canvas19.getContext('webgpu');
+} catch {}
+let renderBundle30 = renderBundleEncoder28.finish({label: '\ucd20\u{1fa3f}\u8f61\u2e2a\u8e64\u0a68\u{1f7aa}\u0c6e\u0558\u3f78\u82ee'});
+try {
+renderBundleEncoder21.setPipeline(pipeline17);
+} catch {}
+let arrayBuffer1 = buffer9.getMappedRange(0, 18796);
+try {
+commandEncoder57.clearBuffer(buffer10, 12908, 79388);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer15]);
+} catch {}
+let commandEncoder62 = device3.createCommandEncoder({label: '\u03e2\u{1fe6b}\u{1f6dd}\ud3d4\u0fa2\ufa86'});
+let renderBundleEncoder31 = device3.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let video18 = await videoWithData();
+let commandEncoder63 = device3.createCommandEncoder({label: '\uac6c\uac7e\u0725\u52e4\u{1f943}\u0f2c\ue78b'});
+let externalTexture31 = device3.importExternalTexture({source: video1, colorSpace: 'srgb'});
+let offscreenCanvas15 = new OffscreenCanvas(263, 295);
+try {
+adapter0.label = '\u527a\udb98';
+} catch {}
+try {
+offscreenCanvas15.getContext('2d');
+} catch {}
+let bindGroup11 = device1.createBindGroup({label: '\uc6d5\u34ee\u{1fb82}', layout: bindGroupLayout9, entries: []});
+let commandEncoder64 = device1.createCommandEncoder({label: '\ucda6\u0382'});
+let commandBuffer17 = commandEncoder46.finish({label: '\u{1fb6d}\u0571\u66d9\u{1f9d6}'});
+let texture34 = device1.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 187},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({
+  label: '\u01b0\u306f\ub14f\ue646\u{1f96d}',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+  sampleCount: 1,
+});
+let sampler28 = device1.createSampler({
+  label: '\u02ae\u58ee\ub0de\u{1f9e2}\uab8d\ued60',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.94,
+  compare: 'less-equal',
+});
+try {
+renderBundleEncoder26.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(1256, undefined, 4145793332, 37040761);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer7, 43040, buffer6, 17224, 55572);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let promise11 = device1.createRenderPipelineAsync({
+  label: '\u0b99\u3add\u70c8',
+  layout: pipelineLayout5,
+  multisample: {},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'keep', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 3770968933,
+    stencilWriteMask: 1373901219,
+    depthBiasSlopeScale: 254.1211729643939,
+    depthBiasClamp: 859.8094447297968,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 684,
+        attributes: [
+          {format: 'float32x4', offset: 164, shaderLocation: 7},
+          {format: 'float16x2', offset: 188, shaderLocation: 20},
+          {format: 'uint32x2', offset: 136, shaderLocation: 10},
+          {format: 'float32x2', offset: 8, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1024,
+        attributes: [
+          {format: 'unorm16x2', offset: 400, shaderLocation: 16},
+          {format: 'sint32x4', offset: 280, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 216, shaderLocation: 4},
+          {format: 'float16x4', offset: 348, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 792,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 72, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 108, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 168, shaderLocation: 12},
+          {format: 'uint8x4', offset: 196, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 128,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 4, shaderLocation: 17},
+          {format: 'uint32x3', offset: 40, shaderLocation: 15},
+          {format: 'uint16x2', offset: 24, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 19},
+          {format: 'sint16x2', offset: 8, shaderLocation: 0},
+          {format: 'uint16x2', offset: 28, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32', offset: 256, shaderLocation: 5},
+          {format: 'uint8x4', offset: 728, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 1244, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 876, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(video17);
+let externalTexture32 = device3.importExternalTexture({source: videoFrame10, colorSpace: 'srgb'});
+let canvas20 = document.createElement('canvas');
+let computePassEncoder25 = commandEncoder62.beginComputePass({label: '\ua661\u{1f80d}\uf660\ucc0b\uca47\u183a\u7f50\u00fa\u8cef\u{1fb17}\u6ef6'});
+let sampler29 = device3.createSampler({
+  label: '\u02e1\u8951',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 40.14,
+  maxAnisotropy: 1,
+});
+let externalTexture33 = device3.importExternalTexture({label: '\u441b\ud755', source: videoFrame5, colorSpace: 'srgb'});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video17.height = 57;
+gc();
+offscreenCanvas8.height = 726;
+let canvas21 = document.createElement('canvas');
+try {
+canvas20.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img16 = await imageWithData(282, 85, '#c3dcea71', '#464b6487');
+let gpuCanvasContext16 = canvas21.getContext('webgpu');
+canvas9.width = 1191;
+let imageData17 = new ImageData(64, 84);
+canvas19.width = 61;
+let querySet39 = device1.createQuerySet({label: '\ucab2\u5578\u0c21\u0adc\u{1fe22}\uf490\ua5c7\ub54f', type: 'occlusion', count: 1366});
+let externalTexture34 = device1.importExternalTexture({label: '\u17b2\u{1fdaf}\ue379\u{1fb61}\u{1ff36}\u5b15\u06c2\u09a7\u{1f69f}', source: videoFrame9});
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline25);
+} catch {}
+let arrayBuffer2 = buffer9.getMappedRange(221992, 84452);
+try {
+commandEncoder56.copyBufferToBuffer(buffer7, 185740, buffer10, 76996, 23456);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 359}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 730, y: 72 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline38 = device1.createRenderPipeline({
+  label: '\u21fd\ube3c\u1095\u7ee4\ufb24\u6eb3\u0038\u808f',
+  layout: 'auto',
+  multisample: {mask: 0xadaff568},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint'}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.RED}, {format: 'rgba32uint'}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32float'}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 48, attributes: []},
+      {
+        arrayStride: 132,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 60, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 22},
+          {format: 'float32x4', offset: 0, shaderLocation: 12},
+          {format: 'sint8x4', offset: 24, shaderLocation: 14},
+          {format: 'float32', offset: 12, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 5},
+          {format: 'uint16x4', offset: 12, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 48, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 1964,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 160, shaderLocation: 10}],
+      },
+    ],
+  },
+});
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder65 = device1.createCommandEncoder({label: '\u{1f8f2}\u3be1\uee72\u4edc\u1e4e\u{1fc38}'});
+let querySet40 = device1.createQuerySet({label: '\u5d82\u011e\u1e90\ub5f4\u0b2b\u{1fde6}', type: 'occlusion', count: 134});
+let texture35 = device1.createTexture({
+  label: '\ue5ec\u{1fd14}\u06a0\u55de\u0e6c\udc9e\uf35a\u46a8\u0277',
+  size: {width: 96, height: 1, depthOrArrayLayers: 88},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView71 = texture19.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 162, arrayLayerCount: 10});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle31 = renderBundleEncoder16.finish({label: '\u1262\ua550\u8aeb'});
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 8052, new Float32Array(46705), 20535, 4128);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 32, y: 51 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder26 = commandEncoder29.beginComputePass({});
+let externalTexture35 = device1.importExternalTexture({
+  label: '\uaea4\uaaab\u{1ff7e}\ud699\u0345\ud637\u{1f97b}\u7697\u0ecb\ud282\uf517',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+let pipeline39 = device1.createRenderPipeline({
+  label: '\u54e7\u03d6',
+  layout: pipelineLayout4,
+  multisample: {mask: 0xf63076d2},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'constant'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 48, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 56, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 96, shaderLocation: 2},
+          {format: 'uint16x4', offset: 40, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 44, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 14, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 50, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 212, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 24, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 332, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 376,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 64, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', unclippedDepth: true},
+});
+let videoFrame13 = new VideoFrame(canvas15, {timestamp: 0});
+let canvas22 = document.createElement('canvas');
+let commandEncoder66 = device1.createCommandEncoder();
+let querySet41 = device1.createQuerySet({label: '\u6118\u0928\uca41\u04f3\u{1fd1b}\u0721\u00ff', type: 'occlusion', count: 2539});
+let textureView72 = texture17.createView({label: '\u189e\u0d0e\u0166\u5c79\u8a37\u0a82', dimension: '2d', baseArrayLayer: 6});
+let computePassEncoder27 = commandEncoder57.beginComputePass();
+let renderBundle32 = renderBundleEncoder23.finish({});
+try {
+commandEncoder43.copyBufferToBuffer(buffer8, 35036, buffer6, 20100, 51576);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer6, 26672, 35392);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer1), /* required buffer size: 538043 */
+{offset: 100, bytesPerRow: 161, rowsPerImage: 257}, {width: 21, height: 1, depthOrArrayLayers: 14});
+} catch {}
+let promise12 = device1.queue.onSubmittedWorkDone();
+let pipeline40 = device1.createComputePipeline({
+  label: '\u{1fe11}\uc064\ued9f\u94e7\u075e\u01d6\u079e\ucb34',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let querySet42 = device1.createQuerySet({label: '\u2bd7\u8ed5\u0ff2\u2d8a\u7515\ub849\u8a9f', type: 'occlusion', count: 1919});
+let commandBuffer18 = commandEncoder45.finish({label: '\u{1fab8}\u0e24\u42ff\u0187\u043c\ua890\u1b41\u0b68\u1f78\u058b\u{1fea8}'});
+let renderBundle33 = renderBundleEncoder30.finish();
+let externalTexture36 = device1.importExternalTexture({
+  label: '\u0881\u038b\u{1fc0a}\u920a\u0a6e\u36fa\u0517\u7a16\u{1f8c6}\u{1f943}\ub958',
+  source: videoFrame13,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup6, new Uint32Array(679), 210, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 748 widthInBlocks: 187 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4028 */
+  offset: 3280,
+  buffer: buffer7,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 187, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(querySet40, 80, 32, buffer5, 24576);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandBuffer19 = commandEncoder63.finish({label: '\u27f3\ue4a4\u08e6\u{1f81a}'});
+let renderBundle34 = renderBundleEncoder31.finish({});
+try {
+  await promise12;
+} catch {}
+let canvas23 = document.createElement('canvas');
+let texture36 = device1.createTexture({
+  label: '\uc337\ua780\u219e\u0450\uf006',
+  size: [384, 1, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView73 = texture26.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 20, arrayLayerCount: 256});
+let computePassEncoder28 = commandEncoder39.beginComputePass({label: '\u404b\u09a6\u{1ff95}\u5863\u068a\u681e\u5065\ua181'});
+let renderBundleEncoder34 = device1.createRenderBundleEncoder({
+  label: '\u{1fada}\u4d15\u{1fe64}\u082a',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+});
+let renderBundle35 = renderBundleEncoder16.finish({label: '\ufd8a\u7636\u0144\u18ef\u0598\u4b20\u05e6\u43a9'});
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 70832, new DataView(new ArrayBuffer(61215)), 28333, 18184);
+} catch {}
+let gpuCanvasContext17 = canvas23.getContext('webgpu');
+let imageData18 = new ImageData(104, 196);
+let sampler30 = device1.createSampler({
+  label: '\u4a9e\ua876\u8ffe\uf41b\u0e6e\u8a08\u8e2a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.31,
+  compare: 'less-equal',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder26.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6120, undefined);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 54},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 27, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder67 = device1.createCommandEncoder({label: '\u3a73\u0e30'});
+let externalTexture37 = device1.importExternalTexture({
+  label: '\uefe3\ufb7d\u82a9\u07d6\ue812\ub78d\u{1f6e9}\u0c75\u{1fa87}',
+  source: videoFrame7,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer8, 79508, buffer6, 65252, 8644);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(85, 198);
+let videoFrame14 = new VideoFrame(canvas2, {timestamp: 0});
+let bindGroupLayout18 = device1.createBindGroupLayout({entries: []});
+let texture37 = device1.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 425},
+  mipLevelCount: 7,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView74 = texture30.createView({baseMipLevel: 5, mipLevelCount: 1});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder({
+  label: '\u05ae\uba30',
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'rg8sint', 'rgba8uint', 'rgba8uint', 'rgba8sint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup6, new Uint32Array(9485), 5406, 0);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4119, undefined, 0, 4013771554);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer10, 62932, 6888);
+dissociateBuffer(device1, buffer10);
+} catch {}
+let video19 = await videoWithData();
+try {
+adapter2.label = '\u06f4\u06db\u28c1\u{1f7d3}';
+} catch {}
+let bindGroupLayout19 = device3.createBindGroupLayout({
+  label: '\u8b74\u3acc\u96a3\u{1ff5b}\u76a1\u5f41\u1578\ub7a5',
+  entries: [
+    {binding: 1556, visibility: 0, externalTexture: {}},
+    {
+      binding: 1410,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 260,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let pipelineLayout8 = device3.createPipelineLayout({
+  label: '\u{1f773}\ueb4f\u0b3a\u6e99\u0a59\uae30\u{1f978}\u82f6\u0983',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout19, bindGroupLayout19],
+});
+let commandEncoder68 = device3.createCommandEncoder({});
+let commandBuffer20 = commandEncoder68.finish({label: '\u66ff\u0a40\u{1fb6f}'});
+let bindGroup12 = device1.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 5295, resource: externalTexture34},
+    {binding: 2853, resource: externalTexture13},
+    {binding: 4083, resource: sampler17},
+  ],
+});
+let commandEncoder69 = device1.createCommandEncoder({label: '\ua9be\u0111\u{1ffdb}\ue1eb'});
+let textureView75 = texture17.createView({label: '\u198f\u076e', format: 'astc-6x5-unorm-srgb', baseArrayLayer: 6, arrayLayerCount: 1});
+let offscreenCanvas17 = new OffscreenCanvas(120, 464);
+let buffer12 = device1.createBuffer({
+  label: '\u5b93\u{1ff17}\uab03\u972d\u77f8\u{1f9ff}\ua7c3\u0d68\u0eeb',
+  size: 124092,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder70 = device1.createCommandEncoder({label: '\u0f7a\u0d1c\u{1fc74}\u0128\u01fd\u11b4\u0979\u1981\u{1ff9c}'});
+let textureView76 = texture26.createView({dimension: '2d', format: 'bgra8unorm-srgb', baseArrayLayer: 16});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder({
+  label: '\ua462\u0502\u5332\u{1ff55}',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder34.setVertexBuffer(7379, undefined, 2929758083, 193861126);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer12);
+dissociateBuffer(device1, buffer12);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 1, depthOrArrayLayers: 425}
+*/
+{
+  source: offscreenCanvas15,
+  origin: { x: 8, y: 28 },
+  flipY: false,
+}, {
+  texture: texture37,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 97},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise13 = device1.createRenderPipelineAsync({
+  label: '\ue12c\u6544\ub712\u{1f823}\u{1fa8d}\ubef7\u78db',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8unorm', writeMask: 0}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 580, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 68, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 124, shaderLocation: 18},
+          {format: 'float32x2', offset: 944, shaderLocation: 19},
+          {format: 'float32x2', offset: 92, shaderLocation: 8},
+          {format: 'float32x3', offset: 88, shaderLocation: 7},
+          {format: 'sint16x4', offset: 288, shaderLocation: 17},
+          {format: 'sint32x2', offset: 52, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 376, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 21},
+          {format: 'sint32', offset: 8, shaderLocation: 14},
+          {format: 'uint16x4', offset: 20, shaderLocation: 13},
+          {format: 'uint32x2', offset: 108, shaderLocation: 3},
+          {format: 'uint8x4', offset: 68, shaderLocation: 22},
+          {format: 'float16x2', offset: 248, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 168, shaderLocation: 9},
+          {format: 'uint32x4', offset: 280, shaderLocation: 10},
+          {format: 'uint32', offset: 44, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 216, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 940, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 1408, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 648,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 8, shaderLocation: 20},
+          {format: 'sint8x4', offset: 36, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', unclippedDepth: true},
+});
+let bindGroupLayout20 = pipeline40.getBindGroupLayout(4);
+let texture38 = device1.createTexture({
+  label: '\u{1fe60}\u{1fd8c}\u83d8\ua26c\u{1ffb9}\ubf31\u{1f867}\ucd2a\u{1f75f}',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let textureView77 = texture36.createView({label: '\u{1fbdf}\u3774\u{1f74c}\u{1fd67}\u4e44', dimension: '2d-array'});
+let computePassEncoder29 = commandEncoder65.beginComputePass({label: '\u7cc7\ue733'});
+try {
+buffer10.destroy();
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 4,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device1.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let video20 = await videoWithData();
+let externalTexture38 = device1.importExternalTexture({label: '\u0ebd\u4932\u{1fcf9}\u8877\u{1fc12}\u8744\uf498\ud44b\u0494\u7d4b\ua607', source: video19});
+try {
+commandEncoder54.copyBufferToBuffer(buffer7, 50580, buffer12, 103492, 16488);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer12);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 62, y: 14 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline41 = device1.createComputePipeline({
+  label: '\ud55a\ud3eb\u{1feed}\u9c97',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let canvas24 = document.createElement('canvas');
+try {
+canvas24.getContext('webgl2');
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas16.getContext('webgpu');
+try {
+window.someLabel = shaderModule7.label;
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(667, 596);
+let shaderModule8 = device3.createShaderModule({
+  label: '\u0a69\uc61e\u114b',
+  code: `@group(2) @binding(1556)
+var<storage, read_write> n2: array<u32>;
+@group(1) @binding(1410)
+var<storage, read_write> parameter4: array<u32>;
+@group(1) @binding(1556)
+var<storage, read_write> n3: array<u32>;
+@group(0) @binding(260)
+var<storage, read_write> parameter5: array<u32>;
+@group(2) @binding(1410)
+var<storage, read_write> n4: array<u32>;
+@group(2) @binding(260)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(1410)
+var<storage, read_write> n5: array<u32>;
+@group(0) @binding(1556)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(4) f1: f32,
+  @location(1) f2: f32,
+  @location(6) f3: vec2<i32>,
+  @location(2) f4: vec4<i32>,
+  @location(3) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder71 = device3.createCommandEncoder({});
+let texture39 = device3.createTexture({
+  label: '\u{1fe24}\ud7a5\u{1ff1d}\u{1fa74}\uca38\u0b4a\ua556\ub843\ue23f',
+  size: {width: 480, height: 5, depthOrArrayLayers: 599},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle36 = renderBundleEncoder31.finish();
+let sampler31 = device3.createSampler({
+  label: '\ua094\u188b\u0481\uc9df\u0e5b',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 31.10,
+  lodMaxClamp: 38.40,
+});
+try {
+device3.queue.submit([commandBuffer20, commandBuffer19]);
+} catch {}
+let commandEncoder72 = device3.createCommandEncoder({label: '\u0185\ud4bc\u{1f684}\u1486\u07bd\u{1f67e}\u800e\u88f2\uc62d\u9fad'});
+let texture40 = device3.createTexture({
+  label: '\u6b37\u099f\uc259\u1907\u{1f7c2}\u{1fb46}\ub740',
+  size: {width: 568, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView78 = texture40.createView({label: '\u{1fc1f}\u6838\u{1fa25}\u4aa0\u98a5\u4346', baseMipLevel: 2});
+let promise15 = device3.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule8, entryPoint: 'vertex0', buffers: []},
+});
+let gpuCanvasContext19 = offscreenCanvas18.getContext('webgpu');
+let gpuCanvasContext20 = offscreenCanvas17.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({});
+let canvas25 = document.createElement('canvas');
+try {
+externalTexture6.label = '\u{1fe22}\u3a02\u0028\u0f5c\uf287';
+} catch {}
+try {
+adapter0.label = '\u6fa8\u{1ff11}\u{1f869}\u{1f836}';
+} catch {}
+let texture41 = device1.createTexture({
+  label: '\u7bf3\u0b2c',
+  size: {width: 96, height: 1, depthOrArrayLayers: 189},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let renderBundle37 = renderBundleEncoder18.finish();
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline25);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 53588, new Int16Array(3583), 1879);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 509 */
+{offset: 201, bytesPerRow: 353}, {width: 77, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(img0);
+try {
+canvas25.getContext('2d');
+} catch {}
+gc();
+let texture42 = device1.createTexture({
+  label: '\u{1fea5}\u2df0\u{1f914}\u2688\u384a\u4c83\ue91e\uae8d',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView79 = texture23.createView({label: '\u{1f8f1}\u0684\uf352\ub53a'});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({
+  label: '\u{1fc59}\u{1fd80}\ub1a6\u7386\u2b23',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+});
+let externalTexture39 = device1.importExternalTexture({label: '\u{1fabb}\u1f9c\u{1ff14}\u05e6', source: videoFrame11, colorSpace: 'srgb'});
+try {
+commandEncoder41.resolveQuerySet(querySet15, 9, 2777, buffer5, 6400);
+} catch {}
+let pipeline42 = device1.createComputePipeline({
+  label: '\uec21\u1409',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let img17 = await imageWithData(38, 181, '#b372ba6e', '#fdfd7759');
+let imageData19 = new ImageData(68, 164);
+let shaderModule9 = device3.createShaderModule({
+  code: `@group(0) @binding(1410)
+var<storage, read_write> field5: array<u32>;
+@group(2) @binding(1410)
+var<storage, read_write> function4: array<u32>;
+@group(2) @binding(260)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(1556)
+var<storage, read_write> parameter7: array<u32>;
+@group(1) @binding(260)
+var<storage, read_write> function5: array<u32>;
+@group(0) @binding(260)
+var<storage, read_write> parameter8: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(1) f1: vec3<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(4) f3: f32,
+  @location(2) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec2<i32>, @location(14) a1: vec2<f32>, @location(12) a2: vec4<i32>, @location(2) a3: vec3<f32>, @location(0) a4: f16, @location(6) a5: vec4<f16>, @location(16) a6: u32, @builtin(vertex_index) a7: u32, @location(8) a8: vec4<f32>, @location(1) a9: i32, @location(11) a10: vec4<i32>, @location(13) a11: vec2<u32>, @location(7) a12: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let textureView80 = texture40.createView({label: '\udf85\u0a8c\u60c9\ub2f7\uaa4f\u6a1d', baseMipLevel: 1, baseArrayLayer: 0});
+let renderBundleEncoder38 = device3.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler32 = device3.createSampler({
+  label: '\u3642\u3065\u0bd4\u{1fce2}\u0633\u{1f749}\u{1fa60}\u8bf1\u0765',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.24,
+  lodMaxClamp: 72.14,
+  compare: 'always',
+  maxAnisotropy: 2,
+});
+try {
+gpuCanvasContext17.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let video21 = await videoWithData();
+let img18 = await imageWithData(168, 99, '#70a71f7a', '#d21c66f4');
+let renderBundle38 = renderBundleEncoder31.finish({label: '\u776e\u755c'});
+let sampler33 = device3.createSampler({
+  label: '\u04d0\u56ed\u79b4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(48)), /* required buffer size: 21408 */
+{offset: 408, bytesPerRow: 4258}, {width: 496, height: 5, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video18);
+let commandEncoder73 = device2.createCommandEncoder({label: '\ucb11\u127f\u0350\ue1d9\u{1fb4f}\u39fa\u0837\u{1f7d4}\u0858\u640c\u{1f659}'});
+let textureView81 = texture22.createView({dimension: '2d', aspect: 'stencil-only', mipLevelCount: 2, baseArrayLayer: 316});
+let externalTexture40 = device2.importExternalTexture({label: '\u{1ffd4}\u0db4', source: video10, colorSpace: 'display-p3'});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 12, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 18, y: 74 },
+  flipY: true,
+}, {
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext21 = canvas22.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas26 = document.createElement('canvas');
+try {
+canvas26.getContext('bitmaprenderer');
+} catch {}
+let sampler34 = device3.createSampler({
+  label: '\u{1fbd7}\ufe9e\uac28\u0d34',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 49.09,
+  lodMaxClamp: 74.25,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+let externalTexture41 = device3.importExternalTexture({label: '\u{1ffcb}\u{1f85c}\u0ae2\u{1fbd9}\u002a\ub737', source: video7});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 1893 */
+{offset: 869, bytesPerRow: 1122}, {width: 128, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet43 = device1.createQuerySet({
+  label: '\u6f5a\u0e70\u09a5\u96b3\u7326\u{1fc8b}\u{1f68d}\u{1f6b0}\u07e4\u9969',
+  type: 'occlusion',
+  count: 939,
+});
+let textureView82 = texture21.createView({label: '\u1a00\u028a\u0ea7\u038c\u5685', baseMipLevel: 1, mipLevelCount: 3});
+let renderBundleEncoder39 = device1.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'r32sint', 'r8unorm', 'rgba16uint', 'r32uint', 'bgra8unorm', 'rgba32float'],
+});
+try {
+computePassEncoder24.setPipeline(pipeline33);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer8, 13068, buffer10, 100124, 8292);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 54704, new BigUint64Array(62491), 4098, 560);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas13,
+  origin: { x: 48, y: 8 },
+  flipY: true,
+}, {
+  texture: texture38,
+  mipLevel: 2,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData20 = new ImageData(184, 16);
+let commandEncoder74 = device3.createCommandEncoder({});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 233 */
+{offset: 233, bytesPerRow: 3191}, {width: 375, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule10 = device3.createShaderModule({
+  label: '\u982a\u076c\u7b85\ubc60\u{1fdfd}',
+  code: `@group(2) @binding(1410)
+var<storage, read_write> global4: array<u32>;
+@group(2) @binding(1556)
+var<storage, read_write> n6: array<u32>;
+@group(1) @binding(1410)
+var<storage, read_write> type10: array<u32>;
+@group(0) @binding(260)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(1410)
+var<storage, read_write> n8: array<u32>;
+@group(1) @binding(260)
+var<storage, read_write> local7: array<u32>;
+@group(2) @binding(260)
+var<storage, read_write> parameter9: array<u32>;
+@group(1) @binding(1556)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(1556)
+var<storage, read_write> type11: array<u32>;
+
+@compute @workgroup_size(2, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(0) f1: vec2<u32>,
+  @location(4) f2: f32,
+  @location(2) f3: vec4<i32>,
+  @location(1) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec2<f32>, @location(33) a1: vec4<i32>, @location(12) a2: vec3<u32>, @location(45) a3: vec4<f16>, @location(47) a4: vec2<f16>, @location(49) a5: vec2<f16>, @location(11) a6: vec3<u32>, @location(40) a7: u32, @location(8) a8: i32, @builtin(sample_index) a9: u32, @location(44) a10: vec2<u32>, @location(58) a11: vec4<f32>, @builtin(sample_mask) a12: u32, @location(51) a13: vec4<f32>, @location(26) a14: vec4<i32>, @location(29) a15: vec4<f32>, @builtin(front_facing) a16: bool, @location(41) a17: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(3) f0: u32,
+  @location(8) f1: vec2<i32>,
+  @location(1) f2: f32,
+  @location(7) f3: vec3<f16>,
+  @location(16) f4: vec2<f32>,
+  @location(12) f5: vec3<f16>,
+  @location(2) f6: vec2<f16>,
+  @location(0) f7: vec2<f32>,
+  @location(13) f8: f16,
+  @location(9) f9: vec3<f32>,
+  @location(14) f10: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(49) f70: vec2<f16>,
+  @location(40) f71: u32,
+  @location(14) f72: vec2<f16>,
+  @location(44) f73: vec2<u32>,
+  @location(12) f74: vec3<u32>,
+  @location(11) f75: vec3<u32>,
+  @location(51) f76: vec4<f32>,
+  @location(52) f77: f16,
+  @location(41) f78: u32,
+  @location(58) f79: vec4<f32>,
+  @location(5) f80: vec2<i32>,
+  @location(33) f81: vec4<i32>,
+  @location(37) f82: vec2<f16>,
+  @location(26) f83: vec4<i32>,
+  @location(47) f84: vec2<f16>,
+  @location(7) f85: vec2<f32>,
+  @builtin(position) f86: vec4<f32>,
+  @location(4) f87: vec2<f16>,
+  @location(25) f88: vec2<f32>,
+  @location(28) f89: i32,
+  @location(29) f90: vec4<f32>,
+  @location(45) f91: vec4<f16>,
+  @location(8) f92: i32,
+  @location(3) f93: vec4<u32>,
+  @location(21) f94: vec3<f32>,
+  @location(61) f95: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<i32>, @location(4) a1: vec4<i32>, a2: S5, @location(10) a3: vec4<i32>, @location(17) a4: f16, @location(6) a5: vec4<f32>, @location(11) a6: vec3<f16>, @location(5) a7: vec4<i32>, @builtin(instance_index) a8: u32, @builtin(vertex_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView83 = texture40.createView({aspect: 'all', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder30 = commandEncoder74.beginComputePass({label: '\u035d\u6fd3\u2191\u027f\u982d\u{1fd12}'});
+try {
+device3.pushErrorScope('internal');
+} catch {}
+document.body.prepend(video10);
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroup13 = device1.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [
+    {binding: 4083, resource: sampler17},
+    {binding: 2853, resource: externalTexture20},
+    {binding: 5295, resource: externalTexture26},
+  ],
+});
+let commandEncoder75 = device1.createCommandEncoder({label: '\u{1fcee}\u{1f761}\u4269\u3f33\u{1f6e2}\u1a34\uf0b3\u4567'});
+let textureView84 = texture35.createView({
+  label: '\ud726\ub46d\u0b24\u37a7\u{1fbd5}\u02d7\u9376\u6da9\u{1f7e4}',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder40 = device1.createRenderBundleEncoder({
+  label: '\u{1f9bc}\ub43e',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba8uint', 'r8uint', 'r32sint', 'r32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle39 = renderBundleEncoder26.finish({label: '\u7961\u{1fb74}\u{1fefa}'});
+try {
+commandEncoder54.clearBuffer(buffer6, 3616, 23460);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+renderBundleEncoder27.pushDebugGroup('\ubfb0');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 61396, new Int16Array(17538));
+} catch {}
+document.body.prepend(canvas16);
+let texture43 = device3.createTexture({
+  label: '\ue310\u{1fca7}\u{1f6bf}\ue78d\u9a7a\ua1e0\u0097\u0e63\u7779\u1dbf\u196a',
+  size: [240],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+let textureView85 = texture43.createView({label: '\u0f5f\uca8c', mipLevelCount: 1});
+try {
+commandEncoder62.insertDebugMarker('\u{1f6cc}');
+} catch {}
+gc();
+try {
+adapter4.label = '\u098a\u01e0\u96d0\u{1fb01}\u0d87\ue9a8';
+} catch {}
+let pipelineLayout9 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout19]});
+video11.width = 190;
+let offscreenCanvas19 = new OffscreenCanvas(61, 76);
+let imageData21 = new ImageData(52, 156);
+try {
+offscreenCanvas19.getContext('2d');
+} catch {}
+let shaderModule11 = device1.createShaderModule({
+  label: '\u{1fcc8}\u0822\ub757\uf581\uef45\uc536',
+  code: `@group(4) @binding(4083)
+var<storage, read_write> function6: array<u32>;
+@group(0) @binding(2853)
+var<storage, read_write> field6: array<u32>;
+@group(1) @binding(2853)
+var<storage, read_write> function7: array<u32>;
+@group(2) @binding(5295)
+var<storage, read_write> type12: array<u32>;
+@group(3) @binding(5295)
+var<storage, read_write> field7: array<u32>;
+@group(3) @binding(4083)
+var<storage, read_write> global5: array<u32>;
+@group(0) @binding(5295)
+var<storage, read_write> parameter11: array<u32>;
+@group(1) @binding(5295)
+var<storage, read_write> local8: array<u32>;
+@group(4) @binding(2853)
+var<storage, read_write> n9: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> n10: array<u32>;
+@group(2) @binding(2853)
+var<storage, read_write> local9: array<u32>;
+@group(4) @binding(5295)
+var<storage, read_write> n11: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(7) f2: vec3<f32>,
+  @location(0) f3: vec4<u32>,
+  @location(4) f4: vec4<u32>,
+  @location(5) f5: vec4<u32>,
+  @location(2) f6: vec4<f32>,
+  @location(6) f7: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: i32, @location(13) a1: f16, @location(10) a2: vec3<f16>, @location(18) a3: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout21 = device1.createBindGroupLayout({label: '\u21e0\u7d6d\u66db', entries: []});
+let textureView86 = texture18.createView({aspect: 'all', baseMipLevel: 7});
+let sampler35 = device1.createSampler({addressModeV: 'repeat', mipmapFilter: 'nearest', lodMinClamp: 98.05, lodMaxClamp: 98.75});
+try {
+renderBundleEncoder21.setPipeline(pipeline39);
+} catch {}
+document.body.prepend(img13);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+video1.width = 43;
+let device4 = await adapter4.requestDevice({
+  label: '\u2687\ufa45\u8918\u5758\u20f7',
+  requiredLimits: {
+    maxBindGroups: 5,
+    maxColorAttachmentBytesPerSample: 50,
+    maxVertexAttributes: 21,
+    maxVertexBufferArrayStride: 62517,
+    maxStorageTexturesPerShaderStage: 30,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 8748,
+    maxDynamicUniformBuffersPerPipelineLayout: 27603,
+    maxBindingsPerBindGroup: 9891,
+    maxTextureArrayLayers: 1332,
+    maxTextureDimension1D: 12609,
+    maxTextureDimension2D: 11213,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 211445813,
+    maxUniformBuffersPerShaderStage: 30,
+    maxSampledTexturesPerShaderStage: 43,
+    maxInterStageShaderVariables: 67,
+    maxInterStageShaderComponents: 121,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let computePassEncoder31 = commandEncoder71.beginComputePass();
+let renderBundleEncoder41 = device3.createRenderBundleEncoder({
+  label: '\u7f5c\u78f5\u{1ff5b}\u22f0\ud255\uae77\ufaf6\u8574\u0b37',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let promise16 = device3.queue.onSubmittedWorkDone();
+let pipeline43 = device3.createComputePipeline({
+  label: '\u9e1c\u7d7c\u{1fe6f}\u2d7b\u0e23',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule8, entryPoint: 'compute0'},
+});
+let pipeline44 = await promise15;
+let img19 = await imageWithData(200, 201, '#d1e35600', '#bae1fa04');
+let videoFrame15 = new VideoFrame(offscreenCanvas11, {timestamp: 0});
+try {
+  await promise16;
+} catch {}
+video8.height = 179;
+let texture44 = device4.createTexture({
+  size: [240, 1, 1064],
+  mipLevelCount: 8,
+  dimension: '2d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let externalTexture42 = device4.importExternalTexture({label: '\u{1fd0d}\u086b\u0cd3\uc88a\u2ff5\uecc8\uf21d', source: video21});
+let imageBitmap19 = await createImageBitmap(imageBitmap9);
+let commandEncoder76 = device4.createCommandEncoder({label: '\u8704\u4e37\u0d56\u09ce\ua523\u{1f8cb}\uf878\u2718\u{1fc9e}'});
+let textureView87 = texture44.createView({dimension: '2d', baseMipLevel: 7, mipLevelCount: 1, baseArrayLayer: 865});
+let sampler36 = device4.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.50,
+  lodMaxClamp: 64.18,
+  compare: 'greater',
+});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder76.pushDebugGroup('\u0e93');
+} catch {}
+let video22 = await videoWithData();
+let renderBundle40 = renderBundleEncoder26.finish();
+let sampler37 = device1.createSampler({
+  label: '\u0470\u05fd\u03f4\u{1f9dd}\u0623\u0634\ue448\u{1febc}\u09ce\u7aa7\u968b',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 55.44,
+  lodMaxClamp: 86.60,
+});
+try {
+renderBundleEncoder37.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup6, new Uint32Array(2348), 313, 0);
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 424 widthInBlocks: 106 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28316 */
+  offset: 28316,
+  bytesPerRow: 512,
+  buffer: buffer7,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 106, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer12);
+dissociateBuffer(device1, buffer12);
+} catch {}
+try {
+renderBundleEncoder21.insertDebugMarker('\u{1fdba}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 11240, new Int16Array(55970));
+} catch {}
+let pipeline45 = await device1.createComputePipelineAsync({
+  label: '\u{1fdd6}\u0c0a\udfc7\u0c89\uba00',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let promise17 = device1.createRenderPipelineAsync({
+  label: '\uf6c7\u5d8a\u57d2\ub745\u463f\ua541\u5690',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one'},
+  },
+}, {format: 'rgba16float'}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 348,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 40, shaderLocation: 18},
+          {format: 'float16x4', offset: 4, shaderLocation: 19},
+          {format: 'float16x4', offset: 24, shaderLocation: 0},
+          {format: 'sint16x4', offset: 24, shaderLocation: 8},
+          {format: 'sint32x4', offset: 20, shaderLocation: 13},
+          {format: 'sint32x4', offset: 24, shaderLocation: 21},
+          {format: 'sint32x4', offset: 44, shaderLocation: 4},
+          {format: 'uint32x3', offset: 52, shaderLocation: 15},
+          {format: 'float32x3', offset: 176, shaderLocation: 10},
+          {format: 'float32', offset: 60, shaderLocation: 9},
+          {format: 'float32x2', offset: 80, shaderLocation: 1},
+          {format: 'uint32x4', offset: 280, shaderLocation: 11},
+          {format: 'float32x4', offset: 4, shaderLocation: 5},
+          {format: 'sint32x3', offset: 64, shaderLocation: 17},
+          {format: 'uint16x4', offset: 48, shaderLocation: 2},
+          {format: 'uint8x2', offset: 28, shaderLocation: 20},
+          {format: 'float32x4', offset: 168, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 1300,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 140, shaderLocation: 12},
+          {format: 'sint16x2', offset: 416, shaderLocation: 16},
+          {format: 'float16x2', offset: 708, shaderLocation: 7},
+          {format: 'uint8x2', offset: 216, shaderLocation: 6},
+          {format: 'sint32', offset: 412, shaderLocation: 22},
+          {format: 'sint16x2', offset: 96, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let textureView88 = texture40.createView({
+  label: '\u2ffd\u08be\u{1fff8}\u6dfa\u630f\uc3dd\ua7b1\ubf49\uada7',
+  dimension: '2d-array',
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder42 = device3.createRenderBundleEncoder({
+  label: '\uec6c\u{1f76c}\u2282\u6771\u09be',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder42.setVertexBuffer(328, undefined);
+} catch {}
+let canvas27 = document.createElement('canvas');
+try {
+canvas27.getContext('webgpu');
+} catch {}
+let pipelineLayout10 = device3.createPipelineLayout({bindGroupLayouts: []});
+let pipeline46 = device3.createRenderPipeline({
+  label: '\u0c82\u1b2d\uee8a\u1902\u0415\u{1fc62}\u{1f73f}\u{1ffae}\u9bda',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16sint'}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 684441822,
+    depthBias: -1205844883,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 640, attributes: [{format: 'sint32x4', offset: 64, shaderLocation: 12}]},
+      {
+        arrayStride: 1088,
+        attributes: [
+          {format: 'snorm16x2', offset: 44, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 448, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 892, attributes: [{format: 'float32x4', offset: 260, shaderLocation: 14}]},
+      {
+        arrayStride: 2500,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 916, shaderLocation: 16},
+          {format: 'sint32', offset: 288, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 452, shaderLocation: 2},
+          {format: 'float32x2', offset: 304, shaderLocation: 0},
+          {format: 'sint32x4', offset: 408, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 1796, attributes: [{format: 'sint8x2', offset: 290, shaderLocation: 10}]},
+      {
+        arrayStride: 1136,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 252, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+offscreenCanvas3.width = 380;
+let bindGroup14 = device1.createBindGroup({label: '\ub127\u{1f694}', layout: bindGroupLayout9, entries: []});
+let commandEncoder77 = device1.createCommandEncoder({label: '\u8374\u04bd\u{1fe84}\uc442\u676d\u{1fbb9}'});
+let querySet44 = device1.createQuerySet({label: '\u06e4\u{1ff3b}\u0869\u0671\udeda\u{1f9b8}\uabdd\u1608', type: 'occlusion', count: 3784});
+let textureView89 = texture26.createView({
+  label: '\uea91\u51df\u{1fbac}\ua22b\u1d48\u29e7\u9702\u0e61\u00e3',
+  baseMipLevel: 3,
+  baseArrayLayer: 257,
+  arrayLayerCount: 32,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup14, new Uint32Array(3047), 1647, 0);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 32440, new DataView(new ArrayBuffer(64087)), 25376, 2052);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 3 */
+{offset: 3}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView90 = texture36.createView({label: '\u4abe\u0fcd\ub83d\u{1fb97}\u43b2\u{1f92b}'});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup5);
+} catch {}
+let buffer13 = device1.createBuffer({size: 469988, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder78 = device1.createCommandEncoder({label: '\u2749\u{1f774}\u03bc\uc25f\u{1fad0}\u002a\u07ac\u0414\u85c7\ub9e8'});
+let texture45 = device1.createTexture({
+  label: '\u4144\u08cf\ua925\u0a66\u008c\u4c05\ucd6f\u{1fb7d}\u01a2',
+  size: [192, 1, 651],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 848 widthInBlocks: 53 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 20560 */
+  offset: 20560,
+  buffer: buffer12,
+}, {width: 53, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer12);
+} catch {}
+let promise18 = device1.createRenderPipelineAsync({
+  label: '\ub7e3\ue353\uf256\ue86a\u{1ff4e}\u0307\uabb0\u7e3b\u{1f8b4}',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less-equal', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 2336584828,
+    stencilWriteMask: 11148112,
+    depthBiasSlopeScale: 783.0243582553451,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 804,
+        attributes: [
+          {format: 'sint16x4', offset: 48, shaderLocation: 0},
+          {format: 'uint8x4', offset: 68, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 32, shaderLocation: 18},
+          {format: 'snorm16x4', offset: 408, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 212, shaderLocation: 7},
+          {format: 'uint32x2', offset: 116, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 68,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x4', offset: 4, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 19},
+          {format: 'float32x4', offset: 4, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 8, shaderLocation: 21},
+          {format: 'uint32', offset: 284, shaderLocation: 13},
+          {format: 'sint8x4', offset: 36, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 52, shaderLocation: 11},
+          {format: 'float32', offset: 12, shaderLocation: 20},
+          {format: 'sint32', offset: 0, shaderLocation: 5},
+          {format: 'uint32x4', offset: 16, shaderLocation: 22},
+          {format: 'uint32x4', offset: 424, shaderLocation: 15},
+          {format: 'sint8x2', offset: 304, shaderLocation: 14},
+          {format: 'uint32', offset: 124, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 1488, attributes: []},
+      {
+        arrayStride: 92,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 56, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+});
+let textureView91 = texture44.createView({dimension: '2d', format: 'r16float', baseMipLevel: 0, mipLevelCount: 5, baseArrayLayer: 757});
+let sampler38 = device4.createSampler({
+  label: '\u0283\ua709\u04e1',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.95,
+  lodMaxClamp: 56.25,
+  compare: 'less-equal',
+});
+let buffer14 = device3.createBuffer({size: 704263, usage: GPUBufferUsage.INDEX});
+let commandEncoder79 = device3.createCommandEncoder({label: '\u085d\u04b7\u{1fa7d}\u436d\u0113\u0d00\u{1f65a}\u0f20\u{1fe50}'});
+let renderBundle41 = renderBundleEncoder38.finish({label: '\u{1f9d3}\u{1f799}\u029f\udb0c\u029b\u{1f933}\u275f\u61e6\u838b'});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline43);
+} catch {}
+let pipeline47 = device3.createComputePipeline({
+  label: '\u{1fe48}\ucd7b\u062c\u3eec\u04d7\u{1fec1}\ub0e6\u1499\u72b4',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let imageBitmap20 = await createImageBitmap(video7);
+let promise19 = adapter4.requestAdapterInfo();
+let promise20 = adapter4.requestAdapterInfo();
+let buffer15 = device4.createBuffer({
+  size: 178071,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let querySet45 = device4.createQuerySet({type: 'occlusion', count: 3129});
+let textureView92 = texture44.createView({label: '\u2db3\u4ed3', dimension: '2d', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 809});
+offscreenCanvas11.width = 3840;
+let commandEncoder80 = device4.createCommandEncoder({label: '\u0c22\uf1e9\u{1fe4b}\u{1ff18}\u0c10\u7b39\uc333'});
+let textureView93 = texture44.createView({
+  label: '\u0b2b\u4bef\u2661\u0ba9\u9cc9\ud93c\u{1feeb}\ue662\u542c',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 318,
+});
+try {
+commandEncoder80.resolveQuerySet(querySet45, 2151, 222, buffer15, 43776);
+} catch {}
+gc();
+let computePassEncoder32 = commandEncoder80.beginComputePass({label: '\u0354\ua46a\u0541\u0728\u0343\u81a4'});
+try {
+querySet45.destroy();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let commandEncoder81 = device1.createCommandEncoder({label: '\ub453\uf029\u{1f979}\u{1fa1e}\u3b34\u28c5\u837a\u08b1\u48ab'});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet42, 1697, 92, buffer5, 44544);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 740, new Int16Array(10065), 7981, 1184);
+} catch {}
+let promise21 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 425}
+*/
+{
+  source: imageBitmap18,
+  origin: { x: 8, y: 0 },
+  flipY: true,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 73},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline48 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32float'}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 60,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 4, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 6, shaderLocation: 5},
+          {format: 'sint16x2', offset: 4, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 22},
+          {format: 'float16x2', offset: 4, shaderLocation: 21},
+          {format: 'float32', offset: 4, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 1260, attributes: [{format: 'uint16x2', offset: 104, shaderLocation: 0}]},
+      {
+        arrayStride: 1808,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 176, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let bindGroupLayout22 = device4.createBindGroupLayout({
+  label: '\uaa33\u4bfc',
+  entries: [
+    {
+      binding: 6601,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let textureView94 = texture44.createView({label: '\u{1f60e}\u53fc', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 823, arrayLayerCount: 77});
+let computePassEncoder33 = commandEncoder76.beginComputePass({label: '\u0935\u{1f7e6}\u0a86'});
+let sampler39 = device4.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.58,
+  lodMaxClamp: 91.33,
+  maxAnisotropy: 5,
+});
+try {
+gpuCanvasContext16.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+canvas3.height = 1959;
+try {
+  await promise20;
+} catch {}
+let texture46 = device1.createTexture({
+  label: '\ua926\u1e40\u0fa5\u8c0c',
+  size: {width: 48, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8sint'],
+});
+let textureView95 = texture45.createView({
+  label: '\u{1f71f}\u0f3e\u0a61\u74b5\u{1f7a9}\u{1ffed}\u214b\u0126',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderBundleEncoder36.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(buffer13, 179036, buffer6, 18504, 71864);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 100000 */
+  offset: 100000,
+  bytesPerRow: 0,
+  rowsPerImage: 88,
+  buffer: buffer7,
+}, {
+  texture: texture30,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 8});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 359}
+*/
+{
+  source: imageBitmap14,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 42},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline49 = device1.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule5, entryPoint: 'compute0'}});
+document.body.prepend(canvas23);
+let img20 = await imageWithData(32, 6, '#f5f58b5b', '#eafad7ae');
+let video23 = await videoWithData();
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let querySet46 = device4.createQuerySet({label: '\u{1fdc5}\u1cc2\u3afa\u3373', type: 'occlusion', count: 82});
+let textureView96 = texture44.createView({
+  label: '\u{1fca9}\u{1fff3}\u0cd5\uc46f',
+  dimension: '2d-array',
+  baseMipLevel: 7,
+  baseArrayLayer: 502,
+  arrayLayerCount: 123,
+});
+let externalTexture43 = device4.importExternalTexture({label: '\u12cd\u34db\u6dee\u0706\u{1f9c5}\u{1fb90}\u817c\u000a\ue43b\u0f10\u71f9', source: video1});
+try {
+gpuCanvasContext4.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder82 = device1.createCommandEncoder();
+let texture47 = device1.createTexture({
+  size: [192, 1, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let textureView97 = texture25.createView({label: '\u87ff\u0444\u035c\ub340', format: 'rgba8unorm-srgb'});
+let computePassEncoder34 = commandEncoder41.beginComputePass();
+let renderBundle42 = renderBundleEncoder20.finish({label: '\uccfa\ub907\ue99c\u09ff\uecb8\ua325\u6e99'});
+let externalTexture44 = device1.importExternalTexture({
+  label: '\ud228\u{1f7e2}\u09e2\u{1f6b1}\u{1f9ee}\u0c93\u0013\u90c6',
+  source: videoFrame6,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 57},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 328 widthInBlocks: 328 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 102587 */
+  offset: 16571,
+  bytesPerRow: 512,
+  rowsPerImage: 24,
+  buffer: buffer10,
+}, {width: 328, height: 0, depthOrArrayLayers: 8});
+dissociateBuffer(device1, buffer10);
+} catch {}
+let img21 = await imageWithData(117, 215, '#651786c7', '#4c540225');
+let commandEncoder83 = device4.createCommandEncoder({label: '\u9f4f\u0450\u7c24\u0fad\uc5f3\u0770\u0842\u0e2e\ud231\u{1fd23}'});
+let querySet47 = device4.createQuerySet({label: '\ua5b1\u4287\u{1fd56}\u097c\u{1f9a7}\ud06a', type: 'occlusion', count: 3492});
+let texture48 = device4.createTexture({
+  label: '\uc3f2\u6c9f\u172a\u0967\u02cb\u9dec\ubcba\u8e60\ucb9b\u{1f766}\u{1fcf5}',
+  size: [480, 1, 1211],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let computePassEncoder35 = commandEncoder83.beginComputePass();
+let sampler40 = device4.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.90,
+  lodMaxClamp: 97.38,
+  maxAnisotropy: 5,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 70},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 61372775 */
+{offset: 191, bytesPerRow: 1972, rowsPerImage: 133}, {width: 420, height: 0, depthOrArrayLayers: 235});
+} catch {}
+let promise22 = device4.queue.onSubmittedWorkDone();
+video6.height = 255;
+canvas7.height = 1891;
+let querySet48 = device3.createQuerySet({
+  label: '\u9500\u0f23\u9b5a\u3124\u182d\u73a3\u{1fc47}\u{1fedf}\ucca6\uf848\u2f22',
+  type: 'occlusion',
+  count: 5,
+});
+let textureView98 = texture40.createView({label: '\u0ac6\ubc63\uf29f\u4039\u{1fd32}', dimension: '2d-array'});
+let computePassEncoder36 = commandEncoder72.beginComputePass();
+let externalTexture45 = device3.importExternalTexture({source: videoFrame13});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas16.width = 4144;
+let bindGroupLayout23 = device4.createBindGroupLayout({
+  label: '\ub7c5\u{1fb7c}\u00b4\u0e9c\ufab0\u867f\u057d\ub72e\u1d5e\u{1fd02}',
+  entries: [
+    {
+      binding: 1741,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder84 = device4.createCommandEncoder({label: '\u2337\u{1f683}\u5f7b\u8909\u0c8d\uaba9\u{1fa67}'});
+let textureView99 = texture48.createView({label: '\u8b29\u0cdd\ue0ea\ub4a8\u0643\u17c0'});
+let computePassEncoder37 = commandEncoder84.beginComputePass();
+let renderBundleEncoder43 = device4.createRenderBundleEncoder({label: '\u3bdf\u0c6c\u0d5f\uf038\u7056\u{1fe49}', colorFormats: ['rgba8uint']});
+let renderBundle43 = renderBundleEncoder43.finish({label: '\uefa9\u4065\u5687\u{1fdfa}\ua7a6\u9901\u2ed6\u014b\u031b\u{1fb5e}\u7737'});
+let externalTexture46 = device4.importExternalTexture({
+  label: '\u{1fc31}\u40dd\u0c79\uf98c\u4a09\u08f0\u8ea8\u05f8\u1c64\u{1f9d4}',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+let offscreenCanvas20 = new OffscreenCanvas(66, 878);
+let pipelineLayout11 = device4.createPipelineLayout({
+  label: '\u{1f880}\u0d7a\u6b86\udba2\u0dd6\u0798\u0a2a\u{1faea}\u{1f887}\u0121\u0baa',
+  bindGroupLayouts: [bindGroupLayout22, bindGroupLayout23],
+});
+let renderBundleEncoder44 = device4.createRenderBundleEncoder({label: '\u{1f874}\ubb14\u084f\u1264\uda64', colorFormats: ['rgba8uint'], sampleCount: 1});
+let externalTexture47 = device4.importExternalTexture({source: videoFrame12, colorSpace: 'srgb'});
+document.body.prepend(canvas22);
+let commandEncoder85 = device3.createCommandEncoder();
+let promise23 = device3.queue.onSubmittedWorkDone();
+let gpuCanvasContext22 = offscreenCanvas20.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule12 = device4.createShaderModule({
+  label: '\u{1f9c6}\u{1fa09}\u0c77\u{1fe45}\u{1fd64}\u{1fd03}\u2ba3\u09cc\u0d8c\u{1f771}',
+  code: `@group(1) @binding(1741)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(6601)
+var<storage, read_write> local10: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(5) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView100 = texture44.createView({baseMipLevel: 6, baseArrayLayer: 330, arrayLayerCount: 116});
+let renderBundle44 = renderBundleEncoder44.finish({label: '\ub5dd\u728a\u{1f6bc}\u{1ff34}'});
+let promise24 = device4.createRenderPipelineAsync({
+  label: '\u{1ff5f}\u{1fc32}\u{1fbfb}\u03a8\u2875\u{1fc0c}\u253c\u2dc4\u{1fcd8}\ue629\u{1faa1}',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'replace', passOp: 'invert'},
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 1418084339,
+    stencilWriteMask: 2232197785,
+    depthBias: 449545801,
+    depthBiasClamp: 273.62370752784045,
+  },
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+try {
+  await promise23;
+} catch {}
+let img22 = await imageWithData(175, 157, '#234353b3', '#fd08fd14');
+let commandEncoder86 = device4.createCommandEncoder({label: '\u{1ff72}\u292e\u9f26\u0f7a'});
+let textureView101 = texture44.createView({
+  label: '\u026e\ub1ea\ub829\u0264\ua84c\u27b7\u26d0\uecfd\u0b1d\u0957',
+  aspect: 'all',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 229,
+  arrayLayerCount: 548,
+});
+let sampler41 = device4.createSampler({
+  label: '\ud739\u046f\ub920\ud677',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 57.48,
+  compare: 'never',
+  maxAnisotropy: 15,
+});
+let pipeline50 = device4.createRenderPipeline({
+  label: '\u24c1\u0e0e\u2493\u0406\udf6c\uabb7',
+  layout: 'auto',
+  multisample: {mask: 0xef724391},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+  await promise22;
+} catch {}
+let commandEncoder87 = device4.createCommandEncoder({label: '\uaef2\uf34b\u0c56\ubb05\uc7ec\u0f0e\u829d\uc316\u0001'});
+let texture49 = device4.createTexture({
+  label: '\u{1f703}\u4f71\u9cd0\uc6d9\u{1f876}\u3d57\u0e67\u0832\ub093\u04bc',
+  size: {width: 120, height: 1, depthOrArrayLayers: 123},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8snorm', 'r8snorm', 'r8snorm'],
+});
+let renderBundleEncoder45 = device4.createRenderBundleEncoder({
+  label: '\uc590\u0e3b\u400e\udb13\u0ac3\u0f47\u8364\u59d5\u0923',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+});
+let sampler42 = device4.createSampler({
+  label: '\uabcc\u{1f744}\u5688\u{1f844}\u{1f7f4}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.34,
+  lodMaxClamp: 64.36,
+  compare: 'less-equal',
+  maxAnisotropy: 5,
+});
+let imageBitmap21 = await createImageBitmap(imageData8);
+let imageData22 = new ImageData(68, 36);
+let commandEncoder88 = device3.createCommandEncoder({});
+let texture50 = device3.createTexture({
+  label: '\u0569\u531b\u53fc\u{1f6cf}\u0349\u1683\u6a0d\u0ecb\uee13\ub779',
+  size: [240, 2, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let renderBundle45 = renderBundleEncoder38.finish();
+try {
+computePassEncoder36.pushDebugGroup('\u{1fd8a}');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 278, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(10782), /* required buffer size: 10782 */
+{offset: 238, bytesPerRow: 1203}, {width: 115, height: 9, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let shaderModule13 = device3.createShaderModule({
+  label: '\ue22d\u{1f7aa}\u9005',
+  code: `@group(2) @binding(260)
+var<storage, read_write> parameter12: array<u32>;
+@group(2) @binding(1556)
+var<storage, read_write> parameter13: array<u32>;
+@group(0) @binding(260)
+var<storage, read_write> global7: array<u32>;
+@group(1) @binding(1556)
+var<storage, read_write> parameter14: array<u32>;
+@group(0) @binding(1410)
+var<storage, read_write> type13: array<u32>;
+@group(1) @binding(1410)
+var<storage, read_write> type14: array<u32>;
+@group(2) @binding(1410)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @location(60) f0: vec3<f32>,
+  @location(39) f1: vec2<u32>,
+  @location(55) f2: vec3<f16>,
+  @location(42) f3: vec3<i32>,
+  @location(0) f4: u32,
+  @location(46) f5: f16,
+  @location(52) f6: i32,
+  @builtin(front_facing) f7: bool,
+  @builtin(sample_index) f8: u32,
+  @location(58) f9: vec3<i32>,
+  @location(3) f10: vec4<f16>,
+  @location(53) f11: vec2<f32>,
+  @location(37) f12: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(3) f1: vec3<i32>,
+  @location(2) f2: vec4<i32>,
+  @location(4) f3: f32,
+  @location(1) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: vec3<i32>, @location(45) a1: vec3<u32>, @location(13) a2: vec4<f16>, a3: S6, @location(17) a4: f16, @location(18) a5: f32, @builtin(sample_mask) a6: u32, @builtin(position) a7: vec4<f32>, @location(43) a8: vec2<f16>, @location(49) a9: vec3<i32>, @location(38) a10: vec2<f32>, @location(44) a11: vec3<u32>, @location(50) a12: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(46) f96: f16,
+  @location(16) f97: vec3<i32>,
+  @location(3) f98: vec4<f16>,
+  @location(37) f99: vec2<f32>,
+  @location(13) f100: vec4<f16>,
+  @location(0) f101: u32,
+  @location(44) f102: vec3<u32>,
+  @location(42) f103: vec3<i32>,
+  @location(52) f104: i32,
+  @location(55) f105: vec3<f16>,
+  @builtin(position) f106: vec4<f32>,
+  @location(45) f107: vec3<u32>,
+  @location(49) f108: vec3<i32>,
+  @location(39) f109: vec2<u32>,
+  @location(60) f110: vec3<f32>,
+  @location(50) f111: vec3<i32>,
+  @location(58) f112: vec3<i32>,
+  @location(38) f113: vec2<f32>,
+  @location(17) f114: f16,
+  @location(53) f115: vec2<f32>,
+  @location(43) f116: vec2<f16>,
+  @location(18) f117: f32
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<f16>, @location(2) a1: vec4<f32>, @location(7) a2: vec2<u32>, @location(15) a3: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer16 = device3.createBuffer({
+  label: '\u2cc0\u{1f8ac}\u9120\u{1fe44}',
+  size: 170136,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let commandEncoder89 = device3.createCommandEncoder({label: '\u9c6c\u68cc\uedcc\u{1f638}\u0a49\u0706\u0a8d\u{1fbe7}\ub965\u0ff4\u8022'});
+let textureView102 = texture50.createView({label: '\u{1f9a3}\u944a\u5abb\u{1fc4d}\ua3a8\u{1ff8e}\u{1f64c}\u6198\u9e81\u{1fc8c}'});
+let arrayBuffer3 = buffer16.getMappedRange(95296, 29996);
+let offscreenCanvas21 = new OffscreenCanvas(826, 890);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let videoFrame16 = videoFrame13.clone();
+let canvas28 = document.createElement('canvas');
+let buffer17 = device1.createBuffer({
+  label: '\ude72\u{1fd9b}\u{1f83b}\ubd12\u797a\u0179\uc904\u5e51\u{1fafa}\u0ee4\u085b',
+  size: 107670,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder90 = device1.createCommandEncoder({label: '\ucda2\u024a\ub859\u7385\ua06d\uf2be\u{1ff3a}'});
+try {
+renderBundleEncoder29.setVertexBuffer(1137, undefined);
+} catch {}
+let arrayBuffer4 = buffer9.getMappedRange(45416, 34392);
+try {
+commandEncoder55.copyBufferToBuffer(buffer8, 221036, buffer6, 71968, 8816);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder81.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1456 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 36688 */
+  offset: 36688,
+  rowsPerImage: 167,
+  buffer: buffer10,
+}, {width: 91, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet18, 230, 785, buffer5, 20224);
+} catch {}
+let pipeline51 = device1.createComputePipeline({
+  label: '\u0d6d\u5f66\u{1f73b}\u{1fe09}\u0f84\u0c4d\u0fef\uef9f\uc662\uc6b2\ud866',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+let pipeline52 = device1.createRenderPipeline({
+  label: '\u0b4b\u0b04\u49ef\u{1fbdf}\ub8a7\u5eab\u{1f957}\u3cf8',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0x14376b8},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {
+  format: 'rgba8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32float'}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2832357920,
+    depthBiasSlopeScale: 955.4512688707664,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 980,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 172, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 508, shaderLocation: 7},
+          {format: 'sint32x2', offset: 972, shaderLocation: 5},
+          {format: 'uint16x4', offset: 180, shaderLocation: 22},
+          {format: 'uint16x4', offset: 144, shaderLocation: 15},
+          {format: 'float32', offset: 476, shaderLocation: 16},
+          {format: 'sint8x4', offset: 936, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 676, shaderLocation: 11},
+          {format: 'float32', offset: 72, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 412, shaderLocation: 4},
+          {format: 'sint16x4', offset: 72, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 976, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 364, shaderLocation: 9},
+          {format: 'uint16x4', offset: 260, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 116, shaderLocation: 18},
+          {format: 'sint16x4', offset: 580, shaderLocation: 0},
+          {format: 'uint32x3', offset: 44, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 344,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 20, shaderLocation: 13},
+          {format: 'float16x4', offset: 4, shaderLocation: 20},
+          {format: 'uint16x4', offset: 240, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 112, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 48, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+});
+let gpuCanvasContext23 = canvas28.getContext('webgpu');
+let textureView103 = texture28.createView({mipLevelCount: 3});
+try {
+commandEncoder55.copyBufferToBuffer(buffer13, 374912, buffer6, 18360, 52892);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let computePassEncoder38 = commandEncoder88.beginComputePass({label: '\u759f\u058e\u{1f9d1}\u0614\u1a66\u18d5'});
+let renderBundle46 = renderBundleEncoder42.finish({});
+try {
+computePassEncoder38.setPipeline(pipeline47);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(642), /* required buffer size: 642 */
+{offset: 642, rowsPerImage: 128}, {width: 146, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView104 = texture48.createView({mipLevelCount: 1});
+let computePassEncoder39 = commandEncoder86.beginComputePass({label: '\ud124\u{1fa79}\u0f7c\ubedf\uecc7\ub1ad\u2deb\u0d86\u{1f713}\u0f05'});
+let renderPassEncoder0 = commandEncoder87.beginRenderPass({
+  label: '\u887e\ube7e\u00b9\u9475\ua466\u0e07\u7e6d\u0a5b',
+  colorAttachments: [{
+  view: textureView104,
+  depthSlice: 411,
+  clearValue: { r: 708.7, g: 541.1, b: -817.6, a: -436.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet45,
+  maxDrawCount: 802941498,
+});
+let sampler43 = device4.createSampler({
+  label: '\ue9ed\u{1f99f}\uc9b3\ud591\uc7bb\u2f26',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.77,
+  lodMaxClamp: 90.31,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle43, renderBundle43, renderBundle43, renderBundle43, renderBundle43, renderBundle43, renderBundle44, renderBundle43]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 237.4, g: -534.5, b: 737.7, a: 19.32, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3344);
+} catch {}
+try {
+renderPassEncoder0.setViewport(321.5, 0.4754, 98.69, 0.07477, 0.2411, 0.3811);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline50);
+} catch {}
+let pipeline53 = await device4.createRenderPipelineAsync({
+  label: '\uc004\u0846\ub6f2\u3597\ua578\u0e32\u91ea\u0f20\u5b73\uc50c\uebe5',
+  layout: 'auto',
+  multisample: {mask: 0xc32b7583},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {topology: 'point-list'},
+});
+let bindGroupLayout24 = device3.createBindGroupLayout({
+  label: '\u{1f8d2}\u9903\u{1fecf}\u07a6\u{1f68a}\uae5a\u095c\u0b22\u{1ff99}\u034c\u8d2a',
+  entries: [
+    {
+      binding: 693,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 798, visibility: 0, externalTexture: {}},
+  ],
+});
+let commandEncoder91 = device3.createCommandEncoder();
+let querySet49 = device3.createQuerySet({label: '\u16a5\u6cdd', type: 'occlusion', count: 234});
+let textureView105 = texture39.createView({
+  label: '\u65b5\u{1fb7f}\uba67\u323b\u0815\u{1f731}\u{1fb1a}\u9b19\u{1fd97}\u0d81',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle47 = renderBundleEncoder42.finish({label: '\u{1fe25}\u05fe\ud876\u{1f802}\u11cf\u9de1\u{1f62d}\u{1ff05}'});
+try {
+device3.queue.submit([]);
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas21.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+adapter5.label = '\u{1f8af}\u0cf5\u3ecb\uf2cc\u5bd6\u0d2b\u7daf\u01f7\ub3c6';
+} catch {}
+let commandEncoder92 = device1.createCommandEncoder({label: '\u01fd\u33f1\u0f9c\u0067'});
+let texture51 = device1.createTexture({
+  label: '\u2946\ud9ae',
+  size: [384, 1, 1],
+  mipLevelCount: 7,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({
+  label: '\u6346\uf065\u{1fbf6}\u3b37',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup6, new Uint32Array(8501), 6916, 0);
+} catch {}
+let videoFrame17 = new VideoFrame(img15, {timestamp: 0});
+let pipelineLayout12 = device3.createPipelineLayout({
+  label: '\u{1facd}\uf64c\u08b6\u{1fb04}',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout24, bindGroupLayout19, bindGroupLayout19],
+});
+let querySet50 = device3.createQuerySet({type: 'occlusion', count: 2374});
+let textureView106 = texture40.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler44 = device3.createSampler({
+  label: '\u{1ffbf}\u162d\u{1feef}\uf573',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.01,
+  maxAnisotropy: 17,
+});
+let pipeline54 = await device3.createRenderPipelineAsync({
+  label: '\u{1fdb8}\u0661\u0a54\ub115\u23d5\u884f\u8dbb',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 916,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 60, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 116, shaderLocation: 8},
+          {format: 'float16x2', offset: 84, shaderLocation: 2},
+          {format: 'float32x3', offset: 372, shaderLocation: 14},
+          {format: 'uint32', offset: 180, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 156, shaderLocation: 6},
+          {format: 'sint16x4', offset: 0, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 332, shaderLocation: 7},
+          {format: 'sint32', offset: 728, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 60, shaderLocation: 0},
+          {format: 'sint16x2', offset: 108, shaderLocation: 10},
+          {format: 'sint8x2', offset: 502, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', unclippedDepth: true},
+});
+try {
+  await promise21;
+} catch {}
+let textureView107 = texture44.createView({
+  label: '\u2f9f\u{1f88d}\u{1f6c6}\u{1fc8c}\u0625\u{1ff27}\u0ca4\uc6d0\u6cc0\u8efe\u42d7',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 919,
+  arrayLayerCount: 110,
+});
+let renderBundle48 = renderBundleEncoder44.finish();
+try {
+renderPassEncoder0.beginOcclusionQuery(290);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(338.2, 0.6577, 59.31, 0.2169, 0.7592, 0.8866);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 1147363350);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline53);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let device5 = await adapter5.requestDevice({
+  label: '\u8f88\u5c6e\u09fc\u0b51\u0217\u{1f8c3}\u0266\u0ce0\ue60b\u0438',
+  defaultQueue: {label: '\u03a4\u7813\uaf0a\u17f5\ufbfe\u7a14\u0aaa\u97b3\u0064\u7f3a\u{1f7c7}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 41,
+    maxVertexAttributes: 19,
+    maxVertexBufferArrayStride: 12840,
+    maxStorageTexturesPerShaderStage: 40,
+    maxStorageBuffersPerShaderStage: 12,
+    maxDynamicStorageBuffersPerPipelineLayout: 38343,
+    maxDynamicUniformBuffersPerPipelineLayout: 20381,
+    maxBindingsPerBindGroup: 5527,
+    maxTextureArrayLayers: 1612,
+    maxTextureDimension1D: 16311,
+    maxTextureDimension2D: 15903,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 178369821,
+    maxUniformBuffersPerShaderStage: 33,
+    maxSampledTexturesPerShaderStage: 26,
+    maxInterStageShaderVariables: 24,
+    maxInterStageShaderComponents: 99,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let texture52 = device3.createTexture({
+  label: '\u0427\u5e1a',
+  size: {width: 568},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView108 = texture50.createView({label: '\u0085\u0381\u0311\u0ae2\u3d6a\u7c52\u0ae7\u62b1', mipLevelCount: 1});
+let computePassEncoder40 = commandEncoder62.beginComputePass({label: '\u{1fb98}\u0640\u0442\ua4f0\u0ca6\u2454\u37f0'});
+let externalTexture48 = device3.importExternalTexture({
+  label: '\u04c6\u0a2b\u0ec1\ua801\u0d66\u{1feec}\udb24\u{1fec1}\u0c3e\u95de\u15c2',
+  source: video13,
+  colorSpace: 'srgb',
+});
+let promise25 = device3.createRenderPipelineAsync({
+  label: '\u{1f848}\u06fe\u{1f817}\u04bb\ua8f2\u{1f6d0}\uf94c\u059a\u83ff\u{1ff59}\ud80a',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0xe71e5dbb},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2932,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 396, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 208, shaderLocation: 2},
+          {format: 'sint32x3', offset: 648, shaderLocation: 15},
+          {format: 'float32x4', offset: 384, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 180, shaderLocation: 11},
+          {format: 'sint8x2', offset: 2318, shaderLocation: 8},
+          {format: 'float32x2', offset: 1880, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 464, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 476, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 1968, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 196, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 1268, shaderLocation: 6},
+          {format: 'uint32x4', offset: 376, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 240,
+        attributes: [
+          {format: 'float32x2', offset: 48, shaderLocation: 0},
+          {format: 'sint16x2', offset: 0, shaderLocation: 5},
+          {format: 'sint32', offset: 20, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 76, shaderLocation: 9},
+          {format: 'sint8x2', offset: 44, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+});
+let texture53 = device4.createTexture({
+  label: '\u0a57\u{1fc53}\u8079',
+  size: [240],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+try {
+renderPassEncoder0.setScissorRect(286, 1, 129, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(298.5, 0.01029, 166.8, 0.7066, 0.9153, 0.9371);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(779135107, 1201317033, 936660563, -1053902597, 773836926);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 596310187);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5487, undefined);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(3226, undefined);
+} catch {}
+try {
+renderBundleEncoder45.insertDebugMarker('\uba60');
+} catch {}
+let shaderModule14 = device1.createShaderModule({
+  label: '\u124b\ub0fb\u5087\u7467\u4d4a\ub164\uc51d\u{1f957}\u0593\udbed',
+  code: `@group(0) @binding(5295)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> n12: array<u32>;
+
+@compute @workgroup_size(7, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+  @location(83) f0: vec3<f16>,
+  @builtin(sample_index) f1: u32,
+  @builtin(front_facing) f2: bool,
+  @location(79) f3: i32,
+  @location(62) f4: vec3<i32>,
+  @location(55) f5: vec2<f32>,
+  @location(33) f6: vec3<i32>,
+  @location(32) f7: vec2<f32>,
+  @location(34) f8: vec3<u32>,
+  @location(60) f9: vec4<u32>,
+  @location(11) f10: vec2<u32>,
+  @location(58) f11: vec2<i32>,
+  @location(73) f12: vec2<f32>,
+  @location(24) f13: i32,
+  @location(4) f14: vec4<f32>,
+  @location(88) f15: vec3<f32>,
+  @location(94) f16: vec3<f32>,
+  @location(16) f17: f32,
+  @location(72) f18: u32,
+  @location(70) f19: vec4<f32>,
+  @location(82) f20: u32,
+  @builtin(sample_mask) f21: u32,
+  @location(5) f22: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(4) f1: vec4<u32>,
+  @location(7) f2: vec3<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(0) f4: vec4<u32>,
+  @location(2) f5: vec4<f32>,
+  @location(3) f6: vec4<u32>,
+  @location(6) f7: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(42) a0: vec2<i32>, @location(25) a1: f32, a2: S8, @location(61) a3: vec2<i32>, @location(7) a4: vec3<f32>, @location(64) a5: vec4<f32>, @location(76) a6: vec2<u32>, @builtin(position) a7: vec4<f32>, @location(13) a8: vec2<i32>, @location(49) a9: vec4<f16>, @location(86) a10: f16, @location(89) a11: f32, @location(21) a12: i32, @location(10) a13: f32, @location(68) a14: f32, @location(6) a15: vec4<u32>, @location(80) a16: vec3<u32>, @location(47) a17: vec4<i32>, @location(19) a18: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(1) f0: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(64) f118: vec4<f32>,
+  @location(83) f119: vec3<f16>,
+  @location(10) f120: f32,
+  @location(60) f121: vec4<u32>,
+  @location(88) f122: vec3<f32>,
+  @location(4) f123: vec4<f32>,
+  @location(34) f124: vec3<u32>,
+  @builtin(position) f125: vec4<f32>,
+  @location(61) f126: vec2<i32>,
+  @location(47) f127: vec4<i32>,
+  @location(33) f128: vec3<i32>,
+  @location(24) f129: i32,
+  @location(94) f130: vec3<f32>,
+  @location(89) f131: f32,
+  @location(21) f132: i32,
+  @location(73) f133: vec2<f32>,
+  @location(62) f134: vec3<i32>,
+  @location(7) f135: vec3<f32>,
+  @location(32) f136: vec2<f32>,
+  @location(55) f137: vec2<f32>,
+  @location(79) f138: i32,
+  @location(86) f139: f16,
+  @location(68) f140: f32,
+  @location(76) f141: vec2<u32>,
+  @location(6) f142: vec4<u32>,
+  @location(82) f143: u32,
+  @location(49) f144: vec4<f16>,
+  @location(13) f145: vec2<i32>,
+  @location(58) f146: vec2<i32>,
+  @location(72) f147: u32,
+  @location(5) f148: vec2<f16>,
+  @location(19) f149: vec4<i32>,
+  @location(70) f150: vec4<f32>,
+  @location(80) f151: vec3<u32>,
+  @location(42) f152: vec2<i32>,
+  @location(11) f153: vec2<u32>,
+  @location(25) f154: f32,
+  @location(16) f155: f32
+}
+
+@vertex
+fn vertex0(a0: S7) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup15 = device1.createBindGroup({
+  label: '\u{1f96c}\u3701\u04f2\uc2da\u181e\u9068\u{1fe74}\u0aa6\u362d\u1360',
+  layout: bindGroupLayout11,
+  entries: [{binding: 3263, resource: textureView84}, {binding: 4172, resource: sampler28}],
+});
+let sampler45 = device1.createSampler({
+  label: '\udc9e\ud571\u{1f8ee}\u043d\udef2',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 16.93,
+  lodMaxClamp: 72.54,
+});
+try {
+computePassEncoder16.setPipeline(pipeline49);
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer6, 12816, 3792);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let pipeline55 = device1.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32uint', writeMask: 0}, {
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 820848232,
+    stencilWriteMask: 2781011016,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 448,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 20, shaderLocation: 22},
+          {format: 'uint32x4', offset: 12, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 5},
+          {format: 'float32x2', offset: 24, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 10},
+          {format: 'uint16x2', offset: 116, shaderLocation: 16},
+          {format: 'sint32x2', offset: 176, shaderLocation: 8},
+          {format: 'uint8x2', offset: 10, shaderLocation: 15},
+          {format: 'float16x2', offset: 200, shaderLocation: 4},
+          {format: 'float32x2', offset: 304, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 256, shaderLocation: 0},
+          {format: 'float32x3', offset: 204, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 384, stepMode: 'vertex', attributes: []},
+      {arrayStride: 512, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 716,
+        attributes: [
+          {format: 'sint32x2', offset: 12, shaderLocation: 7},
+          {format: 'sint32x3', offset: 0, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 136, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 48, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 260, shaderLocation: 1},
+          {format: 'sint32x2', offset: 128, shaderLocation: 18},
+          {format: 'uint32x3', offset: 676, shaderLocation: 12},
+          {format: 'float32x2', offset: 604, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 156, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let querySet51 = device3.createQuerySet({label: '\uc24c\u2342\u{1f6b3}\uafc4\u375c\ub05b', type: 'occlusion', count: 164});
+let renderBundleEncoder47 = device3.createRenderBundleEncoder({
+  label: '\u0285\u13c6\ub43a',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+});
+let sampler46 = device3.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.22,
+  lodMaxClamp: 55.11,
+});
+try {
+computePassEncoder36.popDebugGroup();
+} catch {}
+let promise26 = device3.createRenderPipelineAsync({
+  label: '\u4dcf\u23e1\u3d97\u038b\u{1ff49}\u6e00\u0785',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALL}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1816,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 496, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 204, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 60, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 500, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 604, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 1872,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 116, shaderLocation: 1},
+          {format: 'sint8x2', offset: 340, shaderLocation: 10},
+          {format: 'sint16x2', offset: 632, shaderLocation: 11},
+          {format: 'sint16x4', offset: 148, shaderLocation: 12},
+          {format: 'uint32x3', offset: 220, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 932, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 760, attributes: [{format: 'unorm16x2', offset: 56, shaderLocation: 7}]},
+    ],
+  },
+});
+try {
+adapter1.label = '\u5ff2\u0ebe\u0a9e';
+} catch {}
+let bindGroupLayout25 = device5.createBindGroupLayout({
+  label: '\u368d\u0557\u7858\u06f6\u{1fd9a}',
+  entries: [{binding: 2878, visibility: 0, sampler: { type: 'filtering' }}],
+});
+let texture54 = device5.createTexture({
+  label: '\u{1fcf2}\u004f\u0d2e\u1ece\u{1f683}\u{1ffe6}\u0a93\u9094\u0c6a',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg11b10ufloat'],
+});
+let externalTexture49 = device5.importExternalTexture({source: videoFrame14});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let sampler47 = device4.createSampler({
+  label: '\u109f\u4069\ub5cf\u0f50\u812b\u4f13\u99e9\u50e6',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 61.57,
+  lodMaxClamp: 83.02,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 419.0, g: -346.2, b: 791.1, a: -944.3, });
+} catch {}
+let querySet52 = device3.createQuerySet({label: '\ue2bd\u05f8\u0755\u3bf7\u{1fd36}\u0afd\u375b\u9c33\u080a', type: 'occlusion', count: 1955});
+let pipeline56 = await device3.createRenderPipelineAsync({
+  label: '\u{1f884}\u0784\u{1fbf7}\u0e8f\ue533\ued3c\uc5d7\u0e3c\u5b5c',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 516,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 20, shaderLocation: 8},
+          {format: 'sint16x4', offset: 4, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 136, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 52, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 76, shaderLocation: 17},
+          {format: 'sint8x4', offset: 0, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 13},
+          {format: 'sint32', offset: 32, shaderLocation: 15},
+          {format: 'float32x2', offset: 12, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 216, shaderLocation: 7},
+          {format: 'float32', offset: 360, shaderLocation: 1},
+          {format: 'float32x3', offset: 0, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 1676,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 616, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 48, shaderLocation: 14},
+          {format: 'sint16x4', offset: 252, shaderLocation: 5},
+          {format: 'uint8x2', offset: 412, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 734, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 536, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageBitmap22 = await createImageBitmap(img6);
+let pipelineLayout13 = device3.createPipelineLayout({
+  label: '\uc93d\u5597\u3dbe\uf3de\u0f05\u008e\u599e\u0860\uc7b0\u{1fad6}',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout24, bindGroupLayout19, bindGroupLayout24, bindGroupLayout19, bindGroupLayout19],
+});
+let commandEncoder93 = device3.createCommandEncoder({label: '\u0e33\u26c1'});
+let textureView109 = texture43.createView({label: '\ua448\u{1fdcd}\u0a7a\u01b2\u493f\uea14\u6776\ubbe2'});
+try {
+renderBundleEncoder41.setIndexBuffer(buffer14, 'uint32', 501956, 12016);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 116, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 157, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise27 = device3.queue.onSubmittedWorkDone();
+let shaderModule15 = device1.createShaderModule({
+  label: '\u06c1\u5f20\u3c15\u{1fe6a}\u02c2\u{1f763}\uceca\u0c2a\u73ba',
+  code: `@group(0) @binding(2853)
+var<storage, read_write> field9: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> global8: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(53) f0: vec2<i32>,
+  @location(80) f1: vec3<f32>,
+  @location(64) f2: vec3<u32>,
+  @location(49) f3: vec3<u32>,
+  @location(6) f4: vec3<i32>,
+  @location(5) f5: vec3<f16>,
+  @location(55) f6: vec3<i32>,
+  @location(23) f7: f16,
+  @location(59) f8: vec3<f16>,
+  @location(84) f9: vec3<i32>,
+  @location(26) f10: vec4<f32>,
+  @location(89) f11: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(5) f1: vec4<u32>,
+  @location(4) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>,
+  @location(7) f4: vec4<f32>,
+  @location(3) f5: vec4<u32>,
+  @location(1) f6: vec4<f32>,
+  @location(6) f7: f32
+}
+
+@fragment
+fn fragment0(a0: S10, @location(72) a1: vec2<f32>, @location(3) a2: vec4<i32>, @location(14) a3: vec4<u32>, @location(18) a4: vec4<f16>, @builtin(position) a5: vec4<f32>, @location(11) a6: vec2<f16>, @location(56) a7: vec4<u32>, @location(92) a8: f16, @location(0) a9: vec4<f16>, @location(81) a10: vec4<f16>, @location(57) a11: vec2<f16>, @location(7) a12: f32, @location(75) a13: vec3<f32>, @location(34) a14: vec4<u32>, @location(69) a15: vec3<u32>, @location(24) a16: vec2<f32>, @location(94) a17: u32, @location(2) a18: u32, @location(28) a19: vec3<u32>, @location(19) a20: f16, @builtin(front_facing) a21: bool, @location(25) a22: i32, @location(48) a23: vec2<i32>, @builtin(sample_mask) a24: u32, @builtin(sample_index) a25: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(16) f0: vec3<u32>,
+  @location(10) f1: vec4<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(0) f3: vec2<f32>,
+  @location(11) f4: u32,
+  @location(1) f5: vec3<f16>,
+  @location(20) f6: vec4<f32>,
+  @location(14) f7: vec3<f32>,
+  @location(15) f8: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(2) f156: u32,
+  @location(56) f157: vec4<u32>,
+  @location(3) f158: vec4<i32>,
+  @location(81) f159: vec4<f16>,
+  @location(14) f160: vec4<u32>,
+  @location(6) f161: vec3<i32>,
+  @location(18) f162: vec4<f16>,
+  @location(0) f163: vec4<f16>,
+  @location(28) f164: vec3<u32>,
+  @location(24) f165: vec2<f32>,
+  @location(5) f166: vec3<f16>,
+  @location(72) f167: vec2<f32>,
+  @location(64) f168: vec3<u32>,
+  @location(55) f169: vec3<i32>,
+  @location(48) f170: vec2<i32>,
+  @location(25) f171: i32,
+  @location(80) f172: vec3<f32>,
+  @location(53) f173: vec2<i32>,
+  @location(26) f174: vec4<f32>,
+  @location(92) f175: f16,
+  @location(11) f176: vec2<f16>,
+  @location(49) f177: vec3<u32>,
+  @location(57) f178: vec2<f16>,
+  @location(7) f179: f32,
+  @location(34) f180: vec4<u32>,
+  @location(75) f181: vec3<f32>,
+  @builtin(position) f182: vec4<f32>,
+  @location(94) f183: u32,
+  @location(59) f184: vec3<f16>,
+  @location(23) f185: f16,
+  @location(69) f186: vec3<u32>,
+  @location(84) f187: vec3<i32>,
+  @location(19) f188: f16,
+  @location(89) f189: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec3<i32>, @location(2) a1: vec4<f32>, @location(19) a2: vec3<i32>, @location(7) a3: i32, @location(3) a4: u32, @location(12) a5: vec3<f32>, @location(17) a6: vec3<f32>, @location(8) a7: f16, @location(9) a8: i32, @location(21) a9: vec2<u32>, a10: S9, @location(22) a11: vec3<u32>, @location(13) a12: f32, @location(4) a13: vec2<f32>, @location(6) a14: vec2<i32>, @location(5) a15: vec2<u32>, @builtin(vertex_index) a16: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderBundleEncoder27.setVertexBuffer(2471, undefined, 0, 2346835725);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer6, 59428, 6096);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let promise28 = device1.createComputePipelineAsync({
+  label: '\u0dd5\u4d8e\u{1f8e2}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let pipeline57 = await promise11;
+try {
+  await promise27;
+} catch {}
+canvas5.height = 255;
+let video24 = await videoWithData();
+let canvas29 = document.createElement('canvas');
+let adapter6 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let video25 = await videoWithData();
+let commandEncoder94 = device1.createCommandEncoder();
+let texture55 = device1.createTexture({
+  label: '\u02c3\u04aa\u{1ff9c}\u7370\u{1f8ed}\u{1f6c0}',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1111},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float'],
+});
+let renderBundleEncoder48 = device1.createRenderBundleEncoder({
+  label: '\u{1f64f}\ue2b6\u{1fd98}\u61d2\u05c1\u{1f64e}\u0538\u3a52',
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'rg8sint', 'rgba8uint', 'rgba8uint', 'rgba8sint', 'r16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder27.setBindGroup(6, bindGroup14);
+} catch {}
+try {
+commandEncoder90.clearBuffer(buffer6, 19292, 51540);
+dissociateBuffer(device1, buffer6);
+} catch {}
+let commandEncoder95 = device5.createCommandEncoder({label: '\u{1f6c6}\u95e5\u09d4\u0820\u88f6\u1459\ua4a0\u69f4'});
+let querySet53 = device5.createQuerySet({type: 'occlusion', count: 1555});
+let texture56 = device5.createTexture({
+  label: '\u{1f868}\u1647\u0398\u0298\u0fb8\u0cb9\u9606\u06db\u0966\ub924',
+  size: [1040],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let videoFrame18 = videoFrame3.clone();
+let buffer18 = device4.createBuffer({
+  label: '\u5740\u8179\u{1f8bb}\u7f36\ua013\u1f46\u08dd\uf00a\u7fa8\u6e0f',
+  size: 784905,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder96 = device4.createCommandEncoder({});
+let texture57 = device4.createTexture({
+  label: '\u0f6a\u{1f802}\u0706\u{1f680}\ud0a9\u89ce\u5a38\ub552\u{1f9bf}\u{1fe99}\u81ce',
+  size: [120, 1, 879],
+  mipLevelCount: 5,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView110 = texture44.createView({
+  label: '\u{1f96a}\u0b85',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 3,
+  baseArrayLayer: 815,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 778.6, g: 159.4, b: 874.9, a: 959.1, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(134, 0, 330, 1);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1430);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer18, 449452212);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer15, 406562975);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline53);
+} catch {}
+let pipeline58 = device4.createRenderPipeline({
+  label: '\u2e84\u0e5d\uc917\u2e39',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 4174044652,
+    stencilWriteMask: 3153264223,
+    depthBias: 438639210,
+    depthBiasSlopeScale: 138.32869579482426,
+    depthBiasClamp: 632.2786203109918,
+  },
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let videoFrame19 = new VideoFrame(canvas20, {timestamp: 0});
+let bindGroupLayout26 = device1.createBindGroupLayout({
+  label: '\u04e0\u{1fcf5}\u36c5\ufcdf\u0939\u{1f966}\u61ec\u0c90\u8609',
+  entries: [
+    {
+      binding: 1583,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let querySet54 = device1.createQuerySet({label: '\u5554\u33ee\u0bcc\u3cb6\u02dd\u{1fbbf}\u063b\u083b\u2dcf', type: 'occlusion', count: 2697});
+let textureView111 = texture17.createView({format: 'astc-6x5-unorm-srgb', baseArrayLayer: 8, arrayLayerCount: 2});
+let sampler48 = device1.createSampler({
+  label: '\ub95a\u047c\u0ff2\u08d9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.65,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 400 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 19344 */
+  offset: 19344,
+  bytesPerRow: 768,
+  buffer: buffer13,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 25, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 384 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 33984 */
+  offset: 33984,
+  rowsPerImage: 6,
+  buffer: buffer10,
+}, {width: 24, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 7640, new BigUint64Array(39653), 23295, 1420);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 2},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(64)), /* required buffer size: 1535259 */
+{offset: 554, bytesPerRow: 131, rowsPerImage: 213}, {width: 5, height: 1, depthOrArrayLayers: 56});
+} catch {}
+let commandEncoder97 = device5.createCommandEncoder({label: '\ue450\u{1fc3a}\u{1f6c2}\u02f6\u0316\u5f3a\uc059'});
+let externalTexture50 = device5.importExternalTexture({label: '\u382a\u{1fe4e}\u{1f8fd}\u8255\u{1f78a}\u084a\u0768\u4815\ua7de\uaa87', source: videoFrame13});
+try {
+gpuCanvasContext9.configure({
+  device: device5,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let video26 = await videoWithData();
+let offscreenCanvas22 = new OffscreenCanvas(178, 305);
+let textureView112 = texture34.createView({label: '\ub34a\u16a1\u{1fe0e}\u{1f676}\u7ced\uf0b9\uf499', format: 'r8unorm'});
+let computePassEncoder41 = commandEncoder56.beginComputePass({});
+let renderBundle49 = renderBundleEncoder19.finish({label: '\u0191\u{1feec}\u90e9\u0b4a\u5810\u299f'});
+try {
+computePassEncoder24.end();
+} catch {}
+let promise29 = buffer13.mapAsync(GPUMapMode.WRITE);
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 416 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 25952 */
+  offset: 25952,
+  buffer: buffer7,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let buffer19 = device3.createBuffer({label: '\uaed9\u35f8', size: 205815, usage: GPUBufferUsage.VERTEX});
+let texture58 = device3.createTexture({
+  label: '\ud308\u07b2\u3c0b\u01cb\u0a26\uf533\u5ac6\u2c42\u68bd\u{1fe38}\ub1d3',
+  size: [60, 1, 74],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView113 = texture40.createView({
+  label: '\u01d6\u9b71\u0f9d\u022b\u806e\u{1f81a}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder47.setVertexBuffer(7, buffer19, 0, 129880);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 854 */
+{offset: 854, bytesPerRow: 1698, rowsPerImage: 78}, {width: 386, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise30 = device3.createComputePipelineAsync({
+  label: '\u6b13\ue181\u0527\u5680\u14a9\u07ba\u0d32\ufd6c',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext25 = offscreenCanvas22.getContext('webgpu');
+video14.width = 253;
+gc();
+let promise31 = adapter2.requestAdapterInfo();
+let commandEncoder98 = device4.createCommandEncoder({label: '\u08ab\u{1fefc}\u165f\uf5b1\ub8f8\u34f6\u037c'});
+let texture59 = device4.createTexture({
+  label: '\u0f6f\u{1fbe6}',
+  size: [120],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let renderBundle50 = renderBundleEncoder45.finish({label: '\uc48c\u853c\u2da0\u02d1'});
+try {
+renderPassEncoder0.drawIndexed(708341810);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer15, 36108, buffer18, 410232, 13100);
+dissociateBuffer(device4, buffer15);
+dissociateBuffer(device4, buffer18);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 60},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 32159815 */
+{offset: 870, bytesPerRow: 439, rowsPerImage: 299}, {width: 39, height: 0, depthOrArrayLayers: 246});
+} catch {}
+let pipeline59 = device4.createRenderPipeline({
+  label: '\u{1f891}\u0826\ueeed\u{1f7f3}\u{1f86f}\ue29d\u84d9\u08f1',
+  layout: pipelineLayout11,
+  multisample: {mask: 0x947ce620},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'not-equal', failOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap'},
+    stencilReadMask: 511740756,
+    stencilWriteMask: 4205362421,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 801.2668270372081,
+  },
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+document.body.prepend(img14);
+let canvas30 = document.createElement('canvas');
+let gpuCanvasContext26 = canvas30.getContext('webgpu');
+let commandEncoder99 = device0.createCommandEncoder({});
+let textureView114 = texture3.createView({
+  label: '\u02a8\u7ebc\u{1fe19}\u793a\u{1f93e}\u0ae4',
+  dimension: '3d',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder42 = commandEncoder22.beginComputePass();
+let externalTexture51 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder3.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 63 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 21797 */
+  offset: 21797,
+  buffer: buffer0,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 63, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 20},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(72)), /* required buffer size: 3900141 */
+{offset: 369, bytesPerRow: 813, rowsPerImage: 218}, {width: 39, height: 1, depthOrArrayLayers: 23});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise31;
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap23 = await createImageBitmap(imageData10);
+try {
+renderBundleEncoder25.setBindGroup(4, bindGroup5, new Uint32Array(9898), 7921, 0);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 15968 widthInBlocks: 998 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 19552 */
+  offset: 19552,
+  rowsPerImage: 243,
+  buffer: buffer7,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 5988, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 24, y: 0, z: 16},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 3190963 */
+{offset: 691, bytesPerRow: 212, rowsPerImage: 88}, {width: 24, height: 1, depthOrArrayLayers: 172});
+} catch {}
+let promise32 = device1.queue.onSubmittedWorkDone();
+let promise33 = device1.createRenderPipelineAsync({
+  label: '\u{1fa3a}\ub566\uc8c9\u079e\u675b\u{1febe}',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src', dstFactor: 'zero'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+  },
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32uint'}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1476,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 708, shaderLocation: 13},
+          {format: 'uint16x4', offset: 320, shaderLocation: 14},
+          {format: 'sint32x2', offset: 220, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 160, shaderLocation: 10},
+          {format: 'sint8x4', offset: 620, shaderLocation: 22},
+          {format: 'uint16x2', offset: 188, shaderLocation: 12},
+          {format: 'uint16x4', offset: 496, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 464, shaderLocation: 3},
+          {format: 'float32x4', offset: 764, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 336, shaderLocation: 9},
+          {format: 'uint32x2', offset: 868, shaderLocation: 16},
+          {format: 'sint32x2', offset: 224, shaderLocation: 18},
+          {format: 'sint16x2', offset: 228, shaderLocation: 7},
+          {format: 'sint8x2', offset: 10, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 180, shaderLocation: 6},
+          {format: 'float16x4', offset: 268, shaderLocation: 0},
+          {format: 'float16x2', offset: 120, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 204, shaderLocation: 20},
+          {format: 'float16x4', offset: 16, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 1304, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 80, shaderLocation: 5},
+          {format: 'float32x3', offset: 20, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let gpuCanvasContext27 = canvas29.getContext('webgpu');
+let canvas31 = document.createElement('canvas');
+let texture60 = device3.createTexture({
+  label: '\u{1fb4f}\u{1fa8c}\u065e\u04b9\ub8fe\uff21\u688f\u03cf\uec42',
+  size: [568],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let textureView115 = texture50.createView({label: '\u{1fd07}\u07fd\u{1fd9d}'});
+try {
+renderBundleEncoder41.setVertexBuffer(2, buffer19, 150748, 40380);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2559 */
+{offset: 559}, {width: 250, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule16 = device2.createShaderModule({
+  label: '\u07b0\u4e83\u093f',
+  code: `
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec2<i32>,
+  @location(6) f2: vec2<u32>,
+  @location(4) f3: vec4<u32>,
+  @location(3) f4: vec3<i32>,
+  @location(2) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup16 = device2.createBindGroup({
+  label: '\u0efc\ua80d\u{1f7c8}\ud02c\u0c20\u022f\u{1f6d5}',
+  layout: bindGroupLayout16,
+  entries: [{binding: 34, resource: sampler27}],
+});
+let textureView116 = texture31.createView({label: '\u{1fddc}\u{1f877}\ud5a2', dimension: '3d', baseMipLevel: 3, arrayLayerCount: 1});
+let promise34 = device2.queue.onSubmittedWorkDone();
+let videoFrame20 = new VideoFrame(img10, {timestamp: 0});
+let pipelineLayout14 = device5.createPipelineLayout({
+  label: '\u2bfc\u04a5\ud76c\uab73\u06bb\u3f56\u55e6\ubc51',
+  bindGroupLayouts: [bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25],
+});
+let textureView117 = texture54.createView({label: '\u065a\u03cd\u{1f9b8}\ucdb7\ufec7\u{1fc40}', dimension: '1d'});
+let renderBundleEncoder49 = device5.createRenderBundleEncoder({
+  label: '\ub4d1\u0385\ub7c5\uf026\u6545\u0947\u490e\u88cc',
+  colorFormats: ['r8unorm', 'r32sint', 'r32sint', 'rgba8uint', 'rgba16float', 'r32float', 'r16sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let offscreenCanvas23 = new OffscreenCanvas(703, 762);
+let video27 = await videoWithData();
+canvas27.height = 1220;
+let shaderModule17 = device1.createShaderModule({
+  code: `@group(1) @binding(3397)
+var<storage, read_write> local11: array<u32>;
+@group(1) @binding(1517)
+var<storage, read_write> local12: array<u32>;
+@group(3) @binding(1517)
+var<storage, read_write> local13: array<u32>;
+@group(5) @binding(1517)
+var<storage, read_write> local14: array<u32>;
+@group(5) @binding(3397)
+var<storage, read_write> parameter15: array<u32>;
+@group(4) @binding(3397)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(2, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+  @location(36) f0: f32,
+  @location(63) f1: vec4<f32>,
+  @location(24) f2: f16,
+  @location(81) f3: vec4<f16>,
+  @location(30) f4: vec4<f32>,
+  @location(45) f5: vec2<i32>,
+  @location(53) f6: vec4<f32>,
+  @location(47) f7: vec3<i32>,
+  @location(25) f8: vec3<f32>,
+  @location(86) f9: vec4<i32>,
+  @builtin(sample_index) f10: u32,
+  @location(57) f11: vec4<f16>,
+  @builtin(front_facing) f12: bool,
+  @location(40) f13: vec3<u32>,
+  @location(48) f14: vec2<i32>,
+  @location(93) f15: vec2<i32>,
+  @location(41) f16: f16,
+  @location(72) f17: vec2<i32>,
+  @location(6) f18: vec2<i32>,
+  @location(78) f19: vec4<i32>,
+  @location(83) f20: f16
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec3<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(1) f2: vec4<f32>,
+  @location(3) f3: vec2<u32>,
+  @location(4) f4: i32,
+  @location(0) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(31) a0: u32, @location(38) a1: vec2<f32>, @location(60) a2: vec4<u32>, @location(55) a3: vec2<f32>, a4: S12, @location(82) a5: vec3<i32>, @location(14) a6: vec3<f32>, @location(4) a7: vec2<f16>, @location(92) a8: vec4<u32>, @location(68) a9: vec3<f16>, @location(39) a10: vec2<f16>, @location(7) a11: vec3<f16>, @location(8) a12: vec4<u32>, @location(43) a13: vec3<u32>, @builtin(position) a14: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(4) f0: vec3<u32>,
+  @location(21) f1: vec2<u32>,
+  @builtin(instance_index) f2: u32
+}
+struct VertexOutput0 {
+  @location(78) f190: vec4<i32>,
+  @location(82) f191: vec3<i32>,
+  @location(55) f192: vec2<f32>,
+  @location(81) f193: vec4<f16>,
+  @builtin(position) f194: vec4<f32>,
+  @location(31) f195: u32,
+  @location(40) f196: vec3<u32>,
+  @location(38) f197: vec2<f32>,
+  @location(72) f198: vec2<i32>,
+  @location(63) f199: vec4<f32>,
+  @location(86) f200: vec4<i32>,
+  @location(30) f201: vec4<f32>,
+  @location(45) f202: vec2<i32>,
+  @location(60) f203: vec4<u32>,
+  @location(41) f204: f16,
+  @location(57) f205: vec4<f16>,
+  @location(14) f206: vec3<f32>,
+  @location(6) f207: vec2<i32>,
+  @location(7) f208: vec3<f16>,
+  @location(25) f209: vec3<f32>,
+  @location(43) f210: vec3<u32>,
+  @location(68) f211: vec3<f16>,
+  @location(39) f212: vec2<f16>,
+  @location(4) f213: vec2<f16>,
+  @location(83) f214: f16,
+  @location(53) f215: vec4<f32>,
+  @location(24) f216: f16,
+  @location(48) f217: vec2<i32>,
+  @location(47) f218: vec3<i32>,
+  @location(36) f219: f32,
+  @location(8) f220: vec4<u32>,
+  @location(93) f221: vec2<i32>,
+  @location(92) f222: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<f32>, @location(2) a1: f16, @location(10) a2: f32, @builtin(vertex_index) a3: u32, @location(8) a4: f32, @location(0) a5: vec2<f32>, @location(18) a6: vec4<u32>, @location(6) a7: vec3<f16>, @location(17) a8: vec3<f32>, a9: S11, @location(12) a10: vec4<f16>, @location(9) a11: vec2<f16>, @location(15) a12: vec4<f16>, @location(5) a13: vec2<i32>, @location(19) a14: f32, @location(14) a15: u32, @location(22) a16: vec3<u32>, @location(20) a17: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup17 = device1.createBindGroup({label: '\u{1fc77}\u8220\u{1f8ef}\u4fac', layout: bindGroupLayout18, entries: []});
+let textureView118 = texture25.createView({
+  label: '\u{1fbc7}\u{1fddc}\u0c39\u0c43\ub96a\u0fe7\u4a54\u0d02\u94dd',
+  format: 'rgba8unorm-srgb',
+  mipLevelCount: 1,
+});
+let sampler49 = device1.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', lodMinClamp: 49.57, lodMaxClamp: 50.24});
+try {
+computePassEncoder34.setBindGroup(6, bindGroup11);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(2, bindGroup17, new Uint32Array(3816), 533, 0);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(buffer17, 'uint16', 38464, 29733);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer13, 65532, buffer12, 97044, 16592);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer12);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer12, 19364, new DataView(new ArrayBuffer(2100)));
+} catch {}
+canvas19.width = 314;
+let buffer20 = device0.createBuffer({
+  label: '\u615f\u437d\u0c14\u8e7b\u0b28\u2278\u{1fc95}\u0326',
+  size: 12640,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+});
+let querySet55 = device0.createQuerySet({label: '\u09e5\u0a9c', type: 'occlusion', count: 3249});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer20, 2360, buffer1, 120256, 8940);
+dissociateBuffer(device0, buffer20);
+dissociateBuffer(device0, buffer1);
+} catch {}
+offscreenCanvas23.width = 411;
+let computePassEncoder43 = commandEncoder91.beginComputePass({label: '\u{1f645}\ud9f2\u0e2f\u428f\u07cc\u07f9\u{1fa8f}'});
+try {
+computePassEncoder38.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(3537, undefined);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 10},
+  aspect: 'all',
+}, new DataView(arrayBuffer3), /* required buffer size: 788532 */
+{offset: 569, bytesPerRow: 268, rowsPerImage: 294}, {width: 43, height: 1, depthOrArrayLayers: 11});
+} catch {}
+try {
+  await promise34;
+} catch {}
+document.body.prepend(img15);
+let texture61 = device3.createTexture({
+  label: '\uc860\u2a1e\u8f1a\u0009\u{1fcc3}\u0df6\u09c6',
+  size: [4544],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView119 = texture58.createView({});
+try {
+computePassEncoder38.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder47.setIndexBuffer(buffer14, 'uint32', 339060);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 74}
+*/
+{
+  source: img7,
+  origin: { x: 6, y: 2 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+  await promise29;
+} catch {}
+let texture62 = gpuCanvasContext6.getCurrentTexture();
+let textureView120 = texture40.createView({label: '\ufad2\u0626\u{1f910}\u0656\u81ed\u0a3e\u0900\u0767\u01f0\u062b', mipLevelCount: 1});
+document.body.prepend(canvas17);
+let shaderModule18 = device1.createShaderModule({
+  code: `@group(2) @binding(5295)
+var<storage, read_write> function9: array<u32>;
+@group(4) @binding(2853)
+var<storage, read_write> type16: array<u32>;
+@group(4) @binding(4083)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(4083)
+var<storage, read_write> global10: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> type17: array<u32>;
+@group(0) @binding(2853)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(2853)
+var<storage, read_write> local15: array<u32>;
+@group(2) @binding(4083)
+var<storage, read_write> global11: array<u32>;
+@group(2) @binding(2853)
+var<storage, read_write> n13: array<u32>;
+@group(4) @binding(5295)
+var<storage, read_write> parameter16: array<u32>;
+@group(1) @binding(5295)
+var<storage, read_write> local16: array<u32>;
+@group(0) @binding(5295)
+var<storage, read_write> field11: array<u32>;
+@group(3) @binding(2853)
+var<storage, read_write> parameter17: array<u32>;
+@group(3) @binding(5295)
+var<storage, read_write> function10: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S14 {
+  @builtin(position) f0: vec4<f32>,
+  @location(59) f1: vec2<u32>,
+  @builtin(front_facing) f2: bool,
+  @builtin(sample_index) f3: u32,
+  @location(63) f4: vec4<u32>,
+  @location(4) f5: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(5) f2: vec4<i32>,
+  @location(4) f3: vec4<u32>,
+  @location(2) f4: vec2<i32>,
+  @location(6) f5: u32,
+  @location(1) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(93) a0: vec4<f16>, @location(32) a1: vec4<i32>, @location(56) a2: vec4<f16>, @location(6) a3: vec3<f32>, @location(21) a4: vec3<f16>, a5: S14) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(13) f0: vec4<f16>,
+  @location(4) f1: vec2<f32>,
+  @location(20) f2: vec3<u32>,
+  @location(9) f3: vec3<u32>,
+  @location(5) f4: i32
+}
+struct VertexOutput0 {
+  @location(32) f223: vec4<i32>,
+  @location(14) f224: vec2<u32>,
+  @location(13) f225: f16,
+  @location(75) f226: f16,
+  @location(59) f227: vec2<u32>,
+  @location(60) f228: i32,
+  @location(15) f229: vec2<u32>,
+  @location(93) f230: vec4<f16>,
+  @location(4) f231: vec2<f16>,
+  @location(12) f232: vec3<f16>,
+  @location(88) f233: vec2<f16>,
+  @location(39) f234: vec4<f32>,
+  @builtin(position) f235: vec4<f32>,
+  @location(78) f236: vec4<f16>,
+  @location(33) f237: vec4<i32>,
+  @location(56) f238: vec4<f16>,
+  @location(9) f239: f32,
+  @location(0) f240: vec2<i32>,
+  @location(62) f241: vec2<f32>,
+  @location(48) f242: f32,
+  @location(6) f243: vec3<f32>,
+  @location(86) f244: u32,
+  @location(66) f245: vec2<i32>,
+  @location(1) f246: f16,
+  @location(22) f247: vec4<u32>,
+  @location(65) f248: f16,
+  @location(17) f249: i32,
+  @location(70) f250: vec2<i32>,
+  @location(28) f251: vec4<f32>,
+  @location(26) f252: vec4<i32>,
+  @location(21) f253: vec3<f16>,
+  @location(72) f254: f16,
+  @location(85) f255: vec2<f16>,
+  @location(63) f256: vec4<u32>,
+  @location(34) f257: vec2<f32>,
+  @location(90) f258: vec2<f32>,
+  @location(47) f259: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: f32, @location(6) a1: vec3<f32>, @location(12) a2: vec2<f16>, @location(2) a3: vec2<f32>, a4: S13, @location(11) a5: vec3<u32>, @location(14) a6: i32, @location(8) a7: vec3<i32>, @location(18) a8: vec2<i32>, @location(3) a9: i32, @location(16) a10: vec3<f32>, @location(22) a11: vec3<f16>, @location(0) a12: vec3<u32>, @location(21) a13: f32, @location(17) a14: vec2<f16>, @location(7) a15: vec4<i32>, @location(10) a16: vec3<i32>, @location(15) a17: vec4<i32>, @location(1) a18: f32, @builtin(vertex_index) a19: u32, @builtin(instance_index) a20: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let commandEncoder100 = device1.createCommandEncoder({label: '\u{1f7ba}\u{1f6c1}\u97ed\u{1faac}'});
+let querySet56 = device1.createQuerySet({label: '\u7298\u9f95\u009b\u522a\u{1f873}\u{1f732}', type: 'occlusion', count: 1561});
+let texture63 = device1.createTexture({
+  size: [48],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView121 = texture27.createView({
+  label: '\u06fa\u08ef\u8c3e\u{1fb6f}\u{1f95f}\u0334',
+  dimension: '3d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let imageData23 = new ImageData(84, 132);
+let texture64 = device1.createTexture({
+  label: '\u0b55\u098b\ue8cc\u5e5f\ue47a\ud56c\uf5af\u{1fba0}\u01cb\u{1f7f9}',
+  size: {width: 384, height: 1, depthOrArrayLayers: 802},
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView122 = texture42.createView({label: '\u{1fb84}\u9a4c\uff97'});
+try {
+renderBundleEncoder21.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(7205, undefined, 0);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline60 = device1.createComputePipeline({
+  label: '\u0008\uf136\u08dd\u{1f710}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+try {
+canvas31.getContext('webgl2');
+} catch {}
+try {
+  await promise32;
+} catch {}
+video4.height = 103;
+let device6 = await adapter6.requestDevice({label: '\u07d7\u0d1e\u4e6c'});
+let img23 = await imageWithData(295, 300, '#fe9e0d50', '#b2baaf40');
+let gpuCanvasContext28 = offscreenCanvas23.getContext('webgpu');
+document.body.prepend(video16);
+let shaderModule19 = device4.createShaderModule({
+  label: '\u{1febb}\u{1fbfb}\ua126\ucb49\u3c34',
+  code: `@group(0) @binding(6601)
+var<storage, read_write> parameter18: array<u32>;
+@group(1) @binding(1741)
+var<storage, read_write> global12: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(5) f1: vec2<f32>,
+  @location(2) f2: u32,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@location(18) a0: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(13) f0: vec3<f16>,
+  @location(1) f1: vec3<i32>,
+  @location(18) f2: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(25) f260: vec3<u32>,
+  @location(49) f261: vec3<i32>,
+  @builtin(position) f262: vec4<f32>,
+  @location(57) f263: f16,
+  @location(66) f264: vec2<u32>,
+  @location(1) f265: vec4<f16>,
+  @location(41) f266: vec3<u32>,
+  @location(55) f267: vec3<u32>,
+  @location(18) f268: vec2<u32>,
+  @location(63) f269: vec3<f16>,
+  @location(48) f270: vec2<f32>,
+  @location(34) f271: vec3<i32>,
+  @location(60) f272: u32,
+  @location(37) f273: u32,
+  @location(14) f274: vec4<u32>,
+  @location(23) f275: u32,
+  @location(8) f276: vec2<u32>,
+  @location(12) f277: vec4<f32>,
+  @location(21) f278: i32,
+  @location(56) f279: f16,
+  @location(11) f280: i32,
+  @location(15) f281: vec3<u32>,
+  @location(40) f282: vec3<u32>,
+  @location(10) f283: vec3<i32>,
+  @location(27) f284: vec4<f32>,
+  @location(51) f285: vec4<f16>,
+  @location(45) f286: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<f16>, @location(11) a1: u32, @location(0) a2: vec3<i32>, @location(10) a3: vec4<i32>, a4: S15, @location(15) a5: u32, @builtin(instance_index) a6: u32, @location(8) a7: vec3<u32>, @location(12) a8: vec4<i32>, @location(20) a9: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderPassEncoder1 = commandEncoder98.beginRenderPass({
+  label: '\ud877\u{1fa28}\u{1f96e}\u7834\u469a',
+  colorAttachments: [{view: textureView104, depthSlice: 83, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet47,
+  maxDrawCount: 559352481,
+});
+try {
+renderPassEncoder0.draw(674571977, 225778306, 979536369, 312112362);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer15, 234103068);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer18, 172736, 529808);
+dissociateBuffer(device4, buffer18);
+} catch {}
+video1.width = 11;
+let buffer21 = device1.createBuffer({
+  label: '\ua7f3\ub773\u0d2b\ue518\u06dd\u1e46\ub043\u0bcf\ufa2b\u0899\u7ad8',
+  size: 141229,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder101 = device1.createCommandEncoder();
+let querySet57 = device1.createQuerySet({label: '\u6208\ue254\u44a1\uabf8', type: 'occlusion', count: 384});
+let sampler50 = device1.createSampler({
+  label: '\u{1f64d}\ua855\u9bcd\u0b2a\u045d',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.82,
+  lodMaxClamp: 64.53,
+  compare: 'greater-equal',
+  maxAnisotropy: 20,
+});
+try {
+  await buffer12.mapAsync(GPUMapMode.READ);
+} catch {}
+let textureView123 = texture52.createView({label: '\ud5b3\u626a'});
+let renderBundleEncoder50 = device3.createRenderBundleEncoder({
+  label: '\ude0d\u{1f88f}',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture52 = device3.importExternalTexture({label: '\ua2e6\u90dc\uc58c\u000a\ue508\ub95c', source: videoFrame3, colorSpace: 'display-p3'});
+let imageData24 = new ImageData(128, 116);
+let textureView124 = texture23.createView({
+  label: '\u{1ff87}\u05c9\u{1fc42}\u48b4\u292e\u09b7\u4b11\uc238\u008c\u9cee',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder18.setPipeline(pipeline41);
+} catch {}
+try {
+  await buffer21.mapAsync(GPUMapMode.WRITE, 64592, 41788);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer7, 224384, buffer6, 78980, 6780);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+commandEncoder101.resolveQuerySet(querySet39, 1135, 187, buffer5, 768);
+} catch {}
+let pipeline61 = device1.createComputePipeline({
+  label: '\ud9b9\u{1fa3f}\u{1f6d0}\ud84a',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let shaderModule20 = device3.createShaderModule({
+  label: '\u67f4\u0688\u2d4e\ud9b5\ub75d\u2b5b\ueb8c\uc5c3\u051e',
+  code: `@group(4) @binding(260)
+var<storage, read_write> global13: array<u32>;
+@group(3) @binding(260)
+var<storage, read_write> local17: array<u32>;
+@group(0) @binding(798)
+var<storage, read_write> type18: array<u32>;
+@group(3) @binding(1410)
+var<storage, read_write> local18: array<u32>;
+@group(0) @binding(693)
+var<storage, read_write> function11: array<u32>;
+@group(1) @binding(798)
+var<storage, read_write> type19: array<u32>;
+@group(2) @binding(693)
+var<storage, read_write> field12: array<u32>;
+@group(4) @binding(1410)
+var<storage, read_write> parameter19: array<u32>;
+@group(4) @binding(1556)
+var<storage, read_write> field13: array<u32>;
+@group(3) @binding(1556)
+var<storage, read_write> local19: array<u32>;
+@group(1) @binding(693)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(3) f1: vec4<i32>,
+  @location(2) f2: vec4<i32>,
+  @location(4) f3: vec2<f32>,
+  @location(1) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(6) f0: vec3<i32>,
+  @location(9) f1: vec3<f32>,
+  @location(16) f2: vec3<f32>,
+  @location(15) f3: vec3<f16>,
+  @builtin(instance_index) f4: u32,
+  @location(17) f5: vec3<f16>,
+  @location(13) f6: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: f32, @location(12) a1: vec4<u32>, @builtin(vertex_index) a2: u32, a3: S16, @location(14) a4: vec3<f16>, @location(11) a5: vec4<i32>, @location(3) a6: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+gpuCanvasContext26.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData25 = new ImageData(180, 236);
+let imageBitmap24 = await createImageBitmap(videoFrame12);
+try {
+  await device6.popErrorScope();
+} catch {}
+let textureView125 = texture44.createView({
+  label: '\u3f2c\ubd37\u0c7c\u07ff\u6cf5\u07e1\u4231\u{1f7e0}\u0f6a\u0562\u49c2',
+  format: 'r16float',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  arrayLayerCount: 1033,
+});
+let externalTexture53 = device4.importExternalTexture({source: videoFrame7});
+try {
+renderPassEncoder0.beginOcclusionQuery(586);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 90, y: 0, z: 176},
+  aspect: 'all',
+},
+{width: 100, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet46, 11, 52, buffer15, 156416);
+} catch {}
+try {
+device4.queue.submit([]);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer2), /* required buffer size: 500620 */
+{offset: 566, bytesPerRow: 146, rowsPerImage: 137}, {width: 4, height: 1, depthOrArrayLayers: 26});
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(99, 954);
+let bindGroup18 = device2.createBindGroup({
+  label: '\ue062\u17dd\u0fa0\u07e3\u0ed9\u0eb2\u{1fe30}\uc01a\u0e67',
+  layout: bindGroupLayout16,
+  entries: [{binding: 34, resource: sampler27}],
+});
+let querySet58 = device2.createQuerySet({label: '\u2ebc\uf3ea\u0023', type: 'occlusion', count: 3990});
+try {
+computePassEncoder23.setPipeline(pipeline36);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 8, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(32, 395);
+let video28 = await videoWithData();
+let canvas32 = document.createElement('canvas');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let canvas33 = document.createElement('canvas');
+let video29 = await videoWithData();
+try {
+adapter2.label = '\ue669\u0373\u004f\u{1f647}\u93f9\u{1fc5e}\ub68f\ucf89\u9501';
+} catch {}
+let texture65 = device1.createTexture({
+  label: '\ucfba\ucb57\u49ff\u7cae\u{1f87b}\u0ec2\u03c1\u0e2f\u2d52\u{1f909}\u0a19',
+  size: {width: 384, height: 1, depthOrArrayLayers: 141},
+  mipLevelCount: 6,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let computePassEncoder44 = commandEncoder38.beginComputePass({label: '\ud09a\u{1fc51}\u0e55\ubfae\u0054\uc6a2\ue005\u073c\u62f1'});
+let renderBundle51 = renderBundleEncoder24.finish({label: '\u7a82\udd1e\u0984\u0061\u2b4f'});
+try {
+renderBundleEncoder34.setVertexBuffer(167, undefined, 0, 365035286);
+} catch {}
+try {
+device1.queue.submit([commandBuffer17, commandBuffer13]);
+} catch {}
+try {
+offscreenCanvas25.getContext('webgl');
+} catch {}
+let renderBundle52 = renderBundleEncoder45.finish({label: '\u0eba\u0d49\u019c'});
+try {
+renderPassEncoder0.executeBundles([renderBundle44, renderBundle50, renderBundle43, renderBundle50, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(345, 0, 14, 1);
+} catch {}
+try {
+renderPassEncoder1.setViewport(103.4, 0.4464, 7.775, 0.4001, 0.3321, 0.6593);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer18, 3783840);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8639, undefined, 3727125895, 174247235);
+} catch {}
+let textureView126 = texture22.createView({
+  label: '\u0cc9\ud75c\u1bf1\udc58\u2f91\uaa68\u{1f9ad}\u3c8b',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 157,
+});
+let renderBundle53 = renderBundleEncoder22.finish({});
+let sampler51 = device2.createSampler({
+  label: '\ue4f5\u506b\ubed4\u52e7\ubbe1\u{1f841}\u0625\u68d6\u7719\u9031',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 92.72,
+});
+let externalTexture54 = device2.importExternalTexture({label: '\u0773\u{1fc97}\u0209\u{1f74b}\u4254\u21f3\u4b6c\ub691', source: video27});
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 96, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: video26,
+  origin: { x: 4, y: 2 },
+  flipY: false,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 12, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = await device2.createComputePipelineAsync({
+  label: '\uc21c\u{1fc39}',
+  layout: 'auto',
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext29 = canvas32.getContext('webgpu');
+let commandEncoder102 = device3.createCommandEncoder({label: '\u286c\u02a2\u0bdd\u9b36\u61c6\u0bb6'});
+let querySet59 = device3.createQuerySet({label: '\u02e0\u5595\ubdb1\ubcf9\u703c\u08f2', type: 'occlusion', count: 3462});
+let textureView127 = texture40.createView({label: '\u8e1d\u8bb4\ua3ba', dimension: '2d-array'});
+let renderBundleEncoder51 = device3.createRenderBundleEncoder({
+  label: '\u0de9\u{1f6d6}',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+});
+let renderBundle54 = renderBundleEncoder31.finish({label: '\u700e\u0ac5\ue49c\u{1f9ae}\u0449\u{1f838}\u6c54\ua3fc'});
+let externalTexture55 = device3.importExternalTexture({label: '\u{1ff90}\u0d92\u12b2', source: video21, colorSpace: 'srgb'});
+try {
+renderBundleEncoder50.setVertexBuffer(7, buffer19, 0, 104973);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 3411076 */
+{offset: 98, bytesPerRow: 262, rowsPerImage: 277}, {width: 1, height: 0, depthOrArrayLayers: 48});
+} catch {}
+let pipeline63 = device3.createRenderPipeline({
+  label: '\u5bc8\uc07e\u0c47\u{1f651}\u67a1\uc21b\u0a51',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0xa0f16735},
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r32float'}, {
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4348,
+        attributes: [
+          {format: 'sint32x3', offset: 156, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 2260, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 160, shaderLocation: 15},
+          {format: 'uint32x2', offset: 2268, shaderLocation: 3},
+          {format: 'uint32x2', offset: 1588, shaderLocation: 12},
+          {format: 'sint8x2', offset: 1376, shaderLocation: 11},
+          {format: 'sint8x2', offset: 4346, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 528, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 1900, shaderLocation: 5},
+          {format: 'float32x4', offset: 1420, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 6, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', unclippedDepth: true},
+});
+let buffer22 = device4.createBuffer({
+  label: '\u8d4b\u2140',
+  size: 32120,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let renderBundle55 = renderBundleEncoder44.finish();
+try {
+renderPassEncoder0.executeBundles([renderBundle43, renderBundle55, renderBundle44, renderBundle43, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline50);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5006, undefined, 0);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer15, 105928, buffer18, 218968, 59140);
+dissociateBuffer(device4, buffer15);
+dissociateBuffer(device4, buffer18);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12204 */
+  offset: 12204,
+  buffer: buffer15,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer15);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 72},
+  aspect: 'all',
+},
+{width: 115, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext23.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline64 = await device4.createComputePipelineAsync({
+  label: '\u{1f9fb}\uc6d0\uc057\uf180',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let pipeline65 = device4.createRenderPipeline({
+  label: '\u5ee8\u087b',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 37808,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 4820, shaderLocation: 10},
+          {format: 'sint32x3', offset: 13776, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 23652,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 4008, shaderLocation: 1},
+          {format: 'uint32x4', offset: 9032, shaderLocation: 11},
+          {format: 'sint16x2', offset: 2824, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 5480, shaderLocation: 13},
+          {format: 'sint8x4', offset: 2924, shaderLocation: 0},
+          {format: 'sint32', offset: 268, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 43968, attributes: []},
+      {arrayStride: 6204, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 18420, shaderLocation: 8},
+          {format: 'uint16x4', offset: 35144, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 11524, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: false},
+});
+video0.width = 163;
+let bindGroupLayout27 = device5.createBindGroupLayout({
+  label: '\u0179\u422b\u0460\ue482\u{1fcec}\u7e48\u713d\u5d39\u3bb9\u5c12\u{1feca}',
+  entries: [
+    {
+      binding: 1016,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 4652,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 4623, visibility: 0, sampler: { type: 'comparison' }},
+  ],
+});
+let textureView128 = texture56.createView({label: '\u0871\u8d64\u0a07\u89f2\u92f4\u7f0e\uca76\u61a8\uc90e\ua1f5'});
+let imageData26 = new ImageData(148, 252);
+let buffer23 = device4.createBuffer({
+  label: '\u0b10\uf6bf\u{1ff2e}\u{1fa84}\ub2a2\uf644\u31b6\uf775',
+  size: 245026,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+});
+let commandEncoder103 = device4.createCommandEncoder({label: '\u0015\u8b99\ubc40\u0793\u0f1a\u96de\uf970\u0e2f\u06bc'});
+let renderPassEncoder2 = commandEncoder103.beginRenderPass({
+  label: '\ufd82\u5d7b\u06b3\u537a\u0e3a\u{1f8ca}\u9aa3\u09e1\u0831\u0dce',
+  colorAttachments: [{
+  view: textureView104,
+  depthSlice: 222,
+  clearValue: { r: 139.4, g: -107.1, b: 78.45, a: 977.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 244339888,
+});
+try {
+renderPassEncoder1.setViewport(361.1, 0.9879, 44.68, 0.00200, 0.2197, 0.2875);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 880925729);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(9863, undefined, 0);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer18, 764452, 12592);
+dissociateBuffer(device4, buffer18);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline66 = await device4.createComputePipelineAsync({
+  label: '\u{1f836}\u84e4\u095e\uf3d5\u0593\u9198\uba2c\ub1b0',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule12, entryPoint: 'compute0'},
+});
+let imageData27 = new ImageData(44, 228);
+let texture66 = device1.createTexture({
+  label: '\u21c1\ubcd6\ueeb3\u0763\u4b11',
+  size: [192, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView129 = texture63.createView({
+  label: '\u{1fdc1}\u034f\u052e\u0a0a\u0849\ue1fb\ucc8c\u39fc\u008a',
+  aspect: 'all',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder52 = device1.createRenderBundleEncoder({
+  label: '\ud402\u{1f8ef}\u0598\u6a8a',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder27.setBindGroup(5, bindGroup12);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer7, 178116, buffer12, 30580, 6244);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer12);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer6, 43640, 37172);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+computePassEncoder16.insertDebugMarker('\u08cb');
+} catch {}
+let pipeline67 = device1.createComputePipeline({
+  label: '\u031c\u{1f636}\u{1ff9a}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule15, entryPoint: 'compute0'},
+});
+let bindGroupLayout28 = device6.createBindGroupLayout({
+  label: '\u3077\ue077\u00f7\u{1fb6e}\ud847\u9001\ue32a\u0467\u{1ffd1}\u0805',
+  entries: [
+    {
+      binding: 382,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 823,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let externalTexture56 = device6.importExternalTexture({label: '\u53bf\u01e3', source: video5, colorSpace: 'display-p3'});
+let querySet60 = device3.createQuerySet({label: '\ube32\u528b', type: 'occlusion', count: 1918});
+let pipeline68 = device3.createComputePipeline({
+  label: '\u{1ff5f}\u0feb\ufd4a\u72e4\u063a\u{1f92e}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame21 = new VideoFrame(canvas33, {timestamp: 0});
+let video30 = await videoWithData();
+let imageBitmap25 = await createImageBitmap(canvas20);
+let canvas34 = document.createElement('canvas');
+let shaderModule21 = device5.createShaderModule({
+  label: '\u0283\ubb8e\uad1c\u030f\u{1fde5}\u{1fc7b}\ue1dd',
+  code: `@group(6) @binding(2878)
+var<storage, read_write> field14: array<u32>;
+@group(0) @binding(2878)
+var<storage, read_write> field15: array<u32>;
+@group(3) @binding(2878)
+var<storage, read_write> function13: array<u32>;
+@group(7) @binding(2878)
+var<storage, read_write> n14: array<u32>;
+@group(4) @binding(2878)
+var<storage, read_write> local20: array<u32>;
+@group(2) @binding(2878)
+var<storage, read_write> parameter20: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: f32,
+  @location(6) f1: vec3<i32>,
+  @location(0) f2: vec3<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(2) f4: vec4<i32>,
+  @location(1) f5: vec2<i32>,
+  @location(4) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(6) f0: vec3<i32>,
+  @location(10) f1: vec2<u32>,
+  @location(5) f2: vec3<f16>,
+  @location(3) f3: u32,
+  @builtin(vertex_index) f4: u32,
+  @location(15) f5: vec4<i32>,
+  @location(14) f6: vec4<f16>,
+  @location(9) f7: vec4<u32>,
+  @builtin(instance_index) f8: u32,
+  @location(13) f9: vec4<f16>
+}
+
+@vertex
+fn vertex0(a0: S17, @location(4) a1: vec3<u32>, @location(17) a2: vec3<f32>, @location(18) a3: vec3<i32>, @location(16) a4: vec4<i32>, @location(8) a5: vec2<f32>, @location(1) a6: vec4<u32>, @location(2) a7: vec3<u32>, @location(12) a8: f16, @location(11) a9: vec3<f16>, @location(7) a10: vec2<i32>, @location(0) a11: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder104 = device5.createCommandEncoder();
+let sampler52 = device5.createSampler({
+  label: '\u0de0\u{1ff76}\ucc15\u43df\u{1f860}\u076a\u0c8b',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 81.25,
+  lodMaxClamp: 86.93,
+});
+try {
+device5.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 125 */
+{offset: 125, rowsPerImage: 32}, {width: 311, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise35 = device5.queue.onSubmittedWorkDone();
+try {
+device5.destroy();
+} catch {}
+video13.height = 166;
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\u0840\u8c67',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout21, bindGroupLayout26, bindGroupLayout17, bindGroupLayout20, bindGroupLayout13],
+});
+let commandEncoder105 = device1.createCommandEncoder({label: '\u25d6\u9e98\u0f9f'});
+try {
+computePassEncoder18.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer13, 49680, buffer12, 123792, 220);
+dissociateBuffer(device1, buffer13);
+dissociateBuffer(device1, buffer12);
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 280 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5236 */
+  offset: 5236,
+  rowsPerImage: 242,
+  buffer: buffer7,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 7},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 3623200 */
+{offset: 230, bytesPerRow: 403, rowsPerImage: 155}, {width: 8, height: 0, depthOrArrayLayers: 59});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 359}
+*/
+{
+  source: offscreenCanvas15,
+  origin: { x: 12, y: 81 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline69 = device1.createRenderPipeline({
+  label: '\u05d7\u006d\u0cad\u2fcf\u0a1b\u8bbf\u7d9c\u{1ff53}',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0x4f00d835},
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: 0}, {format: 'rgba16sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 152,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x2', offset: 20, shaderLocation: 18}],
+      },
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 4, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 92,
+        attributes: [
+          {format: 'float32x4', offset: 0, shaderLocation: 17},
+          {format: 'sint32x4', offset: 12, shaderLocation: 14},
+          {format: 'uint32x3', offset: 16, shaderLocation: 0},
+          {format: 'float16x2', offset: 4, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 21},
+          {format: 'sint32x4', offset: 20, shaderLocation: 3},
+          {format: 'sint32', offset: 4, shaderLocation: 10},
+          {format: 'float32x3', offset: 12, shaderLocation: 19},
+          {format: 'uint16x2', offset: 44, shaderLocation: 9},
+          {format: 'sint16x4', offset: 0, shaderLocation: 15},
+          {format: 'sint32x2', offset: 24, shaderLocation: 7},
+          {format: 'sint16x2', offset: 8, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 54, shaderLocation: 12},
+          {format: 'uint16x2', offset: 68, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 68, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 4},
+          {format: 'float32', offset: 24, shaderLocation: 2},
+          {format: 'float16x4', offset: 0, shaderLocation: 22},
+          {format: 'uint16x2', offset: 44, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let imageBitmap26 = await createImageBitmap(video21);
+let imageData28 = new ImageData(20, 72);
+try {
+canvas33.getContext('webgl');
+} catch {}
+let pipelineLayout16 = device6.createPipelineLayout({bindGroupLayouts: [bindGroupLayout28, bindGroupLayout28]});
+let commandEncoder106 = device6.createCommandEncoder({label: '\u068c\uf2b5\u0a57\u{1f883}\u5138'});
+let externalTexture57 = device6.importExternalTexture({label: '\uf639\u5895\u{1f877}\u{1fb84}\u4c00\u1107', source: video14, colorSpace: 'display-p3'});
+try {
+gpuCanvasContext21.configure({
+  device: device6,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let canvas35 = document.createElement('canvas');
+let bindGroupLayout29 = device1.createBindGroupLayout({label: '\u0aa6\u8a1d\u267f\u{1ff43}\u{1faf4}\u0085\u{1f755}\ue036\u6ecb\u006c', entries: []});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({
+  label: '\u0c2f\u63b4\u77e3\u505f\uc121\u9da5\ubf09',
+  colorFormats: ['rgba8uint', 'rgba8unorm', 'rgba16float', 'rgba8uint', 'rgba32uint', 'rgba8uint', 'r32float', 'r8unorm'],
+});
+let renderBundle56 = renderBundleEncoder37.finish({label: '\u3368\ua7b5\u7583\u0971\u558d\uce95\ua50f\u086d\u{1f755}\u75c6'});
+let externalTexture58 = device1.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup14, new Uint32Array(2282), 897, 0);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer8, 219960, buffer6, 31320, 36724);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline70 = device1.createRenderPipeline({
+  label: '\ucd83\u0a96\u0f0c\u1320\u0139\u3735\u{1f61e}\u{1fddc}\u{1ff46}\u1913',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32uint', writeMask: 0}, {format: 'rgba8uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm'}],
+},
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 984,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 68, shaderLocation: 21},
+          {format: 'float16x2', offset: 36, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 636, shaderLocation: 2},
+          {format: 'float32x4', offset: 228, shaderLocation: 10},
+          {format: 'sint16x2', offset: 176, shaderLocation: 19},
+          {format: 'uint32x3', offset: 72, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 112, shaderLocation: 17},
+          {format: 'uint8x2', offset: 82, shaderLocation: 16},
+          {format: 'sint32', offset: 404, shaderLocation: 7},
+          {format: 'uint32x4', offset: 168, shaderLocation: 5},
+          {format: 'uint8x2', offset: 226, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 344, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 384, shaderLocation: 8},
+          {format: 'uint16x4', offset: 44, shaderLocation: 11},
+          {format: 'float16x2', offset: 20, shaderLocation: 20},
+          {format: 'sint16x2', offset: 412, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 982, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 112,
+        attributes: [
+          {format: 'float16x2', offset: 20, shaderLocation: 13},
+          {format: 'sint32x2', offset: 28, shaderLocation: 6},
+          {format: 'sint32x2', offset: 0, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 1452,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 330, shaderLocation: 4},
+          {format: 'sint16x4', offset: 204, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 16, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let buffer24 = device1.createBuffer({
+  label: '\u0143\u2ee0\u405a\u88d5',
+  size: 109740,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true,
+});
+let sampler53 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.38,
+  lodMaxClamp: 89.63,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder44.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 512 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8320 */
+  offset: 8320,
+  buffer: buffer7,
+}, {
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer6, 72496, 12500);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 359}
+*/
+{
+  source: canvas5,
+  origin: { x: 67, y: 157 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let video31 = await videoWithData();
+let pipelineLayout17 = device4.createPipelineLayout({label: '\u35fe\u61d0\u{1fd82}\u014c\u{1f944}', bindGroupLayouts: [bindGroupLayout23]});
+let externalTexture59 = device4.importExternalTexture({source: videoFrame7, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.setViewport(286.5, 0.9420, 145.9, 0.03634, 0.5297, 0.7981);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer22, 192142870);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer22, 575396629);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet47, 564, 334, buffer15, 162560);
+} catch {}
+let pipeline71 = device4.createRenderPipeline({
+  label: '\u087d\u{1f6db}\u0afe\u1bc2\u01b2',
+  layout: pipelineLayout17,
+  multisample: {count: 4, mask: 0xc7052c18},
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba8uint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'always', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 1307861523,
+    stencilWriteMask: 4294967295,
+    depthBiasClamp: -30.27370333967629,
+  },
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+});
+let video32 = await videoWithData();
+offscreenCanvas9.width = 1634;
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let gpuCanvasContext30 = canvas34.getContext('webgpu');
+let canvas36 = document.createElement('canvas');
+try {
+  await promise35;
+} catch {}
+gc();
+let shaderModule22 = device6.createShaderModule({
+  label: '\u{1f77d}\u0976\u9326\uaadc\udf82\u00d0\u0a78\u735e',
+  code: `@group(0) @binding(382)
+var<storage, read_write> parameter21: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> function14: array<u32>;
+@group(1) @binding(382)
+var<storage, read_write> type20: array<u32>;
+@group(0) @binding(823)
+var<storage, read_write> function15: array<u32>;
+
+@compute @workgroup_size(6, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<i32>,
+  @location(4) f1: vec4<f32>,
+  @location(0) f2: f32,
+  @location(3) f3: vec4<u32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(0) f287: f16,
+  @location(6) f288: vec2<u32>,
+  @location(7) f289: vec2<f32>,
+  @location(2) f290: vec4<u32>,
+  @builtin(position) f291: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(15) a1: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let sampler54 = device6.createSampler({
+  label: '\u9dd9\u8ebf\uc925\u3528\ub780\u0b34\u0496\u0095\u9cf5',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  lodMinClamp: 70.81,
+  lodMaxClamp: 71.98,
+});
+let video33 = await videoWithData();
+let shaderModule23 = device1.createShaderModule({
+  label: '\u{1f82e}\u0b41\ub4d9\u{1feca}\u{1f723}',
+  code: `@group(0) @binding(5295)
+var<storage, read_write> parameter22: array<u32>;
+@group(0) @binding(4083)
+var<storage, read_write> type21: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<f32>,
+  @location(5) f1: vec4<f32>,
+  @location(4) f2: vec2<u32>,
+  @location(2) f3: vec4<f32>,
+  @location(3) f4: vec4<u32>,
+  @location(0) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(6) f0: vec3<f32>,
+  @location(5) f1: f32,
+  @location(14) f2: i32,
+  @location(22) f3: vec3<i32>,
+  @location(12) f4: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<u32>, @location(21) a1: vec2<i32>, @location(2) a2: vec4<f32>, @location(10) a3: vec3<u32>, @location(20) a4: vec4<f32>, @location(0) a5: vec4<f32>, @location(17) a6: vec4<u32>, @location(11) a7: vec3<i32>, @location(19) a8: vec3<f32>, @location(3) a9: vec3<u32>, @location(9) a10: vec3<f16>, @location(8) a11: vec2<i32>, a12: S18, @location(7) a13: vec4<u32>, @location(18) a14: vec4<f16>, @location(4) a15: vec4<u32>, @location(13) a16: vec2<i32>, @location(15) a17: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let texture67 = device1.createTexture({
+  label: '\u91e9\u00f1',
+  size: [384, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle57 = renderBundleEncoder40.finish({label: '\u63f9\ub8cc\u83c8\u8dd8\u4f62\u09cf\u295c\u{1fbe0}'});
+try {
+computePassEncoder18.setBindGroup(6, bindGroup15);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline42);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13776 */
+  offset: 13776,
+  buffer: buffer10,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer6, 12456, 20992);
+dissociateBuffer(device1, buffer6);
+} catch {}
+try {
+renderBundleEncoder27.popDebugGroup();
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let commandEncoder107 = device6.createCommandEncoder({label: '\u08f8\u09f1\u{1fcb3}\u3c5a\ud94b\ufd26\u{1fedf}'});
+let querySet61 = device6.createQuerySet({label: '\u{1f88a}\uef79\u482a\u0058\u{1fc20}\u97e5', type: 'occlusion', count: 2282});
+let renderBundleEncoder54 = device6.createRenderBundleEncoder({
+  label: '\ue986\u57af\u2337',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+video30.width = 204;
+let texture68 = device3.createTexture({
+  label: '\u8f43\uf7f1',
+  size: {width: 240, height: 2, depthOrArrayLayers: 299},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder45 = commandEncoder102.beginComputePass({});
+let renderBundle58 = renderBundleEncoder41.finish({label: '\u{1f92c}\u0662\u049a'});
+try {
+renderBundleEncoder51.setIndexBuffer(buffer14, 'uint32', 477968, 8893);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(7, buffer19, 0, 3090);
+} catch {}
+let arrayBuffer5 = buffer16.getMappedRange(125296, 42728);
+try {
+gpuCanvasContext27.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap27 = await createImageBitmap(offscreenCanvas20);
+canvas35.width = 29;
+let shaderModule24 = device6.createShaderModule({
+  code: `@group(0) @binding(823)
+var<storage, read_write> global14: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(382)
+var<storage, read_write> field16: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @builtin(front_facing) f0: bool,
+  @location(12) f1: i32,
+  @location(2) f2: f32,
+  @location(6) f3: f32,
+  @location(13) f4: vec3<f32>,
+  @location(8) f5: vec4<i32>,
+  @location(3) f6: u32,
+  @location(15) f7: i32,
+  @location(10) f8: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec4<i32>,
+  @location(3) f3: vec4<u32>,
+  @location(0) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec2<u32>, @location(4) a1: u32, @location(14) a2: i32, a3: S20, @location(5) a4: i32, @location(0) a5: vec2<i32>, @location(9) a6: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(11) f0: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(13) f292: vec3<f32>,
+  @location(5) f293: i32,
+  @location(0) f294: vec2<i32>,
+  @location(15) f295: i32,
+  @location(14) f296: i32,
+  @location(3) f297: u32,
+  @location(11) f298: vec4<u32>,
+  @location(8) f299: vec4<i32>,
+  @location(9) f300: f16,
+  @location(7) f301: vec2<u32>,
+  @location(2) f302: f32,
+  @builtin(position) f303: vec4<f32>,
+  @location(1) f304: vec4<f16>,
+  @location(4) f305: u32,
+  @location(12) f306: i32,
+  @location(10) f307: vec2<u32>,
+  @location(6) f308: f32
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<f32>, @location(1) a1: vec2<u32>, @builtin(instance_index) a2: u32, @location(13) a3: vec2<f32>, @location(0) a4: vec3<f16>, @location(6) a5: vec3<i32>, a6: S19, @builtin(vertex_index) a7: u32, @location(8) a8: vec2<u32>, @location(12) a9: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer25 = device6.createBuffer({
+  label: '\u3cf1\u3862\uc746\u0155\ud083\u8681\u3ca1\u5394\u899a',
+  size: 253643,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet62 = device6.createQuerySet({type: 'occlusion', count: 158});
+let texture69 = device6.createTexture({
+  label: '\ufc79\u{1feba}\u06ad\u4b7b',
+  size: [90, 1, 1314],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let computePassEncoder46 = commandEncoder107.beginComputePass({label: '\u5130\u7551\ud5fe\udb66\u{1f92f}\u0587\u{1f6a5}\u{1f618}\u2c76'});
+let externalTexture60 = device6.importExternalTexture({source: video16, colorSpace: 'display-p3'});
+try {
+commandEncoder106.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 66},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let buffer26 = device3.createBuffer({
+  label: '\ub305\u8a10\u{1fb75}\u0353\u1d93',
+  size: 123076,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder108 = device3.createCommandEncoder({label: '\u{1f6c1}\u5eb7\u2c51'});
+let texture70 = device3.createTexture({
+  label: '\u05f4\u3ca1',
+  size: {width: 60, height: 1, depthOrArrayLayers: 74},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture61 = device3.importExternalTexture({
+  label: '\ue0fe\u31aa\u1277\u0154\u4ab2\ud30b\u813d\ua7a5\u305c\u{1fdf4}\u388d',
+  source: video30,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder51.setPipeline(pipeline63);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(7, buffer19, 13032, 101148);
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u08d1');
+} catch {}
+document.body.prepend(canvas35);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video34 = await videoWithData();
+let imageBitmap28 = await createImageBitmap(imageData11);
+let gpuCanvasContext31 = offscreenCanvas24.getContext('webgpu');
+let adapter7 = await navigator.gpu.requestAdapter();
+let commandEncoder109 = device6.createCommandEncoder({label: '\u0123\u{1fb76}\u0e3a\u{1fbaa}\u011e\u0462\u{1fa98}'});
+let externalTexture62 = device6.importExternalTexture({
+  label: '\u0b0e\u0f29\u04dd\u{1fd10}\u{1f7bd}\ucfbb\u{1fa7b}\u3faa',
+  source: video34,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder109.clearBuffer(buffer25, 226612, 9960);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device6,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView130 = texture61.createView({label: '\u72a6\u400c\u{1fdb7}'});
+let renderBundleEncoder55 = device3.createRenderBundleEncoder({colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'], sampleCount: 4});
+try {
+computePassEncoder45.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline63);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder108.clearBuffer(buffer26);
+dissociateBuffer(device3, buffer26);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 240, height: 2, depthOrArrayLayers: 299}
+*/
+{
+  source: img16,
+  origin: { x: 44, y: 45 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline72 = device3.createRenderPipeline({
+  label: '\u{1f9ef}\u{1f7c9}\u{1f6c8}\ueaa1\u05c5\u030d\uc9fb\u1b72\u6c6e\u67d3',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0x7c4e5628},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32float'}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater', failOp: 'keep', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 1911556263,
+    stencilWriteMask: 2723418583,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 12, shaderLocation: 6},
+          {format: 'uint16x2', offset: 12, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 14, shaderLocation: 8},
+          {format: 'float32', offset: 68, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 2},
+          {format: 'sint32x2', offset: 16, shaderLocation: 12},
+          {format: 'float32x4', offset: 0, shaderLocation: 7},
+          {format: 'sint32x4', offset: 20, shaderLocation: 10},
+          {format: 'sint32x2', offset: 32, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 860,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 40, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 24, shaderLocation: 0}],
+      },
+      {arrayStride: 2520, stepMode: 'instance', attributes: []},
+      {arrayStride: 1112, stepMode: 'instance', attributes: []},
+      {arrayStride: 68, attributes: [{format: 'sint32x3', offset: 12, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', unclippedDepth: true},
+});
+let imageBitmap29 = await createImageBitmap(imageData4);
+try {
+adapter4.label = '\u62d0\u9390\u7164\u0a0a\u0fd5\u{1fa17}\u4e39\uc9e2\u9ee1\u{1f7c6}';
+} catch {}
+document.body.prepend(canvas29);
+let shaderModule25 = device6.createShaderModule({
+  code: `@group(0) @binding(382)
+var<storage, read_write> n15: array<u32>;
+@group(0) @binding(823)
+var<storage, read_write> field17: array<u32>;
+@group(1) @binding(382)
+var<storage, read_write> local22: array<u32>;
+
+@compute @workgroup_size(8, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+  @location(12) f0: vec2<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec4<f16>,
+  @location(11) f3: vec4<i32>,
+  @location(8) f4: vec4<f32>,
+  @location(9) f5: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: f32,
+  @location(3) f1: vec4<u32>,
+  @location(2) f2: vec4<f32>,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: i32
+}
+
+@fragment
+fn fragment0(@location(3) a0: vec3<f16>, a1: S21) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(5) f309: vec2<f16>,
+  @location(12) f310: vec2<i32>,
+  @location(0) f311: vec4<f16>,
+  @location(11) f312: vec4<i32>,
+  @location(7) f313: u32,
+  @location(6) f314: vec3<f16>,
+  @location(8) f315: vec4<f32>,
+  @location(1) f316: vec4<i32>,
+  @location(3) f317: vec3<f16>,
+  @location(15) f318: f32,
+  @location(14) f319: f32,
+  @builtin(position) f320: vec4<f32>,
+  @location(4) f321: vec4<i32>,
+  @location(10) f322: vec2<i32>,
+  @location(9) f323: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<i32>, @location(2) a1: vec2<f16>, @location(14) a2: vec2<f16>, @location(5) a3: vec2<u32>, @location(13) a4: vec3<f32>, @location(7) a5: vec3<u32>, @location(9) a6: vec2<i32>, @builtin(vertex_index) a7: u32, @location(0) a8: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder110 = device6.createCommandEncoder({});
+let commandBuffer21 = commandEncoder109.finish({label: '\u{1fbfb}\u07f3\u{1fddd}\u6952\u{1fbe7}\u{1f7cf}\u2895\u6476\u29d3'});
+let texture71 = device6.createTexture({
+  label: '\u{1f91f}\u0f83\u{1f831}\uee7d\u{1fa98}\u{1f68d}\u1ae2',
+  size: [180, 1, 144],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+let renderBundleEncoder56 = device6.createRenderBundleEncoder({
+  label: '\u1d8c\u0394\u0893\u720e\u{1f87f}',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture63 = device6.importExternalTexture({
+  label: '\u0780\u7a54\u0c72\u{1fbb6}\ufd27\u7a74\u46b2\u7507',
+  source: video31,
+  colorSpace: 'display-p3',
+});
+try {
+device6.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 4799660 */
+{offset: 712, bytesPerRow: 169, rowsPerImage: 229}, {width: 3, height: 1, depthOrArrayLayers: 125});
+} catch {}
+let pipeline73 = await device6.createComputePipelineAsync({
+  label: '\u0b30\ub66f\u8ee0\u3b82\u71fc\ua9b8\u0879\u{1fc6d}\u49ca\u41f6',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let pipeline74 = await device6.createRenderPipelineAsync({
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 32, stepMode: 'instance', attributes: []},
+      {arrayStride: 440, stepMode: 'instance', attributes: []},
+      {arrayStride: 64, attributes: [{format: 'sint32x3', offset: 0, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder111 = device4.createCommandEncoder({label: '\u7a53\u6e74'});
+let querySet63 = device4.createQuerySet({label: '\ufb2b\u{1f8b1}\ueabd\u8e46\u4e5c\u{1fb4e}\u{1fcd7}', type: 'occlusion', count: 3564});
+let texture72 = device4.createTexture({
+  label: '\u9a5d\u04cf\u{1f619}\u{1fb52}\u0ae0\u4529\u{1f97d}\uad02\u{1fac5}\uef9c\u0a6b',
+  size: [240],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let textureView131 = texture57.createView({label: '\uaf21\u08fc\u0348', baseMipLevel: 4, baseArrayLayer: 609, arrayLayerCount: 259});
+try {
+renderPassEncoder2.setBlendConstant({ r: -101.7, g: 930.8, b: 996.0, a: -438.2, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3579);
+} catch {}
+try {
+renderPassEncoder0.setViewport(403.5, 0.4636, 52.79, 0.3376, 0.06959, 0.3249);
+} catch {}
+try {
+renderPassEncoder1.draw(1182170685, 960926020, 807142962, 320683999);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1040233840, 1224533405, 905099047, -1231870566);
+} catch {}
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 320 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17484 */
+  offset: 17164,
+  buffer: buffer15,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer15);
+} catch {}
+let gpuCanvasContext32 = canvas36.getContext('webgpu');
+let querySet64 = device4.createQuerySet({label: '\u300b\ucf8c\uefc9\uf663', type: 'occlusion', count: 1923});
+let commandBuffer22 = commandEncoder111.finish();
+let textureView132 = texture49.createView({label: '\u5c43\u4f1b\ub759\u9f49\u{1fe35}\u1052', aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder3 = commandEncoder96.beginRenderPass({
+  label: '\u0ab5\u018f\u{1f871}\u5a05',
+  colorAttachments: [{view: textureView104, depthSlice: 432, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet47,
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle50, renderBundle44, renderBundle43, renderBundle55, renderBundle44, renderBundle43, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2182);
+} catch {}
+try {
+renderPassEncoder0.draw(281267599, 233611912, 151647060, 863676279);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer22, 342829449);
+} catch {}
+let promise36 = buffer18.mapAsync(GPUMapMode.READ, 630488, 11156);
+try {
+device4.queue.submit([]);
+} catch {}
+let pipeline75 = await device4.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 15512, attributes: []},
+      {
+        arrayStride: 15592,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 1456, shaderLocation: 11},
+          {format: 'uint16x2', offset: 3696, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 1660, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 3688,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 1452, shaderLocation: 0},
+          {format: 'uint32x3', offset: 196, shaderLocation: 15},
+          {format: 'sint8x2', offset: 958, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 1472, shaderLocation: 16},
+          {format: 'sint8x2', offset: 624, shaderLocation: 18},
+          {format: 'sint32x3', offset: 144, shaderLocation: 10},
+          {format: 'sint32x4', offset: 148, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 13236,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 1128, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+gc();
+try {
+canvas35.getContext('webgl2');
+} catch {}
+let bindGroup19 = device5.createBindGroup({
+  label: '\u0e12\u{1fa3e}\u7136',
+  layout: bindGroupLayout25,
+  entries: [{binding: 2878, resource: sampler52}],
+});
+let commandEncoder112 = device5.createCommandEncoder();
+let textureView133 = texture54.createView({label: '\u150f\u923d\ua628\u0f2c', aspect: 'all', format: 'rg11b10ufloat'});
+let renderBundle59 = renderBundleEncoder49.finish();
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let externalTexture64 = device3.importExternalTexture({
+  label: '\ufd97\u{1fefd}\u0390\u45cb\u0ffb\u{1fdc8}\ue1f2\u4cd3',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder51.setIndexBuffer(buffer14, 'uint32');
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext22.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+} catch {}
+let pipeline76 = await device3.createComputePipelineAsync({
+  label: '\u{1fc92}\ub92a\u{1fd10}\u{1fcf7}\uce3c\u4386',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule13, entryPoint: 'compute0'},
+});
+let querySet65 = device3.createQuerySet({label: '\u19a1\u04f2\ue7f1\u62ab\u66a1\ue3d3\u7c03\u75a1', type: 'occlusion', count: 3377});
+let commandBuffer23 = commandEncoder93.finish({label: '\u{1f82c}\ub8ca\u71bd\u{1f7e3}\u23c5\u{1f9b6}\ub66e\u005a'});
+let sampler55 = device3.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.80,
+  lodMaxClamp: 56.58,
+  compare: 'greater-equal',
+  maxAnisotropy: 6,
+});
+let externalTexture65 = device3.importExternalTexture({source: videoFrame17, colorSpace: 'srgb'});
+try {
+commandEncoder71.clearBuffer(buffer26);
+dissociateBuffer(device3, buffer26);
+} catch {}
+document.body.prepend(canvas8);
+let videoFrame22 = new VideoFrame(video3, {timestamp: 0});
+let bindGroupLayout30 = device6.createBindGroupLayout({
+  label: '\udf9e\u0699\u{1fa28}',
+  entries: [
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 678, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 440,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder113 = device6.createCommandEncoder({label: '\u0c35\u03a4\u6e05'});
+let querySet66 = device6.createQuerySet({label: '\u07c9\u091d\u{1f83a}\u8bdd\u0c03\ue915\u{1ffc9}\u{1f6bf}', type: 'occlusion', count: 2172});
+let texture73 = device6.createTexture({
+  label: '\u001d\ue1ea\u73db\u4d25',
+  size: {width: 780, height: 1, depthOrArrayLayers: 1652},
+  mipLevelCount: 9,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView134 = texture71.createView({dimension: '2d', baseArrayLayer: 121, arrayLayerCount: 1});
+let renderBundle60 = renderBundleEncoder56.finish({label: '\u5159\u04fd\ub97f\u{1fc27}\u55ed\ueba7\u4d62\u0756\u82bd\u9a62'});
+let externalTexture66 = device6.importExternalTexture({
+  label: '\udc72\u{1fa84}\u93a8\u0935\u502d\u{1f798}\u09dd\u1c84\uab20',
+  source: videoFrame6,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder46.setPipeline(pipeline73);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 534},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer25, 40180, 175900);
+dissociateBuffer(device6, buffer25);
+} catch {}
+let bindGroupLayout31 = device3.createBindGroupLayout({
+  entries: [{binding: 1236, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder114 = device3.createCommandEncoder({label: '\u0d54\u24fc\u{1fa83}\u5305\u06d0\u36db\u3ad7\u6fba'});
+let texture74 = gpuCanvasContext1.getCurrentTexture();
+let textureView135 = texture68.createView({aspect: 'all', baseMipLevel: 2});
+try {
+computePassEncoder40.setPipeline(pipeline76);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline63);
+} catch {}
+try {
+commandEncoder79.clearBuffer(buffer26);
+dissociateBuffer(device3, buffer26);
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(680, 948);
+let offscreenCanvas27 = new OffscreenCanvas(681, 52);
+let imageData29 = new ImageData(20, 100);
+let commandEncoder115 = device4.createCommandEncoder();
+let renderPassEncoder4 = commandEncoder115.beginRenderPass({
+  label: '\u36b1\uca75\ua01e',
+  colorAttachments: [{
+  view: textureView104,
+  depthSlice: 958,
+  clearValue: { r: -534.7, g: 400.2, b: -939.0, a: 272.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet47,
+  maxDrawCount: 1026114998,
+});
+let renderBundleEncoder57 = device4.createRenderBundleEncoder({label: '\u4750\u{1fc78}\u{1fac4}\ub3bf', colorFormats: ['rgba8uint'], stencilReadOnly: true});
+try {
+renderPassEncoder0.setStencilReference(1020);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 9260, new DataView(new ArrayBuffer(43823)), 8106, 4272);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 326},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 47493287 */
+{offset: 127, bytesPerRow: 722, rowsPerImage: 253}, {width: 139, height: 0, depthOrArrayLayers: 261});
+} catch {}
+try {
+gpuCanvasContext31.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let gpuCanvasContext33 = offscreenCanvas26.getContext('webgpu');
+try {
+  await promise36;
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(394, 226);
+let gpuCanvasContext34 = offscreenCanvas28.getContext('webgpu');
+gc();
+let canvas37 = document.createElement('canvas');
+let commandEncoder116 = device3.createCommandEncoder();
+let commandBuffer24 = commandEncoder108.finish({label: '\u7d65\uae7b\ucdde\u06f3'});
+let texture75 = device3.createTexture({
+  size: [240, 2, 299],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+let textureView136 = texture70.createView({label: '\uade8\uc62f\u058f\u70a6', baseMipLevel: 2, mipLevelCount: 1});
+let externalTexture67 = device3.importExternalTexture({label: '\u{1f89f}\u5257', source: video7, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder47.setPipeline(pipeline63);
+} catch {}
+try {
+buffer26.destroy();
+} catch {}
+try {
+commandEncoder114.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14636 */
+  offset: 14632,
+  bytesPerRow: 256,
+  buffer: buffer26,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer26);
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer26);
+dissociateBuffer(device3, buffer26);
+} catch {}
+let videoFrame23 = new VideoFrame(canvas7, {timestamp: 0});
+let bindGroupLayout32 = device4.createBindGroupLayout({label: '\u{1f74e}\ue634\u0fa4\u91bc\u04cd\u6e63\ub53d\uca6f', entries: []});
+let texture76 = device4.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder3.beginOcclusionQuery(213);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle44]);
+} catch {}
+try {
+renderPassEncoder4.setViewport(395.7, 0.2862, 53.30, 0.6117, 0.7681, 0.7985);
+} catch {}
+try {
+renderPassEncoder1.draw(941905043, 622976668);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(565853009, 762562488, 671777887, 206859064, 566930023);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer22, 299837362);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer22, 723081913);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline75);
+} catch {}
+try {
+gpuCanvasContext32.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline77 = device4.createComputePipeline({
+  label: '\u3982\u561b\u0b10\u7822\u0bdd\u4eaf\u0907\u{1fe71}',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+try {
+externalTexture2.label = '\u{1f69f}\u6379\u43c0\u368b';
+} catch {}
+let bindGroupLayout33 = device4.createBindGroupLayout({
+  label: '\u08ed\uc969\uc608',
+  entries: [
+    {
+      binding: 1446,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 2684, visibility: 0, sampler: { type: 'filtering' }},
+  ],
+});
+let textureView137 = texture76.createView({
+  label: '\u{1fa7f}\u01a5\u5fb3\u{1fd7c}\u231d\u0978\u475b\u{1f804}\u{1fc46}',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let sampler56 = device4.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 59.00,
+  lodMaxClamp: 80.13,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(956);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1594);
+} catch {}
+try {
+renderBundleEncoder57.setPipeline(pipeline65);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 380 widthInBlocks: 95 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 59188 */
+  offset: 59188,
+  bytesPerRow: 768,
+  buffer: buffer15,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 95, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer15);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer18, 558072, 14688);
+dissociateBuffer(device4, buffer18);
+} catch {}
+let pipeline78 = device4.createRenderPipeline({
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 3636080794,
+    stencilWriteMask: 863185286,
+  },
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let imageBitmap30 = await createImageBitmap(imageBitmap23);
+gc();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+canvas37.getContext('webgpu');
+} catch {}
+video23.width = 84;
+let imageData30 = new ImageData(224, 128);
+let shaderModule26 = device4.createShaderModule({
+  label: '\u9775\u0478',
+  code: `@group(0) @binding(1741)
+var<storage, read_write> global15: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(6) f1: i32,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(a0: S22, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(1) a1: vec3<u32>, @location(17) a2: vec4<f16>, @location(13) a3: vec4<i32>, @location(0) a4: f32, @location(6) a5: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandBuffer25 = commandEncoder84.finish({});
+let texture77 = device4.createTexture({
+  label: '\u0aeb\u01de\u5ac2\ud9c4',
+  size: [192, 96, 1483],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle52, renderBundle50, renderBundle52, renderBundle55, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 262.0, g: -503.8, b: -819.2, a: -107.7, });
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(625, undefined, 3218594091, 156129525);
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas27.getContext('webgpu');
+let img24 = await imageWithData(66, 26, '#8ae2d83e', '#5088d34b');
+let querySet67 = device6.createQuerySet({label: '\u{1fa44}\uf408\u020f\u84a4\u39a0', type: 'occlusion', count: 4064});
+let texture78 = device6.createTexture({
+  label: '\ucf93\ue81b\ub527\ub15c\u44a6\u0967\u{1f79a}\u{1ffd1}\u{1ff35}',
+  size: {width: 720, height: 1, depthOrArrayLayers: 1164},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder58 = device6.createRenderBundleEncoder({
+  label: '\u06cb\u0e59\u{1f817}\u0168\u7b23\u015d\u8a51\ud9f3\u00d0\u05cd',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle61 = renderBundleEncoder58.finish({label: '\ubd5a\u{1fb09}\u0969\u{1f885}\u3958\u0f11\u26e3\u3a3e\u039a'});
+try {
+renderBundleEncoder54.setVertexBuffer(4650, undefined, 3793124781, 479681393);
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(432, 878);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let video35 = await videoWithData();
+try {
+device3.queue.label = '\u{1fffa}\ue27e';
+} catch {}
+let buffer27 = device3.createBuffer({
+  label: '\u67f0\u0b10\u0744\u060b',
+  size: 333268,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let textureView138 = texture61.createView({format: 'rgba16sint', mipLevelCount: 1});
+let computePassEncoder47 = commandEncoder85.beginComputePass();
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 44},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 4871 */
+{offset: 648, bytesPerRow: 1077, rowsPerImage: 278}, {width: 124, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas4.height = 908;
+let bindGroupLayout34 = device3.createBindGroupLayout({
+  label: '\ub579\u{1f7d1}\u{1f9fe}\u98ae\ucdb6\uffec\u{1f727}',
+  entries: [
+    {
+      binding: 273,
+      visibility: 0,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 1198,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder117 = device3.createCommandEncoder({label: '\u2be1\ucaf5\u4977\u{1f861}\u24bd\u6b89\u4245\u703b\u5629\u0ffe\u{1ffa7}'});
+try {
+renderBundleEncoder50.setVertexBuffer(8, buffer19, 164644, 1280);
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 2,
+  origin: {x: 32, y: 0, z: 11},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 149}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 1,
+  origin: {x: 68, y: 0, z: 49},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup20 = device3.createBindGroup({
+  label: '\u8ceb\u4af1\u0aa6\u{1ffb1}\u{1fdf9}\u{1ff46}\u1ca9',
+  layout: bindGroupLayout31,
+  entries: [{binding: 1236, resource: externalTexture32}],
+});
+let texture79 = device3.createTexture({
+  label: '\u{1f8a6}\u{1fc20}\u{1f9ce}\u06c3\ueec1\u01cd\u0a55\u1dd6\u0d9a\ue866\ue4b6',
+  size: {width: 240, height: 2, depthOrArrayLayers: 299},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView139 = texture68.createView({label: '\ufb5f\u963e\u{1f955}\ua9f4\u6241\u46e4\u0b01\u53d2\u04b2', baseMipLevel: 1});
+let computePassEncoder48 = commandEncoder79.beginComputePass({});
+try {
+computePassEncoder30.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(4, bindGroup20);
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet60, 644, 499, buffer27, 232192);
+} catch {}
+let pipeline79 = device3.createRenderPipeline({
+  label: '\u38a3\u{1fdab}\u04c0\u{1fdef}\uf2c1\u{1fb7e}\u{1ff02}\u01f7',
+  layout: pipelineLayout12,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}, {format: 'r32float', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'zero'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 128,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 76, shaderLocation: 14},
+          {format: 'float32x4', offset: 16, shaderLocation: 16},
+          {format: 'float32x4', offset: 8, shaderLocation: 5},
+          {format: 'float32x2', offset: 36, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 60, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 96, shaderLocation: 15},
+          {format: 'uint32x2', offset: 0, shaderLocation: 3},
+          {format: 'uint8x4', offset: 20, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 464, shaderLocation: 6},
+          {format: 'sint16x4', offset: 380, shaderLocation: 11},
+          {format: 'sint32x2', offset: 80, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let offscreenCanvas30 = new OffscreenCanvas(39, 176);
+let gpuCanvasContext36 = offscreenCanvas30.getContext('webgpu');
+let commandEncoder118 = device6.createCommandEncoder({label: '\u0ee6\u4212\u{1fa6f}'});
+try {
+commandEncoder106.clearBuffer(buffer25, 230560, 7344);
+dissociateBuffer(device6, buffer25);
+} catch {}
+canvas9.width = 2111;
+canvas31.width = 1537;
+try {
+window.someLabel = bindGroupLayout28.label;
+} catch {}
+let bindGroupLayout35 = pipeline73.getBindGroupLayout(0);
+let commandEncoder119 = device6.createCommandEncoder({label: '\u3783\u{1f9b9}'});
+let commandBuffer26 = commandEncoder119.finish({label: '\u{1fe7c}\uce88\u079e\u1a68\u1db0\u3d4b\uf559\ua4af\u{1ff77}'});
+let texture80 = device6.createTexture({
+  label: '\u4ac5\u0a5c\ufd15\u{1f751}\u0574\u{1fa08}\u00e4\u{1f63e}\u1260\u4b32\u3ee7',
+  size: [720],
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder49 = commandEncoder113.beginComputePass();
+let renderBundleEncoder59 = device6.createRenderBundleEncoder({
+  label: '\u{1f664}\u{1fbac}\ud16a\u0a25\uc47b\u4a56\uac5f\u084d',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+});
+try {
+renderBundleEncoder54.setPipeline(pipeline74);
+} catch {}
+try {
+gpuCanvasContext28.configure({
+  device: device6,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline80 = await device6.createComputePipelineAsync({
+  label: '\u7727\u0c5d\u0043\u0532\ud6e6\u{1f6e3}\u5e10\u3d59\u{1fa3a}',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let pipeline81 = device6.createRenderPipeline({
+  label: '\u{1ff66}\u0e07\u0624\ua500\udb42\u01e4',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'src'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgba16uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'dst-alpha'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 1919252622,
+    stencilWriteMask: 2523891106,
+    depthBias: -256700464,
+    depthBiasClamp: 678.1548165127969,
+  },
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 456,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 372, shaderLocation: 9},
+          {format: 'uint8x4', offset: 108, shaderLocation: 7},
+          {format: 'float16x4', offset: 40, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 44, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 1632, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 388,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 108, shaderLocation: 5}, {format: 'float32', offset: 0, shaderLocation: 2}],
+      },
+      {arrayStride: 92, stepMode: 'instance', attributes: []},
+      {arrayStride: 1832, attributes: [{format: 'sint8x2', offset: 1830, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front'},
+});
+let canvas38 = document.createElement('canvas');
+let video36 = await videoWithData();
+let gpuCanvasContext37 = canvas38.getContext('webgpu');
+offscreenCanvas26.height = 761;
+let texture81 = device6.createTexture({
+  label: '\u7528\u05fb\u{1f60a}\u02d7\u0361\u93fe\ud4a3\u98af\u{1f736}\u{1fbac}',
+  size: {width: 390, height: 1, depthOrArrayLayers: 233},
+  mipLevelCount: 8,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView140 = texture78.createView({label: '\u0ef0\u0da1\u9cbd\u5ee3\u{1f9db}', baseMipLevel: 3, mipLevelCount: 2});
+let gpuCanvasContext38 = offscreenCanvas29.getContext('webgpu');
+let img25 = await imageWithData(45, 103, '#191846c6', '#f18d32d4');
+let textureView141 = texture48.createView({label: '\u61a6\u0add\u{1f8d0}\u92ff\u2bb1\u0797', aspect: 'all', format: 'rgba8uint', baseMipLevel: 1});
+let sampler57 = device4.createSampler({
+  label: '\u0ea2\u5d4b\u3c62\u3ed6\u08b3\u09ed\u6761\u0402',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 62.43,
+  lodMaxClamp: 88.79,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder0.drawIndexed(411696653, 1035927397);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder57.setPipeline(pipeline50);
+} catch {}
+try {
+device4.queue.submit([commandBuffer25]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+video11.width = 8;
+gc();
+let imageData31 = new ImageData(172, 252);
+let renderBundle62 = renderBundleEncoder55.finish({label: '\u0099\ubc3a\u{1fc64}\ua4c1\u{1f990}\u0d2d\ua8fe'});
+let sampler58 = device3.createSampler({
+  label: '\u9635\u0425\u0412\u73de\u0875\u0639\ua528\u2033\u7309\u78b7\u{1fbf6}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.81,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder47.setBindGroup(7, bindGroup20);
+} catch {}
+let arrayBuffer6 = buffer27.getMappedRange();
+try {
+window.someLabel = device3.label;
+} catch {}
+let textureView142 = texture68.createView({label: '\u85b9\u02ce', baseMipLevel: 2});
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 37182 */
+  offset: 318,
+  bytesPerRow: 256,
+  rowsPerImage: 144,
+  buffer: buffer26,
+}, {width: 0, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device3, buffer26);
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout36 = device4.createBindGroupLayout({label: '\u745d\u{1f824}\uc59c\uaccf\u426b\u2e4c\u{1f6d0}\ud872\ud605\uee95\u0b02', entries: []});
+let commandEncoder120 = device4.createCommandEncoder({label: '\u2607\u{1f65d}\u041b\u{1faab}\u05a1\u0996\u0122\u{1fa51}\u29a8\u74c9\u8ebe'});
+let commandBuffer27 = commandEncoder120.finish({label: '\u0e9a\u1cf0'});
+let textureView143 = texture44.createView({aspect: 'all', mipLevelCount: 2, baseArrayLayer: 588, arrayLayerCount: 312});
+let externalTexture68 = device4.importExternalTexture({
+  label: '\u04ad\u037b\u0095\u0f99\u3cee\u77ed\u0485\u{1f9b4}\u{1ffbc}',
+  source: videoFrame9,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(240, 1, 144, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(559734970);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 324942473);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(1092169817, 930297966, 4514772, -42135524, 752754477);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 80},
+  aspect: 'all',
+}, new DataView(arrayBuffer3), /* required buffer size: 10903574 */
+{offset: 466, bytesPerRow: 832, rowsPerImage: 78}, {width: 145, height: 1, depthOrArrayLayers: 169});
+} catch {}
+gc();
+let img26 = await imageWithData(231, 290, '#48a6df9b', '#f9e471db');
+document.body.prepend(video17);
+let shaderModule27 = device6.createShaderModule({
+  label: '\u0e99\u0a43\u{1f770}\u0461',
+  code: `@group(0) @binding(823)
+var<storage, read_write> function16: array<u32>;
+@group(1) @binding(382)
+var<storage, read_write> local23: array<u32>;
+@group(0) @binding(382)
+var<storage, read_write> global16: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> field18: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(0) f2: vec2<f32>,
+  @location(1) f3: vec2<i32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f32>, @location(10) a1: vec3<u32>, @location(1) a2: i32, @location(0) a3: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder121 = device6.createCommandEncoder();
+let texture82 = device6.createTexture({
+  label: '\u0f4c\u6c0f\ucd81\ud73a\u98e6\u08cd\ud17c\u79b9\u{1fa1e}',
+  size: [90, 1, 124],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder60 = device6.createRenderBundleEncoder({
+  label: '\u1d62\u4d7d\u03df\u{1f912}\ua201\u{1fce6}',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+});
+let sampler59 = device6.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.02,
+  lodMaxClamp: 97.96,
+});
+try {
+computePassEncoder46.setPipeline(pipeline80);
+} catch {}
+try {
+commandEncoder121.clearBuffer(buffer25, 176980, 73352);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer25, 40176, new BigUint64Array(52555), 9391, 2084);
+} catch {}
+let commandBuffer28 = commandEncoder106.finish({label: '\u7ae1\u{1fe4c}\u296f\u5cf9\ub513\u{1f8da}'});
+let texture83 = device6.createTexture({
+  label: '\u{1fb86}\u89a4\u8d92\uf281\ucfcd',
+  size: [90, 1, 1],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView144 = texture80.createView({label: '\uea33\u08bf\u{1fbe7}\u12db\u7d5f\u{1f64f}\u2cf1\u0abf\u065b\u{1f970}'});
+let renderBundle63 = renderBundleEncoder59.finish({label: '\u945c\u{1fd80}\u8701\u67a8\u{1feae}\u1a55\u{1f697}\u022f\u050b'});
+try {
+renderBundleEncoder60.setPipeline(pipeline74);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer25, 175972, 23228);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+renderBundleEncoder60.insertDebugMarker('\u{1f8c2}');
+} catch {}
+try {
+window.someLabel = externalTexture30.label;
+} catch {}
+let texture84 = device6.createTexture({
+  label: '\u0198\uf743\u{1fe63}\u{1f87f}\ud9df\uc4de',
+  size: {width: 780, height: 1, depthOrArrayLayers: 40},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView145 = texture69.createView({aspect: 'all', baseMipLevel: 6});
+try {
+computePassEncoder46.setPipeline(pipeline73);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+commandEncoder121.clearBuffer(buffer25, 66828, 118832);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+computePassEncoder46.pushDebugGroup('\u0e66');
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 212, y: 37 },
+  flipY: false,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let commandEncoder122 = device4.createCommandEncoder();
+let textureView146 = texture44.createView({baseMipLevel: 3, baseArrayLayer: 643, arrayLayerCount: 95});
+let renderPassEncoder5 = commandEncoder122.beginRenderPass({
+  label: '\u07b4\u083c\u5ed6\u00c5\u{1fa91}\u{1f7cd}\u{1fe68}\u{1f8a1}',
+  colorAttachments: [{
+  view: textureView104,
+  depthSlice: 48,
+  clearValue: { r: -954.7, g: 617.3, b: 939.0, a: -767.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 292237537,
+});
+let externalTexture69 = device4.importExternalTexture({
+  label: '\u19c6\u280e\u0db3\ub502\u004b\u2bfb\ufedb\u{1ff92}\ua0b8',
+  source: videoFrame16,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder3.setViewport(276.0, 0.6058, 47.39, 0.2283, 0.00600, 0.4848);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(927867491);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 15348);
+} catch {}
+try {
+texture48.destroy();
+} catch {}
+let arrayBuffer7 = buffer22.getMappedRange();
+let promise37 = device4.createComputePipelineAsync({
+  label: '\u021a\u668e\u9515\u{1fafa}\u0035\ufaea',
+  layout: 'auto',
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer29 = commandEncoder114.finish({label: '\ubd9d\u{1f9a4}\u0b4f\u0984\ubc16\u{1f7af}\uc15c\u{1f6e3}\u057f\u14f1'});
+let sampler60 = device3.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 95.70,
+  lodMaxClamp: 98.84,
+});
+try {
+computePassEncoder30.setBindGroup(5, bindGroup20, new Uint32Array(6496), 2836, 0);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(5235, undefined, 1222640772, 1575334737);
+} catch {}
+document.body.prepend(img7);
+let offscreenCanvas31 = new OffscreenCanvas(918, 719);
+offscreenCanvas26.height = 1700;
+let imageData32 = new ImageData(56, 248);
+let commandEncoder123 = device4.createCommandEncoder({label: '\u04d2\u1537\u0f1f\u0c07\u{1f7ae}'});
+let texture85 = device4.createTexture({
+  label: '\u07cb\ubd3a\u0520\u23f4\u1488\ub69f\ub123\ua511\u{1fc7d}\u0114\u7010',
+  size: [480],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8uint'],
+});
+let textureView147 = texture49.createView({label: '\u89cc\u0425\u0778\u{1ff15}\uc8f1\u2cfe\u4e63', baseMipLevel: 1, mipLevelCount: 2});
+let renderBundleEncoder61 = device4.createRenderBundleEncoder({label: '\ua49b\u{1fc83}\uf208\u09cc\ub1d3', colorFormats: ['rgba8uint'], depthReadOnly: true});
+let externalTexture70 = device4.importExternalTexture({
+  label: '\u50ff\u{1fcfb}\u03ba\u7d06\u{1f754}\u022e\u04d8\u{1fdc8}',
+  source: video24,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle43, renderBundle50, renderBundle43, renderBundle43, renderBundle48, renderBundle50, renderBundle48, renderBundle48, renderBundle50, renderBundle44]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(394, 1, 46, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer22, 462059914);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder57.draw(1123329705, 28301311, 1203685105, 1027160747);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 50592);
+} catch {}
+try {
+device4.pushErrorScope('internal');
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 852 */
+{offset: 852, rowsPerImage: 153}, {width: 77, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video28.height = 212;
+try {
+gpuCanvasContext30.unconfigure();
+} catch {}
+let canvas39 = document.createElement('canvas');
+let offscreenCanvas32 = new OffscreenCanvas(828, 326);
+let texture86 = device3.createTexture({
+  label: '\ua021\u0713\u0a91\u0d0d\u067e',
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let renderBundle64 = renderBundleEncoder55.finish({});
+try {
+renderBundleEncoder50.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+window.someLabel = bindGroup10.label;
+} catch {}
+gc();
+let canvas40 = document.createElement('canvas');
+try {
+adapter2.label = '\u5b97\ue9eb\u0eb0\u{1ff55}\u{1fe12}\u5315\uf326\u0cbf\u26ac';
+} catch {}
+let commandEncoder124 = device4.createCommandEncoder({});
+let renderBundle65 = renderBundleEncoder43.finish();
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(90.71, 0.2742, 207.7, 0.5103, 0.2351, 0.4037);
+} catch {}
+try {
+renderPassEncoder0.draw(599961690, 744442383, 563700749, 21073781);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 915985365);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer18, 742703304);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder57.draw(788014360, 232826107);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 9252);
+} catch {}
+try {
+commandEncoder124.resolveQuerySet(querySet47, 3418, 55, buffer15, 118272);
+} catch {}
+let promise38 = device4.queue.onSubmittedWorkDone();
+let pipeline82 = device4.createRenderPipeline({
+  label: '\u{1f8a0}\u{1f7a9}\u0d9a\ub317\u9a2f\u{1f6a5}\uefcd\u{1f8f3}\u{1f75b}\uf2c7\u0990',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', passOp: 'zero'},
+    stencilWriteMask: 13547422,
+    depthBias: -1287621336,
+    depthBiasSlopeScale: 722.6345411531762,
+    depthBiasClamp: 124.47212534297921,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 35176, attributes: [{format: 'snorm8x4', offset: 9056, shaderLocation: 17}]},
+      {
+        arrayStride: 1264,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 228, shaderLocation: 0},
+          {format: 'sint16x2', offset: 192, shaderLocation: 13},
+          {format: 'sint8x4', offset: 1260, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 15760, attributes: [{format: 'uint16x2', offset: 8928, shaderLocation: 1}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+gc();
+let gpuCanvasContext39 = offscreenCanvas31.getContext('webgpu');
+gc();
+let imageData33 = new ImageData(16, 220);
+try {
+canvas39.getContext('bitmaprenderer');
+} catch {}
+let querySet68 = device4.createQuerySet({label: '\u0fbc\u095b\u5f3d\u0b63\ub0b2\u0ea2', type: 'occlusion', count: 3208});
+let renderBundleEncoder62 = device4.createRenderBundleEncoder({
+  label: '\u{1f89e}\u3f27\u{1fcd2}\u{1ff8a}\u9e18\u3eb0\u0ad1\u{1f9ba}',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle66 = renderBundleEncoder43.finish();
+try {
+renderPassEncoder1.beginOcclusionQuery(1555);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(333454433, 571629592, 820654672, -588631969, 312473148);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 23968);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(6820, undefined, 2001479922, 423848406);
+} catch {}
+try {
+commandEncoder123.copyBufferToBuffer(buffer15, 103980, buffer18, 71804, 65464);
+dissociateBuffer(device4, buffer15);
+dissociateBuffer(device4, buffer18);
+} catch {}
+try {
+canvas40.getContext('bitmaprenderer');
+} catch {}
+let renderPassEncoder6 = commandEncoder123.beginRenderPass({
+  label: '\u{1fb23}\u0f06\ua20e\u618b\uc839\u9333\u0b85\u0655\u{1ff03}\u{1fd49}',
+  colorAttachments: [{
+  view: textureView137,
+  clearValue: { r: 538.1, g: -672.0, b: 255.3, a: 693.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet64,
+  maxDrawCount: 974889026,
+});
+let externalTexture71 = device4.importExternalTexture({source: videoFrame20, colorSpace: 'display-p3'});
+try {
+computePassEncoder35.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle48, renderBundle50, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder0.draw(153356337, 17278141);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder57.draw(365960573, 482555461, 36616926, 717786171);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(244574925, 332827558);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 6820);
+} catch {}
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 1472 widthInBlocks: 368 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 41464 */
+  offset: 41464,
+  bytesPerRow: 1792,
+  buffer: buffer15,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 368, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer15);
+} catch {}
+let pipeline83 = device4.createComputePipeline({
+  label: '\u{1fbed}\u00c6\u{1fbd3}\u0a47',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let video37 = await videoWithData();
+try {
+  await promise38;
+} catch {}
+let video38 = await videoWithData();
+let imageData34 = new ImageData(232, 204);
+try {
+offscreenCanvas32.getContext('webgl');
+} catch {}
+let imageBitmap31 = await createImageBitmap(imageData33);
+let commandEncoder125 = device6.createCommandEncoder({label: '\u{1f854}\ucb56\u6b7e\u9842\u00d1\u04b8\u09f4\u4ec1\ub128'});
+let renderBundle67 = renderBundleEncoder56.finish({});
+let externalTexture72 = device6.importExternalTexture({source: video7, colorSpace: 'srgb'});
+try {
+querySet61.destroy();
+} catch {}
+try {
+commandEncoder125.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 81},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 73, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let shaderModule28 = device3.createShaderModule({
+  label: '\ufade\u939a\u085c\u0ed3\u53e0\u{1ff8e}\u{1f8c3}\u{1f99e}\u{1fc15}\udf39',
+  code: `@group(5) @binding(1556)
+var<storage, read_write> function17: array<u32>;
+@group(5) @binding(260)
+var<storage, read_write> field19: array<u32>;
+@group(1) @binding(798)
+var<storage, read_write> n16: array<u32>;
+@group(1) @binding(693)
+var<storage, read_write> field20: array<u32>;
+@group(6) @binding(1410)
+var<storage, read_write> n17: array<u32>;
+@group(3) @binding(260)
+var<storage, read_write> function18: array<u32>;
+@group(6) @binding(260)
+var<storage, read_write> n18: array<u32>;
+@group(6) @binding(1556)
+var<storage, read_write> field21: array<u32>;
+@group(3) @binding(1556)
+var<storage, read_write> function19: array<u32>;
+@group(2) @binding(798)
+var<storage, read_write> parameter23: array<u32>;
+@group(4) @binding(798)
+var<storage, read_write> local24: array<u32>;
+@group(5) @binding(1410)
+var<storage, read_write> function20: array<u32>;
+@group(3) @binding(1410)
+var<storage, read_write> type22: array<u32>;
+@group(2) @binding(693)
+var<storage, read_write> field22: array<u32>;
+@group(0) @binding(693)
+var<storage, read_write> n19: array<u32>;
+@group(4) @binding(693)
+var<storage, read_write> global17: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @location(44) f0: vec3<f32>,
+  @location(13) f1: vec3<i32>,
+  @location(31) f2: vec2<f32>,
+  @location(49) f3: f16,
+  @location(0) f4: vec4<u32>,
+  @location(3) f5: vec3<i32>,
+  @location(23) f6: vec3<i32>,
+  @location(34) f7: vec4<u32>,
+  @builtin(sample_mask) f8: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(3) f2: vec4<i32>,
+  @location(2) f3: vec4<i32>,
+  @location(4) f4: f32
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec4<f32>, @location(22) a1: vec4<i32>, @location(16) a2: vec4<f16>, a3: S24) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(1) f0: vec4<f32>,
+  @location(5) f1: vec2<u32>,
+  @location(9) f2: vec4<f16>,
+  @location(13) f3: vec4<f32>,
+  @location(17) f4: f16,
+  @location(7) f5: f32,
+  @builtin(vertex_index) f6: u32,
+  @location(3) f7: vec2<u32>,
+  @location(8) f8: f32,
+  @location(2) f9: vec4<u32>,
+  @builtin(instance_index) f10: u32,
+  @location(12) f11: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(34) f324: vec4<u32>,
+  @location(16) f325: vec4<f16>,
+  @location(0) f326: vec4<u32>,
+  @location(13) f327: vec3<i32>,
+  @location(31) f328: vec2<f32>,
+  @location(49) f329: f16,
+  @location(23) f330: vec3<i32>,
+  @location(3) f331: vec3<i32>,
+  @location(22) f332: vec4<i32>,
+  @builtin(position) f333: vec4<f32>,
+  @location(44) f334: vec3<f32>,
+  @location(17) f335: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f32>, a1: S23, @location(4) a2: vec2<f16>, @location(14) a3: vec2<f16>, @location(16) a4: vec2<i32>, @location(0) a5: vec4<f16>, @location(6) a6: u32, @location(10) a7: vec2<u32>, @location(15) a8: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder126 = device3.createCommandEncoder({label: '\u{1fe0f}\u{1f794}\u821d\u3ed7\ued9e\u4814\u9626\ueab9\uca17'});
+let textureView148 = texture62.createView({
+  label: '\u0db6\u{1f6e4}\u9008\u83c7\u0571\u0ead\u{1fbf0}\u0074\u00f5\u{1f65d}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+let renderBundle68 = renderBundleEncoder47.finish({label: '\u55ac\u9776'});
+try {
+buffer27.destroy();
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 83},
+  aspect: 'all',
+},
+{width: 184, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder89.resolveQuerySet(querySet48, 2, 0, buffer27, 119552);
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(982, 692);
+let textureView149 = texture44.createView({dimension: '2d', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 672, arrayLayerCount: 1});
+let computePassEncoder50 = commandEncoder124.beginComputePass({label: '\ub1a9\u032b\u97af\u2782\u{1fe02}\u0c6f\uaff6'});
+try {
+renderBundleEncoder57.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(9004, undefined, 0);
+} catch {}
+let pipeline84 = device4.createComputePipeline({
+  label: '\u3d60\ua184\u9a0e\u33db\uda7a',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule19, entryPoint: 'compute0'},
+});
+let canvas41 = document.createElement('canvas');
+let computePassEncoder51 = commandEncoder110.beginComputePass();
+let sampler61 = device6.createSampler({
+  label: '\u7893\u9876\u07bd\u7dcc\uf4f2\uf0bb\u00d2\u041b\ue637\u5bc3',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.966,
+  lodMaxClamp: 75.36,
+  maxAnisotropy: 14,
+});
+try {
+commandEncoder118.clearBuffer(buffer25, 172428, 52772);
+dissociateBuffer(device6, buffer25);
+} catch {}
+let commandEncoder127 = device4.createCommandEncoder({label: '\u3bb1\u0387\u856b\u{1f750}\u9c4f\u088c\u{1f962}\u3859\u2ee7\u{1ffd2}\u{1fb6d}'});
+let commandBuffer30 = commandEncoder127.finish({label: '\u{1fc22}\u01f6\u06c4\u908a\u8f6c\u1e68\u1920\u6dd7\u{1f6a3}\ue3ef\ucdb5'});
+let renderBundleEncoder63 = device4.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+try {
+renderPassEncoder3.beginOcclusionQuery(1912);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle65, renderBundle52, renderBundle43, renderBundle52, renderBundle50, renderBundle66, renderBundle44]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer23, 1018568512);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6490, undefined, 0, 2962948881);
+} catch {}
+try {
+renderBundleEncoder57.draw(845540349);
+} catch {}
+try {
+renderBundleEncoder62.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(1314, undefined, 0, 2322886457);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline85 = await promise37;
+let gpuCanvasContext40 = offscreenCanvas33.getContext('webgpu');
+gc();
+let shaderModule29 = device6.createShaderModule({
+  label: '\u957f\uca79\u{1ff84}',
+  code: `@group(0) @binding(382)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> type23: array<u32>;
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec3<f32>,
+  @location(3) f2: vec4<u32>,
+  @location(4) f3: vec4<f32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(7) a0: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer28 = device6.createBuffer({label: '\u17f1\u0445', size: 395412, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let texture87 = device6.createTexture({
+  label: '\uf9b8\u{1f9c2}\u1c05\uc18c\uf286\uadd7\u6c30\u062e\u{1f62f}\u{1f8ab}',
+  size: {width: 720, height: 1, depthOrArrayLayers: 34},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView150 = texture80.createView({label: '\u0e07\u{1fbfd}\u3707\u{1fe97}\u0155\u6882\u5462\uc08e\u8e04\u0097'});
+try {
+  await buffer25.mapAsync(GPUMapMode.READ, 0, 144036);
+} catch {}
+try {
+commandEncoder125.clearBuffer(buffer25, 222260, 6400);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+computePassEncoder46.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device6,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData20,
+  origin: { x: 14, y: 3 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas42 = document.createElement('canvas');
+let offscreenCanvas34 = new OffscreenCanvas(513, 234);
+try {
+offscreenCanvas34.getContext('webgpu');
+} catch {}
+try {
+canvas41.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageData35 = new ImageData(208, 128);
+let textureView151 = texture59.createView({label: '\u{1f6d0}\u03db\u{1f669}\u03b0\ud58c\u1557\ufe5c\u092f\u3665', format: 'rgba8uint'});
+let renderBundleEncoder64 = device4.createRenderBundleEncoder({label: '\u650b\u{1f9e7}\ued3e', colorFormats: ['rgba8uint'], stencilReadOnly: true});
+try {
+renderPassEncoder6.beginOcclusionQuery(1828);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer15, 532376403);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 10972);
+} catch {}
+let commandEncoder128 = device3.createCommandEncoder({label: '\u45ed\u0d7d\u{1fc4f}\u65ff\u08f5\uaddc\u0275\u{1f7fc}'});
+let querySet69 = device3.createQuerySet({label: '\u0540\uccd7\u{1ff1d}\u{1fa6f}\u78d8\u1bf5\u006e\u0113\uebda', type: 'occlusion', count: 1634});
+let textureView152 = texture62.createView({label: '\u1bae\u6232\u0af2\u84e5\uee7b\u{1fcf9}\u14a5', dimension: '2d-array'});
+let computePassEncoder52 = commandEncoder71.beginComputePass({label: '\uccd1\u{1fade}\u8f2b\ud616\u3604\u0843\u1e1d\u67f9\u0a6d\u0d25'});
+let externalTexture73 = device3.importExternalTexture({
+  label: '\u01a5\u0766\u4e50\u{1f673}\u{1f9bd}\ua052\u50d4\uab46\u{1fff6}',
+  source: videoFrame3,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2244 widthInBlocks: 561 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21476 */
+  offset: 21476,
+  bytesPerRow: 2304,
+  buffer: buffer26,
+}, {width: 561, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer26);
+} catch {}
+let videoFrame24 = new VideoFrame(offscreenCanvas33, {timestamp: 0});
+let texture88 = device3.createTexture({
+  label: '\u0eb2\u0743\u0bb5\u630b\u300c\u411c\u{1f661}\u6e16\uc794\u{1fc0d}',
+  size: [2272, 40, 1],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView153 = texture75.createView({label: '\u{1facc}\ue645\u00bb', format: 'rgba16sint', mipLevelCount: 1});
+let computePassEncoder53 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer16, 11544);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer14, 'uint16', 662248);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(4, buffer19, 118336, 18755);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas14.height = 2675;
+gc();
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+let bindGroup21 = device3.createBindGroup({layout: bindGroupLayout31, entries: [{binding: 1236, resource: externalTexture55}]});
+let textureView154 = texture40.createView({label: '\u{1fa4a}\u061a\u{1f8d7}\u7b26\u{1fad1}\u0e1a\u0b6d\u027f', mipLevelCount: 3});
+let sampler62 = device3.createSampler({
+  label: '\uf6af\u0e8a\u020e',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.27,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer16, 157300);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer26, 14756);
+dissociateBuffer(device3, buffer26);
+} catch {}
+let renderBundle69 = renderBundleEncoder58.finish({label: '\u0e77\uc7d5\u1296\u2266\u7e51\u1acd'});
+let externalTexture74 = device6.importExternalTexture({
+  label: '\ucf48\ua058\u4df4\u5487\uf181\u0da5\uf128\u7870\u0b28\ucd8f\u2640',
+  source: video22,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder49.setPipeline(pipeline73);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 10},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 495});
+} catch {}
+try {
+commandEncoder118.resolveQuerySet(querySet62, 127, 18, buffer28, 56576);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas27,
+  origin: { x: 112, y: 15 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout18 = device3.createPipelineLayout({
+  label: '\ua64c\u6ec9\u0708\u0d2e\ufc15\ue4c1\u6559\u0c71\u0d79',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout31],
+});
+let externalTexture75 = device3.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder50.setBindGroup(5, bindGroup20);
+} catch {}
+let pipeline86 = await device3.createComputePipelineAsync({
+  label: '\u3500\u0b09\u27aa\u{1f708}\u{1fcda}\u795a\udad5\u0ec8\u76f5\u0a3f',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let shaderModule30 = device6.createShaderModule({
+  label: '\u{1f953}\ubc12\u{1fe23}\u0d9f\u3cb8\u8668\u3757\u3ce3\u061d\u698e\u650a',
+  code: `@group(1) @binding(382)
+var<storage, read_write> field23: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> n20: array<u32>;
+@group(0) @binding(823)
+var<storage, read_write> local25: array<u32>;
+@group(0) @binding(382)
+var<storage, read_write> field24: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(0) f1: vec3<f32>,
+  @location(1) f2: vec2<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f336: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<u32>, @location(1) a1: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView155 = texture73.createView({
+  label: '\ud58b\u0606\u5f67\u7d5a\u07e4\u8296\u0ddd\u6d61\u76e6\u08fb',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+});
+let renderBundle70 = renderBundleEncoder59.finish({label: '\u{1fa36}\u07b7\u{1fd3c}\u5cfd\uafc7\ue1ce\u0f33\u{1ff58}'});
+try {
+renderBundleEncoder60.setPipeline(pipeline74);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 99, y: 12 },
+  flipY: false,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline87 = await device6.createRenderPipelineAsync({
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm'}],
+},
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 60,
+        attributes: [
+          {format: 'float32x3', offset: 0, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 42, shaderLocation: 2},
+          {format: 'uint32', offset: 0, shaderLocation: 7},
+          {format: 'sint32x2', offset: 8, shaderLocation: 9},
+          {format: 'sint32', offset: 4, shaderLocation: 15},
+          {format: 'float32x4', offset: 8, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 2048, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'uint32x3', offset: 596, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw'},
+});
+try {
+texture42.label = '\ua226\u{1f66c}\u8639\u4891\u06a3\u{1f846}\udb87\u6de1\u899d';
+} catch {}
+try {
+sampler7.label = '\u6f6b\u{1fc77}\u33a2\u{1ff92}\u3843\udbb6';
+} catch {}
+let gpuCanvasContext41 = canvas42.getContext('webgpu');
+let device7 = await adapter7.requestDevice({
+  label: '\u2ae6\u85ae\uecad\u309f',
+  defaultQueue: {label: '\u{1ff56}\u026c'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let bindGroup22 = device4.createBindGroup({
+  label: '\uea70\u0ffe\ub220\u3347\u0ae8\ufac4\u{1fdf5}\u{1f9df}\u{1fbde}\u9981',
+  layout: bindGroupLayout32,
+  entries: [],
+});
+let querySet70 = device4.createQuerySet({label: '\u5373\u8a68\u{1fb65}', type: 'occlusion', count: 2542});
+let texture89 = device4.createTexture({
+  label: '\u0f82\ud2ff\ufe95\u2ae2\u{1fde1}\udb24\u2eab\u{1f9f7}\u0bc0\u0c98\u{1f89f}',
+  size: {width: 120, height: 1, depthOrArrayLayers: 36},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle50, renderBundle66, renderBundle43, renderBundle66, renderBundle65, renderBundle43, renderBundle66, renderBundle44, renderBundle43, renderBundle50]);
+} catch {}
+try {
+renderBundleEncoder57.draw(845221188, 717591245);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(390932311, 1107344602);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 173748);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 1276, new BigUint64Array(32325), 1130, 7684);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let pipelineLayout19 = device4.createPipelineLayout({
+  label: '\u0b8f\uf7a9\u56bf\u6da0\ufc5b\u0718\ue612',
+  bindGroupLayouts: [bindGroupLayout33, bindGroupLayout32, bindGroupLayout22],
+});
+let textureView156 = texture76.createView({
+  label: '\u{1fbe9}\u22a0\u1a73\u{1f827}\udb73\uaf92\ue2c4\u{1fbaf}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+});
+try {
+computePassEncoder35.setBindGroup(4, bindGroup22, new Uint32Array(5322), 941, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.draw(165869613, 348559332);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(1067425226, 891655058, 1095306246, -719797745, 492502272);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline65);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(836, undefined, 2850665705, 1440826964);
+} catch {}
+let arrayBuffer8 = buffer18.getMappedRange(641216, 148);
+try {
+buffer22.unmap();
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let video39 = await videoWithData();
+let shaderModule31 = device4.createShaderModule({
+  label: '\ud0eb\uf6b9\u{1f924}\u04f6\u0183\u0af4\ua9f4\u05e5',
+  code: `@group(0) @binding(1741)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @location(59) f0: f32,
+  @location(41) f1: vec4<f32>,
+  @location(40) f2: vec4<f32>,
+  @location(24) f3: vec4<f32>,
+  @location(28) f4: vec2<f32>,
+  @location(2) f5: vec2<i32>,
+  @location(14) f6: vec4<f32>,
+  @builtin(sample_mask) f7: u32,
+  @location(62) f8: vec3<i32>,
+  @builtin(front_facing) f9: bool,
+  @location(9) f10: vec3<f16>,
+  @location(39) f11: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@location(64) a0: f32, @location(1) a1: vec4<u32>, @location(11) a2: vec2<i32>, @location(65) a3: f32, a4: S26, @location(36) a5: vec2<i32>, @location(56) a6: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(1) f0: vec2<u32>,
+  @location(6) f1: vec3<u32>,
+  @location(3) f2: vec3<i32>,
+  @location(16) f3: vec3<u32>,
+  @location(17) f4: vec4<f32>,
+  @location(4) f5: i32,
+  @builtin(vertex_index) f6: u32,
+  @location(18) f7: u32,
+  @location(20) f8: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(65) f337: f32,
+  @location(44) f338: vec2<f16>,
+  @location(2) f339: vec2<i32>,
+  @location(39) f340: vec2<f16>,
+  @location(33) f341: vec3<f32>,
+  @location(56) f342: vec4<i32>,
+  @location(0) f343: f32,
+  @location(45) f344: u32,
+  @location(59) f345: f32,
+  @location(64) f346: f32,
+  @location(40) f347: vec4<f32>,
+  @location(9) f348: vec3<f16>,
+  @location(62) f349: vec3<i32>,
+  @location(36) f350: vec2<i32>,
+  @location(27) f351: f32,
+  @location(1) f352: vec4<u32>,
+  @location(11) f353: vec2<i32>,
+  @location(41) f354: vec4<f32>,
+  @builtin(position) f355: vec4<f32>,
+  @location(14) f356: vec4<f32>,
+  @location(28) f357: vec2<f32>,
+  @location(24) f358: vec4<f32>,
+  @location(60) f359: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: f16, @location(13) a1: vec4<u32>, @location(0) a2: vec2<f32>, @location(9) a3: f16, @location(11) a4: u32, @location(5) a5: vec3<f16>, @location(8) a6: u32, a7: S25) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer29 = device4.createBuffer({
+  label: '\u6f1a\u{1fe97}\u{1fda4}\u{1fa4c}\u{1f939}\u{1fa2f}\u4c7c\u0e04\u01af\ucad1',
+  size: 183682,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let textureView157 = texture44.createView({
+  label: '\u0a4f\u192e\u697e\u0da9\u{1fbbc}\ub1db',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+  baseArrayLayer: 396,
+});
+let renderBundle71 = renderBundleEncoder62.finish({label: '\u467c\ud34e\u0b9a\u{1f94e}\u4401\u559a'});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(441);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder57.draw(130437617, 1206618358, 588843297, 685891259);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer4), /* required buffer size: 243 */
+{offset: 243}, {width: 48, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+gc();
+let video40 = await videoWithData();
+let bindGroup23 = device4.createBindGroup({
+  label: '\u0ce9\u{1f616}\uc5b2\u8770\u0946\uc7eb\u05ed\u0429\u79c6\u4db4',
+  layout: bindGroupLayout36,
+  entries: [],
+});
+let commandEncoder129 = device4.createCommandEncoder({label: '\u{1f78f}\u{1f9e5}\u{1f6f4}\u{1fdac}\u2696\u0e6b\ue468\u01bf'});
+let querySet71 = device4.createQuerySet({label: '\u07c9\ufa3c\u864e', type: 'occlusion', count: 1552});
+let texture90 = device4.createTexture({
+  label: '\u3e08\uc004\u08fd\ud48f\ue536\u1123\u73ad\u10aa\u52c5\u9915\u52e6',
+  size: [24, 12, 225],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView158 = texture48.createView({
+  label: '\u{1ff46}\u{1f7d4}\u190c\u009c\ua2bf\u0417\u0f64\u248b\u24c9\uc5e1',
+  aspect: 'all',
+  baseMipLevel: 0,
+});
+let renderPassEncoder7 = commandEncoder129.beginRenderPass({
+  label: '\u{1f820}\u6ffc\u2397\u9e8d\u1154\u6e1d\uc7af\u36dd',
+  colorAttachments: [{
+  view: textureView137,
+  clearValue: { r: 56.45, g: 410.8, b: -990.3, a: 11.24, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet63,
+  maxDrawCount: 526990777,
+});
+let renderBundleEncoder65 = device4.createRenderBundleEncoder({label: '\u1fcc\u{1f81a}\u{1f659}\u0657\u07d3\u71f5', colorFormats: ['rgba8uint'], depthReadOnly: true});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder4.setViewport(154.2, 0.4201, 225.1, 0.03798, 0.8319, 0.8436);
+} catch {}
+try {
+  await device4.popErrorScope();
+} catch {}
+let pipeline88 = await device4.createRenderPipelineAsync({
+  label: '\u0a66\u78f1\u1c17\ucf09\u0650\u{1f755}',
+  layout: pipelineLayout17,
+  multisample: {count: 4, mask: 0xdc87a57c},
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'equal', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 2379736817,
+    stencilWriteMask: 1807676767,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14792,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 2744, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 3704,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 584, shaderLocation: 13},
+          {format: 'float32x2', offset: 456, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 21148,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 6972, shaderLocation: 17},
+          {format: 'sint16x2', offset: 13188, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+let querySet72 = device4.createQuerySet({label: '\u08e3\u{1fef2}\u69bb\u5751\u02fd\u{1fb7f}\u7ee7\ud108', type: 'occlusion', count: 3532});
+let renderBundleEncoder66 = device4.createRenderBundleEncoder({label: '\uebb0\u25af\u0f91\u091e', colorFormats: ['rgba8uint'], sampleCount: 1});
+let sampler63 = device4.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.47,
+  lodMaxClamp: 82.34,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder50.setPipeline(pipeline85);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(4, bindGroup23);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup22, new Uint32Array(9467), 912, 0);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(83, 1, 195, 0);
+} catch {}
+try {
+renderBundleEncoder57.draw(192751509, 1058606444, 15179622, 705372235);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(665370189, 411382828);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 33168);
+} catch {}
+offscreenCanvas8.height = 462;
+video13.width = 294;
+let commandEncoder130 = device3.createCommandEncoder({label: '\ub16e\ue585\u1745\u82fe\uefb2\u04c6\u{1f87d}\u069d\u{1f76d}\u{1fe42}'});
+let sampler64 = device3.createSampler({
+  label: '\u0d85\u09c1\u4bd5\ub250\u0eeb\u8770',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 85.69,
+  lodMaxClamp: 96.45,
+});
+try {
+renderBundleEncoder51.setIndexBuffer(buffer14, 'uint32', 598132);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline63);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 8},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 215068 */
+{offset: 778, bytesPerRow: 31, rowsPerImage: 144}, {width: 18, height: 1, depthOrArrayLayers: 49});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 149}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 55, y: 4 },
+  flipY: true,
+}, {
+  texture: texture68,
+  mipLevel: 1,
+  origin: {x: 25, y: 0, z: 96},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline89 = await device3.createRenderPipelineAsync({
+  label: '\u8923\ue3f1',
+  layout: pipelineLayout10,
+  multisample: {mask: 0x28158ca8},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32float', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 268,
+        attributes: [
+          {format: 'sint32x4', offset: 236, shaderLocation: 8},
+          {format: 'float32x2', offset: 140, shaderLocation: 7},
+          {format: 'sint32x4', offset: 32, shaderLocation: 5},
+          {format: 'float32x3', offset: 152, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 48, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 120, shaderLocation: 13},
+          {format: 'sint32x4', offset: 252, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 44, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 64, shaderLocation: 6},
+          {format: 'uint32x3', offset: 64, shaderLocation: 3},
+          {format: 'sint8x4', offset: 48, shaderLocation: 10},
+          {format: 'sint32', offset: 28, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 44, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', unclippedDepth: true},
+});
+let commandEncoder131 = device6.createCommandEncoder({label: '\uebb3\u010a\ua176'});
+let querySet73 = device6.createQuerySet({
+  label: '\u2df0\u8a90\u0684\u16b3\u577a\u0674\u6225\u917a\u{1fb4a}\u07a3',
+  type: 'occlusion',
+  count: 3616,
+});
+let texture91 = device6.createTexture({
+  label: '\u{1feda}\u0808\u04f7\u{1f934}',
+  size: [720],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+let renderBundle72 = renderBundleEncoder56.finish();
+let externalTexture76 = device6.importExternalTexture({label: '\u47d2\u3ac6\u5883\u00f9\u537f\u0273\ua23e\ua4af\u98e9\uda93\u{1feb6}', source: videoFrame3});
+try {
+renderBundleEncoder54.setVertexBuffer(8420, undefined, 0, 750129671);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 110, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 12561538 */
+{offset: 35, bytesPerRow: 3501, rowsPerImage: 211}, {width: 427, height: 1, depthOrArrayLayers: 18});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas20,
+  origin: { x: 14, y: 56 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule32 = device3.createShaderModule({
+  label: '\u{1fd2b}\u3cc5\uc469\u0c33\u0826',
+  code: `@group(1) @binding(1236)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(273)
+var<storage, read_write> function21: array<u32>;
+@group(0) @binding(1198)
+var<storage, read_write> local27: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<f32>,
+  @location(2) f1: vec4<i32>,
+  @location(0) f2: u32,
+  @location(3) f3: vec2<i32>,
+  @location(1) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(10) a1: vec3<i32>, @builtin(vertex_index) a2: u32, @location(11) a3: vec3<f16>, @location(6) a4: vec4<u32>, @location(15) a5: vec4<i32>, @location(16) a6: vec2<f32>, @location(1) a7: vec4<f32>, @location(3) a8: vec4<i32>, @location(13) a9: vec2<i32>, @location(2) a10: vec3<f16>, @location(9) a11: vec2<i32>, @location(7) a12: vec2<f32>, @location(0) a13: vec3<f16>, @location(12) a14: vec4<u32>, @location(14) a15: vec3<u32>, @location(5) a16: vec3<f16>, @location(17) a17: u32, @location(4) a18: i32, @location(8) a19: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder54 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(0, buffer19, 0, 100659);
+} catch {}
+let commandEncoder132 = device7.createCommandEncoder({label: '\u0064\u04a0'});
+try {
+device7.addEventListener('uncapturederror', e => { log('device7.uncapturederror'); log(e); e.label = device7.label; });
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(912, 418);
+let imageData36 = new ImageData(108, 180);
+let querySet74 = device7.createQuerySet({
+  label: '\u1be2\uce82\u44de\u0124\u0f5e\u26d9\u30c5\u40aa\u{1f79e}\uec17',
+  type: 'occlusion',
+  count: 598,
+});
+let renderBundleEncoder67 = device7.createRenderBundleEncoder({
+  label: '\u{1fc14}\uc945\u{1f841}\ufe74\u0c0d\u0f83\u6b6a',
+  colorFormats: ['rgb10a2unorm', 'rgba16sint', 'rg8uint', 'rg8sint', 'r16float'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder67.setVertexBuffer(9233, undefined, 2150770578, 1354222315);
+} catch {}
+offscreenCanvas29.width = 1503;
+let gpuCanvasContext42 = offscreenCanvas35.getContext('webgpu');
+try {
+window.someLabel = sampler54.label;
+} catch {}
+let querySet75 = device6.createQuerySet({label: '\u0d92\u{1fb19}\u6f6e\u3298\ufd0e\u9b15\u5aae\u2930\u8c55', type: 'occlusion', count: 1934});
+let texture92 = device6.createTexture({
+  size: [1560],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let textureView159 = texture69.createView({label: '\u9280\ub8bc\u38a2\u038b', baseMipLevel: 7, baseArrayLayer: 0});
+let renderBundleEncoder68 = device6.createRenderBundleEncoder({
+  label: '\ua17c\u{1f813}\u{1fd86}\u1f21\u0d3b\u1564\u034e\ue02a\uca22\u{1f957}\u06e0',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture77 = device6.importExternalTexture({label: '\ufa68\u{1f66d}\uf973\u07da\u9e0a\u6aba\u08e1', source: video28, colorSpace: 'display-p3'});
+gc();
+try {
+externalTexture56.label = '\u329e\ue35a\ub290\uaaff\u093e';
+} catch {}
+let shaderModule33 = device6.createShaderModule({
+  label: '\u03ee\ufa53\u{1f841}\u0383',
+  code: `@group(0) @binding(382)
+var<storage, read_write> parameter26: array<u32>;
+@group(0) @binding(823)
+var<storage, read_write> function22: array<u32>;
+@group(1) @binding(382)
+var<storage, read_write> field25: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> n21: array<u32>;
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<i32>,
+  @location(3) f1: vec4<u32>,
+  @location(0) f2: vec2<f32>,
+  @location(2) f3: vec4<f32>,
+  @location(4) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout37 = device6.createBindGroupLayout({
+  label: '\u{1f9a4}\u{1fda6}\u0b6a\u0966\u0b44\u{1f82e}',
+  entries: [
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 444,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {binding: 793, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView160 = texture71.createView({label: '\u{1fd7d}\u24f8\u0462\u{1fae0}', dimension: '2d', baseMipLevel: 0, baseArrayLayer: 108});
+let computePassEncoder55 = commandEncoder121.beginComputePass({label: '\u03d4\u{1f7b8}'});
+let renderBundleEncoder69 = device6.createRenderBundleEncoder({
+  label: '\u09a0\u940e\uc6ed\u390b\u0da2\u2812\u90f8\u05d6',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder54.setPipeline(pipeline87);
+} catch {}
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 99, y: 0, z: 40},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 172, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device6.queue.writeBuffer(buffer25, 11856, new BigUint64Array(35778), 2498, 15140);
+} catch {}
+let pipeline90 = await device6.createRenderPipelineAsync({
+  label: '\u06b0\u{1fc65}\uc353\u{1f7fd}\u{1f8c9}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba8unorm'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgb10a2unorm'}],
+},
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 740, shaderLocation: 12},
+          {format: 'float32x2', offset: 496, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 900, shaderLocation: 14},
+          {format: 'uint8x2', offset: 576, shaderLocation: 8},
+          {format: 'uint32x2', offset: 1304, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 648,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 476, shaderLocation: 13},
+          {format: 'sint8x4', offset: 72, shaderLocation: 6},
+          {format: 'uint16x2', offset: 16, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let img27 = await imageWithData(83, 174, '#fccad58a', '#b1a7492d');
+let imageBitmap32 = await createImageBitmap(imageData23);
+let querySet76 = device4.createQuerySet({label: '\u697a\u{1f733}', type: 'occlusion', count: 2333});
+let textureView161 = texture89.createView({label: '\u4ddf\uf827\u{1f6ee}\u0163\ud6e0', dimension: '3d'});
+let renderBundle73 = renderBundleEncoder62.finish({label: '\u8525\u160d\u{1fcff}\uba5b\ud1e4'});
+let externalTexture78 = device4.importExternalTexture({label: '\u0e7d\u0877\uf932\u05c5\u0bf9\u{1fbfd}\uf63c', source: video31, colorSpace: 'srgb'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup22, new Uint32Array(1249), 433, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(2019);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 946.2, g: 136.3, b: -293.5, a: 817.1, });
+} catch {}
+try {
+renderBundleEncoder57.draw(559377231);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 94104, new Float32Array(28609), 11451, 3380);
+} catch {}
+let pipeline91 = device4.createRenderPipeline({
+  label: '\uef73\u030e\u0335\u{1f8a0}\u4093\u{1faac}\u07bd\u029a\ua60c\u{1f88f}\u{1ffe9}',
+  layout: pipelineLayout19,
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+document.body.prepend(img4);
+offscreenCanvas6.width = 277;
+try {
+renderBundleEncoder67.setVertexBuffer(8902, undefined);
+} catch {}
+try {
+device7.addEventListener('uncapturederror', e => { log('device7.uncapturederror'); log(e); e.label = device7.label; });
+} catch {}
+let imageBitmap33 = await createImageBitmap(img1);
+let querySet77 = device7.createQuerySet({label: '\udef9\u9548\u0a15\ua410', type: 'occlusion', count: 282});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let img28 = await imageWithData(31, 197, '#9211791e', '#b69db6e9');
+let shaderModule34 = device4.createShaderModule({
+  code: `@group(1) @binding(1741)
+var<storage, read_write> global18: array<u32>;
+@group(0) @binding(6601)
+var<storage, read_write> field26: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup24 = device4.createBindGroup({
+  label: '\u00f3\u{1faae}\u{1fdc5}\u06dd\u09c9\ubecf\u0a47\u0ba5\u0f9e',
+  layout: bindGroupLayout36,
+  entries: [],
+});
+let commandEncoder133 = device4.createCommandEncoder();
+let querySet78 = device4.createQuerySet({type: 'occlusion', count: 414});
+let textureView162 = texture77.createView({mipLevelCount: 4});
+let computePassEncoder56 = commandEncoder133.beginComputePass({});
+let renderBundleEncoder70 = device4.createRenderBundleEncoder({
+  label: '\uc1ad\uec20\uff3a\u9fa7\u9352\u{1ff7b}',
+  colorFormats: ['rgba8uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder32.setPipeline(pipeline83);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(194);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle48, renderBundle66, renderBundle43, renderBundle50]);
+} catch {}
+try {
+renderBundleEncoder57.draw(29125649, 687233147, 873612757, 1064746322);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 34080);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+buffer29.destroy();
+} catch {}
+canvas39.height = 2409;
+let imageBitmap34 = await createImageBitmap(video14);
+let querySet79 = device4.createQuerySet({
+  label: '\uf720\u{1f78e}\u{1f6d8}\u0055\u398b\u0d07\uc5c1\u0c47\u48c3\u06dc\u3105',
+  type: 'occlusion',
+  count: 3575,
+});
+let renderBundle74 = renderBundleEncoder45.finish({label: '\u{1f6eb}\u25c4\u4257'});
+try {
+renderPassEncoder7.setBindGroup(4, bindGroup23, new Uint32Array(747), 153, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(9216, undefined, 0, 2054113422);
+} catch {}
+try {
+renderBundleEncoder66.setBindGroup(3, bindGroup22, new Uint32Array(6636), 5276, 0);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(1220398477, 56598092, 883002977, -144131547, 334594375);
+} catch {}
+try {
+renderBundleEncoder64.setPipeline(pipeline50);
+} catch {}
+try {
+computePassEncoder50.insertDebugMarker('\uecab');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 47288, new Int16Array(46949), 20327, 11336);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 30216 */
+{offset: 732, bytesPerRow: 54, rowsPerImage: 91}, {width: 0, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let pipeline92 = await device4.createRenderPipelineAsync({
+  label: '\u014d\udd23\u07b6\u{1fa40}\u03f6\udda4\u1ad0\u533c\u0aac',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 4147349244,
+    stencilWriteMask: 284517624,
+    depthBiasSlopeScale: 24.2188265432672,
+    depthBiasClamp: 4.439305895013263,
+  },
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+let shaderModule35 = device3.createShaderModule({
+  code: `@group(0) @binding(1410)
+var<storage, read_write> global19: array<u32>;
+@group(0) @binding(1556)
+var<storage, read_write> local28: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<i32>,
+  @builtin(sample_mask) f1: u32,
+  @location(1) f2: f32,
+  @location(2) f3: vec4<i32>,
+  @location(0) f4: vec3<u32>,
+  @location(4) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @location(8) f0: vec3<i32>,
+  @location(17) f1: vec2<f16>,
+  @location(3) f2: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, @location(1) a1: vec3<f32>, @builtin(vertex_index) a2: u32, @location(10) a3: vec2<u32>, @location(16) a4: f16, @location(13) a5: vec3<f16>, @location(4) a6: vec3<i32>, @builtin(instance_index) a7: u32, @location(2) a8: vec3<f32>, a9: S27, @location(0) a10: vec2<f32>, @location(14) a11: vec2<i32>, @location(9) a12: vec3<i32>, @location(11) a13: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup25 = device3.createBindGroup({
+  label: '\u0d18\u0dae\u5490\u303b',
+  layout: bindGroupLayout31,
+  entries: [{binding: 1236, resource: externalTexture32}],
+});
+let texture93 = device3.createTexture({
+  label: '\u28e0\u0b44\ub312\u0c68\u27ca\u042b',
+  size: {width: 4544, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+let externalTexture79 = device3.importExternalTexture({
+  label: '\u8c04\u0d77\u{1fa9a}\u06e4\u020b\u2515\u0e29\u4d4c\u{1fadc}\u7cd5',
+  source: videoFrame16,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder51.setBindGroup(2, bindGroup25, new Uint32Array(2899), 2816, 0);
+} catch {}
+try {
+querySet59.destroy();
+} catch {}
+let promise39 = device3.queue.onSubmittedWorkDone();
+try {
+  await promise39;
+} catch {}
+let img29 = await imageWithData(196, 225, '#eee753e5', '#9b56ae5a');
+let commandEncoder134 = device4.createCommandEncoder({label: '\u8b90\u{1f995}\u05e8\u7a71\u1465'});
+let renderPassEncoder8 = commandEncoder134.beginRenderPass({
+  label: '\u{1f82c}\u{1fca9}\u8eba\u1ea8',
+  colorAttachments: [{
+  view: textureView137,
+  clearValue: { r: 753.4, g: -938.4, b: 825.8, a: -863.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet76,
+  maxDrawCount: 1172003886,
+});
+let sampler65 = device4.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.37,
+  lodMaxClamp: 91.82,
+});
+try {
+renderPassEncoder7.setScissorRect(218, 1, 10, 0);
+} catch {}
+try {
+renderBundleEncoder57.draw(1197380290);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(866196320, 956906363, 311385769, 775493493, 990151307);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 8268);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline65);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 76240, new Float32Array(9196), 3128, 1536);
+} catch {}
+document.body.prepend(img27);
+let commandEncoder135 = device4.createCommandEncoder({label: '\ue939\u0498\u4d83\u1f48\u9060\u{1fad0}\u{1f705}\ub366\u0c9b\u8b27\u{1f7d1}'});
+let commandBuffer31 = commandEncoder135.finish({label: '\ub2f7\u0919\uc41f\u{1fc89}\u0fc8\u4238\u{1f696}\u0244\u2aba'});
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup24, new Uint32Array(8955), 1000, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline65);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7865, undefined);
+} catch {}
+try {
+renderBundleEncoder64.draw(607819204);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 9968);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder124.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder124.resolveQuerySet(querySet72, 1743, 436, buffer15, 67072);
+} catch {}
+try {
+device4.queue.submit([commandBuffer27]);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 31868, new Float32Array(55688), 53116, 884);
+} catch {}
+let promise40 = device4.queue.onSubmittedWorkDone();
+let pipeline93 = await device4.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule31,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 31860,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 8600, shaderLocation: 16},
+          {format: 'float16x2', offset: 11084, shaderLocation: 5},
+          {format: 'sint8x2', offset: 7680, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 3204, shaderLocation: 0},
+          {format: 'uint16x2', offset: 3092, shaderLocation: 8},
+          {format: 'uint32x2', offset: 2208, shaderLocation: 13},
+          {format: 'float32x4', offset: 3248, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 4376,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 2212, shaderLocation: 6},
+          {format: 'uint16x2', offset: 64, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 6588,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 1572, shaderLocation: 19}],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint8x2', offset: 6870, shaderLocation: 1}]},
+      {
+        arrayStride: 1900,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 308, shaderLocation: 18},
+          {format: 'float32x3', offset: 44, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 13168, attributes: [{format: 'sint16x4', offset: 6160, shaderLocation: 4}]},
+      {arrayStride: 1984, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 15692,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 7004, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let offscreenCanvas36 = new OffscreenCanvas(444, 588);
+let shaderModule36 = device3.createShaderModule({
+  label: '\u{1ff7a}\u0ec3\u067b\ue6b5\u{1f9a6}',
+  code: `@group(1) @binding(693)
+var<storage, read_write> function23: array<u32>;
+@group(0) @binding(693)
+var<storage, read_write> type24: array<u32>;
+@group(4) @binding(1410)
+var<storage, read_write> function24: array<u32>;
+@group(3) @binding(260)
+var<storage, read_write> local29: array<u32>;
+@group(3) @binding(1410)
+var<storage, read_write> n22: array<u32>;
+@group(3) @binding(1556)
+var<storage, read_write> local30: array<u32>;
+@group(4) @binding(1556)
+var<storage, read_write> field27: array<u32>;
+@group(2) @binding(798)
+var<storage, read_write> type25: array<u32>;
+@group(4) @binding(260)
+var<storage, read_write> local31: array<u32>;
+@group(2) @binding(693)
+var<storage, read_write> parameter27: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S29 {
+  @location(22) f0: vec3<i32>,
+  @location(44) f1: vec3<u32>,
+  @location(33) f2: vec2<f32>,
+  @location(6) f3: vec3<f32>,
+  @location(34) f4: vec4<u32>,
+  @location(15) f5: vec4<f32>,
+  @builtin(sample_index) f6: u32,
+  @location(51) f7: vec4<f32>,
+  @location(9) f8: vec3<i32>,
+  @builtin(front_facing) f9: bool,
+  @location(60) f10: vec4<i32>,
+  @location(37) f11: u32,
+  @location(30) f12: vec4<i32>,
+  @location(4) f13: vec3<u32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec3<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(2) f3: vec4<i32>,
+  @location(4) f4: f32,
+  @location(3) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(45) a0: f32, @location(13) a1: vec4<i32>, @location(52) a2: vec4<f16>, @location(47) a3: vec2<f16>, @location(7) a4: vec2<u32>, a5: S29, @location(1) a6: vec4<i32>, @builtin(position) a7: vec4<f32>, @builtin(sample_mask) a8: u32, @location(50) a9: vec3<i32>, @location(3) a10: vec2<i32>, @location(24) a11: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S28 {
+  @location(12) f0: i32
+}
+struct VertexOutput0 {
+  @location(52) f360: vec4<f16>,
+  @location(6) f361: vec3<f32>,
+  @builtin(position) f362: vec4<f32>,
+  @location(47) f363: vec2<f16>,
+  @location(24) f364: vec4<f16>,
+  @location(22) f365: vec3<i32>,
+  @location(13) f366: vec4<i32>,
+  @location(33) f367: vec2<f32>,
+  @location(3) f368: vec2<i32>,
+  @location(44) f369: vec3<u32>,
+  @location(15) f370: vec4<f32>,
+  @location(60) f371: vec4<i32>,
+  @location(50) f372: vec3<i32>,
+  @location(45) f373: f32,
+  @location(1) f374: vec4<i32>,
+  @location(4) f375: vec3<u32>,
+  @location(37) f376: u32,
+  @location(34) f377: vec4<u32>,
+  @location(7) f378: vec2<u32>,
+  @location(30) f379: vec4<i32>,
+  @location(51) f380: vec4<f32>,
+  @location(9) f381: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec4<u32>, @location(11) a1: vec4<f16>, @location(14) a2: f16, @location(7) a3: vec4<f16>, @location(10) a4: u32, @location(17) a5: vec3<i32>, @builtin(vertex_index) a6: u32, @location(0) a7: vec2<f32>, a8: S28, @location(5) a9: vec2<u32>, @location(15) a10: vec4<f16>, @location(16) a11: vec3<f16>, @location(6) a12: f16, @location(8) a13: vec2<i32>, @location(13) a14: u32, @location(2) a15: f32, @location(4) a16: vec3<f16>, @location(9) a17: i32, @builtin(instance_index) a18: u32, @location(3) a19: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder136 = device3.createCommandEncoder({label: '\u35ac\u{1fbd9}\u0937\u0a6e'});
+let texture94 = device3.createTexture({
+  label: '\udc66\u{1f811}\u01be\u6544\u{1fe0c}\u2758\u0913\uca94\ue9d3\u69ed\u0dab',
+  size: [2272],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView163 = texture68.createView({label: '\u3c81\ucba8\uf628', format: 'r32float', baseArrayLayer: 0});
+let computePassEncoder57 = commandEncoder130.beginComputePass({label: '\u8884\u1156\u0aff\u8d59\u0278\u{1f9ba}\u{1fc35}\u06d4\ub444\u{1fb18}'});
+let renderBundle75 = renderBundleEncoder47.finish({label: '\u0028\uf848\u{1f855}'});
+let sampler66 = device3.createSampler({
+  label: '\ufd4f\ufecd\u5283\u{1f667}\u0263\u{1fb34}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.93,
+  lodMaxClamp: 71.58,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup20, []);
+} catch {}
+let pipeline94 = await promise30;
+let pipeline95 = await device3.createRenderPipelineAsync({
+  label: '\u2bb9\u7e81\u{1f607}\u861d\ufca8\u0a27\u6cfb\u06fc\u{1f637}',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32float', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3368,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 160, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 484,
+        attributes: [
+          {format: 'snorm8x2', offset: 44, shaderLocation: 14},
+          {format: 'uint8x2', offset: 92, shaderLocation: 7},
+          {format: 'float32x4', offset: 96, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let videoFrame25 = new VideoFrame(video39, {timestamp: 0});
+let querySet80 = device7.createQuerySet({label: '\u486b\u8b2e\u3bea\u0caa\u{1ff4a}\u{1ffb0}\ub6a9\u{1faf0}', type: 'occlusion', count: 3013});
+let commandBuffer32 = commandEncoder132.finish({label: '\u545d\u03da\uf5cd'});
+let gpuCanvasContext43 = offscreenCanvas36.getContext('webgpu');
+gc();
+let bindGroup26 = device4.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 6601, resource: textureView147}]});
+let renderBundle76 = renderBundleEncoder66.finish({label: '\ua9df\u{1f991}\u02e4\u0b1c\u5b04\ueb99\u6912\u25ea\u4cab\u{1fc58}'});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline93);
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder57.draw(525409382, 1119574449);
+} catch {}
+try {
+renderBundleEncoder64.drawIndexedIndirect(buffer15, 26136);
+} catch {}
+try {
+commandEncoder124.resolveQuerySet(querySet63, 1591, 1077, buffer15, 157952);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 468861 */
+{offset: 137, bytesPerRow: 216, rowsPerImage: 217}, {width: 1, height: 1, depthOrArrayLayers: 11});
+} catch {}
+let canvas43 = document.createElement('canvas');
+let imageBitmap35 = await createImageBitmap(imageBitmap30);
+let canvas44 = document.createElement('canvas');
+let bindGroup27 = device3.createBindGroup({
+  label: '\u07b7\ud3c6',
+  layout: bindGroupLayout31,
+  entries: [{binding: 1236, resource: externalTexture61}],
+});
+let textureView164 = texture62.createView({label: '\u066b\u9fa5', dimension: '2d-array', format: 'bgra8unorm-srgb', mipLevelCount: 1});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup25, new Uint32Array(9138), 6215, 0);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 30, height: 1, depthOrArrayLayers: 37}
+*/
+{
+  source: offscreenCanvas34,
+  origin: { x: 228, y: 32 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame26 = new VideoFrame(canvas31, {timestamp: 0});
+let commandEncoder137 = device4.createCommandEncoder();
+let texture95 = device4.createTexture({
+  label: '\u{1fa4a}\u26f7\u2d75\u30a5',
+  size: [48, 24, 1028],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView165 = texture57.createView({
+  label: '\uf558\uec94\u0dfb\ud399\u0947\u17a2\u1240\u0add\u3448\ud099',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 340,
+});
+let renderPassEncoder9 = commandEncoder137.beginRenderPass({
+  label: '\u0e69\u7b51',
+  colorAttachments: [{
+  view: textureView141,
+  depthSlice: 221,
+  clearValue: { r: 495.6, g: -849.9, b: -494.2, a: -651.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 1028980473,
+});
+let renderBundleEncoder71 = device4.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+let externalTexture80 = device4.importExternalTexture({source: video22});
+try {
+commandEncoder124.resolveQuerySet(querySet72, 1591, 570, buffer15, 117504);
+} catch {}
+canvas41.height = 3833;
+let canvas45 = document.createElement('canvas');
+let img30 = await imageWithData(99, 30, '#e5972e21', '#48181f74');
+let textureView166 = texture19.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 148});
+let renderBundle77 = renderBundleEncoder25.finish({label: '\u03e7\u{1fd72}\ue1c4\udf65\u2413'});
+let pipeline96 = device1.createComputePipeline({
+  label: '\u{1f6fb}\u{1fce4}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+try {
+canvas43.getContext('webgpu');
+} catch {}
+let shaderModule37 = device3.createShaderModule({
+  label: '\u5628\u5021\u8343\u0dfd\u0910\uad8d\u1aac\u5055\u0010\u{1fe4a}\u5e99',
+  code: `@group(0) @binding(1556)
+var<storage, read_write> field28: array<u32>;
+@group(0) @binding(260)
+var<storage, read_write> type26: array<u32>;
+@group(0) @binding(1410)
+var<storage, read_write> local32: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<f32>,
+  @location(2) f1: vec4<i32>,
+  @location(3) f2: vec2<i32>,
+  @location(0) f3: u32,
+  @location(4) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: f16, @builtin(instance_index) a1: u32, @location(2) a2: vec3<u32>, @location(6) a3: vec2<u32>, @location(12) a4: vec4<f16>, @location(5) a5: vec3<f16>, @location(9) a6: vec2<u32>, @location(7) a7: vec4<u32>, @builtin(vertex_index) a8: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let commandEncoder138 = device3.createCommandEncoder();
+let renderBundle78 = renderBundleEncoder31.finish();
+try {
+computePassEncoder57.setPipeline(pipeline76);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline79);
+} catch {}
+try {
+querySet59.destroy();
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let canvas46 = document.createElement('canvas');
+let bindGroupLayout38 = pipeline72.getBindGroupLayout(0);
+let buffer30 = device3.createBuffer({
+  label: '\u{1fce4}\u{1fab7}\ub2a1\u11ec\u730e\u2605\ub23c',
+  size: 2084,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder139 = device3.createCommandEncoder({});
+let querySet81 = device3.createQuerySet({label: '\ud3bf\u0163\u9a9b\u0408\u045f\u08be\ufff9\uea19\u0048\u3ea8', type: 'occlusion', count: 1058});
+let externalTexture81 = device3.importExternalTexture({source: videoFrame6});
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder116.clearBuffer(buffer30);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+commandEncoder136.insertDebugMarker('\u52e9');
+} catch {}
+try {
+device3.queue.submit([commandBuffer24]);
+} catch {}
+let videoFrame27 = new VideoFrame(video9, {timestamp: 0});
+let commandEncoder140 = device3.createCommandEncoder({label: '\ufe6e\u5912\u8f5c\u41fa\u057c\u0100\u{1fb31}\u058c\u6c83\u5d29'});
+let textureView167 = texture70.createView({
+  label: '\u03f3\ueba0\u0ed4\u0b20\u{1fcc4}\udace\u{1fa96}',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let computePassEncoder58 = commandEncoder126.beginComputePass({label: '\ud9fc\u26de\u06db\u7cb0\udccb\uc19c'});
+let renderBundle79 = renderBundleEncoder42.finish({});
+try {
+computePassEncoder57.dispatchWorkgroupsIndirect(buffer16, 110304);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(3, bindGroup27, new Uint32Array(6654), 1379, 0);
+} catch {}
+let promise41 = device3.popErrorScope();
+let pipeline97 = device3.createRenderPipeline({
+  label: '\ua8ab\u0471\u0263\uce3d\u{1f6b6}\u08d6\u0c18\u0af4\u046d\u{1f636}\u6e76',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg8sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3132,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 520, shaderLocation: 8},
+          {format: 'uint16x2', offset: 420, shaderLocation: 5},
+          {format: 'sint8x4', offset: 192, shaderLocation: 12},
+          {format: 'uint32x3', offset: 392, shaderLocation: 3},
+          {format: 'sint32x2', offset: 2612, shaderLocation: 9},
+          {format: 'uint32x4', offset: 2228, shaderLocation: 13},
+          {format: 'float32x2', offset: 2372, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 96, shaderLocation: 2},
+          {format: 'uint16x2', offset: 1112, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 228, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 176,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 4, shaderLocation: 10},
+          {format: 'sint16x4', offset: 32, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 78, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 11},
+          {format: 'float32x2', offset: 4, shaderLocation: 14},
+          {format: 'float32', offset: 48, shaderLocation: 16},
+          {format: 'float32x4', offset: 84, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', unclippedDepth: true},
+});
+let querySet82 = device4.createQuerySet({
+  label: '\u5b58\u{1fc18}\u09b9\u0e36\u{1fe1c}\u0ca4\u6742\u0cd9\u2664\u048c\u0a4e',
+  type: 'occlusion',
+  count: 3718,
+});
+let textureView168 = texture57.createView({label: '\ua470\uc2e1\u891c', dimension: '2d', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 522});
+let computePassEncoder59 = commandEncoder124.beginComputePass();
+let renderBundle80 = renderBundleEncoder70.finish({label: '\ud9a2\u{1f6cd}\u3d50\uc539\ud8fa\u4f37\u{1fddb}'});
+try {
+computePassEncoder35.setPipeline(pipeline85);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup22, new Uint32Array(1158), 105, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle52, renderBundle74, renderBundle66, renderBundle73, renderBundle65, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline93);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 560);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 41352);
+} catch {}
+document.body.prepend(img27);
+let adapter9 = await navigator.gpu.requestAdapter();
+let imageData37 = new ImageData(152, 172);
+let bindGroupLayout39 = device4.createBindGroupLayout({
+  label: '\ub6f8\u9032\u075d\u9a66\u09a8\u{1ff58}\u{1fa08}\u{1ff3c}',
+  entries: [
+    {binding: 992, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 6529,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 2651,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder141 = device4.createCommandEncoder({label: '\u0c64\u0ee8\u{1fe2c}\u0142\u68b2\u035b\u0ad6'});
+let texture96 = device4.createTexture({
+  label: '\u{1fd77}\ue850\u1564\u1e83\u482c\ud55e',
+  size: {width: 240, height: 1, depthOrArrayLayers: 133},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView169 = texture96.createView({
+  label: '\u77fa\u0bdf\u4b97\u{1fecb}\u{1fade}\ufaef\uc7b1',
+  dimension: '3d',
+  baseMipLevel: 3,
+  baseArrayLayer: 0,
+});
+let computePassEncoder60 = commandEncoder141.beginComputePass({label: '\u{1fe4e}\u003d\u858a\u0634\u7ec0\u{1fa89}\uc5dd\u9eb2\u00a3\u7e5d\u7643'});
+try {
+renderPassEncoder0.setViewport(50.78, 0.8876, 17.00, 0.1041, 0.00130, 0.6255);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 12204);
+} catch {}
+try {
+device4.queue.submit([commandBuffer31]);
+} catch {}
+let shaderModule38 = device4.createShaderModule({
+  label: '\u6da2\u33b3\u77c3\u1874\uf328',
+  code: `@group(0) @binding(1741)
+var<storage, read_write> type27: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @location(12) f0: vec2<u32>,
+  @location(5) f1: vec3<u32>,
+  @location(11) f2: vec3<f32>,
+  @location(8) f3: vec3<i32>,
+  @location(18) f4: vec4<f16>,
+  @location(0) f5: vec4<i32>,
+  @location(9) f6: vec2<u32>,
+  @location(3) f7: vec2<i32>,
+  @builtin(instance_index) f8: u32,
+  @location(6) f9: vec2<f16>,
+  @location(14) f10: vec3<u32>,
+  @location(16) f11: u32,
+  @location(17) f12: vec4<f16>,
+  @location(10) f13: vec4<i32>,
+  @location(7) f14: vec4<f32>,
+  @location(4) f15: u32,
+  @location(20) f16: vec2<u32>,
+  @location(15) f17: vec3<f16>,
+  @location(1) f18: vec3<i32>,
+  @location(13) f19: vec3<f16>,
+  @location(2) f20: i32,
+  @location(19) f21: i32
+}
+
+@vertex
+fn vertex0(a0: S30, @builtin(vertex_index) a1: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let querySet83 = device4.createQuerySet({type: 'occlusion', count: 2475});
+let textureView170 = texture85.createView({label: '\u{1fc4b}\u08dd\u096f'});
+let renderBundleEncoder72 = device4.createRenderBundleEncoder({label: '\u630c\u55e1\u{1fba5}\ucf9f', colorFormats: ['rgba8uint'], depthReadOnly: true});
+try {
+computePassEncoder60.setPipeline(pipeline83);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup22, new Uint32Array(2143), 1575, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle43, renderBundle73, renderBundle76, renderBundle65]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1049);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 580);
+} catch {}
+try {
+  await device4.popErrorScope();
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 36744, new Int16Array(6705), 1523, 1712);
+} catch {}
+let img31 = await imageWithData(155, 155, '#f2c3f602', '#3e593cd2');
+let textureView171 = texture87.createView({label: '\ub687\ua658\u06e5\u019b\u0a28\ub024\u{1fc05}\ueb00', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder73 = device6.createRenderBundleEncoder({
+  label: '\u0bcf\u03bd\u5d71\u0bf7',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder46.setPipeline(pipeline80);
+} catch {}
+try {
+commandEncoder118.clearBuffer(buffer25, 27336, 19272);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u9288');
+} catch {}
+let pipeline98 = await device6.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}}});
+let video41 = await videoWithData();
+let querySet84 = device3.createQuerySet({type: 'occlusion', count: 3173});
+let externalTexture82 = device3.importExternalTexture({label: '\u0ab0\ud5f1\u27b1\u0cbf\uc1f1\u{1fd3c}\uf329', source: videoFrame14, colorSpace: 'srgb'});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup27, new Uint32Array(264), 29, 0);
+} catch {}
+try {
+computePassEncoder40.dispatchWorkgroups(5, 4, 3);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+  await device3.popErrorScope();
+} catch {}
+let pipeline99 = device3.createComputePipeline({
+  label: '\u{1ff43}\uebf6\u{1fcb2}\u{1f6ba}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule28, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext30.unconfigure();
+} catch {}
+let canvas47 = document.createElement('canvas');
+gc();
+let commandBuffer33 = commandEncoder131.finish();
+let textureView172 = texture81.createView({
+  label: '\u538b\u{1faba}\u0039\u{1f6aa}\u5778\u61da\ue0fc\u4481',
+  dimension: '2d',
+  baseMipLevel: 7,
+  baseArrayLayer: 228,
+});
+try {
+renderBundleEncoder69.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(1794, undefined, 0, 895377503);
+} catch {}
+try {
+device6.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device6,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 21},
+  aspect: 'all',
+}, new ArrayBuffer(6069808), /* required buffer size: 6069808 */
+{offset: 816, bytesPerRow: 302, rowsPerImage: 157}, {width: 5, height: 0, depthOrArrayLayers: 129});
+} catch {}
+let gpuCanvasContext44 = canvas46.getContext('webgpu');
+try {
+  await promise41;
+} catch {}
+document.body.prepend(canvas35);
+let videoFrame28 = new VideoFrame(video15, {timestamp: 0});
+let commandEncoder142 = device6.createCommandEncoder({label: '\ue9e2\u{1fa2a}\u4adb\u0db4\uf1d8\u{1fc24}\u{1f63b}\uc5b7\u{1fc9b}\ubcd6'});
+let textureView173 = texture82.createView({
+  label: '\ub865\u5cc8\u{1f8d6}\u{1f9db}\u015f\u35fd\u7ab8\u09d8\u{1fb60}',
+  aspect: 'all',
+  baseMipLevel: 1,
+});
+let renderBundleEncoder74 = device6.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle81 = renderBundleEncoder68.finish({label: '\u96e5\u3b85\u0b2a\u{1fc3b}\u0422\u{1f935}'});
+try {
+commandEncoder118.clearBuffer(buffer25, 210920, 23512);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder125.resolveQuerySet(querySet66, 928, 141, buffer28, 321280);
+} catch {}
+let pipeline100 = device6.createRenderPipeline({
+  label: '\u7dfe\u08f5\ua299\u{1f7a3}\ue4cd',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0xf531ca11},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint'}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 532, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let buffer31 = device6.createBuffer({
+  label: '\ua011\u971e\u01f6\u808b\u0bd3\u{1fcbd}\u{1fc6b}\u050e\u088f\u0a72\u0874',
+  size: 402925,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer34 = commandEncoder142.finish();
+let renderBundleEncoder75 = device6.createRenderBundleEncoder({
+  label: '\u0776\u6c57\uf6ed\u2059\ud521\uda97\u0da3\u4d9e',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle82 = renderBundleEncoder56.finish({});
+let sampler67 = device6.createSampler({
+  label: '\u{1fba6}\ufd97\u{1fe4c}\u3eed\u954a',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.476,
+  lodMaxClamp: 54.65,
+});
+try {
+commandEncoder118.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 11144 widthInBlocks: 1393 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24152 */
+  offset: 24152,
+  buffer: buffer25,
+}, {width: 1393, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder118.clearBuffer(buffer25, 155484, 22652);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 646 */
+{offset: 646}, {width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 90, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video12,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture97 = device3.createTexture({
+  label: '\ubdeb\u{1ffef}\u0729\u{1f9c0}\u1602\u{1f7bf}\u0ca1\u{1f6a0}\ue016\u0de3\u2c34',
+  size: {width: 480},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture83 = device3.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder54.setBindGroup(6, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(4, buffer19, 0, 152333);
+} catch {}
+try {
+computePassEncoder53.insertDebugMarker('\u6fae');
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline101 = await device3.createComputePipelineAsync({
+  label: '\udcc8\u045a\u0947\u0c2f\uc367\u{1feab}',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext45 = canvas47.getContext('webgpu');
+try {
+canvas45.getContext('webgl');
+} catch {}
+try {
+window.someLabel = externalTexture47.label;
+} catch {}
+let shaderModule39 = device4.createShaderModule({
+  code: `@group(1) @binding(1741)
+var<storage, read_write> n23: array<u32>;
+@group(0) @binding(6601)
+var<storage, read_write> global20: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+struct S31 {
+  @location(18) f0: vec3<i32>,
+  @location(0) f1: vec4<f16>,
+  @location(11) f2: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(9) f382: vec3<i32>,
+  @location(13) f383: vec4<f32>,
+  @location(10) f384: vec2<u32>,
+  @location(32) f385: vec2<f32>,
+  @location(62) f386: vec2<f16>,
+  @location(8) f387: i32,
+  @location(35) f388: vec3<f32>,
+  @location(20) f389: vec3<f16>,
+  @location(51) f390: vec4<i32>,
+  @location(22) f391: vec3<i32>,
+  @location(63) f392: vec2<f32>,
+  @location(24) f393: vec2<f32>,
+  @builtin(position) f394: vec4<f32>,
+  @location(50) f395: i32,
+  @location(21) f396: vec3<f32>,
+  @location(18) f397: u32,
+  @location(42) f398: f16,
+  @location(3) f399: f32,
+  @location(2) f400: vec2<f16>,
+  @location(4) f401: i32,
+  @location(56) f402: f16,
+  @location(52) f403: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f16>, @location(16) a1: vec2<f16>, @location(19) a2: vec2<f16>, @location(14) a3: vec4<f16>, a4: S31, @builtin(instance_index) a5: u32, @location(2) a6: vec3<u32>, @location(7) a7: vec4<i32>, @location(5) a8: vec2<i32>, @location(12) a9: vec4<i32>, @location(9) a10: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet85 = device4.createQuerySet({label: '\u24ad\u568c\u{1fb5d}\u0dcc\u100b\ub8f8', type: 'occlusion', count: 1002});
+let textureView174 = texture85.createView({});
+let renderBundle83 = renderBundleEncoder45.finish();
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle43, renderBundle48, renderBundle71, renderBundle80, renderBundle55, renderBundle76, renderBundle83, renderBundle73]);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -370.9, g: 64.41, b: 960.2, a: 861.6, });
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(3446);
+} catch {}
+try {
+renderPassEncoder8.setViewport(13.58, 0.3510, 13.93, 0.06015, 0.05240, 0.6896);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 36172);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 27160);
+} catch {}
+let arrayBuffer9 = buffer18.getMappedRange(631464, 1392);
+try {
+device4.queue.submit([commandBuffer22]);
+} catch {}
+let commandEncoder143 = device3.createCommandEncoder({label: '\u{1f70c}\u1496\u0528\ud123\u0b14\u8904\uf86d\u37a6\u0add\u0687\u0e06'});
+let texture98 = device3.createTexture({
+  label: '\u2404\u5a8f\u{1ff3d}\u08f5\u{1f6ae}',
+  size: [240],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView175 = texture98.createView({label: '\uc3b3\ude6f\uf63b\u0500', dimension: '1d', baseMipLevel: 0});
+try {
+renderBundleEncoder50.setPipeline(pipeline79);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 13},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 9});
+} catch {}
+try {
+commandEncoder117.clearBuffer(buffer26);
+dissociateBuffer(device3, buffer26);
+} catch {}
+let pipeline102 = await device3.createRenderPipelineAsync({
+  label: '\u479f\u0a8d\u{1f849}\ue442\u{1fec0}\uf021\u896d\u0292\uc550',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule35,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16sint'}, {format: 'rg8sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule35,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 4, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 648, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 170, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 376, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 48, shaderLocation: 2},
+          {format: 'uint16x4', offset: 68, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 428, shaderLocation: 6},
+          {format: 'sint8x4', offset: 56, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 78, shaderLocation: 16},
+          {format: 'uint8x2', offset: 284, shaderLocation: 11},
+          {format: 'sint32', offset: 184, shaderLocation: 8},
+          {format: 'sint16x2', offset: 536, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 632,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 80, shaderLocation: 4},
+          {format: 'float16x2', offset: 64, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+});
+let video42 = await videoWithData();
+try {
+canvas44.getContext('webgl');
+} catch {}
+let texture99 = device6.createTexture({
+  label: '\u082f\u6bde\u{1f604}\ub18f\u74aa\u5744',
+  size: [3120],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData37,
+  origin: { x: 2, y: 28 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline103 = await device6.createComputePipelineAsync({
+  label: '\u0df2\u3b03\u0759\u255a\u8f96\udf3a\u0708\u04c0\u0d21\u0697',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise40;
+} catch {}
+canvas36.width = 314;
+document.body.prepend(img29);
+video25.height = 195;
+gc();
+gc();
+canvas1.height = 2374;
+let commandEncoder144 = device4.createCommandEncoder({label: '\u4de3\u0c4c\u{1febd}\u0b0f\u00e5\u5061'});
+let computePassEncoder61 = commandEncoder144.beginComputePass({label: '\u03f9\u354e\u08a5\u216f\ue92e\u0c0b\u0c9d\u401a\u0466'});
+let renderBundleEncoder76 = device4.createRenderBundleEncoder({label: '\u0566\u11e4\u{1fee9}\ue2f8\u42a2\u6359\ub43b\uf04a\u28aa', colorFormats: ['rgba8uint']});
+let externalTexture84 = device4.importExternalTexture({label: '\u{1fb78}\u{1fd19}\u{1f849}\u{1fd16}', source: videoFrame17, colorSpace: 'display-p3'});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup23, new Uint32Array(4989), 4623, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(1219);
+} catch {}
+try {
+renderPassEncoder9.setViewport(102.0, 0.4981, 105.3, 0.3906, 0.3398, 0.3886);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer29, 509194323);
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(3, bindGroup24, new Uint32Array(1631), 136, 0);
+} catch {}
+try {
+renderBundleEncoder65.setPipeline(pipeline65);
+} catch {}
+document.body.prepend(video4);
+let imageData38 = new ImageData(132, 180);
+let externalTexture85 = device3.importExternalTexture({source: videoFrame28, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder50.setBindGroup(7, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline79);
+} catch {}
+let commandEncoder145 = device7.createCommandEncoder({label: '\u71b8\u02b0\u0cce\uf95a\u4dcb'});
+let texture100 = device7.createTexture({
+  size: [21, 1, 207],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView176 = texture100.createView({baseMipLevel: 1});
+let renderBundle84 = renderBundleEncoder67.finish({label: '\u{1f872}\u98fd'});
+let externalTexture86 = device7.importExternalTexture({label: '\u00e0\u8178\u0fc5\u3e9c', source: videoFrame1, colorSpace: 'display-p3'});
+let videoFrame29 = new VideoFrame(img25, {timestamp: 0});
+let commandBuffer35 = commandEncoder139.finish({label: '\u0f7b\u01c4\ub67b\u{1fece}\u{1fd75}\ud64d\u9c6b\u698a\uc7b2\u9ad1\u0469'});
+let textureView177 = texture94.createView({label: '\u{1f6b0}\u039b\u5872\u659f'});
+let renderBundleEncoder77 = device3.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle85 = renderBundleEncoder38.finish({});
+try {
+computePassEncoder47.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23832 */
+  offset: 23832,
+  buffer: buffer26,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer26);
+} catch {}
+let renderBundleEncoder78 = device7.createRenderBundleEncoder({
+  label: '\u0b01\u35df\u{1ffd6}\u0ed2',
+  colorFormats: ['rgb10a2unorm', 'rgba16sint', 'rg8uint', 'rg8sint', 'r16float'],
+  depthReadOnly: true,
+});
+let renderBundle86 = renderBundleEncoder78.finish();
+let externalTexture87 = device7.importExternalTexture({label: '\u82a1\u65cd\u5d2f\udfd5\u0f74', source: videoFrame22, colorSpace: 'srgb'});
+offscreenCanvas8.width = 2706;
+canvas36.height = 4524;
+let commandEncoder146 = device7.createCommandEncoder({label: '\u934e\u441f\u{1fa3d}\u05bd'});
+let textureView178 = texture100.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle87 = renderBundleEncoder78.finish();
+let externalTexture88 = device7.importExternalTexture({label: '\u151a\u4912\u853c', source: videoFrame0, colorSpace: 'srgb'});
+let commandEncoder147 = device7.createCommandEncoder({label: '\u0963\ud059\u0bef\u3eb8\uff86\u8fca\u0463\u0f1f'});
+let textureView179 = texture100.createView({
+  label: '\u{1f60c}\u99bf\ufb76\u{1fb42}\u0c3f\u04c4\u{1f70c}\u0f56\u77c2\u{1fdbf}\u8623',
+  baseMipLevel: 1,
+});
+let externalTexture89 = device7.importExternalTexture({label: '\u5d19\ub933\u{1fc64}\u0624\uf193\u96cd', source: video12, colorSpace: 'display-p3'});
+let shaderModule40 = device4.createShaderModule({
+  code: `@group(0) @binding(1741)
+var<storage, read_write> global21: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(0) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(@location(61) a0: vec4<i32>, @location(33) a1: vec4<i32>, @location(13) a2: f16, @location(27) a3: vec3<f32>, @location(21) a4: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @location(19) f0: vec2<u32>,
+  @location(9) f1: vec2<f32>,
+  @location(5) f2: u32,
+  @location(10) f3: f16,
+  @location(14) f4: vec4<f16>,
+  @location(0) f5: vec3<u32>,
+  @location(4) f6: u32,
+  @location(2) f7: vec4<u32>,
+  @location(18) f8: vec2<f32>,
+  @location(17) f9: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(40) f404: vec3<u32>,
+  @location(8) f405: vec3<i32>,
+  @location(61) f406: vec4<i32>,
+  @location(36) f407: u32,
+  @location(33) f408: vec4<i32>,
+  @location(60) f409: f32,
+  @location(43) f410: u32,
+  @location(7) f411: vec4<f16>,
+  @location(27) f412: vec3<f32>,
+  @location(56) f413: vec4<f32>,
+  @location(0) f414: vec3<f16>,
+  @location(13) f415: f16,
+  @location(37) f416: f32,
+  @location(21) f417: vec4<f16>,
+  @location(3) f418: vec2<i32>,
+  @location(2) f419: vec2<f16>,
+  @builtin(position) f420: vec4<f32>,
+  @location(52) f421: i32,
+  @location(23) f422: vec2<u32>,
+  @location(66) f423: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(3) a1: i32, @location(16) a2: vec2<i32>, @location(6) a3: vec3<i32>, @location(13) a4: u32, @location(11) a5: f32, @location(1) a6: vec3<f16>, @location(12) a7: vec4<i32>, @location(20) a8: vec2<f32>, @builtin(instance_index) a9: u32, a10: S32, @location(15) a11: vec4<u32>, @location(7) a12: vec3<u32>, @builtin(vertex_index) a13: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet86 = device4.createQuerySet({type: 'occlusion', count: 3139});
+let textureView180 = texture95.createView({label: '\u0d76\u0186', baseMipLevel: 1, baseArrayLayer: 325, arrayLayerCount: 83});
+try {
+renderPassEncoder4.setBlendConstant({ r: 681.5, g: -438.8, b: 410.4, a: -6.505, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer23, 53309609);
+} catch {}
+try {
+renderBundleEncoder64.draw(1189907700, 388238560, 1157783588, 23864133);
+} catch {}
+let videoFrame30 = new VideoFrame(video0, {timestamp: 0});
+let buffer32 = device4.createBuffer({
+  label: '\uac14\u{1ff67}\u{1f737}\uf539\u5732\u0d5a\u07e0\u0b2e\u{1f7ad}\uf463',
+  size: 438013,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let querySet87 = device4.createQuerySet({label: '\u{1f60d}\uaee6\u0361\uc412\ud472\ufa4f\u3f1c\ua2fa\u4ce4', type: 'occlusion', count: 585});
+let texture101 = device4.createTexture({
+  label: '\u0c51\u0db1\u725f\u0c77\u099e\u{1fea2}\u0415',
+  size: {width: 480, height: 1, depthOrArrayLayers: 67},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let renderBundle88 = renderBundleEncoder72.finish({label: '\u0281\u015b\u{1f88b}\udea3'});
+let sampler68 = device4.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 56.23,
+  lodMaxClamp: 85.53,
+});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(76, 0, 7, 1);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer29, 665542538);
+} catch {}
+try {
+renderBundleEncoder57.draw(644328031, 558337252, 876893673);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(1891, undefined, 0);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer23, 31520, new DataView(new ArrayBuffer(7397)), 508, 100);
+} catch {}
+let promise42 = device4.queue.onSubmittedWorkDone();
+let textureView181 = texture81.createView({
+  label: '\u5750\ue9e9\u98c6\u2ede\u45f5\u0aca\u0aa0\u53df\u0988\u3723\u013a',
+  dimension: '2d',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 156,
+});
+let sampler69 = device6.createSampler({
+  label: '\u{1f96d}\u0f1c\u{1fe75}\u0e34\u0023',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.28,
+  lodMaxClamp: 99.90,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder51.setPipeline(pipeline73);
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1085 */
+  offset: 1085,
+  buffer: buffer31,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device6, buffer31);
+} catch {}
+try {
+commandEncoder125.clearBuffer(buffer25, 238772, 11088);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder125.resolveQuerySet(querySet66, 1828, 125, buffer28, 22016);
+} catch {}
+let renderBundle89 = renderBundleEncoder67.finish({});
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+let imageData39 = new ImageData(100, 32);
+let commandEncoder148 = device6.createCommandEncoder({label: '\u00b0\u8443\ude35\u0e30\u0716\u0a9d\u52ac\u84fc\u0a06\uea3e\u2cf5'});
+let querySet88 = device6.createQuerySet({type: 'occlusion', count: 4058});
+let texture102 = device6.createTexture({
+  label: '\u{1f934}\u324d\u2e7a\uf08b\u{1fde0}\u{1f6b4}\u0298\u0e41\u{1fd94}\u0252',
+  size: {width: 90, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+let computePassEncoder62 = commandEncoder148.beginComputePass({label: '\u92e3\uaf17\ub97f'});
+let renderBundle90 = renderBundleEncoder54.finish({label: '\uf791\u0e17\uf42c\uf388\u0e73\u0fb6'});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline80);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline90);
+} catch {}
+try {
+commandEncoder118.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 9048 widthInBlocks: 1131 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 12560 */
+  offset: 12560,
+  buffer: buffer25,
+}, {width: 1131, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device6, buffer25);
+} catch {}
+let videoFrame31 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let device8 = await adapter9.requestDevice({
+  label: '\ude54\u091e\u4384\ua3cc\u{1f63a}\u0acc\u54ac\u3114\ued53',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 39,
+    maxVertexAttributes: 20,
+    maxVertexBufferArrayStride: 23445,
+    maxStorageTexturesPerShaderStage: 36,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 5693,
+    maxDynamicUniformBuffersPerPipelineLayout: 28371,
+    maxBindingsPerBindGroup: 2438,
+    maxTextureArrayLayers: 901,
+    maxTextureDimension1D: 12750,
+    maxTextureDimension2D: 13458,
+    maxVertexBuffers: 8,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 45016851,
+    maxUniformBuffersPerShaderStage: 23,
+    maxSampledTexturesPerShaderStage: 32,
+    maxInterStageShaderVariables: 124,
+    maxInterStageShaderComponents: 69,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let imageBitmap36 = await createImageBitmap(videoFrame0);
+let commandEncoder149 = device6.createCommandEncoder({label: '\u0355\u5730\u01d1\ubff3\u1d50\u{1fcb4}\u{1fb35}\u28bd'});
+let querySet89 = device6.createQuerySet({label: '\u0172\u{1f764}\u6fc5\u86de\u064a\u0fd2\u37e2', type: 'occlusion', count: 719});
+let texture103 = device6.createTexture({
+  label: '\u{1fc3f}\u{1ff02}\u7e23\uef0e\u0712\uad1d\u0a62\ua7a4\u05fd',
+  size: {width: 720, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline90);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(5533, undefined, 0, 1840142068);
+} catch {}
+try {
+commandEncoder149.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 110520 */
+  offset: 59320,
+  bytesPerRow: 256,
+  rowsPerImage: 50,
+  buffer: buffer31,
+}, {
+  texture: texture69,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 5});
+dissociateBuffer(device6, buffer31);
+} catch {}
+try {
+commandEncoder121.resolveQuerySet(querySet61, 1804, 179, buffer28, 69888);
+} catch {}
+try {
+  await promise42;
+} catch {}
+let textureView182 = texture39.createView({label: '\u1ec7\u{1fb45}\uea8c\u8f1a', format: 'r8unorm', baseMipLevel: 4});
+let computePassEncoder63 = commandEncoder143.beginComputePass();
+let renderBundleEncoder79 = device3.createRenderBundleEncoder({
+  label: '\u1034\u{1f737}\u0feb\uf4db\u50ee',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+});
+let externalTexture90 = device3.importExternalTexture({label: '\u00f6\uaae9\u{1fc85}\u02b7\u0f1a\u03a8', source: video31, colorSpace: 'srgb'});
+try {
+computePassEncoder36.setPipeline(pipeline68);
+} catch {}
+try {
+commandEncoder138.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 20067 */
+  offset: 20067,
+  buffer: buffer26,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer26);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet48, 4, 0, buffer27, 285440);
+} catch {}
+let commandEncoder150 = device6.createCommandEncoder({label: '\u912e\u{1f7a5}\u{1fa15}'});
+let querySet90 = device6.createQuerySet({type: 'occlusion', count: 3595});
+let commandBuffer36 = commandEncoder107.finish({label: '\u{1f954}\u0f3c\u3fd8\u{1f747}\u{1f62c}\ue93b\u44fe\u0ca0\u89c2\u821d\u035c'});
+let textureView183 = texture102.createView({label: '\u5685\uc067\udf85\u03d6', format: 'rgba8unorm-srgb', baseMipLevel: 0, mipLevelCount: 2});
+let computePassEncoder64 = commandEncoder118.beginComputePass({label: '\ue852\u{1fa2a}\u3a6e\u4843\u{1ff80}\u{1ff7c}\uac93\u84b9\ue5bc'});
+try {
+computePassEncoder64.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder74.setIndexBuffer(buffer28, 'uint32', 313532, 67234);
+} catch {}
+try {
+commandEncoder150.resolveQuerySet(querySet61, 1119, 104, buffer28, 127488);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder151 = device4.createCommandEncoder({label: '\ud721\u765c\u2b0e\u0e92\u808d\u090c\u0b9c\ud41a'});
+let texture104 = device4.createTexture({
+  size: {width: 192, height: 96, depthOrArrayLayers: 1028},
+  mipLevelCount: 8,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let textureView184 = texture76.createView({label: '\u0182\u0708\u49d8\ufaab\u0c5a\ub102\u0854\ud606\u5a2b', baseMipLevel: 2});
+let computePassEncoder65 = commandEncoder151.beginComputePass({label: '\u6692\u2709\u7d75\u6f85\u{1facc}\u95e5\u0184\u1a5c\ub942\u09e2'});
+let sampler70 = device4.createSampler({
+  label: '\u00d4\ud77b\u0a7e\u02dd\u2054\u{1ffb3}\u6ae6\uc468\u1a4b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 56.09,
+  lodMaxClamp: 68.76,
+});
+try {
+renderPassEncoder7.setBindGroup(4, bindGroup23, new Uint32Array(5431), 1993, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle52]);
+} catch {}
+try {
+renderPassEncoder7.draw(406037798, 973758536, 402997860, 587067697);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(4208, undefined, 0, 1101118476);
+} catch {}
+let renderBundle91 = renderBundleEncoder50.finish({label: '\u{1fc67}\u0d2a\u{1fda1}\ub393\uade7\u48e9\u{1fb0a}'});
+let sampler71 = device3.createSampler({
+  label: '\u7855\u2414\u5584\u84be\u543f\ub899\ue6b8\u4db3\u0a6b\uc37b\u{1f962}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.56,
+  lodMaxClamp: 46.19,
+  compare: 'less-equal',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder57.dispatchWorkgroupsIndirect(buffer16, 38752);
+} catch {}
+try {
+commandEncoder116.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1184 widthInBlocks: 296 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10252 */
+  offset: 10252,
+  buffer: buffer26,
+}, {width: 296, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer26);
+} catch {}
+let video43 = await videoWithData();
+let img32 = await imageWithData(277, 211, '#b5526d2d', '#4671f56c');
+let video44 = await videoWithData();
+let texture105 = device6.createTexture({
+  label: '\u4059\u07df\u{1f66f}\ue9bb\u0376\u{1fc19}\u9fae\u5087\u09ee\u79a4',
+  size: [90],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder75.setVertexBuffer(4213, undefined, 0, 34701876);
+} catch {}
+try {
+commandEncoder149.copyBufferToBuffer(buffer31, 350508, buffer25, 135404, 28532);
+dissociateBuffer(device6, buffer31);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder149.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13232 */
+  offset: 13224,
+  buffer: buffer31,
+}, {
+  texture: texture69,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device6, buffer31);
+} catch {}
+let pipeline104 = device6.createRenderPipeline({
+  label: '\u082c\u077b\u6ea6\u031f\ud24a\u01f4\u0a87\u{1fbc8}\u{1f756}\u3af5',
+  layout: pipelineLayout16,
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 20, attributes: []},
+      {arrayStride: 160, attributes: []},
+      {arrayStride: 1108, attributes: [{format: 'uint32x3', offset: 24, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder152 = device4.createCommandEncoder({});
+let commandBuffer37 = commandEncoder152.finish({label: '\u04ba\u1ec1\u1bf7\ud6bc'});
+let textureView185 = texture48.createView({mipLevelCount: 1});
+let renderBundleEncoder80 = device4.createRenderBundleEncoder({
+  label: '\u{1fb6f}\u0000\ub1f4\u0ac2\u06f9\u09b9\u018d',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 801.4, g: 484.3, b: -398.6, a: -746.1, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer23, 369195840);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer15, 1178198491);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline93);
+} catch {}
+try {
+renderBundleEncoder57.draw(708463951);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexed(64110158);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 30660);
+} catch {}
+let pipeline105 = device4.createComputePipeline({
+  label: '\u3a71\u8f93\u412c\u89da\u{1f7c7}',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule31, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img18);
+canvas33.height = 1887;
+let bindGroupLayout40 = device4.createBindGroupLayout({
+  label: '\u{1fbfb}\u2d66\u{1f77e}\u{1fb5f}',
+  entries: [{binding: 743, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let querySet91 = device4.createQuerySet({type: 'occlusion', count: 712});
+let texture106 = device4.createTexture({
+  label: '\u4d0b\uf1c4\u{1f8f0}\uadbd\u0684\ue331\u014a\ud7ed\u99d0\u0725',
+  size: {width: 96, height: 48, depthOrArrayLayers: 1028},
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let renderBundle92 = renderBundleEncoder45.finish({label: '\u378d\u0dc8\uaaf5\u7fc7\u0d70\u42f0\ua63c\ucd90'});
+let externalTexture91 = device4.importExternalTexture({
+  label: '\u0842\u{1ffdb}\u16ab\u{1fcb2}\ub8bb\u5725\u{1f678}\u0163\u{1face}\u81dd',
+  source: video27,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder3.setStencilReference(447);
+} catch {}
+try {
+renderPassEncoder8.setViewport(159.8, 0.8203, 79.52, 0.02629, 0.1159, 0.7920);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer23, 171815192);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6062, undefined, 0, 3790710587);
+} catch {}
+try {
+renderBundleEncoder64.drawIndexedIndirect(buffer15, 15788);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 8760);
+} catch {}
+try {
+renderBundleEncoder65.setPipeline(pipeline50);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 117968, new DataView(new ArrayBuffer(13698)), 11388, 160);
+} catch {}
+let querySet92 = device6.createQuerySet({label: '\u2fed\uf3d4\uf904\uac68\u0bd4\uf799', type: 'occlusion', count: 2885});
+let commandBuffer38 = commandEncoder121.finish({label: '\u94fe\u{1fe2e}\u3352'});
+let textureView186 = texture83.createView({dimension: '2d-array'});
+let sampler72 = device6.createSampler({
+  label: '\u0f71\u9404\u{1fa5e}\u371d\uff88\u203c\uf96e\u5bb4\u0927',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+});
+try {
+renderBundleEncoder74.setPipeline(pipeline87);
+} catch {}
+try {
+commandEncoder150.copyTextureToBuffer({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8636 */
+  offset: 8636,
+  buffer: buffer25,
+}, {width: 28, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder150.clearBuffer(buffer25, 217732, 35876);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer25, 15124, new Int16Array(46228), 27697, 624);
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+video21.width = 263;
+let videoFrame32 = new VideoFrame(video36, {timestamp: 0});
+document.body.prepend(canvas5);
+let renderBundleEncoder81 = device8.createRenderBundleEncoder({
+  label: '\uec21\ub293\ua84d\u06a4',
+  colorFormats: ['r32uint', 'rg16float', 'rgba32sint', 'rgba16sint', 'rg16sint', 'r8uint'],
+  depthReadOnly: true,
+});
+let promise43 = device8.queue.onSubmittedWorkDone();
+let bindGroupLayout41 = device3.createBindGroupLayout({
+  label: '\ucad0\ufd3e\u0a80\u2b06',
+  entries: [
+    {
+      binding: 107,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 1742, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder153 = device3.createCommandEncoder();
+let textureView187 = texture75.createView({label: '\uccf0\u1332', aspect: 'all', baseMipLevel: 4});
+let externalTexture92 = device3.importExternalTexture({source: video43});
+let pipeline106 = device3.createComputePipeline({
+  label: '\ub381\ubc6a\ucfe5\u{1f7db}\u39f4\u6deb\u615a\u291a\uac03\u1d70',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule28, entryPoint: 'compute0', constants: {}},
+});
+let promise44 = device3.createRenderPipelineAsync({
+  label: '\u4ca7\u{1f8e7}\ud7e9\u{1f6df}\ud8dc\u{1fab1}\u05ed',
+  layout: pipelineLayout9,
+  multisample: {mask: 0x20c18ab6},
+  fragment: {
+  module: shaderModule37,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 3848457614,
+    stencilWriteMask: 824694331,
+    depthBias: 1619507921,
+    depthBiasSlopeScale: 759.6963965218014,
+  },
+  vertex: {
+    module: shaderModule37,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 788, attributes: [{format: 'uint8x2', offset: 10, shaderLocation: 7}]},
+      {
+        arrayStride: 820,
+        attributes: [
+          {format: 'float16x4', offset: 312, shaderLocation: 14},
+          {format: 'uint16x2', offset: 8, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 34, shaderLocation: 12},
+          {format: 'float16x2', offset: 228, shaderLocation: 5},
+          {format: 'uint8x2', offset: 112, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 3036, stepMode: 'instance', attributes: []},
+      {arrayStride: 964, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 824, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'uint32x3', offset: 1392, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas36);
+let buffer33 = device8.createBuffer({
+  size: 498244,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let externalTexture93 = device8.importExternalTexture({label: '\ubb4d\u0787\u{1fbc0}\u8ece\u0d4d', source: videoFrame1, colorSpace: 'srgb'});
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+document.body.prepend(img31);
+try {
+gpuCanvasContext44.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame33 = new VideoFrame(canvas14, {timestamp: 0});
+try {
+  await promise43;
+} catch {}
+document.body.prepend(img19);
+let texture107 = device8.createTexture({
+  size: {width: 813, height: 20, depthOrArrayLayers: 171},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView188 = texture107.createView({label: '\ub897\ua142\u{1fca1}\ua8fa\u3d8a'});
+let renderBundleEncoder82 = device8.createRenderBundleEncoder({
+  label: '\u9013\u8a8a\u32c9\u06ae\u05bc',
+  colorFormats: ['r32uint', 'rg16float', 'rgba32sint', 'rgba16sint', 'rg16sint', 'r8uint'],
+  sampleCount: 1,
+});
+let sampler73 = device8.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 64.71,
+  lodMaxClamp: 72.07,
+  maxAnisotropy: 12,
+});
+let imageBitmap37 = await createImageBitmap(videoFrame25);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+canvas6.width = 6541;
+offscreenCanvas17.height = 991;
+try {
+adapter6.label = '\u2c8d\u8655\u3462\u0c93\uebbe\udcf0\u0ba7\u7c1e\ubfa9\u0554';
+} catch {}
+let commandEncoder154 = device3.createCommandEncoder({});
+let textureView189 = texture58.createView({label: '\u3079\u0f67\u09fb\u66a4\u0c8b\u70d2\u0165\u9c11\u95be', baseMipLevel: 1});
+let sampler74 = device3.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 35.91,
+  lodMaxClamp: 62.68,
+});
+try {
+computePassEncoder63.setBindGroup(6, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder77.setPipeline(pipeline79);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(6, buffer19, 0);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 897, y: 8, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 37, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(390, 279);
+try {
+offscreenCanvas37.getContext('webgl2');
+} catch {}
+let buffer34 = device4.createBuffer({
+  label: '\u4e19\u{1fc1c}\u0df7\ue321\u07c9\u8a48\u{1ffc1}\uea23\u{1f9c1}\u{1f9c1}\ud418',
+  size: 464306,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder155 = device4.createCommandEncoder({label: '\u{1f624}\ue103\u{1fcc1}\ua398\u08e7\u0dad\u626f\u060d\u9a22'});
+let textureView190 = texture48.createView({label: '\u0d27\u{1ff09}\u{1f95f}\u0cc6', baseMipLevel: 1});
+let computePassEncoder66 = commandEncoder155.beginComputePass({label: '\u0899\u088b\ub793\u0e29\u08d8\u{1fc8c}\u{1f7d3}\u{1fc64}\u{1fc33}\u04ae\u0f13'});
+try {
+renderPassEncoder7.setStencilReference(1869);
+} catch {}
+try {
+renderPassEncoder0.setViewport(382.0, 0.2607, 44.05, 0.02644, 0.4797, 0.5299);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 982819114);
+} catch {}
+try {
+renderBundleEncoder80.setBindGroup(1, bindGroup23, new Uint32Array(746), 418, 0);
+} catch {}
+try {
+renderBundleEncoder64.draw(183506764);
+} catch {}
+try {
+renderBundleEncoder64.drawIndexed(281537714, 652121533);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 129612);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 7896);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(9980, undefined, 0, 1086064394);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 50812, new Int16Array(5712), 5109, 36);
+} catch {}
+let pipeline107 = device4.createComputePipeline({
+  label: '\u058b\u9972\u02eb\u{1fe30}',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let canvas48 = document.createElement('canvas');
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let querySet93 = device3.createQuerySet({label: '\udc41\u7be1\u641f\u{1fb61}\uc40a', type: 'occlusion', count: 3805});
+let textureView191 = texture43.createView({label: '\u88c7\u040e\u0856\u0309\u697c\u{1f6bb}\u9084\ua541', arrayLayerCount: 1});
+let externalTexture94 = device3.importExternalTexture({label: '\u0230\ue86e\u0622', source: video29, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder79.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder79.setPipeline(pipeline79);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(10, buffer19);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 750, y: 7, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 102, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 167, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 933 */
+{offset: 933, bytesPerRow: 936}, {width: 166, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let video45 = await videoWithData();
+let renderBundleEncoder83 = device6.createRenderBundleEncoder({
+  label: '\u0e8c\u0e9c\u{1fd30}\u00fa\u{1f870}\u8196\ua705\u037c',
+  colorFormats: ['r8unorm', 'r32sint', 'rgba8unorm', 'rgba16uint', 'rgb10a2unorm'],
+});
+try {
+commandEncoder150.copyBufferToBuffer(buffer31, 311080, buffer25, 251896, 1528);
+dissociateBuffer(device6, buffer31);
+dissociateBuffer(device6, buffer25);
+} catch {}
+let commandBuffer39 = commandEncoder149.finish({label: '\u5497\u9ba8\u{1f719}\u8c3a\u{1fd07}\u5cad\u1c65'});
+let textureView192 = texture82.createView({label: '\u0281\u{1fec6}', mipLevelCount: 1});
+let externalTexture95 = device6.importExternalTexture({
+  label: '\u0503\u{1f9f2}\u210e\u{1fb86}\u{1fa83}\u4b67\u657e',
+  source: videoFrame30,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder75.insertDebugMarker('\u89e3');
+} catch {}
+let video46 = await videoWithData();
+let videoFrame34 = new VideoFrame(canvas25, {timestamp: 0});
+try {
+window.someLabel = externalTexture88.label;
+} catch {}
+let querySet94 = device7.createQuerySet({type: 'occlusion', count: 1820});
+let sampler75 = device7.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 47.68,
+  lodMaxClamp: 51.54,
+});
+let externalTexture96 = device7.importExternalTexture({source: video8, colorSpace: 'srgb'});
+let commandEncoder156 = device7.createCommandEncoder({});
+let commandBuffer40 = commandEncoder147.finish({label: '\u3b31\u66f5\u032a\u{1f616}\u{1fa3c}'});
+let texture108 = device7.createTexture({
+  label: '\u030d\u54b2\u3c8c',
+  size: {width: 720, height: 192, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let textureView193 = texture108.createView({label: '\u029b\uc9ff\u0d52\uf857\u0c94\u{1fe5f}\u0c96\u0b66\u{1ff18}', baseMipLevel: 0});
+let renderBundleEncoder84 = device7.createRenderBundleEncoder({
+  label: '\u{1f672}\u33d2\u{1f8b1}',
+  colorFormats: ['rgb10a2unorm', 'rgba16sint', 'rg8uint', 'rg8sint', 'r16float'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder84.setVertexBuffer(8862, undefined, 0, 1913107470);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 111},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 369511 */
+{offset: 743, bytesPerRow: 172, rowsPerImage: 268}, {width: 5, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let promise45 = device7.queue.onSubmittedWorkDone();
+try {
+  await promise45;
+} catch {}
+let bindGroupLayout42 = device4.createBindGroupLayout({
+  label: '\u821d\u89a2\u{1fdc3}\uc20c\u0e6d\ud6e8\u{1fb8a}\u{1f914}',
+  entries: [
+    {
+      binding: 6043,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 5037,
+      visibility: 0,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup28 = device4.createBindGroup({layout: bindGroupLayout22, entries: [{binding: 6601, resource: textureView132}]});
+let texture109 = device4.createTexture({
+  label: '\u4f74\ua752\u{1ffa4}',
+  size: [240],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView194 = texture53.createView({label: '\u0896\u37a6\u9754\ub74a\u{1ff88}\u0bb5', dimension: '1d'});
+let renderBundleEncoder85 = device4.createRenderBundleEncoder({
+  label: '\u2578\u{1fba6}\uaa0c\u0c57\u0a6f\uf50b\u{1fe67}\u7c30\u{1f7d4}',
+  colorFormats: ['rgba8uint'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(2482);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.draw(280356789, 604874312, 652013610, 115483396);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(993, undefined, 0, 59006648);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexed(16030835);
+} catch {}
+try {
+renderBundleEncoder57.drawIndexedIndirect(buffer15, 15488);
+} catch {}
+let promise46 = buffer32.mapAsync(GPUMapMode.READ, 155280, 259032);
+try {
+device4.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 284807 */
+{offset: 887, bytesPerRow: 52, rowsPerImage: 195}, {width: 12, height: 0, depthOrArrayLayers: 29});
+} catch {}
+let imageData40 = new ImageData(84, 160);
+let shaderModule41 = device6.createShaderModule({
+  code: `@group(1) @binding(382)
+var<storage, read_write> local33: array<u32>;
+@group(0) @binding(382)
+var<storage, read_write> field29: array<u32>;
+@group(1) @binding(823)
+var<storage, read_write> n24: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(0) f2: vec3<f32>,
+  @location(2) f3: vec4<f32>,
+  @location(1) f4: i32,
+  @location(7) f5: vec4<u32>,
+  @location(4) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S33 {
+  @location(2) f0: vec2<f16>,
+  @location(5) f1: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: u32, a1: S33, @location(6) a2: f32, @builtin(vertex_index) a3: u32, @location(15) a4: i32, @location(10) a5: vec2<i32>, @location(14) a6: vec3<f32>, @location(9) a7: vec3<i32>, @location(3) a8: vec2<i32>, @location(0) a9: i32, @location(11) a10: vec2<f32>, @location(1) a11: vec4<u32>, @location(12) a12: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder157 = device6.createCommandEncoder({label: '\u039a\u00ad\ufebc'});
+let textureView195 = texture83.createView({label: '\u{1fbd7}\u01e3', baseMipLevel: 1});
+try {
+renderBundleEncoder74.setIndexBuffer(buffer28, 'uint32', 369724, 4425);
+} catch {}
+try {
+renderBundleEncoder73.setPipeline(pipeline74);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 3434 */
+{offset: 982}, {width: 613, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline108 = await device6.createRenderPipelineAsync({
+  label: '\u0227\u675d\u{1ff09}',
+  layout: pipelineLayout16,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 4115662274,
+    stencilWriteMask: 79131716,
+    depthBias: 333109210,
+    depthBiasSlopeScale: 9.599960961172997,
+  },
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 208, shaderLocation: 11},
+          {format: 'sint32x2', offset: 168, shaderLocation: 0},
+          {format: 'uint32x3', offset: 124, shaderLocation: 10},
+          {format: 'sint32', offset: 76, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(796, 301);
+let pipelineLayout20 = device4.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder158 = device4.createCommandEncoder({label: '\ua7ba\u{1fd18}\ua96a\ucae7\u{1fa66}\u{1fc4c}\u01f8\u63d9\u{1f7f3}'});
+let renderPassEncoder10 = commandEncoder158.beginRenderPass({
+  colorAttachments: [{
+  view: textureView169,
+  depthSlice: 2,
+  clearValue: { r: 344.2, g: 244.7, b: -329.1, a: 811.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet71,
+  maxDrawCount: 1225069781,
+});
+let externalTexture97 = device4.importExternalTexture({
+  label: '\u{1fde1}\ud594\u2b4c\uce38\u29bc\u533c\u085e\u47f9\u01e9',
+  source: video19,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(37, 0, 35, 1);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexed(780466453, 517668559, 319810122, -174398557, 368687466);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer15, 66100);
+} catch {}
+let device9 = await adapter8.requestDevice({
+  label: '\u08bd\u1c94\ud5b2\u0be7\u0705\uc145\u0fec',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 39,
+    maxVertexAttributes: 27,
+    maxVertexBufferArrayStride: 52435,
+    maxStorageTexturesPerShaderStage: 6,
+    maxStorageBuffersPerShaderStage: 37,
+    maxDynamicStorageBuffersPerPipelineLayout: 55809,
+    maxDynamicUniformBuffersPerPipelineLayout: 22044,
+    maxBindingsPerBindGroup: 8570,
+    maxTextureArrayLayers: 1839,
+    maxTextureDimension1D: 14809,
+    maxTextureDimension2D: 12696,
+    maxVertexBuffers: 10,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 91553748,
+    maxUniformBuffersPerShaderStage: 31,
+    maxSampledTexturesPerShaderStage: 22,
+    maxInterStageShaderVariables: 17,
+    maxInterStageShaderComponents: 87,
+  },
+});
+let img33 = await imageWithData(282, 175, '#147954bb', '#2060419d');
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+let imageBitmap38 = await createImageBitmap(imageData13);
+let texture110 = device9.createTexture({
+  label: '\u042b\u0b53\u8c97\u0ac1\u4194\u529f',
+  size: [4320, 160, 1],
+  mipLevelCount: 12,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+device9.addEventListener('uncapturederror', e => { log('device9.uncapturederror'); log(e); e.label = device9.label; });
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroup29 = device4.createBindGroup({layout: bindGroupLayout40, entries: [{binding: 743, resource: externalTexture78}]});
+let commandEncoder159 = device4.createCommandEncoder({label: '\u08dd\ua1ee\u{1f716}\u2bb6\ud815\u4d24\u91b7'});
+let textureView196 = texture106.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 952});
+let renderPassEncoder11 = commandEncoder159.beginRenderPass({
+  label: '\u{1fdbf}\uc673\u{1f799}\u{1fa78}\u0596\u0256\u0cee\u0e8c\u678a',
+  colorAttachments: [{
+  view: textureView169,
+  depthSlice: 6,
+  clearValue: { r: 233.6, g: -448.8, b: -256.4, a: 894.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet82,
+  maxDrawCount: 417547259,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup29, new Uint32Array(7246), 1450, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(381);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(379, 1, 33, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(577454462, 829301717, 602988274, 86010092);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(648149887);
+} catch {}
+try {
+renderBundleEncoder64.draw(11568244, 970903343, 537733341, 1025205107);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(canvas37);
+gc();
+try {
+canvas48.getContext('2d');
+} catch {}
+let bindGroupLayout43 = device7.createBindGroupLayout({
+  label: '\u{1fc9f}\u6d8b\u6b9c\u6929\u64e2\u062c\u1650\u03fa\u{1fa35}\u4033',
+  entries: [
+    {binding: 977, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 970,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let pipelineLayout21 = device7.createPipelineLayout({
+  label: '\uf837\u{1fa41}\uc6ba\u6313\u1484\u0c0c\u{1fd03}\u{1f61d}\uc39b\u0f06',
+  bindGroupLayouts: [bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43],
+});
+let querySet95 = device7.createQuerySet({
+  label: '\u2b46\uc12a\u8f36\u435b\u44d7\ucc98\u4823\u7c9d\u0f8c\u0157\u058e',
+  type: 'occlusion',
+  count: 124,
+});
+let computePassEncoder67 = commandEncoder145.beginComputePass();
+let sampler76 = device7.createSampler({addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 83.29, lodMaxClamp: 85.01});
+let texture111 = device8.createTexture({
+  label: '\u0db8\u{1ffd0}\u0246\u{1fc9a}\u{1fbc8}\ua563\u1eb7\u060b\u830e\u03bf',
+  size: {width: 813, height: 20, depthOrArrayLayers: 638},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16sint'],
+});
+let textureView197 = texture107.createView({label: '\u7312\udfc1\ub774\ubb96\u279f\u0b1a\u{1f76b}\u{1fd63}', baseMipLevel: 0, arrayLayerCount: 1});
+let imageData41 = new ImageData(8, 248);
+let canvas49 = document.createElement('canvas');
+try {
+renderBundleEncoder81.insertDebugMarker('\u3014');
+} catch {}
+canvas6.width = 739;
+try {
+offscreenCanvas38.getContext('webgpu');
+} catch {}
+let textureView198 = texture92.createView({});
+let externalTexture98 = device6.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+renderBundleEncoder69.setIndexBuffer(buffer28, 'uint16', 110206, 70777);
+} catch {}
+let pipeline109 = await device6.createRenderPipelineAsync({
+  label: '\u561c\u06c7\u0acc\u0a13\u062d\u9d20',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule41,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 3289015024,
+    stencilWriteMask: 3271939488,
+    depthBias: 1715214207,
+    depthBiasSlopeScale: 885.4993192108774,
+  },
+  vertex: {
+    module: shaderModule41,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 36, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 68, shaderLocation: 5},
+          {format: 'uint8x2', offset: 18, shaderLocation: 1},
+          {format: 'sint32x2', offset: 40, shaderLocation: 0},
+          {format: 'float32x2', offset: 24, shaderLocation: 2},
+          {format: 'sint8x4', offset: 20, shaderLocation: 3},
+          {format: 'sint32', offset: 12, shaderLocation: 15},
+          {format: 'float16x2', offset: 24, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 6},
+          {format: 'sint8x4', offset: 4, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 16, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 328,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x2', offset: 48, shaderLocation: 14},
+          {format: 'uint8x2', offset: 56, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'none'},
+});
+try {
+  await promise46;
+} catch {}
+let canvas50 = document.createElement('canvas');
+let buffer35 = device8.createBuffer({label: '\u95ec\ua305', size: 76667, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder160 = device8.createCommandEncoder({label: '\u0b78\u02dd\ude92\ud959\u8abd\u0b9e\u0ade\u01ab\u4ec8\u49a7'});
+let computePassEncoder68 = commandEncoder160.beginComputePass({label: '\u0003\u0524\u0c66\u67ff\u0124\uf1a4\u02dd\u{1f609}\u46ef'});
+let renderBundleEncoder86 = device8.createRenderBundleEncoder({
+  label: '\u4dbb\u0bf2\u{1f947}\u{1fb45}\ub864',
+  colorFormats: ['r32uint', 'rg16float', 'rgba32sint', 'rgba16sint', 'rg16sint', 'r8uint'],
+  depthReadOnly: true,
+});
+let sampler77 = device8.createSampler({
+  label: '\u0f92\ub81e\ua1a0\u22c6\u0927\u{1fb43}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 8.553,
+  lodMaxClamp: 22.80,
+});
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(6, buffer33, 0, 223075);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device8,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+canvas47.height = 3728;
+try {
+  await device9.queue.onSubmittedWorkDone();
+} catch {}
+try {
+canvas49.getContext('2d');
+} catch {}
+let gpuCanvasContext46 = canvas50.getContext('webgpu');
+let offscreenCanvas39 = new OffscreenCanvas(423, 95);
+try {
+offscreenCanvas39.getContext('webgl2');
+} catch {}
+let bindGroupLayout44 = device3.createBindGroupLayout({entries: [{binding: 1785, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }}]});
+let querySet96 = device3.createQuerySet({type: 'occlusion', count: 3261});
+let texture112 = device3.createTexture({
+  label: '\u{1fe3e}\u7a72\u22e2\u101f\u031b\uc241\u4ae1\u{1f8e8}\u038c\udc8d',
+  size: {width: 4544, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 10,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let externalTexture99 = device3.importExternalTexture({
+  label: '\u0f2f\u{1f6a6}\u31e2\u{1fa39}\u02f7\ueeea\u051f\u7c8e\u{1f781}\u1c93\u0933',
+  source: video25,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder47.setBindGroup(9, bindGroup21);
+} catch {}
+try {
+commandEncoder117.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 171, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 149}
+*/
+{
+  source: offscreenCanvas35,
+  origin: { x: 46, y: 85 },
+  flipY: true,
+}, {
+  texture: texture68,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img33);
+let offscreenCanvas40 = new OffscreenCanvas(1016, 778);
+let video47 = await videoWithData();
+let imageData42 = new ImageData(184, 176);
+try {
+adapter4.label = '\ua611\u03ca\u6778\u{1fdfd}\u{1fa27}\ufb6d';
+} catch {}
+let shaderModule42 = device6.createShaderModule({
+  label: '\u{1f778}\u9101\ue586\u6c89\uc9f0\u77b1\u73ff\u0388\u{1f6ae}\u{1fef4}',
+  code: `@group(1) @binding(823)
+var<storage, read_write> field30: array<u32>;
+@group(0) @binding(823)
+var<storage, read_write> function25: array<u32>;
+@group(1) @binding(382)
+var<storage, read_write> n25: array<u32>;
+
+@compute @workgroup_size(5, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(4) f1: vec4<f32>,
+  @location(0) f2: vec3<f32>,
+  @location(1) f3: vec4<i32>,
+  @location(3) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(13) a1: vec2<f32>, @builtin(sample_mask) a2: u32, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f424: vec4<f32>,
+  @location(13) f425: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f32>, @location(1) a1: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder161 = device6.createCommandEncoder({label: '\u{1fb16}\ua3aa\u{1f804}\u050d\u0828\ub4f0\u81b6\u65a3\u0ee2\u{1fafb}\u0c79'});
+let computePassEncoder69 = commandEncoder125.beginComputePass({label: '\u{1f774}\u4425\u{1feb5}'});
+let externalTexture100 = device6.importExternalTexture({label: '\u{1f9f8}\u{1f95a}\u7576\u{1feeb}\u07e3', source: video40, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder73.setPipeline(pipeline74);
+} catch {}
+try {
+commandEncoder161.copyBufferToBuffer(buffer31, 369896, buffer25, 251320, 1060);
+dissociateBuffer(device6, buffer31);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer25, 182404, 22552);
+dissociateBuffer(device6, buffer25);
+} catch {}
+gc();
+let gpuCanvasContext47 = offscreenCanvas40.getContext('webgpu');
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let imageData43 = new ImageData(92, 108);
+let bindGroupLayout45 = device3.createBindGroupLayout({
+  label: '\uca78\uc737\u9e91\u0bac\u0418\u2577\u0e91\u038f',
+  entries: [
+    {
+      binding: 1453,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 1038,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 226,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let textureView199 = texture88.createView({label: '\u{1f76b}\u{1ffad}\u{1f995}\u2751\uf52f', baseMipLevel: 1});
+let renderBundle93 = renderBundleEncoder79.finish({label: '\u{1f694}\u3a05'});
+let sampler78 = device3.createSampler({
+  label: '\u6f8d\u0ed2\uc932\uc919\u7da6\u{1fc41}\u01af\u40c4',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.60,
+  compare: 'less-equal',
+});
+try {
+renderBundleEncoder77.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas4.height = 1853;
+let canvas51 = document.createElement('canvas');
+let video48 = await videoWithData();
+let commandBuffer41 = commandEncoder118.finish();
+let textureView200 = texture91.createView({label: '\u{1fc87}\u2ef0\ud207\u0f01\u{1ff3e}\u050d'});
+try {
+computePassEncoder62.setPipeline(pipeline73);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline74);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer25, 68776, 83928);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+commandEncoder150.resolveQuerySet(querySet92, 1528, 650, buffer28, 234496);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer25, 87760, new DataView(new ArrayBuffer(58131)), 37790, 8512);
+} catch {}
+try {
+  await device6.queue.onSubmittedWorkDone();
+} catch {}
+let textureView201 = texture110.createView({label: '\ud2fa\u99d9', baseMipLevel: 7, mipLevelCount: 4, arrayLayerCount: 1});
+try {
+canvas51.getContext('webgl');
+} catch {}
+let commandEncoder162 = device3.createCommandEncoder({label: '\u01d1\ue627\u7e7e\u7f45\u{1f9b7}\u0055\u3694\u0945\u05d8\u01dc\u2c08'});
+let querySet97 = device3.createQuerySet({type: 'occlusion', count: 2953});
+try {
+renderBundleEncoder77.setBindGroup(5, bindGroup21, new Uint32Array(7684), 7520, 0);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline63);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(3, buffer19, 0, 149455);
+} catch {}
+try {
+commandEncoder116.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 73532 */
+  offset: 15420,
+  bytesPerRow: 256,
+  rowsPerImage: 227,
+  buffer: buffer26,
+}, {width: 18, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device3, buffer26);
+} catch {}
+try {
+device3.queue.submit([commandBuffer35]);
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(425, 407);
+let textureView202 = texture82.createView({label: '\u1bd0\u{1f754}\ua052', baseMipLevel: 3, mipLevelCount: 1});
+try {
+renderBundleEncoder75.setVertexBuffer(87, undefined, 0);
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer25, 232812, 3164);
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer25, 97832, new BigUint64Array(48530), 17433, 200);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap19,
+  origin: { x: 269, y: 64 },
+  flipY: true,
+}, {
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline110 = device6.createRenderPipeline({
+  label: '\u0cb0\u01ea\u363e\u0352',
+  layout: pipelineLayout16,
+  multisample: {},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 2720762155,
+    stencilWriteMask: 108288786,
+    depthBias: 0,
+    depthBiasSlopeScale: 866.5744838900579,
+  },
+  vertex: {
+    module: shaderModule42,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 744, attributes: [{format: 'unorm16x4', offset: 40, shaderLocation: 1}]},
+      {arrayStride: 164, stepMode: 'instance', attributes: []},
+      {arrayStride: 40, attributes: [{format: 'float16x2', offset: 8, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+let querySet98 = device7.createQuerySet({label: '\ua950\ua43b\u0aa4\u8ff4\u{1fa33}\u1e67\u{1f9aa}\ufa7a', type: 'occlusion', count: 3291});
+let renderBundleEncoder87 = device7.createRenderBundleEncoder({
+  label: '\u0b90\u55c8\u087f',
+  colorFormats: ['rgb10a2unorm', 'rgba16sint', 'rg8uint', 'rg8sint', 'r16float'],
+});
+let sampler79 = device7.createSampler({
+  label: '\uafa2\u046f\u9beb\u5080\u46e9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 67.51,
+  lodMaxClamp: 79.33,
+});
+try {
+renderBundleEncoder87.setVertexBuffer(6547, undefined, 1295777536);
+} catch {}
+let gpuCanvasContext48 = offscreenCanvas41.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(732, 75);
+let bindGroup30 = device3.createBindGroup({layout: bindGroupLayout44, entries: [{binding: 1785, resource: sampler78}]});
+let commandEncoder163 = device3.createCommandEncoder({label: '\u{1f78d}\u{1fea8}\ub865\u21be\uf07a\u348a\u3fc5\u{1f826}\u0e59\u92cd\u1b50'});
+let renderBundleEncoder88 = device3.createRenderBundleEncoder({
+  label: '\u{1fa04}\u{1f6bd}\u218e\u0775\ub1d2\u91e4',
+  colorFormats: ['rg16sint', 'rg32sint', 'rg8unorm', 'rgba8sint'],
+  depthReadOnly: false,
+});
+let externalTexture101 = device3.importExternalTexture({source: videoFrame8, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder51.setIndexBuffer(buffer14, 'uint16', 647590, 54572);
+} catch {}
+try {
+renderBundleEncoder88.setVertexBuffer(3, buffer19, 95440);
+} catch {}
+try {
+commandEncoder163.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 404, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder136.resolveQuerySet(querySet65, 2266, 38, buffer27, 283136);
+} catch {}
+let bindGroupLayout46 = device9.createBindGroupLayout({
+  label: '\u615a\u0037\u{1f759}\u0f0b\u0e39\u0241\u4773',
+  entries: [
+    {
+      binding: 123,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 406208, hasDynamicOffset: true },
+    },
+    {binding: 152, visibility: 0, externalTexture: {}},
+    {
+      binding: 5017,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let commandEncoder164 = device9.createCommandEncoder({label: '\ufab3\u155b\u09c3\u{1f687}\u05ae\ue84a\u308e\u05e4\u081a\u1710\u6881'});
+let querySet99 = device9.createQuerySet({
+  label: '\u2743\u05d8\u0a08\uab4b\u2141\u{1ff2f}\u604d\u0a39\u3371\ua5b9\u5a6c',
+  type: 'occlusion',
+  count: 331,
+});
+let texture113 = device9.createTexture({
+  size: [1080, 40, 1],
+  mipLevelCount: 8,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let externalTexture102 = device9.importExternalTexture({source: videoFrame32, colorSpace: 'display-p3'});
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 5,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer5), /* required buffer size: 396 */
+{offset: 396}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let img34 = await imageWithData(127, 235, '#0ee8d608', '#5ff7b882');
+let gpuCanvasContext49 = offscreenCanvas42.getContext('webgpu');
+let shaderModule43 = device7.createShaderModule({
+  label: '\ubdeb\uc120\u{1fbc8}\ue7be\ue0fc\ud52e',
+  code: `@group(3) @binding(977)
+var<storage, read_write> parameter28: array<u32>;
+@group(3) @binding(970)
+var<storage, read_write> n26: array<u32>;
+@group(1) @binding(977)
+var<storage, read_write> local34: array<u32>;
+@group(0) @binding(977)
+var<storage, read_write> type28: array<u32>;
+@group(1) @binding(970)
+var<storage, read_write> function26: array<u32>;
+@group(2) @binding(970)
+var<storage, read_write> type29: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(1) f1: vec4<i32>,
+  @location(3) f2: vec2<i32>,
+  @location(0) f3: vec4<f32>,
+  @location(4) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(6) a0: vec2<u32>, @location(9) a1: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f426: vec4<f32>,
+  @location(13) f427: vec4<f16>,
+  @location(14) f428: vec3<u32>,
+  @location(6) f429: vec2<u32>,
+  @location(9) f430: vec3<f32>,
+  @location(4) f431: vec4<u32>,
+  @location(5) f432: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f32>, @location(6) a1: u32, @location(8) a2: vec2<f16>, @location(7) a3: vec3<f16>, @location(12) a4: vec3<i32>, @location(13) a5: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let computePassEncoder70 = commandEncoder156.beginComputePass();
+let sampler80 = device7.createSampler({
+  label: '\u009d\u7ee7\u5cd5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 25.86,
+});
+try {
+gpuCanvasContext30.configure({
+  device: device7,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 69, y: 7, z: 0},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 320097 */
+{offset: 649, bytesPerRow: 2478}, {width: 566, height: 129, depthOrArrayLayers: 1});
+} catch {}
+let pipeline111 = device7.createComputePipeline({
+  label: '\u0091\u0375\u{1fc28}',
+  layout: 'auto',
+  compute: {module: shaderModule43, entryPoint: 'compute0'},
+});
+let pipeline112 = await device7.createRenderPipelineAsync({
+  label: '\ud16c\ub36b\u{1f785}\u8e4b\u960e\u0d5c\u8032\uabd8\u8a45\udec0',
+  layout: pipelineLayout21,
+  multisample: {},
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-src'},
+  },
+}, {format: 'rgba16sint', writeMask: 0}, {format: 'rg8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'constant'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {failOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 4247049698,
+    stencilWriteMask: 569439481,
+    depthBias: 617093652,
+    depthBiasClamp: 203.42396258947355,
+  },
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 252,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 56, shaderLocation: 6},
+          {format: 'float32x2', offset: 64, shaderLocation: 7},
+          {format: 'sint32', offset: 24, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 356, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 180,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 8, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 1180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 40, shaderLocation: 8},
+          {format: 'sint8x2', offset: 674, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let querySet100 = device9.createQuerySet({
+  label: '\u4210\u4e2b\u018e\u{1f69f}\u{1fb1c}\uaa60\u39ed\uf27c\u{1f7e4}',
+  type: 'occlusion',
+  count: 3027,
+});
+let textureView203 = texture110.createView({label: '\u08ff\u524e\u{1f904}\u9bf2\u04b6\u1498', format: 'rg8uint', baseMipLevel: 11});
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 9,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 549, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device9.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup31 = device4.createBindGroup({layout: bindGroupLayout32, entries: []});
+let commandEncoder165 = device4.createCommandEncoder({});
+let textureView204 = texture72.createView({label: '\u2ce1\ud30e\u26e7\u0eb6\u0f6d'});
+try {
+computePassEncoder32.setBindGroup(4, bindGroup26);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(2799);
+} catch {}
+try {
+renderPassEncoder7.draw(118177308, 934135015, 326387321, 293017850);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(229470223, 966925860);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer18, 1190475266);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder64.draw(373488960, 403808887, 100626835);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexed(1036878038);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 15480);
+} catch {}
+try {
+renderBundleEncoder71.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder165.copyBufferToBuffer(buffer22, 636, buffer32, 144840, 12440);
+dissociateBuffer(device4, buffer22);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+commandEncoder165.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36744 */
+  offset: 36744,
+  bytesPerRow: 0,
+  rowsPerImage: 61,
+  buffer: buffer15,
+}, {
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 8, y: 6, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 848});
+dissociateBuffer(device4, buffer15);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 598 */
+{offset: 598, bytesPerRow: 571}, {width: 73, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline113 = device4.createRenderPipeline({
+  label: '\u6002\u{1f9ee}\u032e\u0585\u08e5\u{1ff57}',
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule39,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 54656,
+        attributes: [
+          {format: 'float32', offset: 17380, shaderLocation: 16},
+          {format: 'sint32', offset: 2624, shaderLocation: 5},
+          {format: 'sint8x2', offset: 4912, shaderLocation: 7},
+          {format: 'float32', offset: 6724, shaderLocation: 14},
+          {format: 'sint16x2', offset: 7744, shaderLocation: 12},
+          {format: 'sint8x2', offset: 4012, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 4700, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 3956, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 13804, shaderLocation: 19},
+          {format: 'float32x2', offset: 22100, shaderLocation: 9},
+          {format: 'uint32x3', offset: 16940, shaderLocation: 2},
+          {format: 'sint32', offset: 29060, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: false,
+},
+});
+let bindGroup32 = device4.createBindGroup({layout: bindGroupLayout23, entries: [{binding: 1741, resource: sampler42}]});
+let textureView205 = texture90.createView({label: '\u2809\u00c6', baseMipLevel: 1, mipLevelCount: 5});
+let renderPassEncoder12 = commandEncoder165.beginRenderPass({
+  colorAttachments: [{
+  view: textureView190,
+  depthSlice: 50,
+  clearValue: { r: 343.0, g: -49.72, b: 789.3, a: -62.16, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet83,
+  maxDrawCount: 816121766,
+});
+try {
+computePassEncoder66.setPipeline(pipeline105);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(2671);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(1887);
+} catch {}
+try {
+renderPassEncoder0.draw(553273638, 1155427752, 1038716165, 479707712);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer15, 713438771);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder85.setBindGroup(4, bindGroup23, new Uint32Array(2248), 388, 0);
+} catch {}
+try {
+renderBundleEncoder57.draw(555670776, 850156681, 95727382, 1012628452);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer15, 42280);
+} catch {}
+let pipeline114 = await device4.createComputePipelineAsync({
+  label: '\u6c12\u0753\uf837',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas0.width = 1556;
+let offscreenCanvas43 = new OffscreenCanvas(246, 86);
+let renderBundle94 = renderBundleEncoder84.finish({});
+let externalTexture103 = device7.importExternalTexture({label: '\uc5b7\uea5d\u7514\u7d79', source: video1, colorSpace: 'display-p3'});
+let gpuCanvasContext50 = offscreenCanvas43.getContext('webgpu');
+let bindGroupLayout47 = device3.createBindGroupLayout({
+  label: '\uc17e\ufc53\u0003',
+  entries: [
+    {
+      binding: 1661,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 1433,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroupLayout48 = pipeline56.getBindGroupLayout(2);
+let texture114 = device3.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let textureView206 = texture62.createView({baseArrayLayer: 0});
+let computePassEncoder71 = commandEncoder136.beginComputePass({label: '\u006f\u07b2\u2df4\u05d7\u{1ff28}\u63a6\u0f73\u0e66\u03a4\u01d8\u3f34'});
+let renderBundleEncoder89 = device3.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle95 = renderBundleEncoder89.finish({label: '\uc772\u243a\u07b5\u0b33'});
+try {
+renderBundleEncoder51.setVertexBuffer(5, buffer19, 127024, 61965);
+} catch {}
+let pipeline115 = device3.createComputePipeline({
+  label: '\u56a2\u096a\u8bb3\u4eb1\u0adc\u00b1',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule20, entryPoint: 'compute0'},
+});
+let video49 = await videoWithData();
+let imageBitmap39 = await createImageBitmap(imageBitmap16);
+let pipelineLayout22 = device9.createPipelineLayout({
+  label: '\ue44b\u{1fd2d}\u{1ff87}',
+  bindGroupLayouts: [bindGroupLayout46, bindGroupLayout46, bindGroupLayout46],
+});
+let commandEncoder166 = device9.createCommandEncoder({label: '\u{1f996}\uc88a\u04cf'});
+let textureView207 = texture113.createView({label: '\u07b2\u0dd4', baseMipLevel: 4, mipLevelCount: 2});
+let computePassEncoder72 = commandEncoder164.beginComputePass({label: '\u0b68\u0462\u8ca0\u575d\u{1fd85}\u{1fd4c}\u008a'});
+let renderBundleEncoder90 = device9.createRenderBundleEncoder({
+  label: '\u500a\u7b46\u9275\u{1f663}\u4fdc\u{1fdc8}\uce99\u0657',
+  colorFormats: ['r16float', 'rgba16float', 'bgra8unorm', 'r8unorm', 'r16sint'],
+  sampleCount: 4,
+});
+let sampler81 = device9.createSampler({
+  label: '\u3144\u{1fa27}\ue6bb\u08f8\u2982\u{1fdee}\u037e\ud97d\udb00\u0faa\u0b4c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 36.79,
+  lodMaxClamp: 89.27,
+});
+try {
+device9.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 2,
+  origin: {x: 240, y: 5, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(31848), /* required buffer size: 31848 */
+{offset: 532, bytesPerRow: 901}, {width: 341, height: 35, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext48.unconfigure();
+} catch {}
+let commandEncoder167 = device3.createCommandEncoder({label: '\u3c00\u{1fa81}\u8a14\u813c\u35fb\u7267\u0e49\uc7ac\u240d\u{1ffb9}'});
+let textureView208 = texture40.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle96 = renderBundleEncoder55.finish({label: '\u4d7b\u068b'});
+try {
+computePassEncoder47.setBindGroup(5, bindGroup21, new Uint32Array(4057), 1341, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline43);
+} catch {}
+try {
+gpuCanvasContext38.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(494), /* required buffer size: 494 */
+{offset: 494}, {width: 160, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData44 = new ImageData(80, 232);
+let textureView209 = texture72.createView({label: '\u3b89\u07a9\u{1f969}\u027b\u02b3\u{1ff5b}\u47a7\u06f7', baseArrayLayer: 0});
+let externalTexture104 = device4.importExternalTexture({label: '\ua2c7\u0399\u364a', source: videoFrame4});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 776.8, g: -45.16, b: -163.3, a: 759.0, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(408.2, 0.8236, 39.23, 0.01892, 0.4395, 0.8657);
+} catch {}
+try {
+renderPassEncoder7.draw(662199600, 382450441, 1073334246, 590293762);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer22, 828696543);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder57.drawIndirect(buffer15, 12924);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 8},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer5), /* required buffer size: 1400043 */
+{offset: 29, bytesPerRow: 146, rowsPerImage: 93}, {width: 5, height: 11, depthOrArrayLayers: 104});
+} catch {}
+let pipeline116 = await device4.createComputePipelineAsync({layout: pipelineLayout20, compute: {module: shaderModule38, entryPoint: 'compute0', constants: {}}});
+let pipeline117 = await device4.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule12, entryPoint: 'vertex0', buffers: []},
+  primitive: {},
+});
+let textureView210 = texture108.createView({
+  label: '\u{1f693}\u7300\uf2fd\ue698\u{1fee2}\u{1fe99}\u00aa\ufd3f\u9c7e\u430d\u8c14',
+  dimension: '2d-array',
+  arrayLayerCount: 1,
+});
+let canvas52 = document.createElement('canvas');
+try {
+canvas52.getContext('2d');
+} catch {}
+let canvas53 = document.createElement('canvas');
+let querySet101 = device3.createQuerySet({label: '\u6e44\u0488\u4a02\u{1f9ce}', type: 'occlusion', count: 1210});
+try {
+computePassEncoder57.dispatchWorkgroups(2, 3, 5);
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 240, height: 2, depthOrArrayLayers: 299}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 7, y: 4 },
+  flipY: true,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 129},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline118 = await device3.createRenderPipelineAsync({
+  label: '\u0c53\uce78\u1a49\u49fe\u4716\u23ff\u4641\u2a18\u04c0\u8079',
+  layout: pipelineLayout8,
+  multisample: {mask: 0x909f064a},
+  fragment: {
+  module: shaderModule37,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 3445641064,
+    stencilWriteMask: 429176527,
+    depthBias: -2014854892,
+    depthBiasSlopeScale: 258.6462707952104,
+  },
+  vertex: {
+    module: shaderModule37,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 0, attributes: [{format: 'uint16x4', offset: 648, shaderLocation: 7}]},
+      {arrayStride: 296, stepMode: 'instance', attributes: []},
+      {arrayStride: 852, attributes: [{format: 'unorm16x2', offset: 16, shaderLocation: 14}]},
+      {
+        arrayStride: 1968,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 656, shaderLocation: 2},
+          {format: 'float16x4', offset: 1960, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 1152, stepMode: 'instance', attributes: []},
+      {arrayStride: 592, stepMode: 'instance', attributes: []},
+      {arrayStride: 364, attributes: []},
+      {
+        arrayStride: 1360,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 180, shaderLocation: 9},
+          {format: 'uint16x2', offset: 832, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 1864, attributes: [{format: 'float32', offset: 844, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let buffer36 = device6.createBuffer({
+  label: '\u0daa\uaaa6\uf1d7\ud1c9\u277c\u{1fa47}\uc763\u{1f9cf}\u57ca\u5c7c',
+  size: 103396,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let texture115 = device6.createTexture({
+  label: '\u0958\u0c69',
+  size: [360, 1, 15],
+  mipLevelCount: 5,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView211 = texture92.createView({label: '\u348c\ub020\u{1ffb9}\u{1ff0d}\uf51a\u{1fc2c}\u23a1', dimension: '1d'});
+let renderBundle97 = renderBundleEncoder60.finish({label: '\u7353\u{1fd8d}\u535f\u406a'});
+let sampler82 = device6.createSampler({
+  label: '\u{1f70b}\ua1b0\u05c1\u4bd9\u{1fa2e}\ub253\u07af\u038f\u6ae2\u8ee5\u6b0a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 75.06,
+  lodMaxClamp: 91.70,
+});
+let externalTexture105 = device6.importExternalTexture({
+  label: '\u0476\u0b59\u{1f785}\u1de5\u6710\u09fd\u{1fe77}\uaf83',
+  source: videoFrame25,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+commandEncoder157.insertDebugMarker('\u1e86');
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageData45 = new ImageData(100, 36);
+let video50 = await videoWithData();
+let buffer37 = device4.createBuffer({size: 417235, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let texture116 = device4.createTexture({
+  label: '\u{1faaf}\u0716\uc648\u0553\u334f\u945b\u{1face}',
+  size: {width: 192, height: 96, depthOrArrayLayers: 1028},
+  mipLevelCount: 8,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let sampler83 = device4.createSampler({
+  label: '\uc6d4\u{1ff98}\u0683',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.53,
+  compare: 'less-equal',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder7.setBlendConstant({ r: 817.9, g: 29.36, b: 441.2, a: 891.8, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(2971);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer15, 224);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+let commandEncoder168 = device7.createCommandEncoder();
+let textureView212 = texture108.createView({label: '\u051d\ub63f', dimension: '2d-array', aspect: 'all', baseMipLevel: 0});
+let computePassEncoder73 = commandEncoder168.beginComputePass({label: '\uda2a\u737d\u00b4\u{1f9d6}\u0d4f\u{1ff1d}\u048e\u{1f73c}\u33fb'});
+let externalTexture106 = device7.importExternalTexture({
+  label: '\udf6b\u{1fa9a}\u{1fdb4}\uee92\u035e\u6a89\u{1fa35}',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+device7.queue.copyExternalImageToTexture(/*
+{width: 720, height: 192, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas26,
+  origin: { x: 212, y: 377 },
+  flipY: false,
+}, {
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 211, y: 74, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 94, height: 55, depthOrArrayLayers: 0});
+} catch {}
+let canvas54 = document.createElement('canvas');
+let imageBitmap40 = await createImageBitmap(video20);
+try {
+canvas53.getContext('webgpu');
+} catch {}
+gc();
+let querySet102 = device9.createQuerySet({
+  label: '\u0c16\u02e5\u0448\u{1fd8b}\u0a0e\ud29c\u{1f949}\u51d1\u4e01\u617a\u{1f8b4}',
+  type: 'occlusion',
+  count: 1845,
+});
+let commandBuffer42 = commandEncoder166.finish({label: '\u0f7f\u2f76\u{1fc07}'});
+let textureView213 = texture113.createView({
+  label: '\ua907\u2c27\u{1f640}\u0ac5\u{1fc07}\u0f70\u{1fbe1}\u803f\u{1ff6a}\u9f4d',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundle98 = renderBundleEncoder90.finish();
+let promise47 = device9.queue.onSubmittedWorkDone();
+try {
+canvas54.getContext('webgl2');
+} catch {}
+let texture117 = device0.createTexture({
+  size: [1024, 40, 223],
+  mipLevelCount: 10,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm-srgb'],
+});
+let textureView214 = texture0.createView({
+  label: '\u418b\u{1fa8e}\u405c\u55d2\u0957\u78bf\u{1ffb2}\u12d3',
+  dimension: '2d',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 4,
+  baseArrayLayer: 95,
+});
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext46.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext45.unconfigure();
+} catch {}
+let imageBitmap41 = await createImageBitmap(canvas0);
+let promise48 = adapter2.requestAdapterInfo();
+offscreenCanvas11.width = 2294;
+let texture118 = device9.createTexture({
+  label: '\u{1fbdd}\u0826\u{1f97f}\u4059\u01a2\u51e7\u660f\ube42',
+  size: [1080, 40, 1],
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+});
+let textureView215 = texture110.createView({
+  label: '\u9ac5\u0627\u{1fc25}\u0a1a\u06ae\u544d\u{1ff3b}\u26d1\u{1f7d7}\ucefd\u{1ffd4}',
+  dimension: '2d-array',
+  format: 'rg8uint',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder169 = device9.createCommandEncoder({label: '\ud04a\u00c2\u73fd\u0f66\u{1ffd3}\u8d7c\u5b22'});
+let querySet103 = device9.createQuerySet({label: '\u70a2\u6ef9\u9d00\u0e86\udb58\u0344', type: 'occlusion', count: 3984});
+let textureView216 = texture118.createView({
+  label: '\ua70a\u136f\u80cf\uee23\ucc82\u{1f635}\u26c0',
+  format: 'rgba16float',
+  baseMipLevel: 1,
+  arrayLayerCount: 1,
+});
+try {
+device9.queue.submit([commandBuffer42]);
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 108 */
+{offset: 108}, {width: 49, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture22.label;
+} catch {}
+try {
+  await promise47;
+} catch {}
+let commandEncoder170 = device9.createCommandEncoder({label: '\uf977\u{1ff55}\uf8b6'});
+let textureView217 = texture118.createView({label: '\u731d\u{1fcbc}\u85a9', baseMipLevel: 1});
+try {
+device9.pushErrorScope('validation');
+} catch {}
+let imageData46 = new ImageData(28, 120);
+let computePassEncoder74 = commandEncoder116.beginComputePass({label: '\u04d2\u0716\u{1fcf7}\u6e8a\ueb37\u{1fd40}\ub4a0\ua1d9\u0b21\ub788\uab19'});
+let externalTexture107 = device3.importExternalTexture({label: '\u35ba\ud424', source: video38, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder77.setVertexBuffer(9, buffer19, 0);
+} catch {}
+let pipeline119 = device3.createRenderPipeline({
+  label: '\u295b\ud140\u0e34\ud860\u322e\u{1ff86}\u1ffb\u0997\u5b9c',
+  layout: pipelineLayout10,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16sint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 1820, attributes: []},
+      {arrayStride: 296, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1128,
+        attributes: [
+          {format: 'uint32x2', offset: 924, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 44, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 352, attributes: [{format: 'float16x2', offset: 140, shaderLocation: 15}]},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 164, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 212, attributes: []},
+      {arrayStride: 1400, attributes: [{format: 'float32', offset: 988, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+  await promise48;
+} catch {}
+let imageData47 = new ImageData(140, 108);
+let querySet104 = device3.createQuerySet({
+  label: '\uf254\u5e97\u0c4f\uf04c\u082e\uab7d\u02ab\u{1fe42}\u9ee3\u1b8d\u98fa',
+  type: 'occlusion',
+  count: 3267,
+});
+let texture119 = device3.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder91 = device3.createRenderBundleEncoder({
+  label: '\u9845\u0e11\ue054\u0c66\u2b38\u00a3\u87f9\u014c\u003f\u8c12\u6cf8',
+  colorFormats: ['rg16sint', 'rg32sint', 'rg8unorm', 'rgba8sint'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder77.setVertexBuffer(2, buffer19, 0, 87603);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet93, 2685, 153, buffer27, 71168);
+} catch {}
+let canvas55 = document.createElement('canvas');
+let img35 = await imageWithData(208, 278, '#e949c690', '#49c56fb4');
+let texture120 = device4.createTexture({
+  label: '\u8bae\u048d\u27ab\u63fe\u4974\u7634\u633b',
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView218 = texture95.createView({
+  label: '\u5c1f\ud23e\ufcdb\u{1fb00}\u{1fe0b}\u{1fb90}\uf87d\u0e0b\u8ca1\ufdf6\ufd11',
+  dimension: '2d-array',
+  format: 'rgba8uint',
+  mipLevelCount: 1,
+  baseArrayLayer: 979,
+  arrayLayerCount: 46,
+});
+let renderBundle99 = renderBundleEncoder45.finish({label: '\u{1fa6a}\u40d6\u0739'});
+let externalTexture108 = device4.importExternalTexture({label: '\u0ceb\u82f5\u{1fcc2}\u0272\u07d2\u5c82\u03ca\u08dd', source: video35, colorSpace: 'srgb'});
+try {
+computePassEncoder65.setPipeline(pipeline66);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(878855184);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer37, 'uint16', 173556, 89849);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder71.drawIndexed(786957465, 342763527);
+} catch {}
+try {
+renderBundleEncoder64.drawIndirect(buffer15, 30568);
+} catch {}
+let gpuCanvasContext51 = canvas55.getContext('webgpu');
+try {
+textureView59.label = '\u73fe\u0a7f\u{1fc88}\u{1fb33}\u{1fd7d}';
+} catch {}
+gc();
+let bindGroup33 = device3.createBindGroup({
+  label: '\u{1faef}\ud856\u{1fe07}\u{1f934}',
+  layout: bindGroupLayout44,
+  entries: [{binding: 1785, resource: sampler78}],
+});
+let commandEncoder171 = device3.createCommandEncoder({label: '\u{1faf3}\u853e\ua1fd\u{1f910}\ud03e\u0d43'});
+let querySet105 = device3.createQuerySet({label: '\u0dc0\ufe56\u0a05\uee2e\ud3aa', type: 'occlusion', count: 3378});
+let sampler84 = device3.createSampler({
+  label: '\u{1fe76}\u{1f9e1}\u2214\u1144\u0b62\ufdf0\u501c\u{1f8bb}\u0671\u0971\u4e58',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.41,
+  lodMaxClamp: 61.58,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder57.dispatchWorkgroups(3, 1, 3);
+} catch {}
+try {
+renderBundleEncoder77.setPipeline(pipeline119);
+} catch {}
+let pipeline120 = device3.createRenderPipeline({
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0x2a4876ad},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32float', writeMask: GPUColorWrite.ALL}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilReadMask: 2987194245,
+    stencilWriteMask: 2363190590,
+    depthBias: 321250444,
+  },
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 164,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 12, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 7},
+          {format: 'uint32x2', offset: 28, shaderLocation: 1},
+          {format: 'sint32', offset: 20, shaderLocation: 17},
+          {format: 'float32x4', offset: 8, shaderLocation: 16},
+          {format: 'float32', offset: 72, shaderLocation: 15},
+          {format: 'sint8x4', offset: 0, shaderLocation: 8},
+          {format: 'float32x2', offset: 32, shaderLocation: 11},
+          {format: 'sint32', offset: 0, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 1848, attributes: [{format: 'float32', offset: 292, shaderLocation: 14}]},
+      {
+        arrayStride: 808,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 652, shaderLocation: 4},
+          {format: 'uint16x4', offset: 308, shaderLocation: 10},
+          {format: 'uint8x4', offset: 552, shaderLocation: 3},
+          {format: 'sint32x2', offset: 564, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 1496,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 750, shaderLocation: 13}],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 4708, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 2128,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 1444, shaderLocation: 5}],
+      },
+    ],
+  },
+});
+let textureView219 = texture118.createView({label: '\ucced\u{1f77e}\u{1fc7b}\u5287\u0ea7\ub9ea\u0cfe\u1971\u{1fbdc}', dimension: '2d-array'});
+let video51 = await videoWithData();
+try {
+window.someLabel = textureView7.label;
+} catch {}
+let computePassEncoder75 = commandEncoder162.beginComputePass();
+let renderBundleEncoder92 = device3.createRenderBundleEncoder({
+  label: '\u0cfa\u{1f6b6}\ub5ea\u0ab0\u1472\u53b6\u09b5\u{1fca0}\ubf2c',
+  colorFormats: ['r16uint', 'r32float', 'rgba16sint', 'rg8sint', 'r8unorm'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder77.setVertexBuffer(2, buffer19, 0, 84466);
+} catch {}
+try {
+adapter7.label = '\u{1fec8}\u65f7\ud5d3';
+} catch {}
+let textureView220 = texture60.createView({label: '\uddb8\u{1f821}\ufd2f\uf2fc\u8a7b\u8e84\uc754\u{1fa39}\u{1f695}'});
+let renderBundleEncoder93 = device3.createRenderBundleEncoder({colorFormats: ['rg16sint', 'rg32sint', 'rg8unorm', 'rgba8sint'], depthReadOnly: true});
+try {
+renderBundleEncoder92.setVertexBuffer(0, buffer19, 0, 77350);
+} catch {}
+let promise49 = device3.createRenderPipelineAsync({
+  label: '\u{1fe0b}\u0498',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule28,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'r32float', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint'}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 1483809863,
+    stencilWriteMask: 103584344,
+    depthBiasClamp: 92.61575808095844,
+  },
+  vertex: {
+    module: shaderModule28,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2716,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 1284, shaderLocation: 5},
+          {format: 'uint32x2', offset: 32, shaderLocation: 6},
+          {format: 'uint32x4', offset: 184, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 2112, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 332, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 520, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 16,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x2', offset: 4, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 14},
+          {format: 'float16x4', offset: 0, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 11},
+          {format: 'float32x3', offset: 0, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 248,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 14, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 708,
+        attributes: [
+          {format: 'float32x4', offset: 24, shaderLocation: 9},
+          {format: 'sint8x2', offset: 60, shaderLocation: 16},
+          {format: 'float32', offset: 224, shaderLocation: 15},
+          {format: 'uint16x4', offset: 112, shaderLocation: 3},
+          {format: 'uint16x2', offset: 52, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 1528, attributes: []},
+      {
+        arrayStride: 500,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 92, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let shaderModule44 = device6.createShaderModule({
+  label: '\u0e86\u{1f820}\u7703\uf39b\u4a29\u7fb7\u470e\u0c30',
+  code: `@group(0) @binding(382)
+var<storage, read_write> function27: array<u32>;
+@group(0) @binding(823)
+var<storage, read_write> global22: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(4) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(2) f3: vec4<f32>,
+  @location(1) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S34 {
+  @location(6) f0: vec2<i32>,
+  @builtin(instance_index) f1: u32,
+  @location(8) f2: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: u32, @location(13) a1: vec3<f16>, @location(14) a2: vec3<u32>, @location(10) a3: vec3<f32>, @location(0) a4: vec2<u32>, a5: S34, @location(7) a6: vec2<i32>, @location(11) a7: vec3<f32>, @location(3) a8: u32, @location(9) a9: vec4<u32>, @location(2) a10: u32, @location(12) a11: vec4<f16>, @location(5) a12: vec2<u32>, @location(15) a13: vec3<f16>, @location(4) a14: vec4<f32>, @builtin(vertex_index) a15: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView221 = texture84.createView({label: '\u9811\u01e8\u02b7\u0328\u08f1\ufdc8\uc464\u0d18'});
+let renderBundle100 = renderBundleEncoder73.finish({label: '\uaa50\u8ab9\u{1fec3}\ua6ac'});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 87947 */
+{offset: 779, bytesPerRow: 274, rowsPerImage: 106}, {width: 9, height: 1, depthOrArrayLayers: 4});
+} catch {}
+let pipeline121 = device6.createComputePipeline({layout: pipelineLayout16, compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}}});
+let commandEncoder172 = device8.createCommandEncoder({});
+try {
+commandEncoder160.copyBufferToBuffer(buffer33, 317864, buffer35, 11148, 16696);
+dissociateBuffer(device8, buffer33);
+dissociateBuffer(device8, buffer35);
+} catch {}
+try {
+gpuCanvasContext47.unconfigure();
+} catch {}
+canvas36.height = 222;
+let commandEncoder173 = device9.createCommandEncoder({label: '\u2962\u{1fae2}\u{1fbe6}'});
+let textureView222 = texture110.createView({dimension: '2d-array', baseMipLevel: 6, mipLevelCount: 4, baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundle101 = renderBundleEncoder90.finish();
+let externalTexture109 = device9.importExternalTexture({label: '\uc062\u{1feca}', source: videoFrame4, colorSpace: 'display-p3'});
+gc();
+let sampler85 = device9.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.10,
+  lodMaxClamp: 74.77,
+  compare: 'greater-equal',
+});
+try {
+device9.queue.submit([]);
+} catch {}
+let imageData48 = new ImageData(116, 36);
+let img36 = await imageWithData(180, 268, '#2ae368aa', '#e7749f4a');
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('DONE')
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -104,6 +104,7 @@ public:
     void setLastError(NSString*);
     void waitForCommandBufferCompletion();
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
+    bool submitWillBeInvalid() const;
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1214,6 +1214,11 @@ void CommandEncoder::makeInvalid(NSString* errorString)
         m_cachedCommandBuffer.get()->makeInvalid(errorString);
 }
 
+bool CommandEncoder::submitWillBeInvalid() const
+{
+    return m_makeSubmitInvalid;
+}
+
 void CommandEncoder::makeSubmitInvalid(NSString* errorString)
 {
     m_makeSubmitInvalid = true;

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -75,7 +75,8 @@ public:
 
     Device& device() const { return m_device; }
 
-    bool isValid() const { return m_computeCommandEncoder; }
+    bool isValid() const;
+    id<MTLComputeCommandEncoder> computeCommandEncoder() const;
 
 private:
     ComputePassEncoder(id<MTLComputeCommandEncoder>, const WGPUComputePassDescriptor&, CommandEncoder&, Device&);


### PR DESCRIPTION
#### 1623111a075f7d416a24f31c74da76388b5129ed
<pre>
[WebGPU] Render / compute commands should be no-ops when the command buffer will be discarded
<a href="https://bugs.webkit.org/show_bug.cgi?id=274290">https://bugs.webkit.org/show_bug.cgi?id=274290</a>
&lt;radar://128202440&gt;

Reviewed by Dan Glastonbury.

There was validation logic however it did not take into account
destroyed render targets, which are still valid to call commands
on.

A destroyed render target will result in the command buffer being
discarded when it is submitted, so we can make all the encoding
operations no-ops.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274290-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274290.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::submitWillBeInvalid const):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
(WebGPU::ComputePassEncoder::isValid const): Deleted.
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
(WebGPU::ComputePassEncoder::dispatch):
(WebGPU::ComputePassEncoder::runPredispatchIndirectCallValidation):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::ComputePassEncoder::setBindGroup):
(WebGPU::ComputePassEncoder::isValid const):
(WebGPU::ComputePassEncoder::computeCommandEncoder const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::beginOcclusionQuery):
(WebGPU::RenderPassEncoder::endOcclusionQuery):
(WebGPU::RenderPassEncoder::errorValidatingAndBindingBuffers):
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::draw):
(WebGPU::RenderPassEncoder::drawIndexed):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::renderCommandEncoder const):
(WebGPU::RenderPassEncoder::setBindGroup):
(WebGPU::RenderPassEncoder::setBlendConstant):
(WebGPU::RenderPassEncoder::setScissorRect):
(WebGPU::RenderPassEncoder::setStencilReference):
Call helper function so command recording becomes no-ops for
command buffers which will be discarded.

Canonical link: <a href="https://commits.webkit.org/279034@main">https://commits.webkit.org/279034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b62db08a3fb876263c4171eddf06c2b2076d2126

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54608 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/38111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42540 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54399 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29285 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23615 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1185 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45652 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57173 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51811 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2603 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49935 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49177 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11425 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29574 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64118 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28407 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12135 "Passed tests") | 
<!--EWS-Status-Bubble-End-->