### PR TITLE
[GTK] Better scaling for DPI.

### DIFF
--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -86,6 +86,16 @@ bool screenHasInvertedColors()
 
 double fontDPI()
 {
+#if !USE(GTK4)
+    // The code in this conditionally-compiled block is needed in order to
+    // respect the GDK_DPI_SCALE setting that was present in GTK3 as an
+    // additional font scaling factor.
+    if (auto* display = gdk_display_get_default()) {
+        if (auto* screen = gdk_display_get_default_screen(display))
+            return gdk_screen_get_resolution(screen);
+    }
+#endif
+
     static GtkSettings* gtkSettings = gtk_settings_get_default();
     if (gtkSettings) {
         int gtkXftDpi;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -88,7 +88,6 @@
 #include <wtf/text/StringBuilder.h>
 
 #if PLATFORM(GTK)
-#include "GtkSettingsManager.h"
 #include "WebKitFaviconDatabasePrivate.h"
 #include "WebKitInputMethodContextImplGtk.h"
 #include "WebKitPointerLockPermissionRequest.h"
@@ -353,8 +352,6 @@ struct _WebKitWebViewPrivate {
 
     CString defaultContentSecurityPolicy;
     WebKitWebExtensionMode webExtensionMode;
-
-    double textScaleFactor;
 
     bool isWebProcessResponsive;
 };
@@ -947,25 +944,6 @@ static void webkitWebViewConstructed(GObject* object)
 
     priv->backForwardList = adoptGRef(webkitBackForwardListCreate(&getPage(webView).backForwardList()));
     priv->windowProperties = adoptGRef(webkitWindowPropertiesCreate());
-
-#if PLATFORM(GTK)
-    double dpi = GtkSettingsManager::singleton().settingsState().xftDPI.value() / 1024.0;
-    priv->textScaleFactor = dpi / 96.;
-    getPage(webView).setTextZoomFactor(priv->textScaleFactor);
-    GtkSettingsManager::singleton().addObserver([webView](const GtkSettingsState& state) {
-        if (!state.xftDPI)
-            return;
-
-        double dpi = state.xftDPI.value() / 1024.0;
-        auto& page = getPage(webView);
-        auto zoomFactor = page.textZoomFactor() / webView->priv->textScaleFactor;
-        webView->priv->textScaleFactor = dpi / 96.;
-        page.setTextZoomFactor(zoomFactor * webView->priv->textScaleFactor);
-    }, webView);
-#else
-    priv->textScaleFactor = 1;
-#endif
-
     priv->isWebProcessResponsive = true;
 }
 
@@ -1188,10 +1166,6 @@ static void webkitWebViewDispose(GObject* object)
 
 #if PLATFORM(WPE)
     webView->priv->view->close();
-#endif
-
-#if PLATFORM(GTK)
-    GtkSettingsManager::singleton().removeObserver(webView);
 #endif
 
     G_OBJECT_CLASS(webkit_web_view_parent_class)->dispose(object);
@@ -3966,11 +3940,17 @@ void webkit_web_view_set_zoom_level(WebKitWebView* webView, gdouble zoomLevel)
     if (webkit_web_view_get_zoom_level(webView) == zoomLevel)
         return;
 
+#if PLATFORM(GTK)
+    auto pageScale = webkitWebViewBaseGetPageScale(WEBKIT_WEB_VIEW_BASE(webView));
+#else
+    const double pageScale = 1.0;
+#endif
+
     auto& page = getPage(webView);
     if (webkit_settings_get_zoom_text_only(webView->priv->settings.get()))
-        page.setTextZoomFactor(zoomLevel * webView->priv->textScaleFactor);
+        page.setTextZoomFactor(zoomLevel);
     else
-        page.setPageZoomFactor(zoomLevel);
+        page.setPageZoomFactor(zoomLevel * pageScale);
     g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_ZOOM_LEVEL]);
 }
 
@@ -3989,9 +3969,15 @@ gdouble webkit_web_view_get_zoom_level(WebKitWebView* webView)
 {
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), 1);
 
+#if PLATFORM(GTK)
+    auto pageScale = webkitWebViewBaseGetPageScale(WEBKIT_WEB_VIEW_BASE(webView));
+#else
+    const double pageScale = 1.0;
+#endif
+
     auto& page = getPage(webView);
     gboolean zoomTextOnly = webkit_settings_get_zoom_text_only(webView->priv->settings.get());
-    return zoomTextOnly ? page.textZoomFactor() / webView->priv->textScaleFactor : page.pageZoomFactor();
+    return zoomTextOnly ? page.textZoomFactor() : page.pageZoomFactor() / pageScale;
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -48,6 +48,7 @@
 
 WebKitWebViewBase* webkitWebViewBaseCreate(const API::PageConfiguration&);
 WebKit::WebPageProxy* webkitWebViewBaseGetPage(WebKitWebViewBase*);
+double webkitWebViewBaseGetPageScale(WebKitWebViewBase*);
 void webkitWebViewBaseCreateWebPage(WebKitWebViewBase*, Ref<API::PageConfiguration>&&);
 void webkitWebViewBaseSetTooltipText(WebKitWebViewBase*, const char*);
 void webkitWebViewBaseSetTooltipArea(WebKitWebViewBase*, const WebCore::IntRect&);


### PR DESCRIPTION
#### 5713584438d253c13cb10966d7bac9cef1f9082f
<pre>
[GTK] Better scaling for DPI.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247980">https://bugs.webkit.org/show_bug.cgi?id=247980</a>

Reviewed by Michael Catanzaro.

Revises the web page rendering to scale all page elements with respect
to the fontDPI. In essence, this prioritizes the consistency that a
CSS 1em length for a 96px font should be identical to a CSS 1in length,
over compliance with the standard that a CSS 1px dimension should be the
integer multiple of a device pixel that best approximates a &quot;reference
pixel&quot; subtending .0213 degrees at the expected viewing distance (1/96th
of an inch at 28 inches).

The implementation moves the text scaling factor formerly in
WebKitWebView.cpp (responsive to the xft-dpi setting) into
WebKitWebViewBase.cpp, and changes it into a page scaling factor. The
page scaling factor is refreshed when any possible input for computing
it changes.

This PR differs from the previous one submitted in resolution of 247980
in that it employs a much simpler formula for scaling that should both
affect fewer instances of WebKitGTK running in practice, and should
also resolve <a href="https://bugs.webkit.org/show_bug.cgi?id=250138">https://bugs.webkit.org/show_bug.cgi?id=250138</a>

* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::fontDPI):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
(webkitWebViewDispose):
(webkit_web_view_set_zoom_level):
(webkit_web_view_get_zoom_level):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(_WebKitWebViewBasePrivate::_WebKitWebViewBasePrivate):
(refreshInternalScaling):
(webkitWebViewBaseUpdateDisplayID):
(webkitWebViewBaseDispose):
(webkitWebViewBaseGetScaleFactors):
(deviceScaleFactorChanged):
(webkitWebViewBaseCreateWebPage):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:

Canonical link: <a href="https://commits.webkit.org/278962@main">https://commits.webkit.org/278962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c345ab377030605d0275a78bd7bdbdb3d84c677

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42387 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1785 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56958 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49783 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11401 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->