### PR TITLE
Style checker shouldn't complain about `requires (MyConcept)`

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1620,8 +1620,8 @@ def check_spacing_for_function_call(line, line_number, file_state, error):
     # " (something)[something]"
     # Note that we assume the contents of [] to be short enough that
     # they'll never need to wrap.
-    if (  # Ignore control structures.
-        not search(r'\b(if|for|while|switch|return|new|delete)\b', function_call)
+    if (  # Ignore control structures / c++20 concept constraints.
+        not search(r'\b(if|for|while|switch|return|new|delete|requires)\b', function_call)
         # Ignore lambda functions
         and not regex_for_lambdas_and_blocks(function_call, line_number, file_state, error)
         # Ignore pointers/references to functions.

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -5000,6 +5000,17 @@ class WebKitStyleTest(CppStyleTestBase):
             ['Extra space after ( in function call  [whitespace/parens] [4]',
              'Extra space before )  [whitespace/parens] [2]'])
 
+        # Ignore concept constraints.
+        self.assert_multi_line_lint(
+            'template<typename T>\n'
+            'requires (MyConcept<T>)\n'
+            'int f(T a);',
+            '')
+
+        self.assert_multi_line_lint(
+            'int foo(int a, int b) requires (MyConcept<T>) { return a + b; }',
+            '')
+
         # Ignore spacing inside four char code.
         self.assert_multi_line_lint(
             'CTFontTableTag os2Tag = \'OS/2\';',


### PR DESCRIPTION
#### 479314b7018c909d99dcff4714b6ec2171652339
<pre>
Style checker shouldn&apos;t complain about `requires (MyConcept)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=274324">https://bugs.webkit.org/show_bug.cgi?id=274324</a>
<a href="https://rdar.apple.com/128284081">rdar://128284081</a>

Reviewed by Jonathan Bedard.

Right now the style checker will complain about an extra space before the
arguments to a function call when you do `requires (MyConcept)`. We should
treat spaces after `requires` the same way we treat spaces after other keywords.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_spacing_for_function_call):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_spacing):

Canonical link: <a href="https://commits.webkit.org/278922@main">https://commits.webkit.org/278922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24291de9d7a344927e061b1254cf6ca7cfa5f6eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51979 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31290 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4351 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54281 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2385 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/55240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54073 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/4351 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51824 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/4351 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/860 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48101 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/4351 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56834 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/4351 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48907 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7595 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/28065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->