### PR TITLE
[JSC] Fire WatchpointSet directly in StructureTransitionStructureStubClearingWatchpoint / AdaptiveValueStructureStubClearingWatchpoint

### DIFF
--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -117,11 +117,6 @@ PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine(Type type, cons
 
 PolymorphicAccessJITStubRoutine::~PolymorphicAccessJITStubRoutine() = default;
 
-void PolymorphicAccessJITStubRoutine::setWatchpoints(std::unique_ptr<WatchpointsOnStructureStubInfo>&& watchpoints)
-{
-    m_watchpoints = WTFMove(watchpoints);
-}
-
 void PolymorphicAccessJITStubRoutine::observeZeroRefCountImpl()
 {
     if (m_isInSharedJITStubSet) {
@@ -131,7 +126,7 @@ void PolymorphicAccessJITStubRoutine::observeZeroRefCountImpl()
 
     // Now PolymorphicAccessJITStubRoutine is no longer referenced. So Watchpoints inside WatchpointSet do not matter. Let's eagerly clear them
     m_watchpointSet = nullptr;
-    m_watchpoints = nullptr;
+    m_watchpoints.clear();
     Base::observeZeroRefCountImpl();
 }
 

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -38,9 +38,11 @@
 namespace JSC {
 
 class AccessCase;
+class AdaptiveValueStructureStubClearingWatchpoint;
 class CallLinkInfo;
 class JITStubRoutineSet;
 class OptimizingCallLinkInfo;
+class StructureTransitionStructureStubClearingWatchpoint;
 class WatchpointsOnStructureStubInfo;
 
 // Use this stub routine if you know that your code might be on stack when
@@ -96,6 +98,8 @@ public:
     friend class JITStubRoutine;
     friend class GCAwareJITStubRoutine;
 
+    using Watchpoints = Bag<std::variant<StructureTransitionStructureStubClearingWatchpoint, AdaptiveValueStructureStubClearingWatchpoint>>;
+
     PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner);
     ~PolymorphicAccessJITStubRoutine();
 
@@ -113,9 +117,7 @@ public:
 
     void addedToSharedJITStubSet();
 
-
-    const WatchpointsOnStructureStubInfo* watchpoints() const { return m_watchpoints.get(); }
-    void setWatchpoints(std::unique_ptr<WatchpointsOnStructureStubInfo>&&);
+    Watchpoints& watchpoints() { return m_watchpoints; }
     WatchpointSet& watchpointSet() { return *m_watchpointSet.get(); }
     void invalidate();
 
@@ -149,7 +151,7 @@ private:
     FixedVector<StructureID> m_weakStructures;
     RefPtr<WatchpointSet> m_watchpointSet;
     HashCountedSet<CodeBlock*> m_owners;
-    std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
+    Watchpoints m_watchpoints;
 };
 
 // Use this if you want to mark one additional object during GC if your stub


### PR DESCRIPTION
#### 1ece8d08db4db2af3bee8ffe4d7e16e281d03525
<pre>
[JSC] Fire WatchpointSet directly in StructureTransitionStructureStubClearingWatchpoint / AdaptiveValueStructureStubClearingWatchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=274323">https://bugs.webkit.org/show_bug.cgi?id=274323</a>
<a href="https://rdar.apple.com/128283244">rdar://128283244</a>

Reviewed by Keith Miller.

This is a preparation of separating this WatchpointSet from code. In Handler IC, it is possible that we would like to invalidate the code, or just invalidating handler.
To support both cases, StructureTransitionStructureStubClearingWatchpoint / AdaptiveValueStructureStubClearingWatchpoint will directly fire WatchpointSet instead of
holding PolymorphicAccessJITStubRoutine. So we can use WatchpointSet placed in Handler later.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::addWatchpoint):
(JSC::ensureReferenceAndInstallWatchpoint):
(JSC::ensureReferenceAndAddWatchpoint):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
(JSC::StructureTransitionStructureStubClearingWatchpoint::fireInternal):
(JSC::AdaptiveValueStructureStubClearingWatchpoint::handleFire):
(JSC::WatchpointsOnStructureStubInfo::addWatchpoint): Deleted.
(JSC::WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint): Deleted.
(JSC::WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint): Deleted.
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::observeZeroRefCountImpl):
(JSC::PolymorphicAccessJITStubRoutine::setWatchpoints): Deleted.
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::PolymorphicAccessJITStubRoutine::watchpoints):
(JSC::PolymorphicAccessJITStubRoutine::watchpoints const): Deleted.

Canonical link: <a href="https://commits.webkit.org/278958@main">https://commits.webkit.org/278958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85ca4b5957173401d4443fa02218f0d46adbb448

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2758 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42366 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1758 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2170 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/928 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45391 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56916 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49760 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48982 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29301 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63860 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7612 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28139 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12057 "Passed tests") | 
<!--EWS-Status-Bubble-End-->