### PR TITLE
[WebGPU] Release assert trigged in PipelineLayout::offsetVectorForBindGroup

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2125,6 +2125,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274271.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274275.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274275.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274317.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274317.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274317-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274317-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274317.html
+++ b/LayoutTests/fast/webgpu/fuzz-274317.html
@@ -1,0 +1,8117 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u4419\u5a91\ue00b\ub423\ucb60\u40ca'});
+let querySet0 = device0.createQuerySet({
+  label: '\u1243\u{1fdb1}\u02da\u1316\u007c\u6e1a\uecc6\u09a0\u{1ffc8}\u832a\uf02e',
+  type: 'occlusion',
+  count: 1669,
+});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u{1faf1}\ud7eb\u40f1\u{1fb97}\u{1fe1b}'});
+let sampler0 = device0.createSampler({
+  label: '\u8650\uf862\u{1f946}\u0fe5\u120a\uad37\u89e1\uce0a\u00a2\u{1fb8f}\u6fd9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.17,
+  lodMaxClamp: 98.59,
+  maxAnisotropy: 5,
+});
+let canvas0 = document.createElement('canvas');
+let querySet1 = device0.createQuerySet({label: '\u9f00\u{1f8f4}\u650d\ua859\u03f4\u58d7', type: 'occlusion', count: 583});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\ued1d\u{1feed}\u0f48\u3ca3\u95b8\u{1fbf5}\u{1fee1}'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer0 = commandEncoder1.finish({label: '\u70f2\uad48\uff74\u3860\u8f3d'});
+let sampler1 = device0.createSampler({
+  label: '\u090e\uf8a5\u3057\ue558\u4023\u15b8\u1aec\u{1fd9f}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 96.62,
+});
+try {
+computePassEncoder0.pushDebugGroup('\u6b8c');
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({label: '\u0e6c\uaeb2\u0832\ua58b\u{1fcb5}\u177d\udcf0\ua320\ua90c'});
+let commandBuffer1 = commandEncoder2.finish();
+canvas0.width = 1631;
+let commandEncoder3 = device0.createCommandEncoder({label: '\u7ffc\u0495\u717b'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1f893}\ub947\u0df8\u00aa\u6c7c\u0218\ua2b4\u5321\u{1f949}',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: false,
+});
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+canvas0.getContext('2d');
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({entries: [{binding: 692, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }}]});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u0e00\u{1f66e}\u{1fbcf}\u{1ff68}\u{1fcca}\u45fe\u{1fd1c}\u8558\ufe24\u000d',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let buffer0 = device0.createBuffer({
+  label: '\u{1f60d}\u364e\u{1fdd0}\u0c10\u046d\uc352\u0a03\u{1feb1}',
+  size: 140064,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1f644}\u1360\uec42\uabb7'});
+let querySet2 = device0.createQuerySet({
+  label: '\ub7eb\u0888\u982a\u0908\u1567\ucc00\u14a5\u{1fa7c}\u9b17\u0e03',
+  type: 'occlusion',
+  count: 3335,
+});
+canvas0.width = 1076;
+let sampler2 = device0.createSampler({
+  label: '\u{1ff62}\u0054\u{1fe63}\u151c\ub7eb',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 41.19,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.label = '\ub441\ufbf3';
+} catch {}
+let buffer1 = device0.createBuffer({
+  label: '\u096e\u{1fa04}\u{1febc}\udeda\u467f',
+  size: 1048576,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture0 = device0.createTexture({
+  label: '\u1676\ucb76\u{1fc75}\u9e65\uae50\u{1f8ac}\u3587\u2c76\u0365\uac73\u0c36',
+  size: {width: 64, height: 1, depthOrArrayLayers: 1105},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let computePassEncoder1 = commandEncoder3.beginComputePass({label: '\u{1fd1b}\uce3b\u4413\ubbea\u{1f835}\uf022\u0016\u1d09\ua289'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle0 = renderBundleEncoder1.finish();
+try {
+device0.queue.writeBuffer(buffer0, 71416, new DataView(new ArrayBuffer(14504)), 11525, 1868);
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1fb6a}\u8a7c\u9a24\u6f19\udb99\u{1fd72}'});
+let texture1 = device0.createTexture({
+  label: '\u3dc1\u{1ffcf}\u{1fab6}\u7d32\u{1fbed}\ue684\u{1f91c}',
+  size: [608],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+try {
+renderBundleEncoder0.setVertexBuffer(7133, undefined, 0, 2105756929);
+} catch {}
+let texture2 = device0.createTexture({
+  label: '\u0c88\uf9b8\u8cde\uc322\uce96\u5cc5\u{1fb21}\u64d4',
+  size: [128, 1, 92],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView0 = texture2.createView({label: '\u0e30\u00b3\u81cf\u1a19\uaf8e\u0067\u{1ff5a}\u09b4', baseMipLevel: 2, arrayLayerCount: 1});
+let sampler3 = device0.createSampler({
+  label: '\ub767\u0f57\u0eaf\u7857\ud764\u00c1\u{1f798}\u0bc7\u7c3e\u5b72',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 95.45,
+  lodMaxClamp: 97.15,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(56)), /* required buffer size: 3216715 */
+{offset: 615, bytesPerRow: 134, rowsPerImage: 300}, {width: 50, height: 1, depthOrArrayLayers: 81});
+} catch {}
+let texture3 = device0.createTexture({
+  label: '\uf159\u{1f997}\u{1f690}\u0f9c\u0443\u8a8b\u{1f72e}\uc310\ua8f7',
+  size: [32],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({label: '\u31d0\u86ef\u485d\u{1fea0}\uc8d4\u0c72', colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let commandEncoder6 = device0.createCommandEncoder();
+try {
+renderBundleEncoder2.setVertexBuffer(3525, undefined, 3269731636, 568404647);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer1, 314756);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let textureView1 = texture3.createView({label: '\u8c94\u0461\u796d\ua610\u{1f841}\u832b\u2916\uf64e', mipLevelCount: 1});
+try {
+renderBundleEncoder2.setVertexBuffer(8710, undefined, 0);
+} catch {}
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u5d06\ua3b4\u0155\u{1f78b}\ubb98\u04b1\ue0a1\u{1fa14}\u27d4\ucf99',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({});
+try {
+renderBundleEncoder2.setVertexBuffer(5600, undefined, 0, 4186824821);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u0a02\u0d05\u02b6\u928d\u9fad\u2668\u50c9\u249c\u4e8f\u0fc7\u{1f6ad}',
+  code: `@group(2) @binding(692)
+var<storage, read_write> field0: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @location(1) f1: vec3<u32>,
+  @location(4) f2: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<i32>, @location(11) a1: vec3<f32>, @location(5) a2: f32, @location(14) a3: f16, @builtin(vertex_index) a4: u32, @location(8) a5: vec3<u32>, @location(4) a6: f16, @location(7) a7: vec4<i32>, @location(2) a8: u32, @location(12) a9: vec4<i32>, @location(1) a10: u32, @location(9) a11: vec4<f16>, @location(15) a12: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u46d6\u5a4b\u4238\u1157\uf229\u3716'});
+let textureView2 = texture1.createView({label: '\u09ce\u814a\u05a2\u533d\u{1f6af}\u0aa5', format: 'rg8unorm'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\ue63d\u{1fd77}\ub4b2\u01eb\u0406\u{1fd5f}\u0015',
+  colorFormats: ['rg8unorm'],
+  stencilReadOnly: true,
+});
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 28, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let video0 = await videoWithData();
+let imageBitmap0 = await createImageBitmap(canvas0);
+let commandEncoder8 = device0.createCommandEncoder({label: '\u3c72\u0e19\ue5c6\ud095\u5e0b\ub4f5'});
+let querySet3 = device0.createQuerySet({label: '\u{1f776}\u33f8\u{1f6a8}', type: 'occlusion', count: 119});
+let texture4 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8unorm'],
+});
+let textureView3 = texture3.createView({label: '\u08df\u0b14\u8584\u0125\u0e92\u{1ff7e}', aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder3 = commandEncoder8.beginComputePass({label: '\u0583\u{1f9f0}\ua297\u0f6f\u5bf8'});
+let promise0 = buffer1.mapAsync(GPUMapMode.READ, 812464, 221400);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 1, depthOrArrayLayers: 92}
+*/
+{
+  source: canvas0,
+  origin: { x: 282, y: 25 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u5e96\ubac3\u041f\ub5ff\u1419',
+  entries: [
+    {binding: 31, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 515,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 662,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 2625});
+let textureView4 = texture2.createView({
+  label: '\u7584\u0b6f\u0085\u881d\u2e4c\u{1fab9}',
+  format: 'rg8unorm',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderPassEncoder0 = commandEncoder5.beginRenderPass({
+  label: '\u04a0\u0ada\u0b73\u{1fb8d}\u650d\u4e34\ud46f\u{1f9a4}\u774c',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 8,
+  clearValue: { r: 307.0, g: -737.2, b: -431.7, a: 393.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\ue6b3\ufdff\u6f28\uaac0\u1789\u{1fa13}\u08ba\u0e6c\u79e5',
+  colorFormats: ['rg8unorm'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -362.3, g: 850.3, b: 826.0, a: 91.01, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(2.665, 0.8795, 4.097, 0.05432, 0.1310, 0.1508);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater', failOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 1365973269,
+    stencilWriteMask: 3995247496,
+    depthBias: -1934003204,
+    depthBiasSlopeScale: 18.279457443823063,
+    depthBiasClamp: 664.8438753721227,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 24,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 348,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 20, shaderLocation: 12},
+          {format: 'uint8x2', offset: 106, shaderLocation: 15},
+          {format: 'sint16x4', offset: 100, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 172, shaderLocation: 14},
+          {format: 'uint8x4', offset: 24, shaderLocation: 1},
+          {format: 'float16x4', offset: 100, shaderLocation: 5},
+          {format: 'uint32x4', offset: 80, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 72, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 244, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 4, shaderLocation: 7},
+          {format: 'float32x3', offset: 20, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back', unclippedDepth: true},
+});
+let img0 = await imageWithData(220, 19, '#e3cbb112', '#54c7100d');
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u4ffb\u5f9a\ub70d\uf8f5\u{1ff5c}\u{1f93d}\uee38\u0c6d',
+  bindGroupLayouts: [bindGroupLayout1],
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0e4a\ued0e\u8bad\uf9ce\u6c29\ufea3\ude21\ue418\u08c3'});
+let querySet5 = device0.createQuerySet({label: '\ua5dc\u0683\u0eca\u0e9d\u0d8c', type: 'occlusion', count: 3909});
+let renderPassEncoder1 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 9,
+  clearValue: { r: -304.0, g: 228.8, b: -951.0, a: -222.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 261940284,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 50 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 36642 */
+  offset: 36642,
+  buffer: buffer0,
+}, {width: 25, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder();
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u6086\u0791\ub46b\u09e8\u672a\u{1fdbc}\u{1fbc2}\u6819\u78f9'});
+let renderPassEncoder2 = commandEncoder9.beginRenderPass({
+  label: '\u0a07\u00ec\uf81a\ued84\u{1fc6e}',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 9,
+  clearValue: { r: -630.3, g: -532.1, b: -736.8, a: -650.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 452625441,
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(11);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(8, 1, 8, 0);
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer0, 36284);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 442 */
+{offset: 442}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder3 = commandEncoder11.beginRenderPass({
+  label: '\u27e2\u46b8\u27a1\u0479\uacf7\u{1fd11}\u332c\u0923\u43a6\uaaa6',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 9,
+  clearValue: { r: 209.2, g: -915.9, b: 668.6, a: -937.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 956884969,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u0642\u{1ffe6}\ue78d\u047b\u9ce3\ud9f2\u3753\u{1f7ec}\u66dc',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle1 = renderBundleEncoder2.finish({label: '\u055c\u6455\u07d2\u730b\u5bcd\u02c1\u88e7\u4b81\u1975\uc0c3'});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(833);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\uda65');
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\u0266\u{1f64b}\uce1f\u09b3\u1dc7\u0011\u38ab\u4a04\u6e61\u6ad1\u{1fd3f}',
+  code: `@group(0) @binding(31)
+var<storage, read_write> local0: array<u32>;
+@group(0) @binding(515)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S0 {
+  @location(13) f0: f32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec2<f32>, @location(5) a1: vec4<u32>, @builtin(front_facing) a2: bool, @location(3) a3: vec2<i32>, @location(11) a4: vec4<i32>, @location(4) a5: f32, a6: S0, @location(10) a7: vec3<i32>, @location(1) a8: vec2<f16>, @location(14) a9: vec4<f32>, @builtin(sample_index) a10: u32, @location(7) a11: vec2<u32>, @builtin(sample_mask) a12: u32, @location(9) a13: i32, @location(6) a14: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(1) f0: vec2<f16>,
+  @location(7) f1: vec2<u32>,
+  @location(13) f2: f32,
+  @location(3) f3: vec2<i32>,
+  @location(8) f4: vec2<f32>,
+  @builtin(position) f5: vec4<f32>,
+  @location(14) f6: vec4<f32>,
+  @location(6) f7: vec2<u32>,
+  @location(5) f8: vec4<u32>,
+  @location(4) f9: f32,
+  @location(10) f10: vec3<i32>,
+  @location(11) f11: vec4<i32>,
+  @location(9) f12: i32
+}
+
+@vertex
+fn vertex0(@location(2) a0: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer2 = device0.createBuffer({size: 481812, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u0f49\u3934\u37db\uafcb\uc648\u1cb7\ucc2c\u{1fbfc}\u{1fe63}'});
+let texture5 = device0.createTexture({
+  label: '\u{1f904}\u1661\u9092\u0a99\u{1fbca}\u5c5c\u7e49\u05f9',
+  size: {width: 20, height: 1, depthOrArrayLayers: 1334},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let computePassEncoder5 = commandEncoder12.beginComputePass({});
+let renderPassEncoder4 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 3,
+  clearValue: { r: -536.0, g: -350.5, b: -376.9, a: 622.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 533198047,
+});
+let sampler4 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.10,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder1.beginOcclusionQuery(1428);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -495.6, g: -484.5, b: -645.7, a: 377.0, });
+} catch {}
+try {
+renderPassEncoder3.setViewport(12.93, 0.6637, 1.350, 0.2532, 0.2238, 0.5959);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(615, undefined, 0, 866639367);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 731 */
+{offset: 655}, {width: 38, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView5 = texture1.createView({label: '\u2a6b\u8211\uc871\u7607\u0934\uf0aa\u0fc0\u7e60\ua00a\ud56a'});
+try {
+renderPassEncoder2.beginOcclusionQuery(1154);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -571.8, g: -23.63, b: 328.2, a: -292.8, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1379);
+} catch {}
+document.body.prepend(video0);
+let shaderModule2 = device0.createShaderModule({
+  label: '\u27bf\u0cb2\u450a\ua78e\u{1f615}\u0166\u01cb',
+  code: `@group(0) @binding(31)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(515)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(662)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec2<f32>,
+  @location(4) f3: vec2<u32>,
+  @location(6) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: f16, @builtin(front_facing) a1: bool, @location(13) a2: vec4<i32>, @location(11) a3: u32, @location(15) a4: vec2<u32>, @location(6) a5: vec4<f32>, @location(10) a6: vec3<f16>, @location(5) a7: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(4) f0: vec3<f32>,
+  @location(0) f1: vec4<f16>,
+  @location(9) f2: u32,
+  @location(14) f3: vec4<i32>,
+  @location(7) f4: vec3<u32>,
+  @location(8) f5: vec3<u32>,
+  @location(15) f6: f16,
+  @location(12) f7: vec2<f32>,
+  @location(2) f8: vec4<i32>,
+  @location(3) f9: vec4<f32>,
+  @location(6) f10: vec2<u32>,
+  @location(11) f11: vec4<u32>,
+  @location(1) f12: vec4<u32>,
+  @location(13) f13: vec3<f32>,
+  @builtin(instance_index) f14: u32
+}
+struct VertexOutput0 {
+  @location(5) f13: vec2<f32>,
+  @location(12) f14: vec3<f16>,
+  @location(9) f15: f16,
+  @location(6) f16: vec4<f32>,
+  @location(13) f17: vec4<i32>,
+  @location(11) f18: u32,
+  @location(2) f19: vec3<u32>,
+  @location(8) f20: i32,
+  @builtin(position) f21: vec4<f32>,
+  @location(0) f22: vec3<i32>,
+  @location(15) f23: vec2<u32>,
+  @location(14) f24: f16,
+  @location(10) f25: vec3<f16>,
+  @location(3) f26: vec2<f32>,
+  @location(7) f27: u32
+}
+
+@vertex
+fn vertex0(@location(10) a0: f16, @location(5) a1: vec4<u32>, a2: S1, @builtin(vertex_index) a3: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u069f\u9915\u0622\u0772\u8156\u058a\u104b'});
+let textureView6 = texture4.createView({label: '\ud89b\u0899\u{1f849}\u5a4a\u0875\u619e\u325b\u0c0a\u3a88\u111a', baseMipLevel: 0});
+let computePassEncoder6 = commandEncoder13.beginComputePass({label: '\u8a39\u27cf\u1a1f'});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(2024);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle0, renderBundle0, renderBundle1, renderBundle0, renderBundle1, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3051);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 11}
+*/
+{
+  source: canvas0,
+  origin: { x: 26, y: 13 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler5 = device0.createSampler({
+  label: '\u907b\uef82\uc9cd\u9e28\u028d\u311e\u7638\u{1fe6a}\u{1fe0f}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'not-equal',
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder4.setVertexBuffer(3206, undefined, 3614095070, 247983594);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2852, undefined, 0, 1273018777);
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+video0.height = 121;
+gc();
+try {
+commandBuffer0.label = '\u{1fe3f}\u01c2\u8312\ub008\u0305\u{1f8ac}\uc041\u2d92';
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  label: '\u5fb4\u034e\u{1fdd3}\u0e9d\u03e1\u14e4\u74f2\u0235',
+  layout: bindGroupLayout0,
+  entries: [{binding: 692, resource: sampler5}],
+});
+let textureView7 = texture0.createView({label: '\u1004\u0f6e\u344c\u021a\u{1ff7f}\u0acc\u0a88\u{1ff8d}', dimension: '3d', baseMipLevel: 7});
+let sampler6 = device0.createSampler({
+  label: '\u2917\u0d4b\u{1f874}\u{1fbd7}\udd0e\u0c98\u{1fe34}\u{1f728}\u0217\u0750',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.939,
+  lodMaxClamp: 43.80,
+});
+try {
+renderBundleEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(7855), 4145, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 7612, new DataView(new ArrayBuffer(2418)), 1190, 68);
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({
+  label: '\u8508\u{1f633}\u28d8\u82f3\ua61b\u8d3e\u02bd\u7e21\u{1f936}\u0b96',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0]});
+let commandEncoder14 = device0.createCommandEncoder({label: '\ufa8b\u{1f673}\u8347\u031b\u2f2e\ud903\u00a9\u72ac\u319c\ua821\u7ce9'});
+let computePassEncoder7 = commandEncoder14.beginComputePass({label: '\u0a3d\u9a2d\u048f\u0247\ud904\u21db\u981e'});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(8095), 510, 0);
+} catch {}
+try {
+  await buffer0.mapAsync(GPUMapMode.READ, 34056, 2472);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let bindGroup1 = device0.createBindGroup({
+  label: '\u9cf0\u05a9\u092a\u{1fc1b}',
+  layout: bindGroupLayout0,
+  entries: [{binding: 692, resource: sampler5}],
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u{1fce5}\ua7cd'});
+let computePassEncoder8 = commandEncoder15.beginComputePass({label: '\u620c\u887d\u853a\u{1ff74}\uc62b\u0002\u{1f9f3}\u{1f6fa}'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let commandEncoder16 = device0.createCommandEncoder();
+let querySet6 = device0.createQuerySet({label: '\ue0db\ue0d7\u5fb0', type: 'occlusion', count: 1537});
+let computePassEncoder9 = commandEncoder16.beginComputePass({});
+let renderBundle2 = renderBundleEncoder3.finish({label: '\ufcf3\u39f1\u380d\u{1fcdc}\u13a9\u882e\ub177\u{1ff69}'});
+let sampler7 = device0.createSampler({
+  label: '\u6d8f\u7ba6\u0f83',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.37,
+  lodMaxClamp: 80.71,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -340.6, g: -156.9, b: -915.7, a: -76.46, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3461);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  label: '\u0f93\ud5c7\ud7bf\u0c2c',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1056, stepMode: 'instance', attributes: []},
+      {arrayStride: 2020, attributes: []},
+      {arrayStride: 1672, stepMode: 'instance', attributes: []},
+      {arrayStride: 152, stepMode: 'vertex', attributes: [{format: 'uint32', offset: 48, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+gc();
+let renderBundle3 = renderBundleEncoder5.finish({label: '\udd5f\ude26\u3e85\u{1fe98}\u{1fc16}\u0a9f\ufe4b\u1ab9'});
+try {
+renderPassEncoder0.setBlendConstant({ r: 4.021, g: 857.0, b: -501.3, a: 962.3, });
+} catch {}
+try {
+renderPassEncoder3.setViewport(1.379, 0.6154, 8.182, 0.2290, 0.8064, 0.9750);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8051, undefined, 0, 4069569730);
+} catch {}
+let pipeline5 = device0.createComputePipeline({
+  label: '\uef0a\ue7ca\ub213\uaf97\u{1f6d9}\u{1fd43}\u4f95\u0e70\u0bac\u0b0f',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+computePassEncoder7.label = '\u1881\u6885';
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder();
+try {
+computePassEncoder8.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let buffer3 = device0.createBuffer({label: '\u69ab\u78cb\u89ac\u09fc\u{1ff04}\ubac8', size: 93815, usage: GPUBufferUsage.STORAGE});
+let texture6 = device0.createTexture({
+  label: '\u0270\u{1f8c2}\u0abd\u8d28\ub9fc',
+  size: [16],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView8 = texture6.createView({dimension: '1d'});
+let renderBundle4 = renderBundleEncoder3.finish({label: '\uc676\u0a88\ub594\u09e4\ud7fc\u3863\ub852\ua543'});
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -803.0, g: 481.3, b: -579.8, a: -669.5, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(5.964, 0.4257, 5.213, 0.1744, 0.9596, 0.9858);
+} catch {}
+let textureView9 = texture3.createView({label: '\u{1fd52}\u{1f6bc}\u{1f616}\ufae2\u0a3b\u474b', aspect: 'all', baseMipLevel: 0});
+let renderPassEncoder5 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 10,
+  clearValue: { r: 56.58, g: -902.7, b: 676.0, a: -903.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 789222971,
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(6155), 5305, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(14, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(2467);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 1, depthOrArrayLayers: 46}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 545, y: 16 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise1;
+} catch {}
+document.body.prepend(video0);
+let renderBundle5 = renderBundleEncoder0.finish({label: '\u{1ff90}\u0317\u4c3b\ud7da'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 213.4, g: 463.0, b: -503.4, a: -954.4, });
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(344, undefined, 2705512674, 93805557);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u0ae6\u06ba\u3575\ua264\ub6f8\u0521',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1],
+});
+let buffer4 = device0.createBuffer({
+  label: '\ucaa7\u6c6c\ufe4a\u0f8c\u0341\ubbf4\u{1fde3}\u0a0a\u0000',
+  size: 271550,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder18 = device0.createCommandEncoder();
+let texture7 = device0.createTexture({
+  label: '\u{1fc8e}\u0b65\uf0f0\u004f\u651e\u670e\u04bd\u6203\u56df\u0d8c',
+  size: {width: 128, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder5.beginOcclusionQuery(24);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(3, 0, 6, 1);
+} catch {}
+let textureView10 = texture1.createView({});
+let sampler8 = device0.createSampler({
+  label: '\u7d0b\u0ae9\u5d87\uccee\u87d3\u{1fa25}',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.28,
+  lodMaxClamp: 97.53,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\u0e54\u04f5\u0acb\u02e2\ufe6f\u{1fe4f}', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder4.setStencilReference(2787);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(7771), 1299, 0);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(7616, 465540);
+try {
+device0.queue.writeBuffer(buffer1, 1224, new Int16Array(55922));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 269 */
+{offset: 269}, {width: 44, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createRenderPipeline({
+  label: '\u91a4\ubc9a\u{1f7da}\u0058\ua7b6\uf2ee\u9706\u60df',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x73e0e610},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'always', failOp: 'keep', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 3178241832,
+    depthBias: 1198195555,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2048,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 104, shaderLocation: 10},
+          {format: 'uint32x4', offset: 244, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1000,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 348, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 164, shaderLocation: 15},
+          {format: 'sint32', offset: 68, shaderLocation: 2},
+          {format: 'float32x4', offset: 12, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 236, shaderLocation: 13},
+          {format: 'uint32x3', offset: 112, shaderLocation: 9},
+          {format: 'uint32x4', offset: 808, shaderLocation: 7},
+          {format: 'uint32x3', offset: 820, shaderLocation: 1},
+          {format: 'float32x3', offset: 1248, shaderLocation: 0},
+          {format: 'uint16x4', offset: 1376, shaderLocation: 5},
+          {format: 'float32x4', offset: 972, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 14, shaderLocation: 3}],
+      },
+      {arrayStride: 404, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 300,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x4', offset: 112, shaderLocation: 11}],
+      },
+      {arrayStride: 256, stepMode: 'instance', attributes: []},
+      {arrayStride: 248, attributes: [{format: 'sint32x2', offset: 116, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 3038});
+let commandBuffer2 = commandEncoder18.finish({label: '\u3b97\u{1fb31}\u0aa5\u03ef\uff46\u646f\ueabb\u7bd3\u{1fef0}\u53f4'});
+let renderBundle6 = renderBundleEncoder3.finish({label: '\u{1fce7}\u9117\u0b8a\u{1fc5c}\ue9eb\u0a33\u06b1\ue4d8'});
+let sampler9 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.57,
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(7425), 1085, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline4);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({
+  label: '\u5ebe\uce55\u01fa\u833d',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let commandEncoder19 = device0.createCommandEncoder({label: '\ud579\u{1fefd}\u{1f7bf}\u231a\u0a46\ue905\u0bc5\u09bc\u97e0\u1e95'});
+let querySet8 = device0.createQuerySet({
+  label: '\u029a\u9139\u0245\u3771\u7f97\u2082\ua1ef\u2adc\ua098\u{1fb56}\u065a',
+  type: 'occlusion',
+  count: 2964,
+});
+let textureView11 = texture0.createView({label: '\uf490\u286f\ub769\u59cb\u{1fedc}\u022e\u1339', baseMipLevel: 1, mipLevelCount: 5});
+let sampler10 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.16,
+  maxAnisotropy: 3,
+});
+let externalTexture1 = device0.importExternalTexture({label: '\ub0bd\uafac', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.setScissorRect(1, 0, 5, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup1, new Uint32Array(152), 112, 0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 376684, new Float32Array(39752));
+} catch {}
+let querySet9 = device0.createQuerySet({
+  label: '\uaf86\u0126\uecb6\ue055\ua371\u417b\ub373\u{1fa14}\ud4e4\u5b97\u00cd',
+  type: 'occlusion',
+  count: 3675,
+});
+let renderPassEncoder6 = commandEncoder19.beginRenderPass({
+  label: '\uf2ff\u9f44\uf56d',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 5,
+  clearValue: { r: -409.1, g: 737.9, b: -733.5, a: -207.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 1215511262,
+});
+let renderBundle7 = renderBundleEncoder3.finish({});
+let externalTexture2 = device0.importExternalTexture({label: '\u21ca\u{1fb4b}\u0976\u0a51\ubd50\ua889', source: video0, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.beginOcclusionQuery(1385);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle4, renderBundle7, renderBundle4, renderBundle7, renderBundle6]);
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  label: '\ua62d\u7139\ua212\u{1fdbb}\u9489\u{1f872}\u4903',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilWriteMask: 35941670,
+    depthBias: 473085479,
+    depthBiasSlopeScale: 937.0022595738938,
+    depthBiasClamp: 886.1603990333683,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 976,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 100, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 52, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 148,
+        attributes: [
+          {format: 'uint32x4', offset: 32, shaderLocation: 1},
+          {format: 'sint32', offset: 32, shaderLocation: 14},
+          {format: 'float32x4', offset: 36, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 15},
+          {format: 'uint8x4', offset: 48, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 10},
+          {format: 'uint32x2', offset: 100, shaderLocation: 7},
+          {format: 'sint32x2', offset: 20, shaderLocation: 2},
+          {format: 'uint32x3', offset: 32, shaderLocation: 11},
+          {format: 'uint16x4', offset: 36, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 360,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 184, shaderLocation: 13},
+          {format: 'uint32', offset: 4, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 12},
+          {format: 'uint32x3', offset: 348, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let shaderModule3 = device0.createShaderModule({
+  label: '\u83a5\u2733\u2af1\u5480\u6aef\u46c5\ubab5',
+  code: `@group(1) @binding(692)
+var<storage, read_write> n0: array<u32>;
+@group(0) @binding(692)
+var<storage, read_write> local2: array<u32>;
+@group(2) @binding(692)
+var<storage, read_write> local3: array<u32>;
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f32>, @location(15) a1: vec4<i32>, @location(7) a2: vec3<f16>, @location(1) a3: vec2<i32>, @location(6) a4: f32, @location(14) a5: i32, @location(12) a6: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({label: '\u{1f80b}\u273d\uae6a\ub9c3\u068e\u{1fbfa}\u0925\u{1fc44}\ua64f\ud4d0', entries: []});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 856});
+let textureView12 = texture0.createView({label: '\u0f63\uc091\ubd3d', baseMipLevel: 9});
+let sampler11 = device0.createSampler({
+  label: '\u09da\u5f8d\ua2ee\u0eee\u0a2e\ud5de\u9213\u36fa\u8052',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.05,
+  lodMaxClamp: 99.69,
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup0, new Uint32Array(3305), 897, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(837);
+} catch {}
+try {
+renderPassEncoder4.setViewport(0.2542, 0.7708, 2.667, 0.09696, 0.8996, 0.9195);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5002, undefined, 2919788163, 1050389552);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 2354955523,
+    stencilWriteMask: 478780876,
+    depthBias: -1751029757,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 660,
+        attributes: [
+          {format: 'sint16x2', offset: 72, shaderLocation: 12},
+          {format: 'uint32', offset: 0, shaderLocation: 15},
+          {format: 'float32', offset: 176, shaderLocation: 14},
+          {format: 'uint8x4', offset: 112, shaderLocation: 1},
+          {format: 'float32x3', offset: 484, shaderLocation: 11},
+          {format: 'sint32', offset: 96, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 298, shaderLocation: 4},
+          {format: 'sint32', offset: 432, shaderLocation: 6},
+          {format: 'uint8x2', offset: 122, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 624, attributes: [{format: 'uint32x3', offset: 60, shaderLocation: 8}]},
+      {arrayStride: 856, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 376, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+adapter0.label = '\u7606\u809a\u{1f840}\u0071\u{1fb0e}\u08bc\u{1f939}\ue9af\u9132\u6589\u78af';
+} catch {}
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: false});
+let sampler12 = device0.createSampler({
+  label: '\u{1f68a}\u992c\u31ce\u0487\u{1f9c9}\uadf0\u12c9\u{1fde8}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.98,
+  lodMaxClamp: 45.33,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder5.setScissorRect(10, 0, 6, 0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline4);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u7950\u{1f65a}\u0a73\u{1f7ec}\u0bc4\u3cdf\u00f9\u77cc\uca11\u{1f68d}\ude44',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup2 = device0.createBindGroup({label: '\ua179\u0212\u2fdf', layout: bindGroupLayout0, entries: [{binding: 692, resource: sampler5}]});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 4028});
+let textureView13 = texture2.createView({baseMipLevel: 3, baseArrayLayer: 0});
+let sampler13 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup2, new Uint32Array(9030), 6333, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle7, renderBundle1, renderBundle0, renderBundle5, renderBundle4, renderBundle3, renderBundle7, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(1, 1, 15, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 566348, new DataView(new ArrayBuffer(18900)));
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: img0,
+  origin: { x: 14, y: 0 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise2;
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\ue199\u251f\u2a20',
+  entries: [
+    {binding: 108, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 621,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder20 = device0.createCommandEncoder({label: '\uf890\ub865\u{1fb3e}\u0401\u{1f6c9}\u4c89\u03f7'});
+let texture8 = device0.createTexture({
+  label: '\u{1fd68}\u{1f90f}\u{1fb55}\u0512\u{1f9c5}',
+  size: [5],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+});
+let textureView14 = texture1.createView({baseMipLevel: 0});
+let renderPassEncoder7 = commandEncoder20.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 0,
+  clearValue: { r: -924.7, g: -938.8, b: -201.0, a: 319.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+let renderBundle8 = renderBundleEncoder4.finish({label: '\u{1f9be}\u849f'});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.READ, 294952, 267088);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 94 */
+{offset: 94, bytesPerRow: 365}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let buffer5 = device0.createBuffer({
+  label: '\u9728\uade5\udfc5\u{1fa3b}\ueeba\u{1ff22}\u3820\u7230\u5e7b\u079c\u{1fca3}',
+  size: 239189,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setViewport(0.8360, 0.08376, 0.00997, 0.8801, 0.6587, 0.8885);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1777, undefined, 0, 2573576491);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21890 */
+  offset: 21890,
+  rowsPerImage: 242,
+  buffer: buffer5,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let shaderModule4 = device0.createShaderModule({
+  code: `@group(1) @binding(31)
+var<storage, read_write> local4: array<u32>;
+@group(1) @binding(662)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(31)
+var<storage, read_write> parameter0: array<u32>;
+@group(1) @binding(515)
+var<storage, read_write> field2: array<u32>;
+@group(0) @binding(515)
+var<storage, read_write> type1: array<u32>;
+@group(0) @binding(662)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(7, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>,
+  @location(6) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(5) a1: vec2<f32>, @location(2) a2: vec3<f16>, @location(0) a3: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup3 = device0.createBindGroup({
+  label: '\u0cdb\u{1fbf4}\u9d3e\u{1f7f8}\u6275\u{1fdf5}\ue58b',
+  layout: bindGroupLayout0,
+  entries: [{binding: 692, resource: sampler5}],
+});
+let textureView15 = texture4.createView({label: '\u01a2\ucb37\u0019\u80fe\u{1f61a}\u2a0c\ua07d'});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -532.4, g: -668.5, b: 934.5, a: -274.6, });
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer5, 552, buffer0, 30724, 98328);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let img1 = await imageWithData(78, 169, '#b99f5a4c', '#d0733ec5');
+let imageData0 = new ImageData(128, 88);
+let textureView16 = texture3.createView({});
+let renderPassEncoder8 = commandEncoder21.beginRenderPass({
+  label: '\uaafc\u{1f73d}\uc73d\uc3fd\u290f\u0543\u0c16\u0d6f\uc9ac\u{1fc26}\u0797',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 4,
+  clearValue: { r: 927.4, g: 68.68, b: -477.7, a: 934.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({label: '\u{1f8fe}\u85df', colorFormats: ['rg8unorm'], sampleCount: 1});
+let renderBundle9 = renderBundleEncoder2.finish({label: '\u0c2d\u5005\u4b29\u0537\u{1ff13}\uec09\u{1fbac}'});
+let sampler14 = device0.createSampler({
+  label: '\u0716\u0aae\ub915\u02b1\uc7da\u{1fa9e}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.20,
+  lodMaxClamp: 50.32,
+});
+try {
+renderPassEncoder0.setScissorRect(1, 1, 11, 0);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2342, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 839 */
+{offset: 839}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\u84f5\u44bc',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let textureView17 = texture4.createView({label: '\u92c2\u0318\u{1f8a9}\u01de\u3141\u4302', mipLevelCount: 1});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -964.4, g: -132.3, b: -882.0, a: 629.4, });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(32)), /* required buffer size: 57 */
+{offset: 39}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let shaderModule5 = device0.createShaderModule({
+  label: '\u8053\u039d\u07c4\u0db0\u1796\u096a\u04a9\u09a2',
+  code: `@group(0) @binding(692)
+var<storage, read_write> type2: array<u32>;
+@group(2) @binding(692)
+var<storage, read_write> type3: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> local5: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> @location(200) vec4<f32> {
+return vec4<f32>();
+}
+
+struct S2 {
+  @location(2) f0: vec4<f16>,
+  @location(7) f1: vec3<f32>,
+  @builtin(vertex_index) f2: u32,
+  @location(8) f3: f16
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<f32>, @location(4) a1: vec4<f32>, a2: S2, @location(13) a3: i32, @location(9) a4: vec3<i32>, @location(5) a5: vec4<f32>, @location(14) a6: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let sampler15 = device0.createSampler({
+  label: '\u0be4\u5db9\u0429\u{1fc7c}\u8872\u06fd\u{1f91e}\u682a\ub7a9\u2e87\u3277',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.03,
+  lodMaxClamp: 45.02,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup3, new Uint32Array(1544), 1497, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3162, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(993), /* required buffer size: 993 */
+{offset: 993}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline14 = device0.createComputePipeline({
+  label: '\u0903\u2b0d\u2171\u593f\u16f4\u0c9a\u98f8',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext0 = canvas1.getContext('webgpu');
+let textureView18 = texture6.createView({label: '\u{1f938}\u73f8\ud3f7\u7902\u4565', format: 'rg8unorm'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({label: '\u06fa\u{1fad2}\u{1fa44}\u0b31\u{1fddb}', colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline14);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\ua7d4\u06c2\u048d\u{1ff72}\u4130\u00d0\u0d34\ud9ce\ufbdb'});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 787});
+let renderPassEncoder9 = commandEncoder22.beginRenderPass({
+  label: '\u2284\u{1fb1a}\u3797\uc855\u{1f7a8}\u05c8',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 2,
+  clearValue: { r: 984.2, g: 881.5, b: 985.7, a: 97.24, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 132082477,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup2, new Uint32Array(5114), 2466, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup1, new Uint32Array(8928), 1227, 0);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle6, renderBundle6, renderBundle3, renderBundle1, renderBundle3, renderBundle2, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 693.6, g: 878.4, b: 950.5, a: 56.49, });
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 42536 */
+{offset: 36, bytesPerRow: 72, rowsPerImage: 118}, {width: 10, height: 1, depthOrArrayLayers: 6});
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\u00a1\u{1fc98}\uc1bd\u054e\uccb2\u02f5\u{1f8fe}\ufce1\ua198\u{1fd06}\u{1f661}',
+  code: `@group(0) @binding(662)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(515)
+var<storage, read_write> parameter2: array<u32>;
+@group(1) @binding(31)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(662)
+var<storage, read_write> global2: array<u32>;
+@group(1) @binding(515)
+var<storage, read_write> field4: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: u32, @location(6) a1: i32, @location(1) a2: vec3<u32>, @builtin(instance_index) a3: u32, @builtin(vertex_index) a4: u32, @location(15) a5: vec3<u32>, @location(7) a6: vec2<u32>, @location(9) a7: i32, @location(11) a8: vec4<i32>, @location(5) a9: vec2<f16>, @location(13) a10: vec4<f16>, @location(8) a11: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView19 = texture2.createView({label: '\u{1f7ec}\u{1f878}', baseMipLevel: 1, mipLevelCount: 2, arrayLayerCount: 1});
+let sampler16 = device0.createSampler({
+  label: '\u8a09\u1748\u05a5',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 72.84,
+});
+try {
+computePassEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder4.setViewport(0.1073, 0.07794, 1.627, 0.4808, 0.4073, 0.6849);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(9510, undefined, 4249240266, 26465606);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 1, depthOrArrayLayers: 92}
+*/
+{
+  source: imageData0,
+  origin: { x: 27, y: 6 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\u7828\u026b\u0ed2\u08bf\u{1fe56}\uce9c\u09a9\u8ade',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup4 = device0.createBindGroup({label: '\uc591\ue39a', layout: bindGroupLayout0, entries: [{binding: 692, resource: sampler5}]});
+let textureView20 = texture2.createView({mipLevelCount: 3});
+try {
+renderPassEncoder6.setViewport(3.070, 0.9811, 5.189, 0.01840, 0.9602, 0.9647);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(8035, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 0, 29360);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let renderBundle10 = renderBundleEncoder4.finish({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(1099);
+} catch {}
+try {
+renderPassEncoder7.setViewport(0.5179, 0.3058, 0.3859, 0.2241, 0.1464, 0.5959);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup2, new Uint32Array(2138), 1461, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline16 = device0.createComputePipeline({
+  label: '\u221b\ucd1d\u0e19\u4413\u{1fd22}\u0d3f\u32cc\u{1fc6d}\u04e1\uabc3',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline17 = device0.createRenderPipeline({
+  label: '\u{1fe29}\u{1f72b}\u198a\u0319\u0956\u735d\u054f\u{1fed9}\ubded',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 216,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 44, shaderLocation: 11},
+          {format: 'sint32x2', offset: 20, shaderLocation: 7},
+          {format: 'uint32x4', offset: 8, shaderLocation: 8},
+          {format: 'float16x4', offset: 16, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 48, shaderLocation: 4},
+          {format: 'uint32', offset: 28, shaderLocation: 1},
+          {format: 'sint32x4', offset: 28, shaderLocation: 6},
+          {format: 'uint16x4', offset: 88, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 14},
+          {format: 'sint32x2', offset: 48, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 720, stepMode: 'instance', attributes: []},
+      {arrayStride: 116, attributes: []},
+      {arrayStride: 2048, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 32, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup5 = device0.createBindGroup({
+  label: '\u{1f754}\u82f8\u9e75\u{1f6c0}\u0872\u0e9b\ue2dc\u3313\u{1f9f4}',
+  layout: bindGroupLayout0,
+  entries: [{binding: 692, resource: sampler5}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u5610\u4345\u{1fdc0}\u{1fc12}\u8903\ub1c8\ub3a1',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout3, bindGroupLayout3, bindGroupLayout0],
+});
+let buffer6 = device0.createBuffer({size: 1041955, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let querySet13 = device0.createQuerySet({
+  label: '\uf96e\u9ff4\u851e\u{1fac8}\u938f\u{1fd6c}\u991b\u{1f6f4}\u{1fd07}',
+  type: 'occlusion',
+  count: 1353,
+});
+let sampler17 = device0.createSampler({
+  label: '\u03c0\u{1fdd2}\uc4da\ua5f2\ud273\u0539\u{1fde8}\u5705\u01b4\uaefe\u080c',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 42.51,
+  lodMaxClamp: 80.96,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle5, renderBundle2, renderBundle3, renderBundle4]);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 1, depthOrArrayLayers: 92}
+*/
+{
+  source: img0,
+  origin: { x: 68, y: 0 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 111, y: 0, z: 39},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise5 = device0.createRenderPipelineAsync({
+  label: '\ua883\u82b0\u051f\u9a24\u0182\uf26c\u0f36',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 3591991528,
+    stencilWriteMask: 653480969,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 648,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x2', offset: 232, shaderLocation: 10},
+          {format: 'uint32', offset: 36, shaderLocation: 12},
+          {format: 'float32x4', offset: 4, shaderLocation: 7},
+          {format: 'float16x4', offset: 264, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 712,
+        attributes: [
+          {format: 'sint8x4', offset: 108, shaderLocation: 15},
+          {format: 'sint32x4', offset: 48, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 144, stepMode: 'vertex', attributes: []},
+      {arrayStride: 68, stepMode: 'instance', attributes: []},
+      {arrayStride: 220, stepMode: 'instance', attributes: []},
+      {arrayStride: 52, attributes: [{format: 'sint32x3', offset: 8, shaderLocation: 14}]},
+    ],
+  },
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u{1f610}\ucee3\uafd3\u3d05',
+  entries: [
+    {
+      binding: 556,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 422,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder23 = device0.createCommandEncoder({label: '\u05ee\u{1ff43}\ube37'});
+let querySet14 = device0.createQuerySet({label: '\u0111\uaff7\uec2c\u2ee7\u0191\u0d88\u8c31\ue666\u062d\ua8cc', type: 'occlusion', count: 3858});
+let textureView21 = texture1.createView({label: '\ue0c9\uba74\u6ecc\ub7df\u03db', baseArrayLayer: 0});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\uc356\u0d4e\u{1fc47}\u05c2\u33aa\u106b\u{1f8ae}\u{1fca6}\uc1df',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(14, 0, 0, 1);
+} catch {}
+let texture9 = device0.createTexture({
+  label: '\u2ac2\u798b\ufcb7\u0c9b\u8129',
+  size: [608],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundle11 = renderBundleEncoder2.finish({label: '\u035a\u0270\u02bf'});
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 480 */
+{offset: 480}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\u15f4\u0fc4',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1],
+});
+let textureView22 = texture4.createView({label: '\uba98\u0cc7\u0d01\u0ef8\u3f1a\ufd72\ue832\u0472\u6b5e\u8909', mipLevelCount: 1});
+try {
+renderPassEncoder7.setBlendConstant({ r: 493.8, g: -993.4, b: -338.6, a: 131.8, });
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer6, 757192, 13568);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet9, 3260, 409, buffer6, 591360);
+} catch {}
+let video1 = await videoWithData();
+let shaderModule7 = device0.createShaderModule({
+  code: `@group(1) @binding(621)
+var<storage, read_write> n1: array<u32>;
+@group(2) @binding(621)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(108)
+var<storage, read_write> parameter3: array<u32>;
+@group(3) @binding(692)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(108)
+var<storage, read_write> local6: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(0) f1: vec3<f32>,
+  @location(6) f2: u32
+}
+
+@fragment
+fn fragment0(@location(13) a0: u32, @location(6) a1: vec4<f16>, @location(8) a2: vec2<i32>, @location(2) a3: vec4<u32>, @location(14) a4: vec2<u32>, @location(15) a5: f32, @location(11) a6: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(11) f28: vec2<u32>,
+  @location(8) f29: vec2<i32>,
+  @location(9) f30: f16,
+  @location(7) f31: f32,
+  @location(14) f32: vec2<u32>,
+  @location(6) f33: vec4<f16>,
+  @location(4) f34: vec4<f32>,
+  @location(2) f35: vec4<u32>,
+  @location(15) f36: f32,
+  @builtin(position) f37: vec4<f32>,
+  @location(13) f38: u32
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<u32>, @location(2) a1: vec3<f16>, @location(8) a2: vec4<f16>, @builtin(vertex_index) a3: u32, @location(6) a4: i32, @location(4) a5: vec2<i32>, @builtin(instance_index) a6: u32, @location(9) a7: vec2<f16>, @location(13) a8: vec2<i32>, @location(3) a9: vec3<u32>, @location(5) a10: vec2<f32>, @location(1) a11: vec2<f32>, @location(10) a12: vec2<u32>, @location(14) a13: f32, @location(0) a14: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture10 = device0.createTexture({
+  size: {width: 5},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView23 = texture0.createView({
+  label: '\u2de7\u06e7\u{1f60d}\u68f5\u1153\u{1f6a4}\uacc4\u3235\u{1fd9a}\u6d20\u{1fb8d}',
+  baseMipLevel: 4,
+});
+let computePassEncoder10 = commandEncoder23.beginComputePass();
+try {
+renderPassEncoder8.executeBundles([renderBundle10, renderBundle2, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 209244, new Float32Array(23891), 20399, 3492);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let videoFrame0 = new VideoFrame(video1, {timestamp: 0});
+try {
+canvas2.getContext('webgl');
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\uee19\u206a\u9994\u0cbc\u01e3\u9ef3\u{1f80a}\u4db9\u6f13\ua929\u3554',
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 286,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 190,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 582});
+let texture11 = device0.createTexture({
+  label: '\u{1fd40}\u0723\u0265',
+  size: {width: 1216},
+  mipLevelCount: 4,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle12 = renderBundleEncoder8.finish();
+let sampler18 = device0.createSampler({
+  label: '\u{1fd9c}\u084c\u{1f6e4}\ua99f\uef0a\u0056',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 84.21,
+  compare: 'greater',
+});
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle7, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(9, 0, 3, 1);
+} catch {}
+try {
+renderPassEncoder6.setViewport(15.42, 0.4713, 0.2747, 0.1841, 0.9040, 0.9082);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline17);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData1 = new ImageData(36, 128);
+let textureView24 = texture1.createView({label: '\u0547\u2de9\ufe88\ub42e\u05d5\u{1fad5}\u86d9\u689f\u0da1\u0771'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u968f\u{1f631}\u89eb\u19c9\ue4fe\u9295\u0f58\u0387\u05b6',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(2523);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 319 */
+{offset: 297, bytesPerRow: 138}, {width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise6 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {count: 1, mask: 0x462d67b6},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 884, attributes: []},
+      {
+        arrayStride: 448,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 64, shaderLocation: 1},
+          {format: 'sint8x2', offset: 62, shaderLocation: 15},
+          {format: 'sint32x2', offset: 224, shaderLocation: 14},
+          {format: 'uint32x2', offset: 52, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 60, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 328, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 260, attributes: [{format: 'snorm16x4', offset: 104, shaderLocation: 7}]},
+    ],
+  },
+});
+try {
+window.someLabel = pipelineLayout5.label;
+} catch {}
+let textureView25 = texture4.createView({label: '\u02a0\u073e', dimension: '1d', format: 'rg8unorm'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\ubd49\u0db2\u{1ff25}\u0693', colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder2.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle11, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(2606);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 121 */
+{offset: 121}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  label: '\u080d\u{1ffd9}',
+  code: `@group(0) @binding(692)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(7) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: i32, @location(9) a1: vec4<i32>, @location(11) a2: f16, @location(10) a3: vec3<i32>, @location(0) a4: vec2<i32>, @builtin(instance_index) a5: u32, @location(13) a6: vec2<u32>, @location(7) a7: vec4<i32>, @location(8) a8: u32, @location(12) a9: u32, @location(3) a10: vec3<i32>, @location(1) a11: vec2<u32>, @location(4) a12: vec2<f32>, @location(14) a13: u32, @location(6) a14: vec4<i32>, @location(15) a15: vec2<i32>, @location(5) a16: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture12 = device0.createTexture({
+  label: '\u{1fe30}\u897b\u017b\u0b40\u{1fab1}\u{1f727}\u01fc\u9908\uece6\u01c5',
+  size: {width: 32},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle13 = renderBundleEncoder2.finish({label: '\u49cb\ua1f1\u{1f670}\uddc8\uc670\u90ca\u{1f926}\u0adb'});
+let externalTexture4 = device0.importExternalTexture({label: '\u070d\uf5b7\ufb0b\u8038\u09d5\uca12\u{1fed8}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder6.setViewport(9.975, 0.5812, 1.533, 0.2629, 0.3922, 0.3991);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4649, undefined, 0, 4116033534);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+  label: '\u1bf7\u66c1\u{1fe02}\u09cc\u0bd5',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let textureView26 = texture5.createView({label: '\ue7c9\ufe20', baseMipLevel: 1, mipLevelCount: 2, arrayLayerCount: 1});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+  label: '\u2ebd\u091e\ub191\u{1ff66}\u{1fa55}\u0458\u23cd\u0f2a\u{1f99e}\u0b88',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let pipeline20 = await promise5;
+document.body.prepend(img0);
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 171,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 311,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 362411, hasDynamicOffset: false },
+    },
+    {
+      binding: 993,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 662, resource: {buffer: buffer2, offset: 334592}},
+    {binding: 31, resource: externalTexture2},
+    {binding: 515, resource: {buffer: buffer2, offset: 166656, size: 275596}},
+  ],
+});
+let textureView27 = texture1.createView({label: '\u{1fbf5}\u04ad'});
+let renderBundle14 = renderBundleEncoder9.finish({});
+let sampler19 = device0.createSampler({
+  label: '\ud1e8\u076a\uee74',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 42.90,
+  lodMaxClamp: 85.77,
+});
+try {
+renderPassEncoder3.setBlendConstant({ r: 285.9, g: 919.6, b: 591.6, a: 283.8, });
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5706, undefined, 469628479, 1836193519);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule8, entryPoint: 'compute0'}});
+let pipeline22 = device0.createRenderPipeline({
+  label: '\u6205\u09dd\u0a69\ucb02',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0xa24db064},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 136,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 68, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 52, shaderLocation: 5},
+          {format: 'float32x4', offset: 4, shaderLocation: 0},
+          {format: 'float16x4', offset: 12, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder24 = device0.createCommandEncoder({label: '\uee5e\ub7f9\u4482\ubb88\u7c9a\u04fc'});
+let textureView28 = texture7.createView({label: '\u{1fa91}\u3d2c\u{1fd85}\uf31b', dimension: '2d-array', baseMipLevel: 7});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle15 = renderBundleEncoder5.finish({label: '\u1a13\u1cdb\u4d4d\uf65e\u8293'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(7447), 1604, 0);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 148.2, g: 240.5, b: -720.1, a: 54.81, });
+} catch {}
+try {
+renderPassEncoder4.setViewport(7.691, 0.02355, 1.561, 0.8271, 0.5721, 0.6079);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer5, 85072, buffer1, 500000, 82296);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 48072 */
+  offset: 48072,
+  buffer: buffer6,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 704 */
+{offset: 682, bytesPerRow: 320}, {width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+  label: '\u0c5b\u06ed\u0dc2\u{1ff03}\u{1feef}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise4;
+} catch {}
+let textureView29 = texture1.createView({label: '\udc34\ud8b7', aspect: 'all', format: 'rg8unorm', baseArrayLayer: 0});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup0, new Uint32Array(2233), 587, 0);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -36.57, g: 337.9, b: 3.707, a: 135.3, });
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3192, undefined, 0, 566976561);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 1, depthOrArrayLayers: 92}
+*/
+{
+  source: canvas1,
+  origin: { x: 216, y: 5 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let videoFrame1 = new VideoFrame(canvas1, {timestamp: 0});
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u0681\u4a1e\u0007\u1fa4',
+  entries: [
+    {
+      binding: 374,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let bindGroupLayout8 = pipeline7.getBindGroupLayout(1);
+let buffer7 = device0.createBuffer({
+  label: '\u01ed\ud8eb',
+  size: 577583,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture13 = device0.createTexture({
+  label: '\u{1fab4}\u0288\u0823\u0028\u000f\u9fca',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let textureView30 = texture0.createView({baseMipLevel: 7, mipLevelCount: 2});
+let renderPassEncoder10 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 6,
+  clearValue: { r: 649.4, g: 768.8, b: -339.6, a: 529.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+let renderBundle16 = renderBundleEncoder12.finish({label: '\u0c96\u2c38\u0a3c\u{1f765}\u353f\u7614\u{1fde2}\u29ac\u{1fd08}\u5ae3'});
+let sampler20 = device0.createSampler({
+  label: '\u071c\u{1f966}\u{1ff09}\u{1f68e}\u4c85\u0211\u{1fc3a}\u23e1',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.03,
+  lodMaxClamp: 83.67,
+  compare: 'never',
+  maxAnisotropy: 3,
+});
+let externalTexture5 = device0.importExternalTexture({label: '\u9953\u{1f776}\ue6a4\ubf52\u08c9\ubbf3', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(73);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(8, 0, 4, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3415);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2443, undefined, 3016809135, 1110047521);
+} catch {}
+let pipeline24 = await promise6;
+let commandEncoder25 = device0.createCommandEncoder({label: '\u074e\u9670\u6a18\u{1f658}\u9a4a\u{1fe3b}\u0b7d'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle17 = renderBundleEncoder2.finish();
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0, new Uint32Array(3896), 2722, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(2961);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(8, 1, 6, 0);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(2444);
+} catch {}
+try {
+renderPassEncoder3.setViewport(6.740, 0.7785, 8.838, 0.06868, 0.00499, 0.3425);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 186160, 294439);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(9056, undefined);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet10, 785, 64, buffer6, 77312);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u0aca');
+} catch {}
+let pipeline25 = await device0.createRenderPipelineAsync({
+  label: '\u40ff\u7893\ub69f\ua86f\u9b91\u0663\u6602\u103b',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x8e966cdd},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 1162591213,
+    stencilWriteMask: 1876277562,
+    depthBiasSlopeScale: 73.67187131849033,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1208,
+        attributes: [
+          {format: 'unorm8x4', offset: 28, shaderLocation: 4},
+          {format: 'sint32x4', offset: 228, shaderLocation: 0},
+          {format: 'sint8x4', offset: 32, shaderLocation: 15},
+          {format: 'float32x4', offset: 20, shaderLocation: 11},
+          {format: 'sint32x2', offset: 152, shaderLocation: 9},
+          {format: 'sint32x2', offset: 84, shaderLocation: 7},
+          {format: 'uint16x2', offset: 36, shaderLocation: 1},
+          {format: 'uint8x4', offset: 380, shaderLocation: 14},
+          {format: 'uint32x3', offset: 272, shaderLocation: 12},
+          {format: 'sint32x2', offset: 212, shaderLocation: 3},
+          {format: 'uint32x2', offset: 80, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x2', offset: 730, shaderLocation: 10},
+          {format: 'uint16x4', offset: 192, shaderLocation: 13},
+          {format: 'sint32x4', offset: 896, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 556, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 396,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 120, shaderLocation: 2},
+          {format: 'sint8x4', offset: 12, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+let renderPassEncoder11 = commandEncoder25.beginRenderPass({
+  label: '\u0627\uf5d1',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 0,
+  clearValue: { r: -352.8, g: 185.1, b: 477.4, a: -125.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 1149878251,
+});
+let renderBundle18 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup3, new Uint32Array(1136), 498, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(746);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 974.7, g: 245.1, b: 764.6, a: 514.7, });
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline24);
+} catch {}
+let texture14 = device0.createTexture({
+  label: '\u0856\u7591\u029a\u8e21\u0504\ufd6e\u7875\u084a\u34ac',
+  size: {width: 5},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler21 = device0.createSampler({
+  label: '\uecb6\u0cf9',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.94,
+  lodMaxClamp: 98.45,
+  compare: 'greater-equal',
+  maxAnisotropy: 20,
+});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u02a0\u011f\uff8a\u16d6\u33a2\ubb72\u1efe\u0cf7\u1aba\u{1f8ab}\u894c',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(882);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -815.0, g: 570.5, b: 341.9, a: -496.8, });
+} catch {}
+try {
+renderPassEncoder4.setViewport(6.967, 0.9410, 5.496, 0.03568, 0.6398, 0.8362);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6020, undefined, 0, 1927087369);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let commandBuffer3 = commandEncoder26.finish({label: '\u4530\uc30a'});
+let textureView31 = texture13.createView({label: '\ua8e4\u{1fda6}\ucbed', format: 'rg8unorm'});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -128.7, g: -511.3, b: 459.5, a: 491.2, });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 45},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 33287 */
+{offset: 811, bytesPerRow: 353, rowsPerImage: 2}, {width: 53, height: 0, depthOrArrayLayers: 47});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 1, depthOrArrayLayers: 46}
+*/
+{
+  source: canvas0,
+  origin: { x: 173, y: 12 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 662, resource: {buffer: buffer2, offset: 367872}},
+    {binding: 31, resource: externalTexture5},
+    {binding: 515, resource: {buffer: buffer2, offset: 430848, size: 17056}},
+  ],
+});
+let textureView32 = texture8.createView({});
+let sampler22 = device0.createSampler({
+  label: '\u{1fb40}\u3a25\ufad0\u0e86\u7b04\u{1ff21}\u0bfe\uafe5\ue7cf',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.28,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup4, new Uint32Array(8606), 685, 0);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(12, 1, 1, 0);
+} catch {}
+let video2 = await videoWithData();
+let querySet16 = device0.createQuerySet({label: '\u0ffd\u{1fc36}\ub0e6', type: 'occlusion', count: 3084});
+let textureView33 = texture11.createView({label: '\u{1f7a3}\u61c1\u2461\u9483\u0c24\u2370\ubede\u178e\u02fd\ufb24'});
+let renderBundle19 = renderBundleEncoder12.finish({label: '\u15c9\u06bd\u{1fdaf}\u0561\ub625\u0767\u0ce5\u{1f7d9}\ufaa1'});
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 53.48,
+  lodMaxClamp: 78.05,
+});
+try {
+renderBundleEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({label: '\u0343\udd90\u186f\u{1ff20}\u4236\u807b\u466a\u9dd0\u8c0c', entries: []});
+let texture15 = device0.createTexture({
+  label: '\ud8be\u4209\u{1fbe8}\u{1f856}\u{1fc5f}\u5e59\u560a\u{1f683}\ue346\u{1f748}',
+  size: [64],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle20 = renderBundleEncoder9.finish({label: '\u2422\u76b4\u075c\ua521\u1b38\u7864'});
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(3902);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 265026, 295167);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(200, undefined, 0, 3541107834);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+  label: '\u{1fab3}\u7672\ue8fe\u{1ffcf}\u3a28\uf984',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 4294967295,
+    depthBias: 568927972,
+    depthBiasSlopeScale: 282.1449447689797,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1244,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 0, shaderLocation: 7}, {format: 'sint8x4', offset: 728, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 0, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 96, shaderLocation: 8},
+          {format: 'sint32x4', offset: 4, shaderLocation: 13},
+          {format: 'float32x4', offset: 16, shaderLocation: 5},
+          {format: 'float32x3', offset: 12, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 36, shaderLocation: 2},
+          {format: 'float32x2', offset: 12, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', unclippedDepth: true},
+});
+let img2 = await imageWithData(138, 289, '#b61072c4', '#15350044');
+let bindGroup8 = device0.createBindGroup({layout: bindGroupLayout9, entries: []});
+let texture16 = device0.createTexture({
+  label: '\u0540\u0858\u349c\u06c1\u06ba\u1577\u9847\u8f45\u002d',
+  size: [32],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 868.9, g: -566.1, b: -142.4, a: 146.6, });
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 61904, new DataView(new ArrayBuffer(48025)), 10203, 12136);
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  label: '\u{1fe5d}\u0c8c\u{1fcd8}\u8720\u5dfc\u8736\u{1ffe0}\u{1f6ac}\u0dd8',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 232,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 16, shaderLocation: 8}],
+      },
+      {arrayStride: 152, attributes: [{format: 'float32', offset: 0, shaderLocation: 0}]},
+      {arrayStride: 296, stepMode: 'instance', attributes: []},
+      {arrayStride: 152, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 140,
+        attributes: [
+          {format: 'float16x4', offset: 36, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+});
+let querySet17 = device0.createQuerySet({label: '\u{1fb99}\u0da0\u1b2d\u065c\u{1fa8b}', type: 'occlusion', count: 2071});
+let textureView34 = texture0.createView({label: '\u0bab\u{1f83e}\u9e02\ua3fb\ue4f2\u0225\u{1fb2a}\uf3a5\u{1f75d}\u0fa2', baseMipLevel: 8});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup3, new Uint32Array(4193), 3812, 0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle16, renderBundle10, renderBundle16]);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({label: '\u07bc\u{1f698}\uaf3e\u0991\u0c95\ua234\u{1f907}\u{1fbd4}\u0053'});
+let textureView35 = texture6.createView({label: '\u{1fd94}\u09ca\ua2a8\ucc6b\ufe6c\uff19\u0dd7\u{1f9be}\u3e04\u5162\u01fd'});
+let computePassEncoder11 = commandEncoder27.beginComputePass({});
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint32', 577576);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline17);
+} catch {}
+let arrayBuffer1 = buffer1.getMappedRange(387160, 146680);
+try {
+buffer2.unmap();
+} catch {}
+let video3 = await videoWithData();
+let textureView36 = texture16.createView({
+  label: '\u{1f84b}\u0479\u94d0\u075b\uaabc\u0e0a\u0a71\u7447',
+  aspect: 'all',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle21 = renderBundleEncoder13.finish({label: '\u5642\ud593\u5363\u97c0\u044d\uce13\u{1f618}'});
+let externalTexture7 = device0.importExternalTexture({
+  label: '\u0525\u0b60\u9761\u{1fd04}\ueb3f\u765a\u035e\u{1f67e}\u0ec6',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder7.beginOcclusionQuery(432);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -197.6, g: 596.9, b: 358.6, a: 845.0, });
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(3385);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  label: '\u{1fdd6}\uc14c\u31bb',
+  code: `@group(3) @binding(31)
+var<storage, read_write> global4: array<u32>;
+@group(2) @binding(692)
+var<storage, read_write> type5: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> n3: array<u32>;
+@group(3) @binding(662)
+var<storage, read_write> function1: array<u32>;
+@group(3) @binding(515)
+var<storage, read_write> parameter4: array<u32>;
+@group(0) @binding(692)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @location(12) f0: vec3<f16>,
+  @location(3) f1: vec2<f32>,
+  @location(15) f2: i32,
+  @location(11) f3: i32,
+  @location(2) f4: vec3<f32>,
+  @builtin(sample_index) f5: u32,
+  @builtin(front_facing) f6: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec2<i32>, @location(5) a1: vec3<f32>, @location(4) a2: vec4<f32>, a3: S4, @builtin(sample_mask) a4: u32, @builtin(position) a5: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @builtin(instance_index) f0: u32,
+  @location(5) f1: vec4<f16>,
+  @location(7) f2: vec2<u32>,
+  @location(6) f3: f32,
+  @location(12) f4: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(11) f39: i32,
+  @location(2) f40: vec3<f32>,
+  @builtin(position) f41: vec4<f32>,
+  @location(15) f42: i32,
+  @location(5) f43: vec3<f32>,
+  @location(10) f44: vec2<i32>,
+  @location(4) f45: vec4<f32>,
+  @location(3) f46: vec2<f32>,
+  @location(12) f47: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: u32, @location(1) a1: i32, @location(8) a2: f32, @location(11) a3: vec2<f32>, a4: S3, @location(13) a5: f32, @location(4) a6: vec2<f32>, @location(0) a7: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u0885\u02ec\u{1f7fc}\u227f\u96f3\u5015\ufa10\u263b\u0623',
+  entries: [
+    {
+      binding: 692,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 802,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let textureView37 = texture13.createView({label: '\u4b44\u0a49\u08ee', mipLevelCount: 1});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u01ba\u1c2b\u9f43\u969c\u18e2\u6515\u841e\u23cc',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder11.setBlendConstant({ r: -447.0, g: 274.1, b: 175.5, a: 333.0, });
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(8)), /* required buffer size: 433 */
+{offset: 433, bytesPerRow: 363}, {width: 32, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync({
+  label: '\uc534\u07ff\u3504',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let pipeline29 = device0.createRenderPipeline({
+  label: '\u638c\u0285\uf643\u94d1\u15fa\uf5fe\u9327\u5e38',
+  layout: pipelineLayout4,
+  multisample: {},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2048,
+        attributes: [
+          {format: 'float32x4', offset: 508, shaderLocation: 5},
+          {format: 'uint8x2', offset: 146, shaderLocation: 1},
+          {format: 'uint32', offset: 808, shaderLocation: 8},
+          {format: 'sint8x2', offset: 6, shaderLocation: 6},
+          {format: 'uint32x3', offset: 216, shaderLocation: 15},
+          {format: 'sint8x2', offset: 336, shaderLocation: 9},
+          {format: 'float32x4', offset: 112, shaderLocation: 13},
+          {format: 'uint8x2', offset: 2046, shaderLocation: 2},
+          {format: 'uint8x4', offset: 96, shaderLocation: 7},
+          {format: 'sint8x2', offset: 106, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+let videoFrame2 = new VideoFrame(videoFrame1, {timestamp: 0});
+let bindGroup9 = device0.createBindGroup({
+  label: '\ua7e4\u{1fee0}\u86e8\uf481\u{1f6a5}\ud2f8\u0298',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 556, resource: {buffer: buffer2, offset: 110080}},
+    {binding: 422, resource: {buffer: buffer3, offset: 18432, size: 68420}},
+  ],
+});
+let commandEncoder28 = device0.createCommandEncoder();
+let textureView38 = texture0.createView({label: '\u{1f8e1}\u{1fd39}', baseMipLevel: 5, mipLevelCount: 3, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder12 = commandEncoder28.beginComputePass({label: '\u7283\uffb9\u09a7\ue303\u0d9d\u{1f8f4}\u04bd\u587d\u8123'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u4634\u{1f790}\u{1fec4}\u0afe\u5b8d\ub398\u{1f817}\u00a0',
+  colorFormats: ['rg8unorm'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(1014);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle8, renderBundle4, renderBundle1]);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+renderBundleEncoder15.pushDebugGroup('\u0175');
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder();
+let texture17 = device0.createTexture({
+  label: '\u041e\u2230\ue981',
+  size: {width: 608, height: 1, depthOrArrayLayers: 297},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let computePassEncoder13 = commandEncoder29.beginComputePass({label: '\u0869\u{1fd51}\u{1f876}\u6888'});
+try {
+renderPassEncoder0.setBlendConstant({ r: -947.4, g: -245.1, b: -376.2, a: 791.8, });
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline27);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData0);
+let commandEncoder30 = device0.createCommandEncoder({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(2, bindGroup1, new Uint32Array(7955), 345, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 246106, 254432);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(3603, undefined, 3841259223, 56453886);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer5, 17464, buffer6, 455788, 98200);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 42 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9228 */
+  offset: 9228,
+  buffer: buffer6,
+}, {width: 21, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+canvas2.height = 1435;
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u4ade\ufc1d\ua196\u8f41\uc67f\ud948\u1448',
+  entries: [
+    {
+      binding: 950,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 109567, hasDynamicOffset: true },
+    },
+    {
+      binding: 197,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 671266, hasDynamicOffset: true },
+    },
+    {
+      binding: 952,
+      visibility: 0,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer8 = device0.createBuffer({
+  label: '\u07eb\u0eca\ub96b\u2049\u{1f717}\ua283\ucb5f\ua069\uf9fb\u0afc\u4af8',
+  size: 149980,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u2d09\u7fbe'});
+let texture18 = device0.createTexture({
+  label: '\u8ef9\u196f\u064f\ueed5\u{1f9a7}\u5471\uf29c\u{1fe11}',
+  size: [32, 1, 234],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let computePassEncoder14 = commandEncoder31.beginComputePass({});
+let renderPassEncoder12 = commandEncoder30.beginRenderPass({
+  label: '\u0858\u01f1\u0def',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 7,
+  clearValue: { r: 175.9, g: -970.9, b: 228.2, a: -102.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler24 = device0.createSampler({label: '\u{1feb1}\u02f5\uc5da\u3d03', addressModeU: 'repeat', lodMinClamp: 9.964, lodMaxClamp: 54.87});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\u2df1\u0d42\u8f67\u5c1c\u{1fc38}\u0983\ubbb6\u{1f8ae}\u7d18\ubd7e\u0781',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder4.setScissorRect(6, 1, 0, 0);
+} catch {}
+let pipeline30 = device0.createComputePipeline({
+  label: '\u3e6c\u022f\u{1fe89}',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let imageData2 = new ImageData(224, 116);
+let buffer9 = device0.createBuffer({size: 676132, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC, mappedAtCreation: true});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer7, 'uint32', 494972, 29021);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline29);
+} catch {}
+let textureView39 = texture1.createView({label: '\u{1fb25}\ue026\uf08b\ue415\ud7ec\u002c\ub489', dimension: '1d'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.17,
+  lodMaxClamp: 95.58,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline31 = device0.createComputePipeline({
+  label: '\u0e87\u0ae2\uf849\u29d0\u0286\u0d2a\uc245\u0bb4\u52ac\u{1f765}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas0 = new OffscreenCanvas(31, 556);
+let imageBitmap2 = await createImageBitmap(video2);
+let imageData3 = new ImageData(96, 8);
+let texture19 = device0.createTexture({
+  label: '\ub5b6\u6694\u{1f6e2}\u5b86\u0b9b\u0ea5\ud844',
+  size: {width: 32, height: 1, depthOrArrayLayers: 1840},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer7, 'uint32', 151368, 17135);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline27);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+try {
+renderBundleEncoder15.popDebugGroup();
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\ua577\u1f5d\ub1a5\u0fbc\uc346\u0a3d\ua383\u28c4\u39c7',
+  entries: [
+    {
+      binding: 194,
+      visibility: 0,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 641, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+let textureView40 = texture4.createView({label: '\u8b7c\udf64\u44cf\u3014\u{1fedc}\ud1b2\u9a13\u06f5\u36a8', baseMipLevel: 0});
+let renderPassEncoder13 = commandEncoder32.beginRenderPass({
+  label: '\ub6bf\u77d9\ubfb2\uaa02\u{1fb0d}\u4ef2\u{1ffb9}\u0d99\u70c6\ud41e',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 7,
+  clearValue: { r: 787.9, g: 803.4, b: 504.7, a: 294.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 14764511,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+try {
+renderPassEncoder3.setBlendConstant({ r: -784.7, g: -58.35, b: -467.4, a: 614.6, });
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer7, 'uint32', 162616, 92850);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+let arrayBuffer2 = buffer8.getMappedRange(123136, 15268);
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer1), /* required buffer size: 817 */
+{offset: 817}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 76, height: 1, depthOrArrayLayers: 37}
+*/
+{
+  source: video3,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 13, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.prepend(img1);
+let img3 = await imageWithData(291, 13, '#541638ae', '#33508740');
+let renderBundle22 = renderBundleEncoder10.finish({label: '\ucb02\u{1fc1d}\u041f\u{1f6ab}\u0cb8'});
+try {
+renderPassEncoder3.executeBundles([renderBundle5, renderBundle7, renderBundle15, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 214272);
+} catch {}
+let pipeline32 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0x1c65cd73},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'invert', passOp: 'keep'},
+    stencilReadMask: 1323187014,
+    stencilWriteMask: 992286309,
+    depthBias: -72586954,
+    depthBiasSlopeScale: 805.3445750454373,
+    depthBiasClamp: -24.5226670238426,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 540,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 208, shaderLocation: 15},
+          {format: 'sint16x2', offset: 136, shaderLocation: 0},
+          {format: 'sint8x2', offset: 494, shaderLocation: 1},
+          {format: 'float16x4', offset: 4, shaderLocation: 6},
+          {format: 'uint32x4', offset: 4, shaderLocation: 12},
+          {format: 'uint32x2', offset: 8, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 768, attributes: []},
+      {
+        arrayStride: 324,
+        attributes: [
+          {format: 'snorm16x4', offset: 156, shaderLocation: 4},
+          {format: 'float32x4', offset: 24, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 112, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+offscreenCanvas0.getContext('bitmaprenderer');
+} catch {}
+let querySet18 = device0.createQuerySet({label: '\ue481\u0792\u6918\u80e1\udfcf\u{1ff68}', type: 'occlusion', count: 3876});
+let textureView41 = texture11.createView({label: '\ub183\u092c\u{1fa17}\u2097', dimension: '1d', baseMipLevel: 2, mipLevelCount: 2});
+try {
+computePassEncoder6.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 121552, new DataView(new ArrayBuffer(41277)), 35157, 1016);
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync({
+  label: '\u6c17\ue279\u931d\u{1fdac}\u3ec9\u5ff3\u4357\ufe68\u5547\u{1fd3d}\u779e',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 3479});
+try {
+computePassEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 20236, new DataView(new ArrayBuffer(52088)), 46353, 600);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: img0,
+  origin: { x: 20, y: 1 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\ufef1\u{1fad1}\uf0e4\u{1fbea}\u088d\u{1fcdb}',
+  entries: [
+    {
+      binding: 640,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 441,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture20 = device0.createTexture({
+  label: '\u01e9\u522b\u0eaa',
+  size: [10],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let textureView42 = texture0.createView({
+  label: '\u4e52\u34ae\ua7ed\u{1f8ed}\uaca0\ue967\u08fe\u41a4\u16d0\u0213\u1f58',
+  baseMipLevel: 1,
+  mipLevelCount: 8,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup8, new Uint32Array(9477), 7113, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle18, renderBundle12, renderBundle17, renderBundle2, renderBundle16, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline29);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 1, depthOrArrayLayers: 92}
+*/
+{
+  source: canvas2,
+  origin: { x: 44, y: 108 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 33},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline34 = device0.createComputePipeline({
+  label: '\u6ed2\u{1ff16}\u02a3\u50ca\u197f\u4041\u15e4\ud7ff\u{1f83e}\u71a2',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline35 = device0.createRenderPipeline({
+  label: '\u{1f85c}\uc062',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0x2bffc259},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 2434340443,
+    stencilWriteMask: 211775309,
+    depthBias: -1963416053,
+    depthBiasSlopeScale: 819.2948705673809,
+    depthBiasClamp: 220.12711555815991,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 776,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 8, shaderLocation: 14},
+          {format: 'float32', offset: 52, shaderLocation: 4},
+          {format: 'sint8x2', offset: 342, shaderLocation: 5},
+          {format: 'uint32x4', offset: 212, shaderLocation: 13},
+          {format: 'uint32', offset: 56, shaderLocation: 12},
+          {format: 'sint8x2', offset: 206, shaderLocation: 7},
+          {format: 'sint16x2', offset: 36, shaderLocation: 15},
+          {format: 'float16x2', offset: 292, shaderLocation: 11},
+          {format: 'sint32x4', offset: 736, shaderLocation: 0},
+          {format: 'sint32x4', offset: 144, shaderLocation: 10},
+          {format: 'uint8x4', offset: 204, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 948,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 144, shaderLocation: 1},
+          {format: 'sint8x4', offset: 344, shaderLocation: 3},
+          {format: 'sint16x4', offset: 280, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 28, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 672,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x4', offset: 408, shaderLocation: 2}],
+      },
+      {arrayStride: 80, attributes: []},
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 32, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let querySet20 = device0.createQuerySet({label: '\u8a41\u079c\u{1fdbe}\u0963\u05c5\u{1fffb}\u{1ffae}', type: 'occlusion', count: 441});
+let texture21 = device0.createTexture({
+  label: '\ue810\u02e5',
+  size: {width: 128, height: 1, depthOrArrayLayers: 43},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let texture22 = gpuCanvasContext0.getCurrentTexture();
+let textureView43 = texture7.createView({label: '\u{1f8f6}\u0a6c', dimension: '2d-array', baseMipLevel: 0});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u28b1\u408c\u{1f9cd}\u0ed8\u856f\u0667\u{1fab8}\u0fba\u867f',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder12.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(1710);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(7, 1, 2, 0);
+} catch {}
+let pipeline36 = device0.createComputePipeline({
+  label: '\u0006\ue3cd\ufc20',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  label: '\u406c\u8083',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 662, resource: {buffer: buffer2, offset: 367616}},
+    {binding: 31, resource: externalTexture2},
+    {binding: 515, resource: {buffer: buffer2, offset: 153856, size: 271380}},
+  ],
+});
+let buffer10 = device0.createBuffer({size: 93168, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX, mappedAtCreation: true});
+let texture23 = device0.createTexture({
+  label: '\uf3d5\ufda0\u06fb\u22d4\u4636\u0754\u07ab\u{1fb71}\ufa6e\u0a57\u14da',
+  size: [40, 1, 152],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup2, new Uint32Array(1920), 207, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1045);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16');
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture24 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let textureView44 = texture1.createView({label: '\u02ee\u0c17\u0342\u{1f6a7}\u0272\u{1fdea}\u{1f946}\ucd21\u87e2\u46f7'});
+try {
+renderPassEncoder4.setScissorRect(11, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer10, 0, 91149);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(canvas2);
+let texture25 = device0.createTexture({
+  label: '\uf010\u793a\u01a7\u3fe7\u0b6a\uc7f2\u{1fdaf}\ud649\u6540\u03ee',
+  size: [16, 1, 1],
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView45 = texture18.createView({label: '\u0e92\ue918\u09ce\u04c1\u6edd\u7a06', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 44});
+let externalTexture9 = device0.importExternalTexture({label: '\uaaff\uc2b5\u02e3\ufd55\u{1f97f}\u1fcb\u3f81\u{1f95d}', source: videoFrame0});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(5, 0, 6, 1);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer10, 24252, 67417);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup0, new Uint32Array(1365), 1242, 0);
+} catch {}
+let pipeline37 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {mask: 0x966d943e},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilWriteMask: 280651750,
+    depthBias: -1604571520,
+    depthBiasClamp: 543.567335989939,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 176, shaderLocation: 5},
+          {format: 'float32x4', offset: 1152, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 92, shaderLocation: 8},
+          {format: 'float16x2', offset: 4, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let buffer11 = device0.createBuffer({
+  label: '\uae80\u0bbb\u{1ffb2}\u79ca\ue99d\u0bf1\u0803\u57d2\ud25a\u0584\ua3c2',
+  size: 287550,
+  usage: GPUBufferUsage.STORAGE,
+});
+let commandEncoder33 = device0.createCommandEncoder({label: '\u{1ff55}\u{1fc11}\u02e3\u3133\u9001\ud8ac\u2699\ub97e\u39df\u036e\u0c06'});
+let renderPassEncoder14 = commandEncoder33.beginRenderPass({
+  label: '\u87a9\uf5c8\u06b3\ue705\u1263\u{1fae2}\u{1f760}',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 6,
+  clearValue: { r: -166.4, g: -982.2, b: -93.36, a: 640.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 135688046,
+});
+try {
+renderPassEncoder0.setVertexBuffer(7359, undefined, 0, 2710320719);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer10, 71324, 19494);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({label: '\u0b5b\u{1fcd4}\ub9e2\u00e9\u32bf\u0f4a\u0338\u95e2\u34d3\u{1fdc9}', entries: []});
+let commandEncoder34 = device0.createCommandEncoder({label: '\u{1ff61}\u0400\u0c96\u{1fd02}\u06ef'});
+let textureView46 = texture15.createView({label: '\ud5fe\u{1ff08}\ufe27\u567b\u{1fc52}\u{1fb50}\u04dc\u7e33\ub577\udd44', format: 'rgba8sint'});
+let renderPassEncoder15 = commandEncoder34.beginRenderPass({
+  label: '\uee2c\u{1fdfb}',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 1,
+  clearValue: { r: -822.7, g: 306.6, b: -330.1, a: -831.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 906712141,
+});
+try {
+renderPassEncoder13.setViewport(14.72, 0.5177, 0.9848, 0.3707, 0.3798, 0.4718);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer10, 47188);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer10, 21116, 55185);
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+  label: '\u8979\u7d9a',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xeafde16e},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 92, attributes: []},
+      {
+        arrayStride: 168,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 124, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 10},
+          {format: 'sint8x4', offset: 20, shaderLocation: 14},
+          {format: 'uint8x4', offset: 44, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 10, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 52, shaderLocation: 0},
+          {format: 'sint8x4', offset: 16, shaderLocation: 2},
+          {format: 'uint32x4', offset: 0, shaderLocation: 8},
+          {format: 'uint8x4', offset: 136, shaderLocation: 9},
+          {format: 'float16x2', offset: 96, shaderLocation: 4},
+          {format: 'uint8x2', offset: 14, shaderLocation: 6},
+          {format: 'uint16x2', offset: 16, shaderLocation: 7},
+          {format: 'uint32x4', offset: 28, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 76, stepMode: 'instance', attributes: []},
+      {arrayStride: 168, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 852, stepMode: 'instance', attributes: []},
+      {arrayStride: 196, attributes: [{format: 'unorm16x2', offset: 16, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup11 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 515, resource: {buffer: buffer2, offset: 311808}},
+    {binding: 662, resource: {buffer: buffer2, offset: 247808}},
+    {binding: 31, resource: externalTexture4},
+  ],
+});
+let buffer12 = device0.createBuffer({
+  label: '\uc025\ua19e\ub3c3\u076a\u{1fb7d}',
+  size: 484824,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder35 = device0.createCommandEncoder();
+let textureView47 = texture19.createView({
+  label: '\u7ae0\u{1f679}\u01f9\u{1fe4b}\u0151\ua06d\u1156\u{1f614}\u443d\u191b\u066b',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let renderPassEncoder16 = commandEncoder35.beginRenderPass({
+  label: '\u07e0\u6bb7\uc626\uc4b2',
+  colorAttachments: [{view: textureView13, depthSlice: 0, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 121680436,
+});
+try {
+renderPassEncoder15.setScissorRect(1, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(8.255, 0.5906, 4.949, 0.2236, 0.4706, 0.8651);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4, buffer10, 13632);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\udf39\u2920\u021d\ue578\u{1f9aa}\u{1fa68}\ud91d\uc841',
+  layout: bindGroupLayout7,
+  entries: [{binding: 67, resource: externalTexture4}, {binding: 374, resource: {buffer: buffer2, offset: 80640}}],
+});
+let textureView48 = texture12.createView({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u634e\u18b3\u001f\u0294\u05c6\u0fae\ufa35\u6221\ub009',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder8.beginOcclusionQuery(562);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 738.9, g: 746.0, b: 595.0, a: -771.8, });
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(2732);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint32', 142644, 374940);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer10, 53900, 14210);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: video2,
+  origin: { x: 3, y: 3 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\u2105\ue9a5\u0752\u463f\u34bb\u05f3\u2ff8\u{1fed1}\u{1fd51}',
+  code: `@group(0) @binding(692)
+var<storage, read_write> local7: array<u32>;
+
+@compute @workgroup_size(2, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: i32,
+  @location(0) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: vec2<u32>, @location(8) a1: vec2<f32>, @location(4) a2: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup13 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 692, resource: sampler20}]});
+let textureView49 = texture24.createView({label: '\u071e\u0b34\u6f83', baseArrayLayer: 0});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup12, [0]);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer7, 'uint16', 269240, 121466);
+} catch {}
+let arrayBuffer3 = buffer8.getMappedRange(138408, 11364);
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 95696, 39324);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageBitmap3 = await createImageBitmap(videoFrame2);
+let commandEncoder36 = device0.createCommandEncoder({});
+let renderPassEncoder17 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{view: textureView4, depthSlice: 3, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 594197072,
+});
+let renderBundle23 = renderBundleEncoder4.finish({label: '\u0e92\u{1f6b8}\ue01d'});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup12, [0]);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16');
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer10, 72872);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u470c');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 294515 */
+{offset: 319, bytesPerRow: 196, rowsPerImage: 79}, {width: 10, height: 0, depthOrArrayLayers: 20});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let buffer13 = device0.createBuffer({
+  label: '\ua69c\u066e\u{1ff84}',
+  size: 258197,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup12, [0]);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(611);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle21, renderBundle16, renderBundle19, renderBundle9, renderBundle21, renderBundle21, renderBundle13, renderBundle20, renderBundle20, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer7, 'uint32', 32148, 217278);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer10, 0, 17654);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup12, new Uint32Array(6210), 5994, 1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 218892, new BigUint64Array(14401));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 388 */
+{offset: 360, bytesPerRow: 50, rowsPerImage: 26}, {width: 14, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let sampler26 = device0.createSampler({
+  label: '\u1bd1\u9533\u0145\u{1f82e}\u0cb8\ue7fd\u20db\udd6f\u03f3',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 63.84,
+  lodMaxClamp: 89.05,
+});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder8.executeBundles([renderBundle17, renderBundle14, renderBundle4, renderBundle21, renderBundle10, renderBundle9, renderBundle8, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2293, undefined, 0, 2327033294);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 31},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 102408 */
+{offset: 946, bytesPerRow: 89, rowsPerImage: 190}, {width: 1, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+let offscreenCanvas1 = new OffscreenCanvas(411, 344);
+let shaderModule11 = device0.createShaderModule({
+  label: '\u6a73\u616f\u4252\u{1fa50}\ued38\u83dc\u386d',
+  code: `
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec4<u32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u0213\u{1feaf}\ucd5a\u{1f7c7}\u0dc7'});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\ufb6c\ueb63\u021a\u0651\u22ed\u1a12\u{1f6ce}\u{1f7a7}',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle24 = renderBundleEncoder5.finish();
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setViewport(14.55, 0.7289, 0.2096, 0.1641, 0.4609, 0.6924);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer8, 137700, buffer0, 94604, 1656);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 48572 */
+  offset: 48542,
+  bytesPerRow: 256,
+  rowsPerImage: 127,
+  buffer: buffer13,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let imageData4 = new ImageData(208, 188);
+let commandEncoder38 = device0.createCommandEncoder({});
+let renderPassEncoder18 = commandEncoder38.beginRenderPass({
+  label: '\u78e8\u2a04\u0fbe\u07d2',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 2,
+  clearValue: { r: -175.4, g: -601.9, b: -966.6, a: 891.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 1089170050,
+});
+try {
+computePassEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup0, new Uint32Array(9037), 142, 0);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(2619);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 41780 */
+  offset: 41780,
+  buffer: buffer9,
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet16, 78, 820, buffer4, 189696);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 59220, new Int16Array(31708));
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\uecad\ufb87\u047f\u0dfa\u{1f8aa}'});
+let textureView50 = texture2.createView({label: '\u0981\u0eb9\u078d\u0618\u{1fdde}\u5024\u{1fd6d}', baseMipLevel: 2, mipLevelCount: 1});
+let renderPassEncoder19 = commandEncoder37.beginRenderPass({
+  label: '\ua1a5\u0b5f\u{1f8c6}\u086c\u{1fce9}\u1ca0\u0358\u{1fe6c}\ua1c1\u1e71',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 6,
+  clearValue: { r: -611.3, g: -671.2, b: -408.8, a: 783.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 1080795072,
+});
+let renderBundle25 = renderBundleEncoder0.finish({});
+let externalTexture11 = device0.importExternalTexture({label: '\uc029\u0231\u{1f90e}\ufb5e', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder17.setScissorRect(16, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 131870);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer7, 'uint32', 241992);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 26246 */
+  offset: 26246,
+  buffer: buffer9,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 69, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 137});
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(querySet5, 1038, 306, buffer6, 200704);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 648480, new Int16Array(29559), 1376, 7292);
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+  label: '\u690e\u0172\uf90e\u{1fa54}\u5f22\u98c4\uf093\ud637',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x95f349c3},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 176,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 0, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 128, shaderLocation: 6},
+          {format: 'sint32', offset: 20, shaderLocation: 0},
+          {format: 'float32', offset: 40, shaderLocation: 11},
+          {format: 'float16x2', offset: 20, shaderLocation: 13},
+          {format: 'sint32', offset: 20, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 28, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 632, attributes: []},
+      {
+        arrayStride: 300,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 32, shaderLocation: 7},
+          {format: 'uint16x2', offset: 60, shaderLocation: 12},
+          {format: 'uint16x2', offset: 4, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(canvas2);
+let querySet21 = device0.createQuerySet({label: '\ubaa5\u0450\u{1fdb3}', type: 'occlusion', count: 1041});
+let textureView51 = texture4.createView({label: '\u056c\u032b\u{1f6e9}\u0181', baseArrayLayer: 0});
+try {
+computePassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(982);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 197, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 30},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let renderPassEncoder20 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{view: textureView4, depthSlice: 10, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet2,
+});
+let sampler27 = device0.createSampler({
+  label: '\u0d51\u0e91\u4aa8\u0f9b\u5168\u867d\u67c6\uce35',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 59.43,
+  lodMaxClamp: 70.38,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup12, new Uint32Array(7378), 4402, 1);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6155, undefined);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let offscreenCanvas2 = new OffscreenCanvas(969, 841);
+let textureView52 = texture23.createView({
+  label: '\u{1ff19}\u05b5\u{1ff11}\u{1f6ac}\u0795\u9be6\ue658\ue7f9\u0248\u03cb\u{1f61f}',
+  baseMipLevel: 1,
+  baseArrayLayer: 85,
+  arrayLayerCount: 35,
+});
+try {
+renderPassEncoder16.setScissorRect(0, 0, 11, 1);
+} catch {}
+try {
+renderPassEncoder12.setViewport(13.25, 0.07153, 1.929, 0.2807, 0.1625, 0.9692);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1090237063, 562169065, 868869087, -519798583);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline17);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u0ca9');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageBitmap1);
+let textureView53 = texture8.createView({label: '\u6e77\u0dc9\u6e91\u77e0\uc346\u3c1f\uff8c\u4617\uc2be', dimension: '1d'});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u077b\u0f08\u09e3\u{1f813}\u{1fc9e}\uae87\u0a0b\u00de\u{1fdbc}\u07ff\uac7a',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let renderBundle26 = renderBundleEncoder18.finish({label: '\u811a\u9d6a\u3e5d\uaa35\u7fc9\ueb96\u2348\u{1f9e0}\u00a8\u7627'});
+try {
+computePassEncoder11.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup2, new Uint32Array(4130), 3449, 0);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(381);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline27);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: canvas2,
+  origin: { x: 35, y: 170 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 25},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas2.getContext('webgl');
+} catch {}
+let textureView54 = texture24.createView({label: '\uc164\u07ef\u0c29\ua7ec\u8f74\u{1fee4}\u982f', dimension: '1d', baseArrayLayer: 0});
+let externalTexture12 = device0.importExternalTexture({label: '\u0c7c\uf0f9', source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup2, new Uint32Array(7858), 272, 0);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(1995);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 864.9, g: -817.0, b: -140.0, a: 831.8, });
+} catch {}
+try {
+renderPassEncoder20.setViewport(12.02, 0.8112, 1.848, 0.1502, 0.7789, 0.9571);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+buffer7.destroy();
+} catch {}
+let pipeline40 = await device0.createComputePipelineAsync({
+  label: '\u{1fa17}\u9c14\u0b44\u{1fefe}\u{1ff8b}\u1034\uaac2',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView55 = texture25.createView({label: '\u4caf\uaf58\u2b3a\u7048\u31ff\u{1fc7a}\u02e8\u064a\u160c', baseMipLevel: 3});
+let renderBundle27 = renderBundleEncoder0.finish({label: '\u0f5c\u1fb4\u862d\uf71a\ub764\u0d29\udaf6'});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup12, new Uint32Array(7192), 2482, 1);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(1470);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(2, 1, 6, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(141013679, 936816271, 409123352, 309368010, 166552161);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer0, 352028613);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer4 = buffer5.getMappedRange(132352, 2636);
+let shaderModule12 = device0.createShaderModule({
+  label: '\uc467\ubee3\u2c2c',
+  code: `@group(2) @binding(692)
+var<storage, read_write> global5: array<u32>;
+@group(3) @binding(515)
+var<storage, read_write> field6: array<u32>;
+@group(1) @binding(692)
+var<storage, read_write> function2: array<u32>;
+@group(3) @binding(662)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @builtin(position) f0: vec4<f32>,
+  @location(15) f1: u32,
+  @location(11) f2: i32,
+  @location(12) f3: vec4<f16>,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(a0: S5, @location(3) a1: vec3<f32>) -> @location(200) vec2<f32> {
+return vec2<f32>();
+}
+
+struct VertexOutput0 {
+  @location(7) f48: f16,
+  @location(11) f49: i32,
+  @location(3) f50: vec3<f32>,
+  @location(12) f51: vec4<f16>,
+  @builtin(position) f52: vec4<f32>,
+  @location(0) f53: vec2<u32>,
+  @location(15) f54: u32
+}
+
+@vertex
+fn vertex0(@location(2) a0: f16, @location(4) a1: vec4<f32>, @builtin(instance_index) a2: u32, @builtin(vertex_index) a3: u32, @location(14) a4: vec4<f32>, @location(11) a5: vec3<i32>, @location(10) a6: vec2<f32>, @location(9) a7: vec2<u32>, @location(8) a8: i32, @location(13) a9: u32, @location(3) a10: vec4<f32>, @location(1) a11: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u{1fda8}\uc103\uf65c\u2110\u0423\u{1f92d}',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout14],
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\ufbc7\u1adc'});
+let textureView56 = texture7.createView({
+  label: '\ue460\u0a7e\u0191\u{1f8e3}\uf7e4\u0a47\ud1eb\u{1f892}\u07b5\u5e5e\uaae7',
+  dimension: '2d-array',
+  mipLevelCount: 2,
+});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup11, [0, 0]);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(2582);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(11, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(40289056, 1082255156, 620160495, 1219079886);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer0, 891759139);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer10);
+} catch {}
+let renderPassEncoder21 = commandEncoder40.beginRenderPass({
+  label: '\uc1f6\u0e55\uf95a\ud5b2\u00e9\udf90\u7ec6\uac41\ueb43\u7ff1\ud9b8',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 5,
+  clearValue: { r: -264.6, g: -515.8, b: -395.7, a: 89.48, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder19.setViewport(1.659, 0.3633, 0.4987, 0.1658, 0.2384, 0.8656);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(808753279, 490784808, 74940517, -1159389869, 147994456);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer10, 28000);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup9, new Uint32Array(4138), 95, 2);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer10, 0, 26597);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer4), /* required buffer size: 1049617 */
+{offset: 293, bytesPerRow: 166, rowsPerImage: 147}, {width: 19, height: 1, depthOrArrayLayers: 44});
+} catch {}
+let pipeline41 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}}});
+let imageData5 = new ImageData(28, 52);
+let commandEncoder41 = device0.createCommandEncoder();
+let textureView57 = texture14.createView({baseMipLevel: 0});
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 0, 9, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer9, 190821078);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 63252 */
+  offset: 63252,
+  buffer: buffer9,
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(30, 732);
+let bindGroup14 = device0.createBindGroup({label: '\ue1ed\ua6d8\u02cc\u4e13\u28d0\u66d2\u3c3a\u{1f988}', layout: bindGroupLayout9, entries: []});
+let textureView58 = texture19.createView({label: '\u1d07\u0387\u8213\u{1f97e}\ucd8d\ube48', dimension: '3d', aspect: 'all', baseMipLevel: 4});
+let renderPassEncoder22 = commandEncoder41.beginRenderPass({
+  label: '\u{1f8a3}\u0658\u0a8c\uea08\u093f\u054e\u{1fd3c}\u1577\u{1fc60}\ucb4d',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 1,
+  clearValue: { r: -289.0, g: -416.1, b: -733.7, a: -108.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 1159352630,
+});
+let externalTexture13 = device0.importExternalTexture({label: '\u{1fab5}\u9f0c', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(6228), 1544, 0);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(2299);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1085567522, 1214498724);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer10);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u069b');
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+  label: '\u08c6\u{1f6ab}\u0a4b\u5856\ub9dc\u03e1\u{1fa84}\u069e\uec3d\u{1f85e}\ubd2e',
+  layout: pipelineLayout6,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 456,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 52, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 44, shaderLocation: 8},
+          {format: 'float16x4', offset: 56, shaderLocation: 4},
+          {format: 'sint32x2', offset: 64, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 672,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x4', offset: 168, shaderLocation: 15},
+          {format: 'uint32x2', offset: 76, shaderLocation: 7},
+          {format: 'float16x2', offset: 28, shaderLocation: 11},
+          {format: 'uint32x3', offset: 208, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 176,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 20, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 700,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 144, shaderLocation: 5}],
+      },
+      {arrayStride: 196, stepMode: 'vertex', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'unorm8x4', offset: 264, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let textureView59 = texture21.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 1});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({label: '\u{1fe48}\u050f\ud28c\u080a', colorFormats: ['rg8unorm']});
+let renderBundle28 = renderBundleEncoder20.finish();
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(917);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer4, 1174159746);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup12, new Uint32Array(7566), 5280, 1);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer10);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let videoFrame3 = videoFrame1.clone();
+let commandEncoder42 = device0.createCommandEncoder({label: '\u250f\u0980\u9e3f'});
+let texture26 = device0.createTexture({
+  label: '\ue441\u0fcf\u{1f843}\ud76d\u04dd\u0493',
+  size: [16, 1, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder15.beginOcclusionQuery(462);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(708);
+} catch {}
+try {
+renderPassEncoder8.setViewport(15.81, 0.8854, 0.04142, 0.04478, 0.9245, 0.9600);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1224846555, 567089679, 303866806);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer10, 12589668);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer0, 1176674717);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 30676 */
+  offset: 30676,
+  buffer: buffer6,
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas3.getContext('2d');
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder();
+let texture27 = device0.createTexture({
+  label: '\u5090\uf0a7\u2d4b\uf50b\u1254\u6885\u0a4a',
+  size: {width: 304, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth32float'],
+});
+let renderPassEncoder23 = commandEncoder43.beginRenderPass({
+  label: '\uead7\uc288\u9773\u0c95',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 381.8, g: 971.6, b: -40.62, a: -769.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 150944309,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup9, new Uint32Array(7362), 41, 2);
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(11, 1, 3, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(3.896, 0.2222, 3.648, 0.3597, 0.5217, 0.6889);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer1, 773587434);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer9, 232968, buffer6, 587680, 241452);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet14, 1711, 1490, buffer4, 95232);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u075f');
+} catch {}
+let pipeline43 = device0.createRenderPipeline({
+  label: '\ueedd\u5343\u{1fd1b}\u{1ff84}\u9b8a\uc863',
+  layout: pipelineLayout5,
+  multisample: {mask: 0xc85d7f71},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'unorm8x2', offset: 32, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 152, shaderLocation: 4},
+          {format: 'float32x2', offset: 84, shaderLocation: 8},
+          {format: 'uint8x2', offset: 6, shaderLocation: 14},
+          {format: 'sint32x3', offset: 28, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 372,
+        attributes: [
+          {format: 'float16x4', offset: 36, shaderLocation: 6},
+          {format: 'sint32x3', offset: 68, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let video4 = await videoWithData();
+let bindGroup15 = device0.createBindGroup({label: '\u4265\u0493\u433a', layout: bindGroupLayout0, entries: [{binding: 692, resource: sampler20}]});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u0deb\u0f4e\u876f\u3b17\u992d\uc4fe\u0cda\u09e1\u05d0\u0795'});
+let textureView60 = texture19.createView({label: '\u02de\u{1feea}\u{1ffef}\u6fad\u708c\u0d75\u3b11', baseMipLevel: 4, mipLevelCount: 1});
+let renderPassEncoder24 = commandEncoder44.beginRenderPass({
+  label: '\u44d9\u8639\u{1f9f2}\u{1fb6f}',
+  colorAttachments: [{view: textureView59, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 448258054,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup12, new Uint32Array(2134), 201, 1);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setViewport(5.697, 0.3922, 7.945, 0.5958, 0.04846, 0.9556);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer3, 215458093);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline27);
+} catch {}
+try {
+  await buffer13.mapAsync(GPUMapMode.WRITE, 149296, 46772);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 18856 */
+  offset: 18856,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline44 = device0.createComputePipeline({
+  label: '\ua918\u09d8\u02b4\u07c3\u{1fc69}\u0fe3\u0929',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let video5 = await videoWithData();
+let textureView61 = texture2.createView({label: '\u0b8c\u342f\u0252\u4637\u{1fa81}\u1c52\u0a79', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder15 = commandEncoder12.beginComputePass();
+let renderBundle29 = renderBundleEncoder5.finish({label: '\u07df\u9430\u{1fe19}\u092a\u{1f8e9}'});
+try {
+computePassEncoder7.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(2436);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(963849934, 859700892, 734706035, 46130161, 692206247);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer6, 85147059);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer10, 0, 2742);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer10, 62760, 22060);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 103261 */
+{offset: 383, bytesPerRow: 50, rowsPerImage: 121}, {width: 14, height: 1, depthOrArrayLayers: 18});
+} catch {}
+let texture28 = device0.createTexture({
+  size: {width: 10, height: 1, depthOrArrayLayers: 19},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView62 = texture16.createView({mipLevelCount: 1});
+let renderPassEncoder25 = commandEncoder42.beginRenderPass({
+  label: '\u{1f603}\uc009\u034d\uf8d5\u{1fc03}\u4062\u5215\u{1fbc0}\u0c2d\u088e\u643f',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 1,
+  clearValue: { r: 375.0, g: -887.1, b: -608.7, a: -249.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 895736251,
+});
+let renderBundle30 = renderBundleEncoder0.finish({label: '\uedf0\u0e07\u0433\uf227\u2c1a\u1649\ue52a\u{1fc0a}\u18fa\ubdf1'});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup9, [0, 1536]);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(2759);
+} catch {}
+try {
+renderPassEncoder7.draw(614474675, 236820660, 25455504, 403212599);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(252504944, 446652014, 1200751911, -50448544, 236876084);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer6, 607259891);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer10, 36176, 56841);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline45 = device0.createRenderPipeline({
+  label: '\u{1f73d}\u517b\u{1ff4a}\u{1fafa}\u{1ff86}\uca90\ub20d\u{1f659}\u7056',
+  layout: pipelineLayout6,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: [{format: 'rg8unorm'}]},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 0, shaderLocation: 4},
+          {format: 'sint16x2', offset: 0, shaderLocation: 6},
+          {format: 'uint8x4', offset: 8, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 10, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 14},
+          {format: 'sint8x4', offset: 56, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 116, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 964,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 228, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 11},
+          {format: 'uint8x2', offset: 962, shaderLocation: 1},
+          {format: 'uint8x2', offset: 350, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 36, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 280,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 28, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+offscreenCanvas1.height = 1184;
+let video6 = await videoWithData();
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u{1fe6c}\u0bc2\ua9b4\u1609\u61af\ueabf\u0bc7\u3de0',
+  entries: [{binding: 357, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let commandEncoder45 = device0.createCommandEncoder({label: '\uc927\u{1f76a}\uf986\ucc0d'});
+let textureView63 = texture25.createView({baseMipLevel: 0, mipLevelCount: 1});
+let renderPassEncoder26 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 17,
+  clearValue: { r: 863.6, g: -170.8, b: 478.3, a: -186.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 301803018,
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle24]);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer11, 270105258);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline29);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 87, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 744 */
+{offset: 732, bytesPerRow: 20}, {width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 608, height: 1, depthOrArrayLayers: 297}
+*/
+{
+  source: video3,
+  origin: { x: 0, y: 6 },
+  flipY: false,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 463, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({
+  label: '\u0008\u019b\u8c8c\u09bc\u8e4b\uf13c\u8161\u067b\u589a\u{1ff3f}\u{1f8af}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule6, entryPoint: 'compute0'},
+});
+let pipeline47 = device0.createRenderPipeline({
+  label: '\uad3d\u081a\uc14d',
+  layout: pipelineLayout7,
+  multisample: {count: 4, mask: 0x8d024a74},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap'},
+    stencilReadMask: 1403696236,
+    stencilWriteMask: 978141824,
+    depthBiasClamp: 491.55841231306283,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 708,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 2, shaderLocation: 1}, {format: 'sint8x4', offset: 0, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 2048,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 696, shaderLocation: 4},
+          {format: 'sint32', offset: 272, shaderLocation: 7},
+          {format: 'uint32x2', offset: 864, shaderLocation: 14},
+          {format: 'sint8x4', offset: 1048, shaderLocation: 15},
+          {format: 'uint16x4', offset: 112, shaderLocation: 12},
+          {format: 'uint32x2', offset: 264, shaderLocation: 8},
+          {format: 'uint16x4', offset: 200, shaderLocation: 13},
+          {format: 'sint32', offset: 408, shaderLocation: 9},
+          {format: 'sint32x2', offset: 1096, shaderLocation: 0},
+          {format: 'sint8x4', offset: 248, shaderLocation: 3},
+          {format: 'sint32x4', offset: 116, shaderLocation: 2},
+          {format: 'sint32', offset: 968, shaderLocation: 10},
+          {format: 'sint16x4', offset: 484, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 122, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder46 = device0.createCommandEncoder();
+try {
+renderPassEncoder23.setStencilReference(1481);
+} catch {}
+try {
+renderPassEncoder15.setViewport(0.5469, 0.4143, 0.00308, 0.5420, 0.8216, 0.9894);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer6, 762584582);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline43);
+} catch {}
+canvas2.width = 273;
+let bindGroup16 = device0.createBindGroup({label: '\u0d78\uc4b8\u{1fb7a}\u0aad\ub4d9\ue939', layout: bindGroupLayout14, entries: []});
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1f7c7}\u09f5\u4e21\ufae9\u02d1\u{1fcfb}\u{1fffc}'});
+let renderPassEncoder27 = commandEncoder46.beginRenderPass({
+  label: '\u{1f8d4}\ucb07\u289d\u0701\u6195\ud251',
+  colorAttachments: [{
+  view: textureView13,
+  depthSlice: 5,
+  clearValue: { r: -573.4, g: -327.9, b: 847.7, a: 934.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 552413486,
+});
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(7.497, 0.4043, 7.002, 0.2363, 0.3749, 0.9225);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline17);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\u061f\u0dc1\u6409\u03b1\u89d0\u3321\u69ae\u0fc7\u5a03\u04da\ucb28',
+  entries: [
+    {
+      binding: 121,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 241,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer14 = device0.createBuffer({label: '\u94b2\u{1fe2c}\u7ebd', size: 2772, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderPassEncoder28 = commandEncoder47.beginRenderPass({
+  label: '\u4446\u{1fd87}\u9045\u{1f613}\uf2a1\u45d3',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 4,
+  clearValue: { r: 539.3, g: -676.3, b: -156.9, a: -423.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 1178802059,
+});
+let sampler28 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.38,
+  lodMaxClamp: 95.60,
+  compare: 'greater-equal',
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup15, new Uint32Array(6112), 5973, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle25, renderBundle16, renderBundle1, renderBundle26, renderBundle26, renderBundle17, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(0, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(89);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer14, 405578672);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer10);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup12, [0]);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\u{1fab1}\u2325\u075f'});
+let textureView64 = texture3.createView({label: '\u05ff\u6d71\uea07\u{1f9dd}\u739c\u0fa4\u7c73'});
+let renderPassEncoder29 = commandEncoder48.beginRenderPass({
+  label: '\uad27\u0dbf\u714b\u8321\uadeb\u{1fb45}',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 6,
+  clearValue: { r: 40.59, g: -872.5, b: -520.1, a: 944.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+let renderBundle31 = renderBundleEncoder14.finish({label: '\u5e4b\u{1fb26}\u0282\uccdf\u{1fffc}\u1b00'});
+let externalTexture14 = device0.importExternalTexture({
+  label: '\u{1fc8c}\uc5a3\u{1f8a6}\u183d\u00a1\uef10\u0808\u03a7',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder12.setPipeline(pipeline46);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(298);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -356.8, g: -815.5, b: -682.3, a: 282.9, });
+} catch {}
+try {
+renderPassEncoder7.draw(814533262, 695693725, 86617308);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup16, new Uint32Array(6428), 1473, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 102560, new Float32Array(23192), 10264, 2360);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u1aa1\u7f86\u044f\uee2b\u{1fee4}',
+  entries: [
+    {binding: 255, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 664,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 302, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u3f54\u9953\u0be0\u04f5\u{1fe07}\u0f86\ufaca\u{1f631}\u0187\u1cf5',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: false,
+});
+try {
+renderPassEncoder29.beginOcclusionQuery(1602);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -54.94, g: 560.0, b: 612.8, a: -272.1, });
+} catch {}
+try {
+renderPassEncoder12.setViewport(14.51, 0.6752, 0.6270, 0.1264, 0.6096, 0.7407);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer10, 0, 786);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u0a3b\uf1ce\u0c1b\u{1f794}\u{1fbec}\ub210\u02d6\u0b5b\u84c8',
+  code: `@group(3) @binding(31)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(692)
+var<storage, read_write> function3: array<u32>;
+@group(3) @binding(662)
+var<storage, read_write> n4: array<u32>;
+@group(2) @binding(692)
+var<storage, read_write> global6: array<u32>;
+@group(3) @binding(515)
+var<storage, read_write> type6: array<u32>;
+
+@compute @workgroup_size(3, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(position) a3: vec4<f32>) -> @location(200) vec3<f32> {
+return vec3<f32>();
+}
+
+struct S6 {
+  @location(5) f0: vec4<f32>,
+  @location(12) f1: vec4<i32>,
+  @location(15) f2: vec4<u32>,
+  @location(13) f3: i32,
+  @location(2) f4: vec3<f32>,
+  @location(3) f5: vec4<i32>,
+  @location(11) f6: vec3<i32>,
+  @location(4) f7: vec3<i32>,
+  @location(0) f8: f16
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<i32>, a1: S6, @location(14) a2: u32, @location(9) a3: vec3<f16>, @location(1) a4: vec2<i32>, @location(6) a5: vec4<f16>, @location(10) a6: vec2<u32>, @location(8) a7: vec2<i32>, @builtin(instance_index) a8: u32, @builtin(vertex_index) a9: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let computePassEncoder16 = commandEncoder49.beginComputePass({label: '\u3a79\u95af\ub082\u{1f825}'});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup13);
+} catch {}
+let arrayBuffer5 = buffer10.getMappedRange();
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 743 */
+{offset: 743}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline48 = device0.createComputePipeline({
+  label: '\u8244\u2e6f\u{1ffcf}\u63d0\u01bd',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+try {
+  await promise8;
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\u{1fe7a}\u45d9',
+  code: `@group(0) @binding(31)
+var<storage, read_write> type7: array<u32>;
+@group(0) @binding(515)
+var<storage, read_write> n5: array<u32>;
+
+@compute @workgroup_size(3, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f55: vec4<f32>,
+  @location(5) f56: u32
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView65 = texture18.createView({label: '\u67d3\u{1f73c}\u8c14\u2c50\u{1fd42}\u{1f604}', baseArrayLayer: 80, arrayLayerCount: 121});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u148b\uc03b\u{1ff97}\u{1f75f}\u0f8b\u1036\u{1ffcf}\u5d19',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder26.setStencilReference(4035);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u{1f7e1}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: video1,
+  origin: { x: 2, y: 5 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.createComputePipelineAsync({
+  label: '\u{1f7e3}\u0ea8\u{1f704}\u0fc5\ua7d5\u0975\u{1f8d2}\u3cc4',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let bindGroupLayout18 = pipeline21.getBindGroupLayout(1);
+let renderBundle32 = renderBundleEncoder24.finish({label: '\u0890\uf31c\ue76e\uf66d\ubb20\ud627\u2e48\u5ed4\u065c\ue621\u0758'});
+let externalTexture15 = device0.importExternalTexture({source: video3, colorSpace: 'srgb'});
+try {
+renderPassEncoder15.setBlendConstant({ r: -245.1, g: 64.51, b: 523.8, a: 977.7, });
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer9, 505636098);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 289952, 201111);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline24);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(2659), 1174, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup12, [0]);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle24, renderBundle0, renderBundle3, renderBundle28, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer0, 407596129);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 53, y: 25 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let renderPassEncoder30 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{view: textureView4, depthSlice: 2, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 925373383,
+});
+let sampler29 = device0.createSampler({
+  label: '\ue416\ubb28\u518f\uf509\u13c1\u078a\u{1f7cc}\ud0b6\ud0d2',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.04,
+  lodMaxClamp: 79.79,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer3, 221333122);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer10, 0, 72019);
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({label: '\u0e1d\uc8b8\ue35e\u{1f747}\u01dc\u65e9'});
+let renderPassEncoder31 = commandEncoder51.beginRenderPass({
+  label: '\u0f3b\u026e\uf372\u{1fc5a}\u0085',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 3,
+  clearValue: { r: 759.2, g: -215.6, b: -957.1, a: 365.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 350991584,
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: -250.4, g: -163.8, b: 772.8, a: 113.8, });
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(2285);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(463763167, 83058429, 344391799);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer10, 491147350);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline24);
+} catch {}
+try {
+computePassEncoder8.pushDebugGroup('\ub485');
+} catch {}
+let pipeline49 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 500,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 40, shaderLocation: 15},
+          {format: 'float32x3', offset: 116, shaderLocation: 7},
+          {format: 'uint32x2', offset: 312, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 222, shaderLocation: 10},
+          {format: 'sint32', offset: 32, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 64, shaderLocation: 6},
+          {format: 'sint32x2', offset: 80, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({label: '\u{1f659}\ucb96'});
+let texture29 = device0.createTexture({
+  label: '\u7a1b\u{1fde0}\u3e73\u{1fd14}',
+  size: {width: 1216, height: 1, depthOrArrayLayers: 35},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView66 = texture18.createView({label: '\u5a14\u7e87\u{1ffc2}\u7944\u{1f7a8}\u5ee0', dimension: '2d', baseArrayLayer: 48});
+let renderPassEncoder32 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 3,
+  clearValue: { r: 452.4, g: 237.9, b: 860.8, a: 910.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 370151041,
+});
+let sampler30 = device0.createSampler({
+  label: '\u{1fd78}\u0eec',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 89.94,
+  lodMaxClamp: 97.01,
+});
+try {
+renderPassEncoder22.executeBundles([renderBundle7, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(673);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(740515019, 774534720, 142104741, 363118635);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 79052, new Float32Array(61682), 50097, 216);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  code: `@group(0) @binding(692)
+var<storage, read_write> field8: array<u32>;
+@group(2) @binding(108)
+var<storage, read_write> global7: array<u32>;
+@group(2) @binding(621)
+var<storage, read_write> function4: array<u32>;
+@group(1) @binding(108)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(621)
+var<storage, read_write> global8: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> @location(200) vec2<f32> {
+return vec2<f32>();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: vec3<i32>, @location(10) a1: u32, @location(12) a2: vec3<f32>, @location(7) a3: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let bindGroup17 = device0.createBindGroup({
+  label: '\u5441\u{1f9ad}\u0ee9\u40b1\uc090\u884e\u629d\u994f\u37ea\u0b8b',
+  layout: bindGroupLayout0,
+  entries: [{binding: 692, resource: sampler28}],
+});
+let buffer15 = device0.createBuffer({label: '\u7aaf\ue8fb\u8e7c', size: 221772, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true});
+let texture30 = device0.createTexture({
+  size: [64],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture16 = device0.importExternalTexture({
+  label: '\u04a1\u0d97\u09f3\u0af2\u76bc\u6f92\u9000\uc5d7\u00ee\u5262\u0018',
+  source: video3,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder3.setPipeline(pipeline46);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -863.8, g: -556.1, b: -640.3, a: -712.4, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(396413175, 1090359536, 356991653);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 1, depthOrArrayLayers: 46}
+*/
+{
+  source: imageData0,
+  origin: { x: 80, y: 19 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline50 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}}});
+let imageData6 = new ImageData(244, 236);
+let promise12 = adapter1.requestAdapterInfo();
+let commandEncoder53 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1650});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(49);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle26, renderBundle19, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(13, 0, 2, 1);
+} catch {}
+try {
+renderPassEncoder7.draw(85315741, 802847734, 865683945, 1209601299);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30656 */
+  offset: 30656,
+  bytesPerRow: 0,
+  rowsPerImage: 137,
+  buffer: buffer9,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+computePassEncoder8.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  label: '\u{1fa77}\u{1f85c}\u0d9a\u03de\u04ce\uec39\ufd61\u3e12',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xd1cd6995},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', passOp: 'zero'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 2050173413,
+    stencilWriteMask: 3836966700,
+    depthBias: -56421289,
+    depthBiasSlopeScale: 625.7748626372365,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 668, attributes: [{format: 'snorm8x2', offset: 28, shaderLocation: 0}]},
+      {
+        arrayStride: 168,
+        attributes: [
+          {format: 'snorm8x4', offset: 52, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 164, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 36, attributes: [{format: 'float32x4', offset: 0, shaderLocation: 8}]},
+    ],
+  },
+});
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\u9df7\u{1ff32}\u092d',
+  entries: [
+    {
+      binding: 986,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 308,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 502, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+  ],
+});
+let bindGroup18 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 357, resource: externalTexture5}]});
+let textureView67 = texture8.createView({
+  label: '\u19a5\u0ae8\u09d3\u2901\u{1fc27}\u{1fca2}\u8f6c\u{1f914}\ue6ec\u54bf',
+  format: 'bgra8unorm',
+  arrayLayerCount: 1,
+});
+let renderPassEncoder33 = commandEncoder53.beginRenderPass({
+  label: '\u0e7a\ufb1d\u3dc7\u63fc\u0c73\u00b7\ufe6e\u7914\ud1aa',
+  colorAttachments: [{
+  view: textureView50,
+  depthSlice: 6,
+  clearValue: { r: 244.9, g: -650.3, b: 270.1, a: -207.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 326772229,
+});
+let externalTexture17 = device0.importExternalTexture({
+  label: '\u2a25\u{1f92a}\u5d15\u{1f622}\u5c2a\u018f\u02e7\u0fa3\u02aa\ue203\u0135',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder11.setViewport(0.6252, 0.4007, 0.1687, 0.03773, 0.00298, 0.1370);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(359830641, 1045966842, 936887489, 819794824, 1084560847);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer10, 782084363);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 343896, new DataView(new ArrayBuffer(677)), 526, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer1), /* required buffer size: 373658 */
+{offset: 878, bytesPerRow: 218, rowsPerImage: 95}, {width: 10, height: 0, depthOrArrayLayers: 19});
+} catch {}
+document.body.prepend(video5);
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 556, visibility: 0, sampler: { type: 'filtering' }},
+    {binding: 961, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+  ],
+});
+let externalTexture18 = device0.importExternalTexture({label: '\u0389\u4367\u662f\ueb5f\u2e8f\uca27\u0f39', source: video6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder7.drawIndirect(buffer10, 410465405);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline43);
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+let pipeline52 = await promise11;
+let img4 = await imageWithData(32, 73, '#1a671ba6', '#1e5eeba0');
+let videoFrame4 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let buffer16 = device0.createBuffer({
+  label: '\u2e6f\u5f61\u0855\u0f72\u6878\u1b11\u5c81\ue5d1',
+  size: 44940,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let querySet23 = device0.createQuerySet({label: '\u0ddd\u0dcd\u4e93\u70b4\u5f80\u239e\u{1fa92}\u0a2d\u0136', type: 'occlusion', count: 2732});
+let externalTexture19 = device0.importExternalTexture({label: '\u2291\u56ba\ubc3d', source: videoFrame4});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(11, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(460506320, 126313798, 262508252);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer10, 97677623);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup5, new Uint32Array(6825), 2328, 0);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline49);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 304, height: 1, depthOrArrayLayers: 148}
+*/
+{
+  source: canvas1,
+  origin: { x: 41, y: 8 },
+  flipY: false,
+}, {
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 96, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let video7 = await videoWithData();
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 358});
+let renderBundle33 = renderBundleEncoder25.finish({label: '\u0c9c\u0fe3\u59d9\u9f22\uaa93'});
+try {
+renderPassEncoder8.beginOcclusionQuery(211);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(21, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(711500126, 441259209, 1224401238, 857742965);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer0, 1169076237);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise10;
+} catch {}
+let textureView68 = texture14.createView({label: '\ua08e\u27b1\ubfa6\u308c', arrayLayerCount: 1});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: false});
+let renderBundle34 = renderBundleEncoder2.finish({label: '\u330f\u0e12'});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup5, new Uint32Array(9790), 8756, 0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle24, renderBundle13, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 559.0, g: 444.7, b: 923.2, a: -136.1, });
+} catch {}
+try {
+renderPassEncoder22.setViewport(0.2631, 0.4050, 0.9943, 0.2077, 0.6726, 0.7961);
+} catch {}
+try {
+renderPassEncoder7.draw(45657909, 753377902, 1217972831, 345838305);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1229067060, 36009070, 580314813, 402961005, 323759235);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer5, 1161866332);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer16, 'uint16', 30556, 6587);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline29);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline53 = device0.createRenderPipeline({
+  label: '\u0c41\u{1f80e}\u0590\ua7c9\u{1f60a}\u0a4c\u9c78\u0e7f\u0963\ub9f7',
+  layout: pipelineLayout4,
+  multisample: {mask: 0xada110fd},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 452,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 8, shaderLocation: 1},
+          {format: 'sint32x2', offset: 264, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 360,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 172, shaderLocation: 15},
+          {format: 'uint16x4', offset: 20, shaderLocation: 7},
+          {format: 'sint32x3', offset: 44, shaderLocation: 11},
+          {format: 'uint8x4', offset: 176, shaderLocation: 8},
+          {format: 'uint32x4', offset: 88, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 824,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 320, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 244, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', unclippedDepth: true},
+});
+let commandEncoder54 = device0.createCommandEncoder();
+let textureView69 = texture7.createView({
+  label: '\u72b0\u0519\u5dfe\u0add\uc2c6\u0e58\u8d18\u0fdd\u8dd1\u{1f863}\u{1ff6b}',
+  format: 'rg8unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(3922);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1221284941);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer10, 11648);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer8, 132948, buffer6, 516524, 9040);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 214 widthInBlocks: 107 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12570 */
+  offset: 12570,
+  buffer: buffer9,
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 107, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  label: '\u{1fab1}\u9eaf',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xe88b3890},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 300, attributes: [{format: 'float32x2', offset: 152, shaderLocation: 8}]},
+      {
+        arrayStride: 388,
+        attributes: [
+          {format: 'sint16x2', offset: 8, shaderLocation: 13},
+          {format: 'sint16x2', offset: 28, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 140, shaderLocation: 2},
+          {format: 'uint8x4', offset: 0, shaderLocation: 3},
+          {format: 'float16x2', offset: 0, shaderLocation: 9},
+          {format: 'sint8x4', offset: 32, shaderLocation: 0},
+          {format: 'sint32', offset: 336, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 128, shaderLocation: 5},
+          {format: 'uint16x2', offset: 100, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 50, shaderLocation: 1},
+          {format: 'float32x2', offset: 56, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 320,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint8x4', offset: 316, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+try {
+  await promise9;
+} catch {}
+gc();
+let canvas3 = document.createElement('canvas');
+let img5 = await imageWithData(50, 192, '#0384219e', '#5fcb4048');
+let bindGroup19 = device0.createBindGroup({label: '\ua851\uc645\ue9dd\ubbaf\u{1fb71}', layout: bindGroupLayout9, entries: []});
+let textureView70 = texture29.createView({label: '\u7e7c\u3dc2\ub855\u5c68\uf798\ua2fa\u339e', baseMipLevel: 7, mipLevelCount: 1});
+let renderPassEncoder34 = commandEncoder54.beginRenderPass({
+  label: '\u06e7\u035a\u{1fa95}',
+  colorAttachments: [{
+  view: textureView12,
+  depthSlice: 1,
+  clearValue: { r: 59.41, g: -481.7, b: 413.6, a: -668.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet20,
+  maxDrawCount: 279092595,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u23a3\u{1f924}\u7736\u0c5a\u25de\u05f1\u5060\u{1f670}\u0a42\u26d7\uf1ca',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle35 = renderBundleEncoder12.finish({label: '\u607e\u0d9f\uc28d\u{1fa92}'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer7, 'uint32', 349112, 15749);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer9, 625112, buffer1, 823436, 7192);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 31518 */
+  offset: 31518,
+  buffer: buffer13,
+}, {
+  texture: texture28,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+let pipeline55 = device0.createComputePipeline({
+  label: '\u{1fa68}\u4fe2\u5c23\u7b14\u032a\u7246',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u0f7e\ub4ba\u1524',
+  entries: [{binding: 964, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let bindGroup20 = device0.createBindGroup({layout: bindGroupLayout21, entries: [{binding: 964, resource: externalTexture8}]});
+let commandEncoder55 = device0.createCommandEncoder();
+let texture31 = device0.createTexture({
+  label: '\uf62c\u3587\u{1ff98}\udcb7\u076c\uc283\u134d\ubb40\uf4fc\u{1f720}',
+  size: [32],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView71 = texture19.createView({label: '\u61f8\u9a32\u31bd\uc145\uef56\u{1f889}\u{1f6ca}', dimension: '3d', baseMipLevel: 5});
+let computePassEncoder17 = commandEncoder55.beginComputePass();
+try {
+renderPassEncoder20.setViewport(5.090, 0.5194, 10.78, 0.3961, 0.6163, 0.7910);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(115475169);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer16, 584417853);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer7, 'uint32', 340904, 227792);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 382 */
+{offset: 382}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas3);
+let bindGroupLayout22 = device0.createBindGroupLayout({label: '\u0b1e\ube66\u0151\u0850\u62a5\u0a37\u436d', entries: []});
+let commandEncoder56 = device0.createCommandEncoder({label: '\u5745\u0614'});
+let computePassEncoder18 = commandEncoder29.beginComputePass({label: '\u71f6\u{1fcac}\u84ff\u7f15'});
+let renderPassEncoder35 = commandEncoder56.beginRenderPass({
+  label: '\u9ec3\u47fb\u0ef9\u{1f6c1}\u0fcb',
+  colorAttachments: [{
+  view: textureView66,
+  clearValue: { r: -186.1, g: 860.4, b: 615.8, a: 64.13, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+  maxDrawCount: 300713951,
+});
+let externalTexture20 = device0.importExternalTexture({source: video0});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup17, new Uint32Array(6770), 557, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle16, renderBundle30, renderBundle17, renderBundle31, renderBundle19, renderBundle14, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -542.5, g: 444.2, b: -461.5, a: -653.6, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(879);
+} catch {}
+let img6 = await imageWithData(243, 188, '#0ee75ada', '#1b5b40e9');
+let commandEncoder57 = device0.createCommandEncoder({label: '\u5e2f\u71db\uac03\u{1fce7}\u6691'});
+let texture32 = device0.createTexture({
+  label: '\u7b75\u0e9a\u99df\u9bf9\u027a\u0098\u0596\u0d33\u1ace',
+  size: {width: 5, height: 1, depthOrArrayLayers: 152},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView72 = texture7.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 5});
+try {
+computePassEncoder16.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder31.setViewport(18.03, 0.8827, 9.319, 0.00011, 0.7103, 0.9866);
+} catch {}
+try {
+renderPassEncoder7.draw(1171777545, 403162139, 832784971);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer7, 1010725593);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 314060, new Int16Array(33475), 6992, 1604);
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 2291320926,
+    stencilWriteMask: 4248932320,
+    depthBias: -543489728,
+    depthBiasSlopeScale: 142.5358889296522,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 64,
+        attributes: [
+          {format: 'uint16x2', offset: 8, shaderLocation: 12},
+          {format: 'float32x2', offset: 4, shaderLocation: 13},
+          {format: 'sint8x4', offset: 52, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 5},
+          {format: 'float32x4', offset: 16, shaderLocation: 8},
+          {format: 'uint32x2', offset: 0, shaderLocation: 7},
+          {format: 'float16x4', offset: 0, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 28, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 60, shaderLocation: 1},
+          {format: 'uint32x4', offset: 112, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 176, attributes: []},
+      {arrayStride: 364, stepMode: 'instance', attributes: []},
+      {arrayStride: 688, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 1208, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\u482a\u72a0\u{1ff75}\u05b6\u5bb1\uffa8\u0e5a\u0b76\u057f\u0391\u73af',
+  entries: [{binding: 165, visibility: 0, externalTexture: {}}],
+});
+let commandEncoder58 = device0.createCommandEncoder();
+let querySet25 = device0.createQuerySet({label: '\u{1fb1f}\u1212\ua599\uebd8\u{1f7c1}\u0785\u07ac\u0d0d\uc5ea', type: 'occlusion', count: 1292});
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.draw(189002304);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(759982925, 1155024147, 535679046, -1010051739, 962851118);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer14, 115819856);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7830 */
+  offset: 7830,
+  buffer: buffer13,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderPassEncoder36 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{
+  view: textureView59,
+  clearValue: { r: -833.5, g: -804.3, b: 889.8, a: -564.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 742579085,
+});
+let externalTexture21 = device0.importExternalTexture({label: '\udddf\u0135\u{1f8c5}\u{1fe41}\u502f\u{1ff28}', source: video6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -667.5, g: 532.4, b: 865.5, a: 562.1, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer2, 638564143);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer16, 'uint16', 35776);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer8, 31924, buffer9, 54340, 117960);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 14224 */
+  offset: 14224,
+  buffer: buffer9,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 29488, new DataView(new ArrayBuffer(35526)), 16698);
+} catch {}
+let commandBuffer4 = commandEncoder58.finish({label: '\u0e2b\ub644\u6522\udecc\u{1f8fe}'});
+let texture33 = device0.createTexture({
+  label: '\u0417\u2bdb\u000c\u0bbe\u080d\u7d35\ud112\uaed3\u02ab\u0292',
+  size: [128, 1, 1621],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView73 = texture6.createView({});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(5, 1, 7, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(644883255, 538048495);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer10, 545836795);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(6090), 358, 0);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 33},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 838354 */
+  offset: 16082,
+  bytesPerRow: 256,
+  rowsPerImage: 146,
+  buffer: buffer6,
+}, {width: 1, height: 0, depthOrArrayLayers: 23});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageData5);
+let shaderModule16 = device0.createShaderModule({
+  label: '\u26c8\ua40e',
+  code: `@group(0) @binding(692)
+var<storage, read_write> type8: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+  @location(9) f0: f32,
+  @location(0) f1: f16,
+  @location(10) f2: vec2<f32>,
+  @location(8) f3: i32,
+  @location(12) f4: vec4<f32>,
+  @location(3) f5: vec2<u32>,
+  @location(15) f6: vec2<f32>,
+  @location(6) f7: vec4<f32>,
+  @location(5) f8: f16,
+  @location(11) f9: vec2<u32>,
+  @builtin(sample_mask) f10: u32,
+  @builtin(position) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(1) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(1) a1: vec4<f32>, a2: S8, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(13) f0: vec2<f16>,
+  @location(8) f1: vec3<f32>,
+  @location(0) f2: vec2<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(2) f4: vec3<f16>,
+  @location(4) f5: vec3<i32>,
+  @location(6) f6: vec3<u32>,
+  @location(9) f7: u32,
+  @location(7) f8: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(10) f57: vec2<f32>,
+  @location(3) f58: vec2<u32>,
+  @location(6) f59: vec4<f32>,
+  @location(12) f60: vec4<f32>,
+  @builtin(position) f61: vec4<f32>,
+  @location(1) f62: vec4<f32>,
+  @location(5) f63: f16,
+  @location(15) f64: vec2<f32>,
+  @location(9) f65: f32,
+  @location(8) f66: i32,
+  @location(0) f67: f16,
+  @location(11) f68: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<i32>, @location(11) a1: vec4<u32>, @location(1) a2: vec2<f16>, a3: S7, @location(12) a4: vec4<i32>, @location(5) a5: vec2<f16>, @location(3) a6: vec2<f16>, @location(15) a7: vec4<u32>, @location(10) a8: f32, @builtin(vertex_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout24 = pipeline38.getBindGroupLayout(0);
+let commandEncoder59 = device0.createCommandEncoder({label: '\u{1ff23}\u018d\u35fe\u98cf\u4df5\u0185\uf9b5\u2dcd\u{1fb67}\uf39e\u{1fb54}'});
+let commandBuffer5 = commandEncoder59.finish();
+let externalTexture22 = device0.importExternalTexture({label: '\u{1f745}\u697f\u{1ffe0}\ufb6d\u3123', source: video6});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(52);
+} catch {}
+try {
+renderPassEncoder7.draw(815825064, 18932523, 638825251, 64101797);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer7, 720213188);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer10);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup20, []);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer16, 'uint32', 16724, 14892);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline43);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer14, 2116, buffer9, 36712, 208);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet8, 1856, 561, buffer4, 120320);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline57 = device0.createComputePipeline({
+  label: '\u12cc\u4a12\uc586\ua5d9\u6311\uc579\u{1f707}\u19b3\ufb3b\u0678\ud9e1',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let video8 = await videoWithData();
+let bindGroupLayout25 = device0.createBindGroupLayout({entries: []});
+let computePassEncoder19 = commandEncoder12.beginComputePass({label: '\ub3bb\u0bc4\u0fab\u408f\u0092'});
+let sampler31 = device0.createSampler({
+  label: '\uff24\u05b5\u{1f737}\u75ce\ua992',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 85.43,
+  lodMaxClamp: 95.80,
+});
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setViewport(0.6541, 0.06150, 2.538, 0.4221, 0.1744, 0.5645);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(68690779, 1042344020);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer8, 682101495);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup13, new Uint32Array(3538), 3359, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 405}
+*/
+{
+  source: img0,
+  origin: { x: 114, y: 13 },
+  flipY: true,
+}, {
+  texture: texture33,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 104},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  label: '\u036a\u{1f975}\ue19a\u0b7b\uec31',
+  layout: bindGroupLayout1,
+  entries: [
+    {binding: 31, resource: externalTexture21},
+    {binding: 515, resource: {buffer: buffer2, offset: 422400}},
+    {binding: 662, resource: {buffer: buffer2, offset: 420608}},
+  ],
+});
+let textureView74 = texture7.createView({label: '\u2530\u0e9c\u01fd\u{1f7ca}\ude42', format: 'rg8unorm', baseMipLevel: 7, mipLevelCount: 1});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u{1fe23}\u{1f8fb}\u3710\u5cc7\u0747\u{1f7ab}\u0e7a\u7952',
+  colorFormats: ['rg8unorm'],
+  stencilReadOnly: false,
+});
+let sampler32 = device0.createSampler({
+  label: '\u{1faf4}\u07e8\u6a8d\u217f\u0f0f\u96ed',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 5.409,
+  lodMaxClamp: 22.49,
+  compare: 'never',
+});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(16, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(6.460, 0.7413, 2.080, 0.1788, 0.1210, 0.3104);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer1, 1071285664);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer10, 0, 92786);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup11, [0, 0]);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer10);
+} catch {}
+let promise13 = device0.createRenderPipelineAsync({
+  label: '\u{1ffdd}\u70ea\ue029\u2a22\u00e3\u675a\u0eeb',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 548, stepMode: 'instance', attributes: []},
+      {arrayStride: 528, stepMode: 'instance', attributes: []},
+      {arrayStride: 16, attributes: [{format: 'sint32', offset: 4, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+canvas3.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({label: '\u{1fb5c}\ub29e\u1c9d\u{1fa54}\u57b7\ua5cb\ue31d\u{1ff55}'});
+let computePassEncoder20 = commandEncoder60.beginComputePass({label: '\u65a4\u9a66\u{1f7f8}\u{1fdf1}\u069e\ub7b0'});
+let renderBundle36 = renderBundleEncoder19.finish({label: '\ub955\u{1fdd9}\ue63e\u0367\u108a'});
+try {
+computePassEncoder11.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 594.6, g: -117.2, b: 686.1, a: 815.9, });
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(11, 0, 10, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(763405280, 616728156, 61657749);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(967625960);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 538168, new BigUint64Array(5517), 163, 1520);
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  label: '\ud2dd\u25b9\ubf41\u0904\u{1ff41}\u749b\u{1f7ed}\udc74',
+  entries: [
+    {
+      binding: 458,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 423,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer17 = device0.createBuffer({
+  label: '\u0972\uf21a\u0077\u9d67\u{1f91c}\u524b\u{1f6e9}\u{1fbbc}\ud3ec',
+  size: 94254,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder61 = device0.createCommandEncoder();
+let texture34 = gpuCanvasContext1.getCurrentTexture();
+let textureView75 = texture20.createView({
+  label: '\u9b0e\ud7c6\u93cc\ubcbf\u0bf8\ucb21\u05d4\u6c72\u6a08\u3ac7',
+  dimension: '1d',
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer8, 902449343);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer15, 0, 180503);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 453966 */
+  offset: 5964,
+  bytesPerRow: 256,
+  rowsPerImage: 250,
+  buffer: buffer9,
+}, {
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 18, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 8});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 70096, new BigUint64Array(22870));
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 1, depthOrArrayLayers: 810}
+*/
+{
+  source: video8,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture33,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandBuffer6 = commandEncoder61.finish({label: '\ub6ca\ud148\u2ba3\u0877\u163f'});
+let texture35 = gpuCanvasContext0.getCurrentTexture();
+let textureView76 = texture31.createView({label: '\u0a96\u1dc1'});
+try {
+renderPassEncoder8.executeBundles([renderBundle4, renderBundle3, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 687.5, g: -217.6, b: -786.1, a: 691.9, });
+} catch {}
+try {
+renderPassEncoder7.draw(99006584, 921501038, 703757133, 95845980);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer6, 704845179);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline45);
+} catch {}
+let arrayBuffer6 = buffer10.getMappedRange(93168, 0);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline58 = await device0.createRenderPipelineAsync({
+  label: '\ueb07\u0a48\u0e1d\ub15f\u52f9\ue0ec',
+  layout: 'auto',
+  multisample: {count: 4},
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg8unorm'}]},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 220,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 76, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 20, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 40, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 60, attributes: [{format: 'unorm10-10-10-2', offset: 0, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  label: '\ub4fa\u085f\u18cd\u08f5',
+  entries: [
+    {binding: 778, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 115, visibility: 0, externalTexture: {}},
+    {
+      binding: 946,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 3357});
+let textureView77 = texture13.createView({label: '\u06c8\u{1f745}\u8055\ub6fb\u{1fa1d}\u0531\u{1f7ed}\ub81d\u1362'});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(16, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer7, 'uint16', 36696, 67596);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer15, 191996, 24350);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 216988, new DataView(new ArrayBuffer(20204)), 13032, 4836);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({label: '\u0b5b\u{1f6b4}\u7e3c\u{1ffbb}\u{1fb1f}\u01b2\u0ffd'});
+let sampler33 = device0.createSampler({
+  label: '\u{1fd0b}\ub71c\ud911\u7400\u0ff7\u{1fc65}\u0759\u2245\u4a95\ue8ba\u58c4',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 89.68,
+  lodMaxClamp: 92.06,
+  compare: 'always',
+});
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(790692348, 875943565, 426822653, 841026259, 260234986);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer5, 71780, buffer6, 374976, 38428);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+renderBundleEncoder7.insertDebugMarker('\u5fd7');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 53752, new DataView(new ArrayBuffer(49521)), 11562, 4644);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(980), /* required buffer size: 980 */
+{offset: 980}, {width: 23, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageData4);
+let texture36 = device0.createTexture({
+  label: '\u7c36\u6da2\u0250\u13af\uc6de',
+  size: [64, 1, 813],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let textureView78 = texture28.createView({label: '\ufeaf\ua54d\u3baf', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.draw(995501886);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(1010428914, 904997831, 1163751806, -12378017, 643219491);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer4, 1121195379);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17320 */
+  offset: 17320,
+  buffer: buffer9,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 2463015 */
+{offset: 729, bytesPerRow: 254, rowsPerImage: 131}, {width: 5, height: 1, depthOrArrayLayers: 75});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let pipeline59 = device0.createRenderPipeline({
+  label: '\ub84e\u{1f94f}\u002c\u1df0\ude34\ud3d8',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha-saturated'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 1883669820,
+    stencilWriteMask: 3164892324,
+    depthBias: -2131342847,
+    depthBiasSlopeScale: 517.4340355703027,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 14, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 428,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 60, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 4},
+          {format: 'float32', offset: 264, shaderLocation: 3},
+          {format: 'float32x4', offset: 208, shaderLocation: 2},
+          {format: 'uint8x2', offset: 2, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 22, shaderLocation: 10},
+          {format: 'float32', offset: 112, shaderLocation: 14},
+          {format: 'uint32x4', offset: 20, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 128,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 48, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+document.body.prepend(canvas0);
+gc();
+let imageData7 = new ImageData(8, 52);
+let commandEncoder63 = device0.createCommandEncoder({});
+let textureView79 = texture32.createView({label: '\ud444\u041c\u{1f9f7}', baseArrayLayer: 124, arrayLayerCount: 1});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u{1faec}\u{1ff80}\u3a99\u4d8e\u{1ff3c}\uaf33\u{1f6bb}\uec07\u{1fec7}\u01b4',
+  colorFormats: ['rgba16uint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture23 = device0.importExternalTexture({label: '\u{1ffc0}\uec92\u0ee8\u62bf\u6699', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer3, 999335101);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 31772 */
+  offset: 31772,
+  bytesPerRow: 0,
+  rowsPerImage: 93,
+  buffer: buffer13,
+}, {
+  texture: texture33,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 49});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder62.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video9 = await videoWithData();
+let commandEncoder64 = device0.createCommandEncoder({label: '\u{1ff50}\ubf64\uefb1\u0385\uae92\u{1f7c0}\u18bc\ude38'});
+let querySet27 = device0.createQuerySet({label: '\u0434\ufe09\u29df\uca53\u0d9d\ua646\u3028\u5892\u48a5\ucb29', type: 'occlusion', count: 386});
+let renderBundle37 = renderBundleEncoder18.finish({});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.05,
+  lodMaxClamp: 16.07,
+  maxAnisotropy: 4,
+});
+let externalTexture24 = device0.importExternalTexture({label: '\u0fab\u02bc\ue47b\ufccb', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder10.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(55);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(345218881, 906655411, 221271105, 26262822, 448697029);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer15, 679854633);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer10, 568629999);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet4, 987, 232, buffer17, 65280);
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  label: '\u0161\u03e7\u89d9\u0a36\u{1fa11}\ufeb9\u0df7\u96c3\u0444\u9501\u0832',
+  layout: bindGroupLayout20,
+  entries: [{binding: 556, resource: sampler11}, {binding: 961, resource: sampler8}],
+});
+let computePassEncoder21 = commandEncoder63.beginComputePass({label: '\u0eab\u{1fe75}\u1cd7'});
+let renderPassEncoder37 = commandEncoder62.beginRenderPass({
+  label: '\u070e\u0bf8\u{1fc61}\u9a0c\u2c9d\u07c7\u08fe\ua43b\u718e\u0b04',
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 244.2, g: 513.9, b: -979.1, a: 931.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 1221195373,
+});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup9, [0, 4608]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 259.9, g: -711.1, b: 936.7, a: 285.0, });
+} catch {}
+try {
+commandEncoder64.clearBuffer(buffer0);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 227404, new DataView(new ArrayBuffer(6621)), 1845);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise15 = device0.createComputePipelineAsync({
+  label: '\u17d7\ucf68',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule17 = device0.createShaderModule({
+  label: '\uc039\u5d7a\ua367\u3672\ubb2a\ud288\u03ff\u02aa\u9c4b\u0b67',
+  code: `@group(0) @binding(621)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(1, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f32>, @location(15) a1: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let textureView80 = texture29.createView({label: '\ue4da\u0030\ub665\u8ffb\u1113\u0362', baseMipLevel: 4, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder22 = commandEncoder64.beginComputePass({label: '\u4d58\uec30\u6f3e\u5293\u1650\u2363\u8782\u017c\u9be9\u0928'});
+let renderBundle38 = renderBundleEncoder26.finish({label: '\u07dd\u{1f847}\u36a1\ua249\u2db7\ue634\u{1fcd3}'});
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer16, 'uint32', 17240);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline49);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer10, 29200, 33619);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData1,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let textureView81 = texture35.createView({label: '\u0d25\u{1fef4}\u4d16\u1590\u{1fa4e}', dimension: '2d'});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u3297\u8185\uc117\ucf46',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle39 = renderBundleEncoder22.finish();
+let externalTexture25 = device0.importExternalTexture({label: '\ue130\u2e77\ude1c\u1ab7\u0c81\ufa4f\u3263\u0718\u08f7\ufee7\u54bb', source: video3});
+try {
+renderPassEncoder11.executeBundles([renderBundle32, renderBundle32, renderBundle10, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(7.593, 0.7606, 5.282, 0.05908, 0.9354, 0.9789);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(81276157, 827521421, 815369295, -1089513038, 1137942517);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer10, 63316, 16978);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer16, 'uint32');
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline45);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 467 */
+{offset: 467}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -236,6 +236,8 @@ const Vector<uint32_t>* PipelineLayout::offsetVectorForBindGroup(uint32_t bindGr
     if (auto it = stageOffsets.find(bindGroupIndex); it != stageOffsets.end()) {
         auto& container = it->value;
         uint32_t stageOffsetIndex = 0;
+        if (bindGroupIndex >= bindGroupLayouts.size())
+            return nullptr;
         auto& bindGroupLayout = bindGroupLayouts[bindGroupIndex];
         for (auto* entryPtr : bindGroupLayout->sortedEntries()) {
             auto& entry = *entryPtr;
@@ -245,7 +247,8 @@ const Vector<uint32_t>* PipelineLayout::offsetVectorForBindGroup(uint32_t bindGr
 
             if (entry.visibility & stage) {
                 auto dynamicOffsetsIndex = entry.dynamicOffsetsIndex;
-                RELEASE_ASSERT(container.size() > stageOffsetIndex && dynamicOffsets.size() > dynamicOffsetsIndex);
+                if (stageOffsetIndex >= container.size() || dynamicOffsetsIndex >= dynamicOffsets.size())
+                    return nullptr;
                 container[stageOffsetIndex] = dynamicOffsets[dynamicOffsetsIndex];
                 ++stageOffsetIndex;
             }


### PR DESCRIPTION
#### cd8059fc28fc95b90f07d6c095468bc79eb26ccb
<pre>
[WebGPU] Release assert trigged in PipelineLayout::offsetVectorForBindGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=274317">https://bugs.webkit.org/show_bug.cgi?id=274317</a>
&lt;radar://128065029&gt;

Reviewed by Dan Glastonbury.

Invalid bind group should return nullptr as it already does in other
places in this member function instead of crashing the GPU process.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274317-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274317.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::offsetVectorForBindGroup):

Canonical link: <a href="https://commits.webkit.org/279013@main">https://commits.webkit.org/279013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/852547eada8cb0992b0f5d7bed05604b8438cd09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55530 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54561 "Failed to checkout and rebase branch from PR 28716") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2677 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54352 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52100 "Failed to checkout and rebase branch from PR 28716") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1138 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57126 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7650 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/28360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->