### PR TITLE
exceptions can't always be checked under silent spill in DFG

### DIFF
--- a/JSTests/stress/generator-cell-with-type.js
+++ b/JSTests/stress/generator-cell-with-type.js
@@ -1,4 +1,4 @@
-iterations = typeof(iterations) === 'undefined' ? 1e6 : iterations;
+iterations = typeof(iterations) === 'undefined' ? 1e5 : iterations;
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/stack-overflow-in-scope-with-catch.js
+++ b/JSTests/stress/stack-overflow-in-scope-with-catch.js
@@ -1,0 +1,23 @@
+let count = 0;
+
+function foo() {
+    if (count++ > 1e5)
+        return;
+    for (let j = 0; j < 5; j++) {
+        try {
+            foo();
+        } catch (e) {
+            Set[Symbol.hasInstance] = function() { };
+            foo();
+        } finally {
+            function bar() { }
+        }
+
+        function goo() {
+            function baz() { }
+            baz();
+            baz(bar);
+        }
+    }
+}
+foo();

--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -24,7 +24,7 @@ function mac_process_jsc_entitlements()
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
         fi
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 )) && [[ -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ]]
         then
             plistbuddy Add :com.apple.private.verified-jit bool YES
             plistbuddy Add :com.apple.security.cs.single-jit bool YES
@@ -48,7 +48,7 @@ function mac_process_testapi_entitlements()
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
         fi
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 )) && [[ -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ]]
         then
             plistbuddy Add :com.apple.private.verified-jit bool YES
             plistbuddy Add :com.apple.security.cs.single-jit bool YES
@@ -76,7 +76,7 @@ function maccatalyst_process_jsc_entitlements()
         fi
     fi
 
-    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
+    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 )) && [[ -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ]]
     then
         plistbuddy Add :com.apple.private.verified-jit bool YES
         plistbuddy Add :com.apple.security.cs.single-jit bool YES
@@ -101,7 +101,7 @@ function maccatalyst_process_testapi_entitlements()
         plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
     fi
 
-    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
+    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 )) && [[ -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ]]
     then
         plistbuddy Add :com.apple.private.verified-jit bool YES
         plistbuddy Add :com.apple.security.cs.single-jit bool YES

--- a/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
@@ -91,29 +91,25 @@ private:
             }
         }
         
-        for (unsigned i = 0; i < m_plans.size(); ++i)
-            jit->silentSpill(m_plans[i]);
         VM& vm = jit->vm();
         switch (m_arrayMode.type()) {
         case Array::Int32:
-            jit->callOperation(operationEnsureInt32, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
+            jit->callOperationWithSilentSpill(m_plans.span(), operationEnsureInt32, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
             break;
         case Array::Double:
-            jit->callOperation(operationEnsureDouble, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
+            jit->callOperationWithSilentSpill(m_plans.span(), operationEnsureDouble, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
             break;
         case Array::Contiguous:
-            jit->callOperation(operationEnsureContiguous, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
+            jit->callOperationWithSilentSpill(m_plans.span(), operationEnsureContiguous, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
             break;
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
-            jit->callOperation(operationEnsureArrayStorage, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
+            jit->callOperationWithSilentSpill(m_plans.span(), operationEnsureArrayStorage, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
             break;
         default:
             CRASH();
             break;
         }
-        for (unsigned i = m_plans.size(); i--;)
-            jit->silentFill(m_plans[i]);
         
         if (m_op == ArrayifyToStructure) {
             ASSERT(m_structure.get());

--- a/Source/JavaScriptCore/dfg/DFGCallArrayAllocatorSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGCallArrayAllocatorSlowPathGenerator.h
@@ -55,11 +55,7 @@ private:
     void generateInternal(SpeculativeJIT* jit) final
     {
         linkFrom(jit);
-        for (unsigned i = 0; i < m_plans.size(); ++i)
-            jit->silentSpill(m_plans[i]);
-        jit->callOperation(m_function, m_resultGPR, SpeculativeJIT::TrustedImmPtr(&jit->vm()), m_structure, m_size, m_storageGPR);
-        for (unsigned i = m_plans.size(); i--;)
-            jit->silentFill(m_plans[i]);
+        jit->callOperationWithSilentSpill(m_plans.span(), m_function, m_resultGPR, SpeculativeJIT::TrustedImmPtr(&jit->vm()), m_structure, m_size, m_storageGPR);
         jit->loadPtr(MacroAssembler::Address(m_resultGPR, JSObject::butterflyOffset()), m_storageGPR);
         jumpTo(jit);
     }
@@ -94,8 +90,7 @@ private:
     void generateInternal(SpeculativeJIT* jit) final
     {
         linkFrom(jit);
-        for (unsigned i = 0; i < m_plans.size(); ++i)
-            jit->silentSpill(m_plans[i]);
+        jit->silentSpill(m_plans);
         GPRReg scratchGPR = AssemblyHelpers::selectScratchGPR(m_sizeGPR, m_storageGPR);
         if (m_contiguousStructure.get() != m_arrayStorageOrContiguousStructure.get()) {
             MacroAssembler::Jump bigLength = jit->branch32(MacroAssembler::AboveOrEqual, m_sizeGPR, MacroAssembler::TrustedImm32(MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH));
@@ -106,9 +101,15 @@ private:
             done.link(jit);
         } else
             jit->move(SpeculativeJIT::TrustedImmPtr(m_contiguousStructure), scratchGPR);
-        jit->callOperation(m_function, m_resultGPR, m_globalObject, scratchGPR, m_sizeGPR, m_storageGPR);
-        for (unsigned i = m_plans.size(); i--;)
-            jit->silentFill(m_plans[i]);
+        jit->setupArguments<decltype(m_function)>(m_globalObject, scratchGPR, m_sizeGPR, m_storageGPR);
+        jit->appendCall(m_function);
+        std::optional<GPRReg> exception = jit->tryHandleOrGetExceptionUnderSilentSpill<decltype(m_function)>(m_plans, m_resultGPR);
+        jit->setupResults(m_resultGPR);
+        jit->silentFill(m_plans);
+
+        if (exception)
+            jit->exceptionCheck(*exception);
+
         jumpTo(jit);
     }
 
@@ -143,11 +144,7 @@ private:
     void generateInternal(SpeculativeJIT* jit) final
     {
         linkFrom(jit);
-        for (unsigned i = 0; i < m_plans.size(); ++i)
-            jit->silentSpill(m_plans[i]);
-        jit->callOperation(m_function, m_resultGPR, m_globalObject, m_structureGPR, m_sizeGPR, m_storageGPR);
-        for (unsigned i = m_plans.size(); i--;)
-            jit->silentFill(m_plans[i]);
+        jit->callOperationWithSilentSpill(m_plans, m_function, m_resultGPR, m_globalObject, m_structureGPR, m_sizeGPR, m_storageGPR);
         jumpTo(jit);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGCallCreateDirectArgumentsSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGCallCreateDirectArgumentsSlowPathGenerator.h
@@ -55,12 +55,7 @@ private:
     void generateInternal(SpeculativeJIT* jit) final
     {
         linkFrom(jit);
-        for (unsigned i = 0; i < m_plans.size(); ++i)
-            jit->silentSpill(m_plans[i]);
-        jit->callOperation(
-            operationCreateDirectArguments, m_resultGPR, SpeculativeJIT::TrustedImmPtr(&jit->vm()), m_structure, m_lengthGPR, m_minCapacity);
-        for (unsigned i = m_plans.size(); i--;)
-            jit->silentFill(m_plans[i]);
+        jit->callOperationWithSilentSpill(m_plans.span(), operationCreateDirectArguments, m_resultGPR, SpeculativeJIT::TrustedImmPtr(&jit->vm()), m_structure, m_lengthGPR, m_minCapacity);
         jit->loadPtr(
             MacroAssembler::Address(m_resultGPR, DirectArguments::offsetOfLength()), m_lengthGPR);
         jumpTo(jit);

--- a/Source/JavaScriptCore/dfg/DFGRegisterBank.h
+++ b/Source/JavaScriptCore/dfg/DFGRegisterBank.h
@@ -75,6 +75,14 @@ class RegisterBank {
     static constexpr SpillHint SpillHintInvalid = 0xffffffff;
 
 public:
+    static constexpr RegisterSetBuilder registersInBank()
+    {
+        RegisterSetBuilder result;
+        for (uint32_t i = 0; i < NUM_REGS; ++i)
+            result.add(BankInfo::toRegister(i), IgnoreVectors);
+        return result;
+    }
+
     RegisterBank()
     {
     }

--- a/Source/JavaScriptCore/dfg/DFGSaneStringGetByValSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSaneStringGetByValSlowPathGenerator.h
@@ -70,11 +70,7 @@ private:
         
         isNeg.link(jit);
 
-        for (unsigned i = 0; i < m_plans.size(); ++i)
-            jit->silentSpill(m_plans[i]);
-        jit->callOperation(operationGetByValStringInt, extractResult(m_resultRegs), m_globalObject, m_baseReg, m_propertyReg);
-        for (unsigned i = m_plans.size(); i--;)
-            jit->silentFill(m_plans[i]);
+        jit->callOperationWithSilentSpill(m_plans, operationGetByValStringInt, extractResult(m_resultRegs), m_globalObject, m_baseReg, m_propertyReg);
         
         jumpTo(jit);
     }

--- a/Source/JavaScriptCore/dfg/DFGSilentRegisterSavePlan.h
+++ b/Source/JavaScriptCore/dfg/DFGSilentRegisterSavePlan.h
@@ -76,8 +76,6 @@ public:
     SilentRegisterSavePlan()
         : m_spillAction(DoNothingForSpill)
         , m_fillAction(DoNothingForFill)
-        , m_register(-1)
-        , m_node(nullptr)
     {
     }
     
@@ -110,14 +108,15 @@ public:
     
     Node* node() const { return m_node; }
     
-    GPRReg gpr() const { return static_cast<GPRReg>(m_register); }
-    FPRReg fpr() const { return static_cast<FPRReg>(m_register); }
+    Reg reg() const { return m_register; }
+    GPRReg gpr() const { return m_register.gpr(); }
+    FPRReg fpr() const { return m_register.fpr(); }
     
 private:
     int8_t m_spillAction;
     int8_t m_fillAction;
-    int8_t m_register;
-    Node* m_node;
+    Reg m_register;
+    Node* m_node { nullptr };
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
@@ -183,10 +183,8 @@ protected:
     void setUp(SpeculativeJIT* jit)
     {
         this->linkFrom(jit);
-        if (m_spillMode == NeedToSpill) {
-            for (unsigned i = 0; i < m_plans.size(); ++i)
-                jit->silentSpill(m_plans[i]);
-        }
+        if (m_spillMode == NeedToSpill)
+            jit->silentSpill(m_plans);
     }
     
     void recordCall(MacroAssembler::Call call)
@@ -196,16 +194,24 @@ protected:
     
     void tearDown(SpeculativeJIT* jit)
     {
-        if (m_exceptionCheckRequirement == ExceptionCheckRequirement::CheckNeeded)
-            jit->exceptionCheck(CCallHelpers::operationExceptionRegister<typename FunctionTraits<FunctionType>::ResultType>());
+        std::optional<GPRReg> exception;
+
+        if (m_exceptionCheckRequirement == ExceptionCheckRequirement::CheckNeeded) {
+            if (m_spillMode == NeedToSpill)
+                exception = jit->tryHandleOrGetExceptionUnderSilentSpill<FunctionType>(m_plans, this->m_result);
+            else
+                jit->exceptionCheck(CCallHelpers::operationExceptionRegister<typename FunctionTraits<FunctionType>::ResultType>());
+        }
 
         if constexpr (!std::is_same_v<ResultType, NoResultTag>)
             jit->setupResults(extractResult(this->m_result));
 
-        if (m_spillMode == NeedToSpill) {
-            for (unsigned i = m_plans.size(); i--;)
-                jit->silentFill(m_plans[i]);
-        }
+        if (m_spillMode == NeedToSpill)
+            jit->silentFill(m_plans);
+
+        if (m_exceptionCheckRequirement == ExceptionCheckRequirement::CheckNeeded && exception)
+            jit->exceptionCheck(*exception);
+
         this->jumpTo(jit);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -318,6 +318,7 @@ void SpeculativeJIT::exceptionCheck(GPRReg exceptionReg)
     HandlerInfo* exceptionHandler;
     bool willCatchException = m_graph.willCatchExceptionInMachineFrame(m_currentNode->origin.forExit, opCatchOrigin, exceptionHandler);
     if (willCatchException) {
+        RELEASE_ASSERT(!m_underSilentSpill);
         unsigned streamIndex = m_outOfLineStreamIndex ? *m_outOfLineStreamIndex : m_stream.size();
         Jump hadException = emitNonPatchableExceptionCheck(vm(), exceptionReg);
         // We assume here that this is called after callOperation()/appendCall() is called.
@@ -674,6 +675,7 @@ void SpeculativeJIT::runSlowPathGenerators(PCToCodeOriginMapBuilder& pcToCodeOri
         auto sizeMarker = markSlowPathIfNeeded(currentNode);
 
         slowPathLambda.generator();
+        ASSERT(!m_underSilentSpill);
         m_outOfLineStreamIndex = std::nullopt;
         if (UNLIKELY(sizeMarker))
             vm().jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_graph.m_plan);
@@ -876,8 +878,9 @@ SilentRegisterSavePlan SpeculativeJIT::silentSavePlanForFPR(VirtualRegister spil
     return SilentRegisterSavePlan(spillAction, fillAction, node, source);
 }
     
-void SpeculativeJIT::silentSpill(const SilentRegisterSavePlan& plan)
+void SpeculativeJIT::silentSpillImpl(const SilentRegisterSavePlan& plan)
 {
+    ASSERT(m_underSilentSpill);
     switch (plan.spillAction()) {
     case DoNothingForSpill:
         break;
@@ -903,8 +906,9 @@ void SpeculativeJIT::silentSpill(const SilentRegisterSavePlan& plan)
     }
 }
     
-void SpeculativeJIT::silentFill(const SilentRegisterSavePlan& plan)
+void SpeculativeJIT::silentFillImpl(const SilentRegisterSavePlan& plan)
 {
+    ASSERT(m_underSilentSpill);
     switch (plan.fillAction()) {
     case DoNothingForFill:
         break;
@@ -2264,9 +2268,7 @@ void SpeculativeJIT::compileToLowerCase(Node* node)
     jump().linkTo(loopStart, this);
     
     slowPath.link(this);
-    silentSpillAllRegisters(lengthGPR);
-    callOperation(operationToLowerCase, lengthGPR, LinkableConstant::globalObject(*this, node), stringGPR, indexGPR);
-    silentFillAllRegisters();
+    callOperationWithSilentSpill(operationToLowerCase, lengthGPR, LinkableConstant::globalObject(*this, node), stringGPR, indexGPR);
     auto done = jump();
 
     loopDone.link(this);
@@ -4430,12 +4432,11 @@ void SpeculativeJIT::compileGetByValForObjectWithString(Node* node, const Scoped
     speculateString(m_graph.varArgChild(node, 1), arg2GPR);
 
     if (canUseFlush == CanUseFlush::No)
-        silentSpillAllRegisters(resultRegs);
-    else
+        callOperationWithSilentSpill(operationGetByValObjectString, resultRegs, LinkableConstant::globalObject(*this, node), arg1GPR, arg2GPR);
+    else {
         flushRegisters();
-    callOperation(operationGetByValObjectString, resultRegs, LinkableConstant::globalObject(*this, node), arg1GPR, arg2GPR);
-    if (canUseFlush == CanUseFlush::No)
-        silentFillAllRegisters();
+        callOperation(operationGetByValObjectString, resultRegs, LinkableConstant::globalObject(*this, node), arg1GPR, arg2GPR);
+    }
 
     jsValueResult(resultRegs, node);
 }
@@ -4456,12 +4457,11 @@ void SpeculativeJIT::compileGetByValForObjectWithSymbol(Node* node, const Scoped
     speculateSymbol(m_graph.varArgChild(node, 1), arg2GPR);
 
     if (canUseFlush == CanUseFlush::No)
-        silentSpillAllRegisters(resultRegs);
-    else
+        callOperationWithSilentSpill(operationGetByValObjectSymbol, resultRegs, LinkableConstant::globalObject(*this, node), arg1GPR, arg2GPR);
+    else {
         flushRegisters();
-    callOperation(operationGetByValObjectSymbol, resultRegs, LinkableConstant::globalObject(*this, node), arg1GPR, arg2GPR);
-    if (canUseFlush == CanUseFlush::No)
-        silentFillAllRegisters();
+        callOperation(operationGetByValObjectSymbol, resultRegs, LinkableConstant::globalObject(*this, node), arg1GPR, arg2GPR);
+    }
 
     jsValueResult(resultRegs, node);
 }
@@ -5256,7 +5256,6 @@ void SpeculativeJIT::emitUntypedOrAnyBigIntBitOp(Node* node)
     gen.endJumpList().append(jump());
 
     gen.slowPathJumpList().link(this);
-    silentSpillAllRegisters(resultRegs);
 
     if (leftOperand.isConst()) {
         leftRegs = resultRegs;
@@ -5266,9 +5265,7 @@ void SpeculativeJIT::emitUntypedOrAnyBigIntBitOp(Node* node)
         moveValue(rightChild->asJSValue(), rightRegs);
     }
 
-    callOperation(snippetSlowPathFunction, resultRegs, LinkableConstant::globalObject(*this, node), leftRegs, rightRegs);
-
-    silentFillAllRegisters();
+    callOperationWithSilentSpill(snippetSlowPathFunction, resultRegs, LinkableConstant::globalObject(*this, node), leftRegs, rightRegs);
 
     gen.endJumpList().link(this);
     jsValueResult(resultRegs, node);
@@ -5472,7 +5469,6 @@ void SpeculativeJIT::emitUntypedOrBigIntRightShiftBitOp(Node* node)
     gen.endJumpList().append(jump());
 
     gen.slowPathJumpList().link(this);
-    silentSpillAllRegisters(resultRegs);
 
     if (leftOperand.isConst()) {
         leftRegs = resultRegs;
@@ -5482,9 +5478,7 @@ void SpeculativeJIT::emitUntypedOrBigIntRightShiftBitOp(Node* node)
         moveValue(rightChild->asJSValue(), rightRegs);
     }
 
-    callOperation(snippetSlowPathFunction, resultRegs, LinkableConstant::globalObject(*this, node), leftRegs, rightRegs);
-
-    silentFillAllRegisters();
+    callOperationWithSilentSpill(snippetSlowPathFunction, resultRegs, LinkableConstant::globalObject(*this, node), leftRegs, rightRegs);
 
     gen.endJumpList().link(this);
     jsValueResult(resultRegs, node);
@@ -5833,8 +5827,6 @@ void SpeculativeJIT::compileMathIC(Node* node, JITBinaryMathIC<Generator>* mathI
             auto slowPathStart = label();
 #endif
 
-            silentSpill(savePlans);
-
             auto innerLeftRegs = leftRegs;
             auto innerRightRegs = rightRegs;
             if (Generator::isLeftOperandValidConstant(leftOperand)) {
@@ -5846,11 +5838,10 @@ void SpeculativeJIT::compileMathIC(Node* node, JITBinaryMathIC<Generator>* mathI
             }
 
             if (addICGenerationState->shouldSlowPathRepatch)
-                addICGenerationState->slowPathCall = callOperation(repatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), innerLeftRegs, innerRightRegs, TrustedImmPtr(mathIC));
+                addICGenerationState->slowPathCall = callOperationWithSilentSpill(savePlans, repatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), innerLeftRegs, innerRightRegs, TrustedImmPtr(mathIC));
             else
-                addICGenerationState->slowPathCall = callOperation(nonRepatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), innerLeftRegs, innerRightRegs);
+                addICGenerationState->slowPathCall = callOperationWithSilentSpill(savePlans, nonRepatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), innerLeftRegs, innerRightRegs);
 
-            silentFill(savePlans);
             jump().linkTo(done, this);
 
             addLinkTask([=] (LinkBuffer& linkBuffer) {
@@ -6464,14 +6455,11 @@ void SpeculativeJIT::compileMathIC(Node* node, JITUnaryMathIC<Generator>* mathIC
             auto slowPathStart = label();
 #endif
 
-            silentSpill(savePlans);
-
             if (icGenerationState->shouldSlowPathRepatch)
-                icGenerationState->slowPathCall = callOperation(repatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), childRegs, TrustedImmPtr(mathIC));
+                icGenerationState->slowPathCall = callOperationWithSilentSpill(savePlans, repatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), childRegs, TrustedImmPtr(mathIC));
             else
-                icGenerationState->slowPathCall = callOperation(nonRepatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), childRegs);
+                icGenerationState->slowPathCall = callOperationWithSilentSpill(savePlans, nonRepatchingFunction, resultRegs, LinkableConstant::globalObject(*this, node), childRegs);
 
-            silentFill(savePlans);
             jump().linkTo(done, this);
 
             addLinkTask([=] (LinkBuffer& linkBuffer) {
@@ -6839,7 +6827,6 @@ void SpeculativeJIT::compileValueDiv(Node* node)
     gen.endJumpList().append(jump());
 
     gen.slowPathJumpList().link(this);
-    silentSpillAllRegisters(resultRegs);
 
     if (leftOperand.isConst()) {
         leftRegs = resultRegs;
@@ -6850,9 +6837,7 @@ void SpeculativeJIT::compileValueDiv(Node* node)
         moveValue(rightChild->asJSValue(), rightRegs);
     }
 
-    callOperation(operationValueDiv, resultRegs, LinkableConstant::globalObject(*this, node), leftRegs, rightRegs);
-
-    silentFillAllRegisters();
+    callOperationWithSilentSpill(operationValueDiv, resultRegs, LinkableConstant::globalObject(*this, node), leftRegs, rightRegs);
 
     gen.endJumpList().link(this);
     jsValueResult(resultRegs, node);
@@ -9201,6 +9186,13 @@ void SpeculativeJIT::compileNewFunction(Node* node)
     
     SpeculateCellOperand scope(this, node->child1());
     GPRReg scopeGPR = scope.gpr();
+
+    JIT_COMMENT(*this, "scopeGPR: ", gprName(scopeGPR));
+
+    probeDebug([=] (Probe::Context& context) {
+        auto* scope = context.gpr<JSCell*>(scopeGPR);
+        RELEASE_ASSERT(scope->inherits<JSScope>());
+    });
 
     FunctionExecutable* executable = node->castOperand<FunctionExecutable*>();
 
@@ -13413,9 +13405,7 @@ void SpeculativeJIT::emitSwitchStringOnString(Node* node, SwitchData* data, GPRR
         data, cases, 0, 0, cases.size(), string, lengthGPR, tempGPR, 0, false);
     
     slowCases.link(this);
-    silentSpillAllRegisters(string);
-    callOperation(operationSwitchString, string, LinkableConstant::globalObject(*this, node), static_cast<size_t>(data->switchTableIndex), TrustedImmPtr(&unlinkedTable), string);
-    silentFillAllRegisters();
+    callOperationWithSilentSpill(operationSwitchString, string, LinkableConstant::globalObject(*this, node), static_cast<size_t>(data->switchTableIndex), TrustedImmPtr(&unlinkedTable), string);
     farJump(string, JSSwitchPtrTag);
 }
 
@@ -14982,9 +14972,7 @@ void SpeculativeJIT::compileGetPropertyEnumerator(Node* node)
         doneCases.append(jump());
 
         slowCases.link(this);
-        silentSpillAllRegisters(scratch1GPR);
-        callOperation(operationGetPropertyEnumeratorCell, scratch1GPR, LinkableConstant::globalObject(*this, node), baseRegs.payloadGPR());
-        silentFillAllRegisters();
+        callOperationWithSilentSpill(operationGetPropertyEnumeratorCell, scratch1GPR, LinkableConstant::globalObject(*this, node), baseRegs.payloadGPR());
 
         doneCases.link(this);
         cellResult(scratch1GPR, node);
@@ -16785,9 +16773,7 @@ void SpeculativeJIT::genericJSValuePeepholeBranch(Node* node, Node* branchNode, 
 
             slowPath.link(this);
 
-            silentSpillAllRegisters(resultGPR);
-            callOperation(helperFunction, resultGPR, LinkableConstant::globalObject(*this, node), arg1Regs, arg2Regs);
-            silentFillAllRegisters();
+            callOperationWithSilentSpill(helperFunction, resultGPR, LinkableConstant::globalObject(*this, node), arg1Regs, arg2Regs);
 
             branchTest32(callResultCondition, resultGPR, taken);
         }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -367,33 +367,48 @@ public:
     // in the GenerationInfo.
     SilentRegisterSavePlan silentSavePlanForGPR(VirtualRegister spillMe, GPRReg source);
     SilentRegisterSavePlan silentSavePlanForFPR(VirtualRegister spillMe, FPRReg source);
-    void silentSpill(const SilentRegisterSavePlan&);
-    void silentFill(const SilentRegisterSavePlan&);
+    void silentSpillImpl(const SilentRegisterSavePlan&);
+    void silentFillImpl(const SilentRegisterSavePlan&);
+
+    RegisterSetBuilder spilledRegsForSilentSpillPlans(const auto& plans)
+    {
+        RegisterSetBuilder usedRegisters;
+        for (auto& plan : plans)
+            usedRegisters.add(plan.reg(), IgnoreVectors);
+        return usedRegisters;
+    }
 
     template<typename CollectionType>
     void silentSpill(const CollectionType& savePlans)
     {
+        ASSERT(!m_underSilentSpill);
+        m_underSilentSpill = true;
         for (unsigned i = 0; i < savePlans.size(); ++i)
-            silentSpill(savePlans[i]);
+            silentSpillImpl(savePlans[i]);
     }
 
     template<typename CollectionType>
     void silentFill(const CollectionType& savePlans)
     {
+        ASSERT(m_underSilentSpill);
         for (unsigned i = savePlans.size(); i--;)
-            silentFill(savePlans[i]);
+            silentFillImpl(savePlans[i]);
+        m_underSilentSpill = false;
     }
 
     template<typename CollectionType>
     void silentSpillAllRegistersImpl(bool doSpill, CollectionType& plans, GPRReg exclude, GPRReg exclude2 = InvalidGPRReg, FPRReg fprExclude = InvalidFPRReg)
     {
         ASSERT(plans.isEmpty());
+        ASSERT(!m_underSilentSpill);
+        if (doSpill)
+            m_underSilentSpill = true;
         for (gpr_iterator iter = m_gprs.begin(); iter != m_gprs.end(); ++iter) {
             GPRReg gpr = iter.regID();
             if (iter.name().isValid() && gpr != exclude && gpr != exclude2) {
                 SilentRegisterSavePlan plan = silentSavePlanForGPR(iter.name(), gpr);
                 if (doSpill)
-                    silentSpill(plan);
+                    silentSpillImpl(plan);
                 plans.append(plan);
             }
         }
@@ -401,7 +416,7 @@ public:
             if (iter.name().isValid() && iter.regID() != fprExclude) {
                 SilentRegisterSavePlan plan = silentSavePlanForFPR(iter.name(), iter.regID());
                 if (doSpill)
-                    silentSpill(plan);
+                    silentSpillImpl(plan);
                 plans.append(plan);
             }
         }
@@ -445,11 +460,8 @@ public:
 
     void silentFillAllRegisters()
     {
-        while (!m_plans.isEmpty()) {
-            SilentRegisterSavePlan& plan = m_plans.last();
-            silentFill(plan);
-            m_plans.removeLast();
-        }
+        silentFill(m_plans);
+        m_plans.clear();
     }
 
     // These methods convert between doubles, and doubles boxed and JSValues.
@@ -941,6 +953,7 @@ public:
     void operationExceptionCheck()
     {
         using ResultType = typename FunctionTraits<OperationType>::ResultType;
+        ASSERT(!m_underSilentSpill);
         exceptionCheck(operationExceptionRegister<ResultType>());
     }
 
@@ -956,7 +969,7 @@ public:
     }
 
     template<typename OperationType, typename... Args>
-    requires (!OperationHasResult<OperationType>)
+    requires (OperationIsVoid<OperationType>)
     JITCompiler::Call callOperation(OperationType operation, Args... args)
     {
         setupArguments<OperationType>(args...);
@@ -977,7 +990,7 @@ public:
     }
 
     template<typename OperationType, typename... Args>
-    requires (!OperationHasResult<OperationType>)
+    requires (OperationIsVoid<OperationType>)
     JITCompiler::Call callOperation(const CodePtr<OperationPtrTag> operation, Args... args)
     {
         setupArguments<OperationType>(args...);
@@ -996,9 +1009,17 @@ public:
         setupResults(result);
     }
 
+    template<typename OperationType, typename... Args>
+    requires (OperationIsVoid<OperationType>)
+    void callOperation(Address address, Args... args)
+    {
+        setupArgumentsForIndirectCall<OperationType>(address, args...);
+        appendCall(Address(GPRInfo::nonArgGPR0, address.offset));
+        operationExceptionCheck<OperationType>();
+    }
 
     template<typename OperationType, typename... Args>
-    requires (!OperationHasResult<OperationType>
+    requires (OperationIsVoid<OperationType>
         && !isExceptionOperationResult<typename FunctionTraits<OperationType>::ResultType>) // Sanity check
     void callOperationWithoutExceptionCheck(Address address, Args... args)
     {
@@ -1018,7 +1039,7 @@ public:
     }
 
     template<typename OperationType, typename... Args>
-    requires (!OperationHasResult<OperationType>
+    requires (OperationIsVoid<OperationType>
         && !isExceptionOperationResult<typename FunctionTraits<OperationType>::ResultType>) // Sanity check
     JITCompiler::Call callOperationWithoutExceptionCheck(OperationType operation, Args... args)
     {
@@ -1036,13 +1057,122 @@ public:
         setupResults(result);
     }
 
-    template<typename OperationType, typename... Args>
-    requires (!OperationHasResult<OperationType>)
-    void callOperation(Address address, Args... args)
+    // There are three cases here:
+    // 1) nullopt the exception was handled
+    // 2) valid GPRReg containing the exception that won't interfere with silentFill.
+    // 3) InvalidGPRReg meaning the exception needs to be loaded from VM.
+    template<typename OperationType, typename ResultRegType>
+    std::optional<GPRReg> tryHandleOrGetExceptionUnderSilentSpill(const auto& plans, ResultRegType result)
     {
-        setupArgumentsForIndirectCall<OperationType>(address, args...);
-        appendCall(Address(GPRInfo::nonArgGPR0, address.offset));
-        operationExceptionCheck<OperationType>();
+        ASSERT(m_underSilentSpill);
+        using ResultType = typename FunctionTraits<OperationType>::ResultType;
+        GPRReg exceptionReg = operationExceptionRegister<ResultType>();
+        CodeOrigin opCatchOrigin;
+        HandlerInfo* exceptionHandler;
+        bool willCatchException = m_graph.willCatchExceptionInMachineFrame(m_currentNode->origin.forExit, opCatchOrigin, exceptionHandler);
+        // The simplest (and most common) case is when we're not going to catch in this frame, then we don't need to fill since
+        // no one's going to look.
+        if (!willCatchException) {
+            exceptionCheck(exceptionReg);
+            return std::nullopt;
+        }
+
+        if (exceptionReg != InvalidGPRReg) {
+            RegisterSetBuilder spilledRegs = spilledRegsForSilentSpillPlans(plans);
+            if constexpr (std::is_same_v<GPRReg, ResultRegType> || std::is_same_v<JSValueRegs, ResultRegType>) {
+                spilledRegs.add(GPRInfo::returnValueGPR, IgnoreVectors);
+                spilledRegs.add(result, IgnoreVectors);
+            }
+
+            if (spilledRegs.buildAndValidate().contains(exceptionReg, IgnoreVectors)) {
+                // It would be nice if we could do m_gprs.tryAllocate() but we're possibly on a slow path and register allocation state is
+                // probably garbage.
+                constexpr RegisterSetBuilder registersInBank = decltype(m_gprs)::registersInBank();
+                // Move to a non-constexpr local so we can call exclude.
+                RegisterSetBuilder possibleRegisters = registersInBank;
+                RegisterSet freeRegs = possibleRegisters.exclude(spilledRegs).buildAndValidate();
+                auto iter = freeRegs.begin();
+                if (iter != freeRegs.end()) {
+                    move(exceptionReg, iter.gpr());
+                    exceptionReg = iter.gpr();
+                } else {
+                    // We tried but there were no free regs.
+                    exceptionReg = InvalidGPRReg;
+                }
+            }
+        }
+
+        return exceptionReg;
+    }
+
+    template<typename OperationType, typename ResultRegType, typename... Args>
+    requires (OperationHasResult<OperationType>)
+    JITCompiler::Call callOperationWithSilentSpill(OperationType operation, ResultRegType result, Args... args)
+    {
+        silentSpillAllRegisters(result);
+        setupArguments<OperationType>(args...);
+        auto call = appendCall(operation);
+
+        std::optional<GPRReg> exceptionReg = tryHandleOrGetExceptionUnderSilentSpill<OperationType>(m_plans, result);
+
+        setupResults(result);
+        silentFillAllRegisters();
+        if (exceptionReg)
+            exceptionCheck(*exceptionReg);
+
+        return call;
+    }
+
+    template<typename OperationType, typename ResultRegType, typename... Args>
+    requires (OperationHasResult<OperationType>)
+    JITCompiler::Call callOperationWithSilentSpill(std::span<const SilentRegisterSavePlan> plans, OperationType operation, ResultRegType result, Args... args)
+    {
+        silentSpill(plans);
+        setupArguments<OperationType>(args...);
+        auto call = appendCall(operation);
+
+        std::optional<GPRReg> exceptionReg = tryHandleOrGetExceptionUnderSilentSpill<OperationType>(plans, result);
+
+        setupResults(result);
+        silentFill(plans);
+        if (exceptionReg)
+            exceptionCheck(*exceptionReg);
+
+        return call;
+    }
+
+    template<typename OperationType, typename... Args>
+    requires (OperationIsVoid<OperationType>)
+    JITCompiler::Call callOperationWithSilentSpill(OperationType operation, Args... args)
+    {
+        silentSpillAllRegisters(InvalidGPRReg);
+        setupArguments<OperationType>(args...);
+        auto call = appendCall(operation);
+
+        std::optional<GPRReg> exceptionReg = tryHandleOrGetExceptionUnderSilentSpill<OperationType>(m_plans, NoResult);
+
+        silentFillAllRegisters();
+        if (exceptionReg)
+            exceptionCheck(*exceptionReg);
+
+        return call;
+    }
+
+    template<typename OperationType, typename... Args>
+    requires (OperationIsVoid<OperationType>)
+    JITCompiler::Call callOperationWithSilentSpill(std::span<const SilentRegisterSavePlan> plans, OperationType operation, Args... args)
+    {
+        silentSpill(plans);
+        setupArguments<OperationType>(args...);
+        auto call = appendCall(operation);
+
+        std::optional<GPRReg> exceptionReg = tryHandleOrGetExceptionUnderSilentSpill<OperationType>(plans, NoResult);
+
+        silentFill(plans);
+        if (exceptionReg)
+            exceptionCheck(*exceptionReg);
+
+        return call;
     }
 
     JITCompiler::Call callThrowOperationWithCallFrameRollback(V_JITOperation_Cb operation, GPRReg codeBlockGPR)
@@ -1921,6 +2051,7 @@ public:
     };
     Vector<SlowPathLambda> m_slowPathLambdas;
     Vector<SilentRegisterSavePlan> m_plans;
+    bool m_underSilentSpill { false };
     std::optional<unsigned> m_outOfLineStreamIndex;
 };
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -373,13 +373,17 @@ AssemblyHelpers::Jump AssemblyHelpers::emitExceptionCheck(VM& vm, ExceptionCheck
     Jump result;
     if (exceptionReg != InvalidGPRReg) {
 #if ASSERT_ENABLED
+        JIT_COMMENT(*this, "Exception validation");
         Jump ok = branchPtr(Equal, AbsoluteAddress(vm.addressOfException()), exceptionReg);
         breakpoint();
         ok.link(this);
 #endif
+        JIT_COMMENT(*this, "Exception check from operation result register");
         result = branchTestPtr(kind == NormalExceptionCheck ? NonZero : Zero, exceptionReg);
-    } else
+    } else {
+        JIT_COMMENT(*this, "Exception check from vm");
         result = branchTestPtr(kind == NormalExceptionCheck ? NonZero : Zero, AbsoluteAddress(vm.addressOfException()));
+    }
 
     if (width == NormalJumpWidth)
         return result;

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -929,6 +929,13 @@ class NoOverlapImpl {
         return noOverlapImpl(used | mask, args...);
     }
 
+    // NoResultTag case, this happens from templates
+    template<typename... Args>
+    static constexpr bool noOverlapImpl(uint64_t used, NoResultTag, Args... args)
+    {
+        return noOverlapImpl(used, args...);
+    }
+
 public:
     // Entry point
     template <typename... Args>

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -205,8 +205,9 @@ private:
 
     static constexpr uint8_t deleted() { return invalid() - 1; }
 
-    unsigned m_index : 7;
+    uint8_t m_index : 7;
 };
+static_assert(sizeof(Reg) == 1);
 
 struct RegHash {
     static unsigned hash(const Reg& key) { return key.hash(); }

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -332,7 +332,14 @@ public:
         {
         }
 
-        inline constexpr Reg operator*() const { return Reg::fromIndex(*m_iter); }
+        inline constexpr Reg reg() const { return Reg::fromIndex(*m_iter); }
+        inline constexpr Reg operator*() const { return reg(); }
+
+        inline constexpr bool isGPR() const { return reg().isGPR(); }
+        inline constexpr bool isFPR() const { return reg().isFPR(); }
+
+        inline constexpr GPRReg gpr() const { return reg().gpr(); }
+        inline constexpr FPRReg fpr() const { return reg().fpr(); }
 
         iterator& operator++()
         {


### PR DESCRIPTION
#### d1282e05222cf31b112823d5c8a08632d5ff0558
<pre>
exceptions can&apos;t always be checked under silent spill in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=274291">https://bugs.webkit.org/show_bug.cgi?id=274291</a>
<a href="https://rdar.apple.com/128067350">rdar://128067350</a>

Reviewed by Yusuke Suzuki.

If we&apos;re catching an exception in the same DFG frame it&apos;s potentially
not safe to check for exceptions under a silent spill. This is because
the OSR exit ramp does not know about the silent spill. So values will
not be restored. There were a couple of possible fixes:

1) teach the DFGVariableEventStream about exceptions under silent spill.
2) add extra metadata about the fact we’re under a silent spill and silent
   fill before hitting the OSR exit ramp.
3) move the exception to an unused gpr until we can silent fill if needed.

I went with option 3. 1. has the problem that it&apos;s complicated and might
be a memory regression. 2. could bloat code size.

I also noticed that my `requires (!OperationHasResult&lt;T&gt;)` checks were not
properly eliminating overloads. This is because when you do e.g.
`requires (!OperationHasResult&lt;int&gt;)` the `OperationHasResult&lt;int&gt;` will
fail SFINAE but that just makes the concept false which then becomes true
in the requirement. Instead we now have a new `OperationIsVoid&lt;T&gt;` concept.

* JSTests/stress/stack-overflow-in-scope-with-catch.js: Added.
(foo.catch.Set.Symbol.hasInstance):
(foo.finally.bar):
(foo.goo.baz):
(foo.goo):
(foo):
* Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGCallArrayAllocatorSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGCallCreateDirectArgumentsSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGSaneStringGetByValSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGSilentRegisterSavePlan.h:
(JSC::DFG::SilentRegisterSavePlan::SilentRegisterSavePlan):
(JSC::DFG::SilentRegisterSavePlan::reg const):
(JSC::DFG::SilentRegisterSavePlan::gpr const):
(JSC::DFG::SilentRegisterSavePlan::fpr const):
* Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h:
(JSC::DFG::CallSlowPathGenerator::setUp):
(JSC::DFG::CallSlowPathGenerator::tearDown):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::exceptionCheck):
(JSC::DFG::SpeculativeJIT::silentSpillImpl):
(JSC::DFG::SpeculativeJIT::silentFillImpl):
(JSC::DFG::SpeculativeJIT::compileToLowerCase):
(JSC::DFG::SpeculativeJIT::silentSpill): Deleted.
(JSC::DFG::SpeculativeJIT::silentFill): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::spillPlanInterferesWithReg):
(JSC::DFG::SpeculativeJIT::silentSpill):
(JSC::DFG::SpeculativeJIT::silentFill):
(JSC::DFG::SpeculativeJIT::silentSpillAllRegistersImpl):
(JSC::DFG::SpeculativeJIT::silentFillAllRegisters):
(JSC::DFG::SpeculativeJIT::operationExceptionCheck):
(JSC::DFG::SpeculativeJIT::callOperation):
(JSC::DFG::SpeculativeJIT::tryHandleOrGetExceptionUnderSilentSpill):
(JSC::DFG::SpeculativeJIT::callOperationWithSilentSpill):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::nonSpeculativePeepholeStrictEq):
(JSC::DFG::SpeculativeJIT::genericJSValueNonPeepholeStrictEq):
(JSC::DFG::SpeculativeJIT::emitCall):
(JSC::DFG::SpeculativeJIT::compileGetByVal):
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::NoOverlapImpl::noOverlapImpl):
* Source/JavaScriptCore/jit/OperationResult.h:
* Source/JavaScriptCore/jit/Reg.h:

Canonical link: <a href="https://commits.webkit.org/279031@main">https://commits.webkit.org/279031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c50b46cd4d67dff0b9d9eea971b0707345bbe269

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3009 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/1927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23613 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2401 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1168 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45635 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57156 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2591 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49165 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11422 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64101 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28390 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12132 "Found 252 new JSC stress test failures: basic-tests.yaml/stress-test.js.bytecode-cache, basic-tests.yaml/stress-test.js.dfg-eager, basic-tests.yaml/stress-test.js.dfg-eager-no-cjit-validate, basic-tests.yaml/stress-test.js.eager-jettison-no-cjit, basic-tests.yaml/stress-test.js.no-cjit-collect-continuously, basic-tests.yaml/stress-test.js.no-cjit-validate-phases, jsc-layout-tests.yaml/js/script-tests/statement-list-item-syntax-errors.js.layout-dfg-eager-no-cjit, microbenchmarks/large-map-iteration.js.bytecode-cache, stress/big-int-unary-plus.js.dfg-eager-no-cjit-validate, stress/compare-bigint-with-number.js.bytecode-cache ... (failure)") | 
<!--EWS-Status-Bubble-End-->