### PR TITLE
If torch is on on a track, muting and unmuting it will switch off the torch

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -1092,6 +1092,7 @@ bool AVVideoCaptureSource::setupCaptureSession()
     [session() addOutput:m_videoOutput.get()];
 
     setSessionSizeFrameRateAndZoom();
+    m_needsTorchReconfiguration = m_needsTorchReconfiguration || torch();
 
     m_sensorOrientation = sensorOrientationFromVideoOutput();
     computeVideoFrameRotation();
@@ -1190,7 +1191,7 @@ void AVVideoCaptureSource::reconfigureIfNeeded()
     if (!m_isRunning || (!m_needsTorchReconfiguration && !m_needsWhiteBalanceReconfiguration))
         return;
 
-    beginConfiguration();
+    startApplyingConstraints();
 
     if (std::exchange(m_needsTorchReconfiguration, false))
         updateTorch();
@@ -1198,7 +1199,7 @@ void AVVideoCaptureSource::reconfigureIfNeeded()
     if (std::exchange(m_needsWhiteBalanceReconfiguration, false))
         updateWhiteBalanceMode();
 
-    commitConfiguration();
+    endApplyingConstraints();
 }
 
 void AVVideoCaptureSource::captureSessionIsRunningDidChange(bool state)


### PR DESCRIPTION
#### 29cddce2522b69778bd95c60e2d9eb60bbd17714
<pre>
If torch is on on a track, muting and unmuting it will switch off the torch
<a href="https://bugs.webkit.org/show_bug.cgi?id=270840">https://bugs.webkit.org/show_bug.cgi?id=270840</a>
<a href="https://rdar.apple.com/124435440">rdar://124435440</a>

Reviewed by Eric Carlson.

When restarting to capture, we were not setting back torch to what it should be.
This would trigger the issue of having torch on, muting capture, unmuting capture and having torch off.
We fix this by ensuring that torch is updated when (re)starting capture.

We do a drive-by fix in AVVideoCaptureSource::reconfigureIfNeeded.
We need to call startApplyingConstraints/endApplyingConstraints instead of beginConfiguration/commitConfiguration, to keep the balance.
Otherwise updateTorch would do an additional beginConfiguration call without any corresponding commitConfiguration.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setupCaptureSession):
(WebCore::AVVideoCaptureSource::reconfigureIfNeeded):

Canonical link: <a href="https://commits.webkit.org/278948@main">https://commits.webkit.org/278948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ee1285060bfd30806d7f28a2c1d478d6eaa9ef6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2619 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42318 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1682 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54026 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28846 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44788 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23372 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26204 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2051 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 7 flakes 8 failures; Uploaded test results; Exiting early after 60 failures. 8294 tests run. 60 failures; Running compile-webkit-without-change") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/810 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48069 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2162 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56782 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27045 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2053 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/56782 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44917 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/56782 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11387 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29183 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->