### PR TITLE
Introduce a TypedArrayView create that solely takes an ArrayBuffer

### DIFF
--- a/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@ public:
     static Ref<GenericTypedArrayView> create(size_t length);
     static Ref<GenericTypedArrayView> create(const typename Adaptor::Type* array, size_t length);
     static Ref<GenericTypedArrayView> create(std::span<const typename Adaptor::Type> data) { return create(data.data(), data.size()); }
+    static Ref<GenericTypedArrayView> create(Ref<ArrayBuffer>&&);
     static Ref<GenericTypedArrayView> create(RefPtr<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);
     static RefPtr<GenericTypedArrayView> tryCreate(size_t length);
     static RefPtr<GenericTypedArrayView> tryCreate(const typename Adaptor::Type* array, size_t length);

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
@@ -58,6 +58,13 @@ Ref<GenericTypedArrayView<Adaptor>> GenericTypedArrayView<Adaptor>::create(
 }
 
 template<typename Adaptor>
+Ref<GenericTypedArrayView<Adaptor>> GenericTypedArrayView<Adaptor>::create(Ref<ArrayBuffer>&& buffer)
+{
+    auto length = buffer->byteLength();
+    return adoptRef(*new GenericTypedArrayView(WTFMove(buffer), 0, length));
+}
+
+template<typename Adaptor>
 Ref<GenericTypedArrayView<Adaptor>> GenericTypedArrayView<Adaptor>::create(
     RefPtr<ArrayBuffer>&& buffer, size_t byteOffset, std::optional<size_t> length)
 {

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,7 +54,7 @@ public:
 private:
     bool didDeflateFinish(int) const;
 
-    ExceptionOr<RefPtr<JSC::ArrayBuffer>> compress(std::span<const uint8_t>);
+    ExceptionOr<Ref<JSC::ArrayBuffer>> compress(std::span<const uint8_t>);
     ExceptionOr<bool> initialize();
 
     explicit CompressionStreamEncoder(unsigned char format)

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,7 +66,7 @@ private:
     bool didInflateFinish(int) const;
     bool didInflateContainExtraBytes(int) const;
 
-    ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompressZlib(std::span<const uint8_t>);
+    ExceptionOr<Ref<JSC::ArrayBuffer>> decompressZlib(std::span<const uint8_t>);
     ExceptionOr<bool> initialize();
 
     explicit DecompressionStreamDecoder(unsigned char format)
@@ -89,11 +89,11 @@ private:
 
     bool m_usingAppleCompressionFramework { false };
 
-    inline ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompress(std::span<const uint8_t>);
+    inline ExceptionOr<Ref<JSC::ArrayBuffer>> decompress(std::span<const uint8_t>);
 
 #if PLATFORM(COCOA)
     compression_stream m_stream;
-    ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompressAppleCompressionFramework(std::span<const uint8_t>);
+    ExceptionOr<Ref<JSC::ArrayBuffer>> decompressAppleCompressionFramework(std::span<const uint8_t>);
     ExceptionOr<bool> initializeAppleCompressionFramework();
 #endif
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -379,8 +379,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
         return;
     case Type::Bytes: {
         RefPtr buffer = takeAsArrayBuffer();
-        auto byteLength = buffer ? buffer->byteLength() : 0;
-        RefPtr view = buffer ? Uint8Array::tryCreate(buffer.releaseNonNull(), 0, byteLength) : nullptr;
+        RefPtr view = buffer ? RefPtr { Uint8Array::create(buffer.releaseNonNull()) } : nullptr;
         fulfillPromiseWithUint8Array(WTFMove(promise), view.get());
         return;
     }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3190,10 +3190,8 @@ void HTMLMediaElement::mediaPlayerKeyNeeded(const SharedBuffer& initData)
 
     WebKitMediaKeyNeededEvent::Init init;
 
-    if (auto initDataBuffer = initData.tryCreateArrayBuffer()) {
-        auto byteLength = initDataBuffer->byteLength();
-        init.initData = Uint8Array::tryCreate(initDataBuffer.releaseNonNull(), 0, byteLength);
-    }
+    if (auto initDataBuffer = initData.tryCreateArrayBuffer())
+        init.initData = Uint8Array::create(initDataBuffer.releaseNonNull());
 
     Ref event = WebKitMediaKeyNeededEvent::create(eventNames().webkitneedkeyEvent, init);
     scheduleEvent(WTFMove(event));

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,11 +88,8 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
     if (bufferSize != arrayBuffer->byteLength())
         return nullptr;
 
-    auto data = Uint8ClampedArray::tryCreate(WTFMove(arrayBuffer), 0, bufferSize);
-    if (!data)
-        return nullptr;
-
-    return create(format, size, data.releaseNonNull());
+    Ref data = Uint8ClampedArray::create(WTFMove(arrayBuffer));
+    return create(format, size, WTFMove(data));
 }
 
 ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::Uint8ClampedArray>&& data)

--- a/Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -87,8 +87,7 @@ RefPtr<Uint8Array> CDMSessionAVFoundationCF::generateKeyRequest(const String&, U
     systemCode = 0;
     destinationURL = String();
 
-    auto keyRequestBuffer = ArrayBuffer::create(CFDataGetBytePtr(keyRequest.get()), CFDataGetLength(keyRequest.get()));
-    return Uint8Array::tryCreate(WTFMove(keyRequestBuffer), 0, keyRequestBuffer->byteLength());
+    return Uint8Array::tryCreate(CFDataGetBytePtr(keyRequest.get()), CFDataGetLength(keyRequest.get()));
 }
 
 void CDMSessionAVFoundationCF::releaseKeys()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,8 +111,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     ALWAYS_LOG(LOGIDENTIFIER);
 
     auto keyRequestBuffer = ArrayBuffer::create([keyRequest bytes], [keyRequest length]);
-    unsigned byteLength = keyRequestBuffer->byteLength();
-    return Uint8Array::tryCreate(WTFMove(keyRequestBuffer), 0, byteLength);
+    return Uint8Array::create(WTFMove(keyRequestBuffer));
 }
 
 void CDMSessionAVFoundationObjC::releaseKeys()


### PR DESCRIPTION
#### 89de003bd68db1f46ecfc9000f341ae919c326ac
<pre>
Introduce a TypedArrayView create that solely takes an ArrayBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=274309">https://bugs.webkit.org/show_bug.cgi?id=274309</a>

Reviewed by Youenn Fablet, Keith Miller and Darin Adler.

This simplifies the setup for callers as they no longer have to obtain
the byteLength or provide the 0 offset.

Also use Ref instead of RefPtr where possible in the compression
module.

* Source/JavaScriptCore/runtime/GenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h:
(JSC::GenericTypedArrayView&lt;Adaptor&gt;::create):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::encode):
(WebCore::CompressionStreamEncoder::flush):
(WebCore::CompressionStreamEncoder::compress):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.h:
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decode):
(WebCore::DecompressionStreamDecoder::flush):
(WebCore::DecompressionStreamDecoder::decompress):
(WebCore::DecompressionStreamDecoder::decompressZlib):
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolve):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerKeyNeeded):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::tryCreate):
* Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.cpp:
(WebCore::CDMSessionAVFoundationCF::generateKeyRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::generateKeyRequest):

Canonical link: <a href="https://commits.webkit.org/279125@main">https://commits.webkit.org/279125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/725feb7a12f9c67f6dae1e9a6081508a0caa5fae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2978 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42697 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2088 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23810 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1436 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45905 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57424 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52064 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27688 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2805 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-subset.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html, wasm/window-postmessage.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50091 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49354 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11480 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29827 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64370 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7708 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28664 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12197 "Passed tests") | 
<!--EWS-Status-Bubble-End-->