### PR TITLE
[curl] Obtain the Content-Length and request header size ourselves.

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -3321,12 +3321,6 @@ webkit.org/b/272127 fast/text/remove-renderer-and-select-crash.html [ Skip ]
 
 http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html [ Failure ]
 
-# Pass on Buildbot, Failure on my PC
-webkit.org/b/272445 http/tests/inspector/network/resource-sizes-network.html [ Failure Pass ]
-webkit.org/b/272445 http/tests/xmlhttprequest/onabort-response-getters.html [ Failure Pass ]
-webkit.org/b/272445 http/tests/xmlhttprequest/onload-progressevent-attributes.html [ Failure Pass ]
-webkit.org/b/272445 http/tests/xmlhttprequest/xmlhttprequest-LSProgressEvent-ProgressEvent-should-match.html [ Failure Pass ]
-
 fast/forms/form-submission-crash-4.html [ Timeout Failure Pass ]
 
 css3/filters/backdrop-filter-page-scale.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -728,19 +728,6 @@ std::optional<long> CurlHandle::getHttpConnectCode()
     return httpConnectCode;
 }
 
-std::optional<long long> CurlHandle::getContentLength()
-{
-    if (!m_handle)
-        return std::nullopt;
-
-    curl_off_t contentLength;
-    CURLcode errorCode = curl_easy_getinfo(m_handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &contentLength);
-    if (errorCode != CURLE_OK)
-        return std::nullopt;
-
-    return contentLength;
-}
-
 std::optional<long> CurlHandle::getHttpAuthAvail()
 {
     auto allowedAuthMethods = CURLAUTH_DIGEST | CURLAUTH_BASIC;
@@ -879,18 +866,12 @@ std::optional<NetworkLoadMetrics> CurlHandle::getNetworkLoadMetrics(MonotonicTim
 
 void CurlHandle::addExtraNetworkLoadMetrics(NetworkLoadMetrics& networkLoadMetrics)
 {
-    long requestHeaderSize = 0;
     curl_off_t requestBodySize = 0;
     long responseHeaderSize = 0;
     char* ip = nullptr;
     long port = 0;
 
-    // FIXME: Gets total request size not just headers https://bugs.webkit.org/show_bug.cgi?id=188363
-    CURLcode errorCode = curl_easy_getinfo(m_handle, CURLINFO_REQUEST_SIZE, &requestHeaderSize);
-    if (errorCode != CURLE_OK)
-        return;
-
-    errorCode = curl_easy_getinfo(m_handle, CURLINFO_SIZE_UPLOAD_T, &requestBodySize);
+    CURLcode errorCode = curl_easy_getinfo(m_handle, CURLINFO_SIZE_UPLOAD_T, &requestBodySize);
     if (errorCode != CURLE_OK)
         return;
 
@@ -915,7 +896,6 @@ void CurlHandle::addExtraNetworkLoadMetrics(NetworkLoadMetrics& networkLoadMetri
         }
     }
 
-    additionalMetrics->requestHeaderBytesSent = requestHeaderSize;
     additionalMetrics->requestBodyBytesSent = requestBodySize;
     additionalMetrics->responseHeaderBytesReceived = responseHeaderSize;
 

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -301,7 +301,6 @@ public:
     std::optional<String> getProxyUrl();
     std::optional<long> getResponseCode();
     std::optional<long> getHttpConnectCode();
-    std::optional<long long> getContentLength();
     std::optional<long> getHttpAuthAvail();
     std::optional<long> getProxyAuthAvail();
     std::optional<long> getHttpVersion();

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -31,6 +31,7 @@
 #include "CertificateInfo.h"
 #include "CurlRequestClient.h"
 #include "CurlRequestScheduler.h"
+#include "HTTPParsers.h"
 #include "MIMETypeRegistry.h"
 #include "NetworkLoadMetrics.h"
 #include "ResourceError.h"
@@ -214,9 +215,7 @@ CURL* CurlRequest::setupTransfer()
 
     m_curlHandle->setHeaderCallbackFunction(didReceiveHeaderCallback, this);
     m_curlHandle->setWriteCallbackFunction(didReceiveDataCallback, this);
-
-    if (m_captureExtraMetrics)
-        m_curlHandle->setDebugCallbackFunction(didReceiveDebugInfoCallback, this);
+    m_curlHandle->setDebugCallbackFunction(didReceiveDebugInfoCallback, this);
 
     m_curlHandle->setTimeout(timeoutInterval());
 
@@ -317,7 +316,7 @@ size_t CurlRequest::didReceiveHeader(String&& header)
     m_response.statusCode = statusCode;
     m_response.httpConnectCode = httpConnectCode;
 
-    if (auto length = m_curlHandle->getContentLength())
+    if (auto length = getContentLength())
         m_response.expectedContentLength = *length;
 
     if (auto proxyURL = m_curlHandle->getProxyUrl())
@@ -517,6 +516,8 @@ int CurlRequest::didReceiveDebugInfo(curl_infotype type, std::span<const char> d
         if (headerFields.size())
             headerFields.remove(0);
 
+        m_requestHeaderSize = requestHeader.length();
+
         for (auto& header : headerFields) {
             auto pos = header.find(':');
             if (pos != notFound) {
@@ -629,11 +630,28 @@ NetworkLoadMetrics CurlRequest::networkLoadMetrics()
 
     if (m_captureExtraMetrics) {
         m_curlHandle->addExtraNetworkLoadMetrics(*networkLoadMetrics);
-        if (auto* additionalMetrics = networkLoadMetrics->additionalNetworkLoadMetricsForWebInspector.get())
+        if (auto* additionalMetrics = networkLoadMetrics->additionalNetworkLoadMetricsForWebInspector.get()) {
+            additionalMetrics->requestHeaderBytesSent = m_requestHeaderSize;
             additionalMetrics->requestHeaders = m_requestHeaders;
+        }
     }
 
     return WTFMove(*networkLoadMetrics);
+}
+
+std::optional<long long> CurlRequest::getContentLength()
+{
+    for (const auto& header : m_response.headers) {
+        if (header.startsWithIgnoringASCIICase("content-length:"_s)) {
+            if (auto splitPosition = header.find(':'); splitPosition != notFound) {
+                auto value = header.substring(splitPosition + 1).trim(deprecatedIsSpaceOrNewline);
+                if (auto length = parseContentLength(value))
+                    return *length;
+            }
+        }
+    }
+
+    return std::nullopt;
 }
 
 size_t CurlRequest::willSendDataCallback(char* ptr, size_t blockSize, size_t numberOfBlocks, void* userData)

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -126,6 +126,7 @@ private:
     void invokeDidReceiveResponse(const CurlResponse&, Function<void()>&& completionHandler = { });
 
     NetworkLoadMetrics networkLoadMetrics();
+    std::optional<long long> getContentLength();
 
     // Callback functions for curl
     static size_t willSendDataCallback(char*, size_t, size_t, void*);
@@ -159,6 +160,7 @@ private:
     Function<void()> m_responseCompletionHandler;
 
     bool m_captureExtraMetrics;
+    size_t m_requestHeaderSize { 0 };
     HTTPHeaderMap m_requestHeaders;
     MonotonicTime m_performStartTime;
     size_t m_totalReceivedSize { 0 };


### PR DESCRIPTION
#### 8a9f0f239bc433855d47938d4d421b1dbac39f46
<pre>
[curl] Obtain the Content-Length and request header size ourselves.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272445">https://bugs.webkit.org/show_bug.cgi?id=272445</a>

Reviewed by Fujii Hironori.

Since curl 8.7.0, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T and
CURLINFO_REQUEST_SIZE  are no longer available in the header callback.
For this reason, we will obtain the Content-Length and request header
size ourselves.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::addExtraNetworkLoadMetrics):
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::setupTransfer):
(WebCore::CurlRequest::didReceiveHeader):
(WebCore::CurlRequest::didReceiveDebugInfo):
(WebCore::CurlRequest::networkLoadMetrics):
(WebCore::CurlRequest::getContentLength):
* Source/WebCore/platform/network/curl/CurlRequest.h:

Canonical link: <a href="https://commits.webkit.org/279553@main">https://commits.webkit.org/279553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c61b987fad00f5c801f5065a9911c4f6703708e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42209 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1613 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56756 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49613 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48868 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7959 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->