### PR TITLE
[GTK][WPE][Skia] Add a setting to enable or disable 2D canvas acceleration

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -149,6 +149,15 @@ static bool webGLEnabled(WebKitURISchemeRequest* request)
 }
 #endif
 
+#if USE(SKIA)
+static bool canvasAccelerationEnabled(WebKitURISchemeRequest* request)
+{
+    auto* webView = webkit_uri_scheme_request_get_web_view(request);
+    ASSERT(webView);
+    return webkit_settings_get_enable_2d_canvas_acceleration(webkit_web_view_get_settings(webView));
+}
+#endif
+
 static bool uiProcessContextIsEGL()
 {
 #if PLATFORM(GTK)
@@ -459,6 +468,10 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 
 #if ENABLE(WEBGL)
     addTableRow(hardwareAccelerationObject, "WebGL enabled"_s, webGLEnabled(request) ? "Yes"_s : "No"_s);
+#endif
+
+#if USE(SKIA)
+    addTableRow(hardwareAccelerationObject, "2D canvas"_s, canvasAccelerationEnabled(request) ? "Accelerated"_s : "Unaccelerated"_s);
 #endif
 
     std::unique_ptr<PlatformDisplay> renderDisplay;

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -415,6 +415,13 @@ webkit_settings_set_enable_accelerated_2d_canvas               (WebKitSettings *
 #endif
 
 WEBKIT_API gboolean
+webkit_settings_get_enable_2d_canvas_acceleration              (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_2d_canvas_acceleration              (WebKitSettings *settings,
+                                                                gboolean        enabled);
+
+WEBKIT_API gboolean
 webkit_settings_get_enable_write_console_messages_to_stdout    (WebKitSettings *settings);
 
 WEBKIT_API void

--- a/Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp
@@ -28,7 +28,6 @@
 #include "WebPreferences.h"
 
 #include "HardwareAccelerationManager.h"
-#include <WebCore/NotImplemented.h>
 
 namespace WebKit {
 
@@ -47,12 +46,6 @@ void WebPreferences::platformInitializeStore()
     setAcceleratedCompositingEnabled(compositingState.acceleratedCompositingEnabled);
     setForceCompositingMode(compositingState.forceCompositingMode);
     setThreadedScrollingEnabled(compositingState.forceCompositingMode);
-#if USE(SKIA)
-    // FIXME: Expose this as a setting when we switch to Skia.
-    static const char* disableAccelerated2DCanvas = getenv("WEBKIT_DISABLE_ACCELERATED_2D_CANVAS");
-    if (disableAccelerated2DCanvas && strcmp(disableAccelerated2DCanvas, "0"))
-        setCanvasUsesAcceleratedDrawing(false);
-#endif
 }
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -390,6 +390,13 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
+#if USE(SKIA)
+    // 2D canvas acceleration is enabled by default.
+    g_assert_true(webkit_settings_get_enable_2d_canvas_acceleration(settings));
+    webkit_settings_set_enable_2d_canvas_acceleration(settings, FALSE);
+    g_assert_false(webkit_settings_get_enable_2d_canvas_acceleration(settings));
+#endif
+
     // WebSecurity is enabled by default.
     g_assert_false(webkit_settings_get_disable_web_security(settings));
     webkit_settings_set_disable_web_security(settings, TRUE);


### PR DESCRIPTION
#### 3cfaf382d2e1dc68c04cf5f2d3c8fa2648f41b17
<pre>
[GTK][WPE][Skia] Add a setting to enable or disable 2D canvas acceleration
<a href="https://bugs.webkit.org/show_bug.cgi?id=274306">https://bugs.webkit.org/show_bug.cgi?id=274306</a>

Reviewed by Alejandro G. Castro.

Add a new setting enable-2d-canvas-acceleration because reusing the
existing deprecated one would confuse introspection and
documentation generation.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::canvasAccelerationEnabled):
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsSetProperty):
(webKitSettingsGetProperty):
(webkit_settings_class_init):
(webkit_settings_get_enable_2d_canvas_acceleration):
(webkit_settings_set_enable_2d_canvas_acceleration):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp:
(WebKit::WebPreferences::platformInitializeStore):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):

Canonical link: <a href="https://commits.webkit.org/278989@main">https://commits.webkit.org/278989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c598df2b23d78ccb557c48ddbfab6c861eb90c4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55194 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37618 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2335 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42320 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54030 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28863 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44799 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23374 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26220 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2068 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 9690 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 12063 tests run. 60 failures; Running compile-webkit-without-change") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/813 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48073 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2157 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56785 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27048 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/2335 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/56785 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28285 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/56785 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29186 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7634 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->