### PR TITLE
[GStreamer] Minor cleanups in GstMappedFrame class

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -223,90 +223,87 @@ class GstMappedFrame {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(GstMappedFrame);
 public:
-
     GstMappedFrame(GstBuffer* buffer, GstVideoInfo* info, GstMapFlags flags)
     {
-        m_isValid = gst_video_frame_map(&m_frame, info, buffer, flags);
+        gst_video_frame_map(&m_frame, info, buffer, flags);
     }
 
     GstMappedFrame(const GRefPtr<GstSample>& sample, GstMapFlags flags)
     {
         GstVideoInfo info;
-
         if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get())))
             return;
 
-        m_isValid = gst_video_frame_map(&m_frame, &info, gst_sample_get_buffer(sample.get()), flags);
+        gst_video_frame_map(&m_frame, &info, gst_sample_get_buffer(sample.get()), flags);
+    }
+
+    ~GstMappedFrame()
+    {
+        // FIXME: Make this un-conditional when the minimum GStreamer dependency version is >= 1.22.
+        if (m_frame.buffer)
+            gst_video_frame_unmap(&m_frame);
     }
 
     GstVideoFrame* get()
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return &m_frame;
     }
 
     uint8_t* ComponentData(int comp) const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_COMP_DATA(&m_frame, comp);
     }
 
     int ComponentStride(int stride) const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_COMP_STRIDE(&m_frame, stride);
     }
 
     GstVideoInfo* info()
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return &m_frame.info;
     }
 
     int width() const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_WIDTH(&m_frame);
     }
 
     int height() const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_HEIGHT(&m_frame);
     }
 
     int format() const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_FORMAT(&m_frame);
     }
 
     void* planeData(uint32_t planeIndex) const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_PLANE_DATA(&m_frame, planeIndex);
     }
 
     int planeStride(uint32_t planeIndex) const
     {
-        RELEASE_ASSERT(m_isValid);
+        RELEASE_ASSERT(isValid());
         return GST_VIDEO_FRAME_PLANE_STRIDE(&m_frame, planeIndex);
     }
 
-    ~GstMappedFrame()
-    {
-        if (m_isValid)
-            gst_video_frame_unmap(&m_frame);
-        m_isValid = false;
-    }
-
-    bool isValid() const { return m_isValid; }
-    explicit operator bool() const { return m_isValid; }
-    bool operator!() const { return !m_isValid; }
+    bool isValid() const { return m_frame.buffer; }
+    explicit operator bool() const { return m_frame.buffer; }
+    bool operator!() const { return !m_frame.buffer; }
 
 private:
     GstVideoFrame m_frame;
-    bool m_isValid { false };
 };
 
 class GstMappedAudioBuffer {


### PR DESCRIPTION
#### 04a4f4adf3f1272fe288b310cdcca6cc8f96c956
<pre>
[GStreamer] Minor cleanups in GstMappedFrame class
<a href="https://bugs.webkit.org/show_bug.cgi?id=274312">https://bugs.webkit.org/show_bug.cgi?id=274312</a>

Reviewed by Xabier Rodriguez-Calvar.

There is no need for a m_isValid boolean attribute because the buffer field on the GstVideoFrame can
be checked instead.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::GstMappedFrame::GstMappedFrame):
(WebCore::GstMappedFrame::~GstMappedFrame):
(WebCore::GstMappedFrame::get):
(WebCore::GstMappedFrame::ComponentData const):
(WebCore::GstMappedFrame::ComponentStride const):
(WebCore::GstMappedFrame::info):
(WebCore::GstMappedFrame::width const):
(WebCore::GstMappedFrame::height const):
(WebCore::GstMappedFrame::format const):
(WebCore::GstMappedFrame::planeData const):
(WebCore::GstMappedFrame::planeStride const):
(WebCore::GstMappedFrame::isValid const):
(WebCore::GstMappedFrame::operator bool const):
(WebCore::GstMappedFrame::operator! const):

Canonical link: <a href="https://commits.webkit.org/278992@main">https://commits.webkit.org/278992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d44ba456bf5fdb843da53ef6ee00c9e8847e1c2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54471 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/37912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/1848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23529 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26402 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2297 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57037 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2498 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49084 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11410 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->