### PR TITLE
[Unified Text Replacement] `willBeginTextReplacementSession` sometimes does not return a context if the text lengths differ

### DIFF
--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -63,6 +63,8 @@ enum class TextIteratorBehavior : uint16_t {
     EntersImageOverlays = 1 << 10,
 
     IgnoresUserSelectNone = 1 << 11,
+
+    EmitsObjectReplacementCharactersForImagesOnly = 1 << 12,
 };
 
 using TextIteratorBehaviors = OptionSet<TextIteratorBehavior>;

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -194,14 +194,15 @@ static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, I
         return attachment;
     }, [] (const TextAttachmentFileWrapper& value) -> RetainPtr<id> {
         RetainPtr<NSData> data = value.data ? bridge_cast((value.data).get()) : nil;
-        RetainPtr<NSFileWrapper> fileWrapper = nil;
-        if (!value.preferredFilename.isNull()) {
-            fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
+
+        RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
+        if (!value.preferredFilename.isNull())
             [fileWrapper setPreferredFilename:filenameByFixingIllegalCharacters((NSString *)value.preferredFilename)];
-        }
+
         auto textAttachment = adoptNS([[PlatformNSTextAttachment alloc] initWithFileWrapper:fileWrapper.get()]);
         if (!value.accessibilityLabel.isNull())
             ((NSTextAttachment*)textAttachment.get()).accessibilityLabel = (NSString *)value.accessibilityLabel;
+
         return textAttachment;
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     }, [] (const MultiRepresentationHEICAttachmentData& value) -> RetainPtr<id> {

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2399,8 +2399,11 @@ AttributedString editingAttributedString(const SimpleRange& range, IncludeImages
     for (TextIterator it(range); !it.atEnd(); it.advance()) {
         auto node = it.node();
 
-        if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(node); imageElement && includeImages == IncludeImages::Yes)
-            [string appendAttributedString:attributedStringWithAttachmentForElement(*imageElement).get()];
+        if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(node); imageElement && includeImages == IncludeImages::Yes) {
+            RetainPtr attachmentAttributedString = attributedStringWithAttachmentForElement(*imageElement);
+            [string appendAttributedString:attachmentAttributedString.get()];
+            stringLength += [attachmentAttributedString length];
+        }
 
         auto currentTextLength = it.text().length();
         if (!currentTextLength)

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -91,6 +91,11 @@ private:
         WebCore::CharacterRange range;
     };
 
+    static WebCore::CharacterRange characterRange(const WebCore::SimpleRange& scope, const WebCore::SimpleRange&);
+    static WebCore::SimpleRange resolveCharacterRange(const WebCore::SimpleRange& scope, WebCore::CharacterRange);
+    static uint64_t characterCount(const WebCore::SimpleRange&);
+    static String plainText(const WebCore::SimpleRange&);
+
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(const WebCore::SimpleRange&) const;
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerByUUID(const WebCore::SimpleRange& outerRange, const WTF::UUID& replacementUUID) const;
 


### PR DESCRIPTION
#### 90bbdbb17a629ae973babc361cf167577eff0668
<pre>
[Unified Text Replacement] `willBeginTextReplacementSession` sometimes does not return a context if the text lengths differ
<a href="https://bugs.webkit.org/show_bug.cgi?id=274325">https://bugs.webkit.org/show_bug.cgi?id=274325</a>
<a href="https://rdar.apple.com/128285414">rdar://128285414</a>

Reviewed by Aditya Keerthi.

The length of the string produced by `editingAttributedString` and the character count produced by
`TextIterator` can sometimes differ. This can happen when there are images in the HTML, as `editingAttributedString`
handles them in a special case.

Fix by adding a new `TextIteratorBehavior` option that acts the same as `EmitsObjectReplacementCharacters`,
but only for images, and then use this behavior anywhere in UnifiedTextReplacementController that
needs character ranges or counts.

Also fix a few issues with attachments in attributed strings:

* When converting an `AttributedString` to an `NSAttributedString` with an attachment, if the attachment
does not have a &quot;preferred&quot; filename, an empty file wrapper will be created. Fix by always creating a file
wrapper.

* When converting HTML with an image to an attributed string, the position of the resulting attachment in
the produced attributed string is sometimes incorrect. This is because the length of the attachment itself
is never taken into account, and so consequent parts of the string will be inserted in too early of a position.
Fix by accounting for the length of the attachment.

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::TextIterator):
(WebCore::TextIterator::handleReplacedElement):
* Source/WebCore/editing/TextIteratorBehavior.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(WebCore::editingAttributedString):
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::characterRange):
(WebKit::UnifiedTextReplacementController::characterCount):
(WebKit::UnifiedTextReplacementController::resolveCharacterRange):
(WebKit::UnifiedTextReplacementController::plainText):
(WebKit::UnifiedTextReplacementController::willBeginTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::textReplacementSessionPerformEditActionForPlainText):
(WebKit::UnifiedTextReplacementController::contextRangeForSessionOrRangeWithUUID const):
(WebKit::UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:

Canonical link: <a href="https://commits.webkit.org/279002@main">https://commits.webkit.org/279002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c4632ac5877e8ffc40c52cfc3d4bbe4968b5c00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42447 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1842 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2289 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1041 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57029 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49842 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49082 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29430 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7640 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->