### PR TITLE
[WebXR] Rendering is incorrect in on-device HQ capture

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm
@@ -1800,26 +1800,9 @@ RenderCommandEncoder &RenderCommandEncoder::setStencilRefVal(uint32_t ref)
     return setStencilRefVals(ref, ref);
 }
 
-RenderCommandEncoder &RenderCommandEncoder::setViewport(const MTLViewport &intialViewport,
+RenderCommandEncoder &RenderCommandEncoder::setViewport(const MTLViewport &viewport,
                                                         id<MTLRasterizationRateMap> map)
 {
-    auto viewport = intialViewport;
-    if (map)
-    {
-        auto adjustedOrigin =
-            [map mapPhysicalToScreenCoordinates:MTLCoordinate2DMake(viewport.originX, (int)viewport.originY)
-                                       forLayer:0];
-        auto adjustedSize =
-            [map mapPhysicalToScreenCoordinates:MTLCoordinate2DMake(viewport.width, viewport.height)
-                                       forLayer:0];
-
-        viewport.originX      = std::max<double>(0, adjustedOrigin.x);
-        viewport.originY      = std::max<double>(0, adjustedOrigin.y);
-        MTLSize screenSize = [map screenSize];
-        viewport.width  = std::min<double>(screenSize.width, ceilf(adjustedSize.x));
-        viewport.height = std::min<double>(screenSize.height, ceilf(adjustedSize.y));
-    }
-
     if (mStateCache.viewport.valid() && mStateCache.viewport.value() == viewport)
     {
         return *this;
@@ -1868,11 +1851,11 @@ RenderCommandEncoder &RenderCommandEncoder::setScissorRect(const MTLScissorRect 
                                                                     clampedRect.height)
                                        forLayer:0];
 
-        clampedRect.x      = (NSUInteger)floorf(adjustedOrigin.x);
-        clampedRect.y      = (NSUInteger)floorf(adjustedOrigin.y);
+        clampedRect.x      = (NSUInteger)roundf(adjustedOrigin.x);
+        clampedRect.y      = (NSUInteger)roundf(adjustedOrigin.y);
         MTLSize screenSize = [map screenSize];
-        clampedRect.width  = std::min<NSUInteger>(screenSize.width, ceilf(adjustedSize.x));
-        clampedRect.height = std::min<NSUInteger>(screenSize.height, ceilf(adjustedSize.y));
+        clampedRect.width  = std::min<NSUInteger>(screenSize.width, roundf(adjustedSize.x));
+        clampedRect.height = std::min<NSUInteger>(screenSize.height, roundf(adjustedSize.y));
     }
 
     mCommands.push(CmdType::SetScissorRect).push(clampedRect);

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -192,19 +192,9 @@ bool WebXROpaqueFramebuffer::supportsDynamicViewportScaling() const
     return true;
 }
 
-IntSize WebXROpaqueFramebuffer::displayFramebufferSize() const
-{
-    return m_framebufferSize;
-}
-
 IntSize WebXROpaqueFramebuffer::drawFramebufferSize() const
 {
-    switch (m_displayLayout) {
-    case PlatformXR::Layout::Layered:
-        return { 2*m_framebufferSize.width(), m_framebufferSize.height() };
-    default:
-        return m_framebufferSize;
-    }
+    return m_framebufferSize;
 }
 
 IntRect WebXROpaqueFramebuffer::drawViewport(PlatformXR::Eye eye) const

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -93,8 +93,9 @@ public:
 
     PlatformXR::LayerHandle handle() const { return m_handle; }
     const WebGLFramebuffer& framebuffer() const { return m_drawFramebuffer.get(); }
-    IntSize displayFramebufferSize() const;
+    // Return the size of the framebuffer is Screen Space
     IntSize drawFramebufferSize() const;
+    // Return the viewport for eye in Screen Space
     IntRect drawViewport(PlatformXR::Eye) const;
 
     void startFrame(const PlatformXR::FrameData::LayerData&);
@@ -120,13 +121,12 @@ private:
     WebGLRenderingContextBase& m_context;
     Attributes m_attributes;
     PlatformXR::Layout m_displayLayout = PlatformXR::Layout::Shared;
-    IntSize m_framebufferSize;
+    IntSize m_framebufferSize; // Physical Space
 #if PLATFORM(COCOA)
-    IntRect m_leftViewport;
-    IntRect m_rightViewport;
-    IntSize m_leftPhysicalSize;
-    IntSize m_rightPhysicalSize;
-    IntSize m_screenSize;
+    IntRect m_leftViewport; // Screen Space
+    IntRect m_rightViewport; // Screen Space
+    IntSize m_leftPhysicalSize; // Physical Space
+    IntSize m_rightPhysicalSize; // Physical Space
 #endif
     WebXRAttachments m_drawAttachments;
     WebXRAttachments m_resolveAttachments;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -56,10 +56,6 @@
 template<typename... Types>
 struct GCGLSpanTuple;
 
-namespace PlatformXR {
-enum class Layout : uint8_t;
-}
-
 namespace WebCore {
 class ImageBuffer;
 class PixelBuffer;

--- a/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
@@ -138,14 +138,14 @@ RetainPtr<MTLRasterizationRateMap> newRasterizationRateMap(GCGLDisplay display, 
     RetainPtr<MTLRasterizationRateMapDescriptor> descriptor = adoptNS([MTLRasterizationRateMapDescriptor new]);
     id<MTLRasterizationRateMapDescriptorSPI> descriptor_spi = (id<MTLRasterizationRateMapDescriptorSPI>)descriptor.get();
         descriptor_spi.skipSampleValidationAndApplySampleAtTileGranularity = YES;
-    descriptor_spi.mutability = MTLMutabilityDefault;
+    descriptor_spi.mutability = MTLMutabilityMutable;
     descriptor_spi.minFactor  = 0.01;
 
-    auto mtlScreenSize = MTLSizeMake(screenSize.width(), screenSize.height(), 0);
-    RetainPtr<MTLRasterizationRateLayerDescriptor> layerDescriptorLeft = [[MTLRasterizationRateLayerDescriptor alloc] initWithSampleCount:mtlScreenSize];
-    RetainPtr<MTLRasterizationRateLayerDescriptor> layerDescriptorRight = [[MTLRasterizationRateLayerDescriptor alloc] initWithSampleCount:mtlScreenSize];
+    constexpr MTLSize maxSampleCount { 256, 256, 1 };
+    RetainPtr<MTLRasterizationRateLayerDescriptor> layerDescriptorLeft = [[MTLRasterizationRateLayerDescriptor alloc] initWithSampleCount:maxSampleCount];
+    RetainPtr<MTLRasterizationRateLayerDescriptor> layerDescriptorRight = [[MTLRasterizationRateLayerDescriptor alloc] initWithSampleCount:maxSampleCount];
 
-    if (horizontalSamplesLeft.size() > mtlScreenSize.width || horizontalSamplesRight.size() > mtlScreenSize.width || verticalSamples.size() > mtlScreenSize.height || !layerDescriptorLeft.get() || !layerDescriptorRight.get())
+    if (horizontalSamplesLeft.size() > maxSampleCount.width || horizontalSamplesRight.size() > maxSampleCount.width || verticalSamples.size() > maxSampleCount.height || !layerDescriptorLeft.get() || !layerDescriptorRight.get())
         return nullptr;
 
     memcpy([layerDescriptorLeft horizontalSampleStorage], horizontalSamplesLeft.data(), horizontalSamplesLeft.size_bytes());
@@ -156,7 +156,7 @@ RetainPtr<MTLRasterizationRateMap> newRasterizationRateMap(GCGLDisplay display, 
     memcpy([layerDescriptorRight verticalSampleStorage], verticalSamples.data(), verticalSamples.size_bytes());
     [layerDescriptorRight setSampleCount:MTLSizeMake(horizontalSamplesRight.size(), verticalSamples.size(), 0)];
 
-    [descriptor setScreenSize:mtlScreenSize];
+    [descriptor setScreenSize:MTLSizeMake(screenSize.width(), screenSize.height(), 0)];
     [descriptor layers][0] = layerDescriptorLeft.get();
     [descriptor layers][1] = layerDescriptorRight.get();
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -259,14 +259,18 @@ struct FrameData {
     };
 
 #if PLATFORM(COCOA)
+    struct RateMapDescription {
+        WebCore::IntSize screenSize;
+        std::array<std::span<const float>, 2> horizontalSamples;
+        // Vertical samples is shared by both horizontalSamples
+        std::span<const float> verticalSamples;
+    };
+
     static constexpr auto LayerSetupSizeMax = std::numeric_limits<uint16_t>::max();
     struct LayerSetupData {
         std::array<std::array<uint16_t, 2>, 2> physicalSize;
         std::array<WebCore::IntRect, 2> viewports;
-        std::array<std::span<const float>, 2> horizontalSamples;
-        std::span<const float> verticalSamples;
-        WebCore::IntSize screenSize;
-        std::array<uint16_t, 2> framebufferSize;
+        RateMapDescription foveationRateMapDesc;
         MachSendRight completionSyncEvent;
     };
 

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -159,10 +159,10 @@ void SimulatedXRDevice::frameTimerFired()
 
     for (auto& layer : m_layers) {
 #if PLATFORM(COCOA)
+        PlatformXR::FrameData::LayerSetupData layerSetupData;
+        layerSetupData.physicalSize[0] = { static_cast<uint16_t>(layer.value.width()), static_cast<uint16_t>(layer.value.height()) };
         data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
-            .layerSetup = PlatformXR::FrameData::LayerSetupData {
-                .framebufferSize { static_cast<uint16_t>(layer.value.width()), static_cast<uint16_t>(layer.value.height()) }
-            },
+            .layerSetup = layerSetupData,
             .colorTexture = { MachSendRight(), false }
         });
 #else

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -101,13 +101,16 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
 };
 
 #if PLATFORM(COCOA)
+[Nested] struct PlatformXR::FrameData::RateMapDescription {
+    WebCore::IntSize screenSize;
+    std::array<std::span<const float>, 2> horizontalSamples;
+    std::span<const float> verticalSamples;
+};
+
 [Nested, RValue] struct PlatformXR::FrameData::LayerSetupData {
     std::array<std::array<uint16_t, 2>, 2> physicalSize;
     std::array<WebCore::IntRect, 2> viewports;
-    std::array<std::span<const float>, 2> horizontalSamples;
-    std::span<const float> verticalSamples;
-    WebCore::IntSize screenSize;
-    std::array<uint16_t, 2> framebufferSize;
+    PlatformXR::FrameData::RateMapDescription foveationRateMapDesc;
     MachSendRight completionSyncEvent;
 };
 


### PR DESCRIPTION
#### 5b6cb5049aac2b44d2b928fdaae5e6625075bf89
<pre>
[WebXR] Rendering is incorrect in on-device HQ capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=274296">https://bugs.webkit.org/show_bug.cgi?id=274296</a>
<a href="https://rdar.apple.com/128248238">rdar://128248238</a>

Reviewed by Mike Wyrzykowski.

When doing on-device HQ capture of WebXR content the rendering is missing the
right eye and the left eye has warping at the edges. This is because
WebXROpaqueFramebuffer was misinterpreting the layered-to-shared layout required
by the Compositor in this mode, where the texture and viewport allocations are
asymmetric.

The core of fixing this was to understand what coordinate space
drawing and blitting operations happen in:
* All drawing to the drawing framebuffer happen in &quot;screen space&quot; of the
  rasterization rate map.
* Blit from shared to layered textures happen in &quot;physical space&quot; of the
  raterization rate map (ie. texture allocation size)

The framebuffer size has been removed from PlatformXR::FrameData::LayerData. The
display framebuffer size is now calculated from the physical sizes instead of
assuming it was twice the width of the framebuffer for layered layout.

Correct viewports in &quot;screen space&quot; are to be passed via
PlatformXR::FrameData::LayerData. Viewport dimensions are no longer converted to
&quot;physical space&quot;.

Additionally:
* Fixed incorrectly using screen size (ie. 4065x5886) in
  -(MTLRasterizationRateLayerDescriptor intWithSampleCount:) to save allocating
  ~180MB of storage for a few hundred floats
* Refactor rasterization rate map descriptor data into
  PlatformXR::FrameData::RateMapDescription to make it clear it&apos;s intended
  use.
* Remove dead code in WebXROpaqueFramebuffer &amp; GraphicsContextGL.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm:
(rx::mtl::RenderCommandEncoder::setViewport): Viewport coordinates are in
rasterization rate map &quot;screen space&quot; and don&apos;t need conversion.
(rx::mtl::RenderCommandEncoder::setScissorRect): Conversion from physical to
screen coordinates requires rounding to the nearest integer, not floor or ceil.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::drawFramebufferSize const):
(WebCore::WebXROpaqueFramebuffer::displayFramebufferSize const): Deleted.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
(WebCore::WebXROpaqueFramebuffer::framebuffer const):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
(WebCore::WebXROpaqueFramebuffer::drawFramebufferSize const):
(WebCore::WebXROpaqueFramebuffer::drawViewport const):
(WebCore::calcFramebufferSize):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::displayFramebufferSize const): Deleted.
(WebCore::convertViewportToPhysicalCoordinates): Deleted.
(WebCore::WebXROpaqueFramebuffer::calculateViewportShared): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm:
(WebCore::newRasterizationRateMap):
* Source/WebCore/platform/xr/PlatformXR.h: Remove dead code PlatformXR::Layout
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:

Canonical link: <a href="https://commits.webkit.org/278975@main">https://commits.webkit.org/278975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fd77679be9a1a182d2a0a652b67c3c66758646d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52155 "Failed to checkout and rebase branch from PR 28695") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2576 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/1840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/54251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1037 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57025 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7622 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->