### PR TITLE
Constructed FormData object should not contain entries for the Image Button submitter by default

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set-expected.txt
@@ -23,5 +23,5 @@ PASS "formData" IDL attribute should have entries for form-associated elements i
 PASS Entries added to "formData" IDL attribute should be submitted.
 PASS Entries added to the "formdata" IDL attribute shouldn't be newline normalized in the resulting FormData
 PASS The constructed FormData object should not contain an entry for the submit button that was used to submit the form.
-FAIL The constructed FormData object should not contain an entry for the image submit button that was used to submit the form. assert_false: expected false got true
+PASS The constructed FormData object should not contain an entry for the image submit button that was used to submit the form.
 

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -85,8 +85,6 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
 
     Ref<HTMLFormElement> protectedForm(*protectedElement->form());
 
-    protectedElement->setActivatedSubmit(true);
-
     m_clickLocation = IntPoint();
     if (event.underlyingEvent()) {
         Event& underlyingEvent = *event.underlyingEvent();
@@ -103,7 +101,6 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
     if (auto currentForm = protectedElement->form())
         currentForm->submitIfPossible(&event, element()); // Event handlers can run.
 
-    protectedElement->setActivatedSubmit(false);
     event.setDefaultHandled();
 }
 


### PR DESCRIPTION
#### 69eafe9632cacda742ab4a042e2bc6836406d55d
<pre>
Constructed FormData object should not contain entries for the Image Button submitter by default

<a href="https://bugs.webkit.org/show_bug.cgi?id=274214">https://bugs.webkit.org/show_bug.cgi?id=274214</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

In 249999@main, WebKit patched the issue for other input types while left out
`ImageInput`, this is to extend similar solution to `image` input.

Originally, when the activedSumbit flag is set for a image input, its value
is appeneded to a FormData. In the case of form submission in event handler,
we include this when build FormData, while we shouldn&apos;t. This removes the following
flag.

Original Patch Credits: Andreu Botella (andreu@andreubotella.com) in bug 234069

* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::handleDOMActivateEvent):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set-expected.txt:

Canonical link: <a href="https://commits.webkit.org/278944@main">https://commits.webkit.org/278944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2101bdc689169d10f60824471eb51a173b59424

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2364 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/842 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48094 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56879 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49742 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11383 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->