### PR TITLE
Use SystemV ABI for C++ entrypoints for JS LLInt

### DIFF
--- a/Source/JavaScriptCore/assembler/MaxFrameExtentForSlowPathCall.h
+++ b/Source/JavaScriptCore/assembler/MaxFrameExtentForSlowPathCall.h
@@ -38,12 +38,8 @@ namespace JSC {
 #if !ENABLE(ASSEMBLER)
 static constexpr size_t maxFrameExtentForSlowPathCall = 0;
 
-#elif CPU(X86_64) && OS(WINDOWS)
-// 4 args in registers, but stack space needs to be allocated for all args.
-static constexpr size_t maxFrameExtentForSlowPathCall = 64;
-
 #elif CPU(X86_64)
-// All args in registers.
+// All args in registers. Windows also uses System V ABI.
 static constexpr size_t maxFrameExtentForSlowPathCall = 0;
 
 #elif CPU(X86)

--- a/Source/JavaScriptCore/assembler/X86_64Registers.h
+++ b/Source/JavaScriptCore/assembler/X86_64Registers.h
@@ -33,8 +33,6 @@
 
 #define RegisterNames X86Registers
 
-#if !OS(WINDOWS)
-
 #define FOR_EACH_GP_REGISTER(macro)             \
     macro(eax, "rax"_s, 0, 0)                     \
     macro(ecx, "rcx"_s, 0, 0)                     \
@@ -52,28 +50,6 @@
     macro(r13, "r13"_s, 0, 1)                     \
     macro(r14, "r14"_s, 0, 1)                     \
     macro(r15, "r15"_s, 0, 1)
-
-#else // OS(WINDOWS)
-
-#define FOR_EACH_GP_REGISTER(macro)             \
-    macro(eax, "rax"_s, 0, 0)                     \
-    macro(ecx, "rcx"_s, 0, 0)                     \
-    macro(edx, "rdx"_s, 0, 0)                     \
-    macro(ebx, "rbx"_s, 0, 1)                     \
-    macro(esp, "rsp"_s, 0, 0)                     \
-    macro(ebp, "rbp"_s, 0, 1)                     \
-    macro(esi, "rsi"_s, 0, 1)                     \
-    macro(edi, "rdi"_s, 0, 1)                     \
-    macro(r8,  "r8"_s,  0, 0)                     \
-    macro(r9,  "r9"_s,  0, 0)                     \
-    macro(r10, "r10"_s, 0, 0)                     \
-    macro(r11, "r11"_s, 0, 0)                     \
-    macro(r12, "r12"_s, 0, 1)                     \
-    macro(r13, "r13"_s, 0, 1)                     \
-    macro(r14, "r14"_s, 0, 1)                     \
-    macro(r15, "r15"_s, 0, 1)
-
-#endif // !OS(WINDOWS)
 
 #define FOR_EACH_FP_REGISTER(macro)             \
     macro(xmm0,  "xmm0"_s,  0, 0)                  \

--- a/Source/JavaScriptCore/heap/MachineStackMarker.cpp
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.cpp
@@ -53,7 +53,6 @@ void MachineThreads::gatherFromCurrentThread(ConservativeRoots& conservativeRoot
 static inline int osRedZoneAdjustment()
 {
     int redZoneAdjustment = 0;
-#if !OS(WINDOWS)
 #if CPU(X86_64)
     // See http://people.freebsd.org/~obrien/amd64-elf-abi.pdf Section 3.2.2.
     redZoneAdjustment = -128;
@@ -61,7 +60,6 @@ static inline int osRedZoneAdjustment()
     // See https://developer.apple.com/library/ios/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html#//apple_ref/doc/uid/TP40013702-SW7
     redZoneAdjustment = -128;
 #endif
-#endif // !OS(WINDOWS)
     return redZoneAdjustment;
 }
 

--- a/Source/JavaScriptCore/interpreter/VMEntryRecord.h
+++ b/Source/JavaScriptCore/interpreter/VMEntryRecord.h
@@ -57,6 +57,6 @@ struct VMEntryRecord {
     SUPPRESS_ASAN EntryFrame* unsafePrevTopEntryFrame() { return m_prevTopEntryFrame; }
 };
 
-extern "C" VMEntryRecord* vmEntryRecord(EntryFrame*);
+extern "C" VMEntryRecord* SYSV_ABI vmEntryRecord(EntryFrame*);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1358,8 +1358,6 @@ public:
             GPRInfo::regT13,
             GPRInfo::regT14,
             GPRInfo::regT15,
-#elif CPU(X86_64) && OS(WINDOWS)
-            // No additional registers.
 #elif CPU(X86_64)
             GPRInfo::regT6,
             GPRInfo::regT7,

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -402,13 +402,8 @@ public:
 #endif // CPU(X86)
 
 #if CPU(X86_64)
-#if !OS(WINDOWS)
 #define NUMBER_OF_ARGUMENT_REGISTERS 6u
 #define NUMBER_OF_CALLEE_SAVES_REGISTERS 5u
-#else
-#define NUMBER_OF_ARGUMENT_REGISTERS 4u
-#define NUMBER_OF_CALLEE_SAVES_REGISTERS 7u
-#endif
 
 class GPRInfo {
 public:
@@ -425,7 +420,6 @@ public:
 
     // Temporary registers.
     static constexpr GPRReg regT0 = X86Registers::eax;
-#if !OS(WINDOWS)
     static constexpr GPRReg regT1 = X86Registers::esi;
     static constexpr GPRReg regT2 = X86Registers::edx;
     static constexpr GPRReg regT3 = X86Registers::ecx;
@@ -433,44 +427,22 @@ public:
     static constexpr GPRReg regT5 = X86Registers::r10;
     static constexpr GPRReg regT6 = X86Registers::edi;
     static constexpr GPRReg regT7 = X86Registers::r9;
-#else
-    static constexpr GPRReg regT1 = X86Registers::edx;
-    static constexpr GPRReg regT2 = X86Registers::r8;
-    static constexpr GPRReg regT3 = X86Registers::r9;
-    static constexpr GPRReg regT4 = X86Registers::r10;
-    static constexpr GPRReg regT5 = X86Registers::ecx;
-#endif
 
     static constexpr GPRReg regCS0 = X86Registers::ebx;
 
-#if !OS(WINDOWS)
     static constexpr GPRReg regCS1 = X86Registers::r12; // metadataTable in LLInt/Baseline
     static constexpr GPRReg regCS2 = X86Registers::r13; // jitDataRegister
     static constexpr GPRReg regCS3 = X86Registers::r14; // numberTagRegister
     static constexpr GPRReg regCS4 = X86Registers::r15; // notCellMaskRegister
-#else
-    static constexpr GPRReg regCS1 = X86Registers::esi;
-    static constexpr GPRReg regCS2 = X86Registers::edi;
-    static constexpr GPRReg regCS3 = X86Registers::r12; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS4 = X86Registers::r13; // jitDataRegister
-    static constexpr GPRReg regCS5 = X86Registers::r14; // numberTagRegister
-    static constexpr GPRReg regCS6 = X86Registers::r15; // notCellMaskRegister
-#endif
 
     // These constants provide the names for the general purpose argument & return value registers.
-#if !OS(WINDOWS)
     static constexpr GPRReg argumentGPR0 = X86Registers::edi; // regT6
     static constexpr GPRReg argumentGPR1 = X86Registers::esi; // regT1
     static constexpr GPRReg argumentGPR2 = X86Registers::edx; // regT2
     static constexpr GPRReg argumentGPR3 = X86Registers::ecx; // regT3
     static constexpr GPRReg argumentGPR4 = X86Registers::r8; // regT4
     static constexpr GPRReg argumentGPR5 = X86Registers::r9; // regT7
-#else
-    static constexpr GPRReg argumentGPR0 = X86Registers::ecx; // regT5
-    static constexpr GPRReg argumentGPR1 = X86Registers::edx; // regT1
-    static constexpr GPRReg argumentGPR2 = X86Registers::r8; // regT2
-    static constexpr GPRReg argumentGPR3 = X86Registers::r9; // regT3
-#endif
+
     static constexpr GPRReg nonArgGPR0 = X86Registers::r10; // regT5 (regT4 on Windows)
     static constexpr GPRReg nonArgGPR1 = X86Registers::eax; // regT0
     static constexpr GPRReg returnValueGPR = X86Registers::eax; // regT0
@@ -482,19 +454,11 @@ public:
     static constexpr GPRReg handlerGPR = GPRInfo::nonPreservedNonArgumentGPR1;
 
     static constexpr GPRReg wasmScratchGPR0 = X86Registers::eax;
-#if !OS(WINDOWS)
     static constexpr GPRReg wasmScratchGPR1 = X86Registers::r10;
-#else
-    static constexpr GPRReg wasmScratchCSR0 = regCS2;
-#endif
+
     static constexpr GPRReg wasmContextInstancePointer = regCS0;
-#if !OS(WINDOWS)
     static constexpr GPRReg wasmBaseMemoryPointer = regCS3;
     static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS4;
-#else
-    static constexpr GPRReg wasmBaseMemoryPointer = regCS5;
-    static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS6;
-#endif
 
     // FIXME: I believe that all uses of this are dead in the sense that it just causes the scratch
     // register allocator to select a different register and potentially spill things. It would be better
@@ -504,22 +468,14 @@ public:
     static constexpr GPRReg toRegister(unsigned index)
     {
         ASSERT_UNDER_CONSTEXPR_CONTEXT(index < numberOfRegisters);
-#if !OS(WINDOWS)
         constexpr GPRReg registerForIndex[numberOfRegisters] = { regT0, regT1, regT2, regT3, regT4, regT5, regT6, regT7, regCS0, regCS1 };
-#else
-        constexpr GPRReg registerForIndex[numberOfRegisters] = { regT0, regT1, regT2, regT3, regT4, regT5, regCS0, regCS1, regCS2, regCS3 };
-#endif
         return registerForIndex[index];
     }
     
     static GPRReg toArgumentRegister(unsigned index)
     {
         ASSERT(index < numberOfArgumentRegisters);
-#if !OS(WINDOWS)
         static const GPRReg registerForIndex[numberOfArgumentRegisters] = { argumentGPR0, argumentGPR1, argumentGPR2, argumentGPR3, argumentGPR4, argumentGPR5 };
-#else
-        static const GPRReg registerForIndex[numberOfArgumentRegisters] = { argumentGPR0, argumentGPR1, argumentGPR2, argumentGPR3 };
-#endif
         return registerForIndex[index];
     }
     
@@ -527,11 +483,7 @@ public:
     {
         ASSERT(reg != InvalidGPRReg);
         ASSERT(static_cast<int>(reg) < 16);
-#if !OS(WINDOWS)
         static const unsigned indexForRegister[16] = { 0, 3, 2, 8, InvalidIndex, InvalidIndex, 1, 6, 4, 7, 5, InvalidIndex, 9, InvalidIndex, InvalidIndex, InvalidIndex };
-#else
-        static const unsigned indexForRegister[16] = { 0, 5, 1, 6, InvalidIndex, InvalidIndex, 7, 8, 2, 3, 4, InvalidIndex, 9, InvalidIndex, InvalidIndex, InvalidIndex };
-#endif
         return indexForRegister[reg];
     }
 
@@ -1083,15 +1035,9 @@ public:
     preferredArgumentJSR()
     {
 #if USE(JSVALUE64)
-#if !OS(WINDOWS)
         return pickJSR<OperationType, ArgNum>(
             GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::argumentGPR2,
             GPRInfo::argumentGPR3, GPRInfo::argumentGPR4, GPRInfo::argumentGPR5);
-#else
-        return pickJSR<OperationType, ArgNum>(
-            GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::argumentGPR2,
-            GPRInfo::argumentGPR3, GPRInfo::nonArgGPR0,   GPRInfo::nonArgGPR1);
-#endif
 #elif USE(JSVALUE32_64)
 #if CPU(ARM_THUMB2)
         // Be careful about GPRInfo::regCS0. It is used as a metadataTable register.

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -158,10 +158,6 @@ RegisterSet RegisterSetBuilder::vmCalleeSaveRegisters()
     result.add(GPRInfo::regCS2, IgnoreVectors);
     result.add(GPRInfo::regCS3, IgnoreVectors);
     result.add(GPRInfo::regCS4, IgnoreVectors);
-#if OS(WINDOWS)
-    result.add(GPRInfo::regCS5, IgnoreVectors);
-    result.add(GPRInfo::regCS6, IgnoreVectors);
-#endif
 #elif CPU(ARM64)
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);
@@ -223,7 +219,6 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
     RegisterSet result;
 #if CPU(X86)
 #elif CPU(X86_64)
-#if !OS(WINDOWS)
     result.add(GPRInfo::regCS1, IgnoreVectors);
     static_assert(GPRInfo::regCS2 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS3 == GPRInfo::numberTagRegister);
@@ -231,15 +226,6 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
     result.add(GPRInfo::regCS2, IgnoreVectors);
     result.add(GPRInfo::regCS3, IgnoreVectors);
     result.add(GPRInfo::regCS4, IgnoreVectors);
-#else
-    result.add(GPRInfo::regCS3, IgnoreVectors);
-    static_assert(GPRInfo::regCS4 == GPRInfo::jitDataRegister);
-    static_assert(GPRInfo::regCS5 == GPRInfo::numberTagRegister);
-    static_assert(GPRInfo::regCS6 == GPRInfo::notCellMaskRegister);
-    result.add(GPRInfo::regCS4, IgnoreVectors);
-    result.add(GPRInfo::regCS5, IgnoreVectors);
-    result.add(GPRInfo::regCS6, IgnoreVectors);
-#endif
 #elif CPU(ARM_THUMB2)
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);
@@ -264,23 +250,12 @@ RegisterSet RegisterSetBuilder::dfgCalleeSaveRegisters()
 #elif CPU(X86_64)
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);
-#if !OS(WINDOWS)
     static_assert(GPRInfo::regCS2 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS3 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS4 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS2, IgnoreVectors);
     result.add(GPRInfo::regCS3, IgnoreVectors);
     result.add(GPRInfo::regCS4, IgnoreVectors);
-#else
-    result.add(GPRInfo::regCS2, IgnoreVectors);
-    result.add(GPRInfo::regCS3, IgnoreVectors);
-    static_assert(GPRInfo::regCS4 == GPRInfo::jitDataRegister);
-    static_assert(GPRInfo::regCS5 == GPRInfo::numberTagRegister);
-    static_assert(GPRInfo::regCS6 == GPRInfo::notCellMaskRegister);
-    result.add(GPRInfo::regCS4, IgnoreVectors);
-    result.add(GPRInfo::regCS5, IgnoreVectors);
-    result.add(GPRInfo::regCS6, IgnoreVectors);
-#endif
 #elif CPU(ARM_THUMB2)
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -48,7 +48,7 @@ Opcode g_opcodeMapWide16[numOpcodeIDs + numWasmOpcodeIDs] = { };
 Opcode g_opcodeMapWide32[numOpcodeIDs + numWasmOpcodeIDs] = { };
 
 #if !ENABLE(C_LOOP)
-extern "C" void llint_entry(void*, void*, void*);
+extern "C" void SYSV_ABI llint_entry(void*, void*, void*);
 
 #if ENABLE(WEBASSEMBLY)
 extern "C" void wasm_entry(void*, void*, void*);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -223,7 +223,7 @@ template<typename... Types> void slowPathLogF(const char*, const Types&...) { }
 
 #endif // LLINT_TRACING
 
-extern "C" UGPRPair llint_trace_operand(CallFrame* callFrame, const JSInstruction* pc, int fromWhere, int operand)
+extern "C" UGPRPair SYSV_ABI llint_trace_operand(CallFrame* callFrame, const JSInstruction* pc, int fromWhere, int operand)
 {
     if (!Options::traceLLIntExecution())
         LLINT_END_IMPL();
@@ -241,7 +241,7 @@ extern "C" UGPRPair llint_trace_operand(CallFrame* callFrame, const JSInstructio
     LLINT_END();
 }
 
-extern "C" UGPRPair llint_trace_value(CallFrame* callFrame, const JSInstruction* pc, int fromWhere, VirtualRegister operand)
+extern "C" UGPRPair SYSV_ABI llint_trace_value(CallFrame* callFrame, const JSInstruction* pc, int fromWhere, VirtualRegister operand)
 {
     if (!Options::traceLLIntExecution())
         LLINT_END_IMPL();
@@ -599,7 +599,7 @@ LLINT_SLOW_PATH_DECL(stack_check)
     LLINT_RETURN_TWO(pc, callFrame);
 }
 
-extern "C" UGPRPair llint_default_call(CallFrame* calleeFrame, CallLinkInfo* callLinkInfo)
+extern "C" UGPRPair SYSV_ABI llint_default_call(CallFrame* calleeFrame, CallLinkInfo* callLinkInfo)
 {
     JSCell* owner = callLinkInfo->ownerForSlowPath(calleeFrame);
     VM& vm = owner->vm();
@@ -614,7 +614,7 @@ extern "C" UGPRPair llint_default_call(CallFrame* calleeFrame, CallLinkInfo* cal
     return encodeResult(callTarget, nullptr);
 }
 
-extern "C" UGPRPair llint_virtual_call(CallFrame* calleeFrame, CallLinkInfo* callLinkInfo)
+extern "C" UGPRPair SYSV_ABI llint_virtual_call(CallFrame* calleeFrame, CallLinkInfo* callLinkInfo)
 {
     JSCell* owner = callLinkInfo->ownerForSlowPath(calleeFrame);
     VM& vm = owner->vm();
@@ -2570,7 +2570,7 @@ static inline UGPRPair dispatchToNextInstructionDuringExit(ThrowScope& scope, Co
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-extern "C" UGPRPair llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue result)
+extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue result)
 {
     // Since all our calling checkpoints do right now is move result into our dest we can just do that here and return.
     CodeBlock* codeBlock = callFrame->codeBlock();
@@ -2634,7 +2634,7 @@ extern "C" UGPRPair llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFr
     return dispatchToNextInstructionDuringExit(scope, codeBlock, pc);
 }
 
-extern "C" UGPRPair llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue /* needed for cCall2 in CLoop */)
+extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue /* needed for cCall2 in CLoop */)
 {
     CodeBlock* codeBlock = callFrame->codeBlock();
     VM& vm = codeBlock->vm();
@@ -2679,7 +2679,7 @@ extern "C" UGPRPair llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, En
     return dispatchToNextInstructionDuringExit(scope, codeBlock, pc);
 }
 
-extern "C" UGPRPair llint_throw_stack_overflow_error(VM* vm, ProtoCallFrame* protoFrame)
+extern "C" UGPRPair SYSV_ABI llint_throw_stack_overflow_error(VM* vm, ProtoCallFrame* protoFrame)
 {
     CallFrame* callFrame = vm->topCallFrame;
     auto scope = DECLARE_THROW_SCOPE(*vm);
@@ -2693,7 +2693,7 @@ extern "C" UGPRPair llint_throw_stack_overflow_error(VM* vm, ProtoCallFrame* pro
 }
 
 #if ENABLE(C_LOOP)
-extern "C" UGPRPair llint_stack_check_at_vm_entry(VM* vm, Register* newTopOfStack)
+extern "C" UGPRPair SYSV_ABI llint_stack_check_at_vm_entry(VM* vm, Register* newTopOfStack)
 {
     bool success = vm->ensureStackCapacityFor(newTopOfStack);
     return encodeResult(reinterpret_cast<void*>(success), 0);
@@ -2706,19 +2706,19 @@ extern "C" void llint_write_barrier_slow(CallFrame* callFrame, JSCell* cell)
     vm.writeBarrier(cell);
 }
 
-extern "C" UGPRPair llint_check_vm_entry_permission(VM*, ProtoCallFrame*)
+extern "C" UGPRPair SYSV_ABI llint_check_vm_entry_permission(VM*, ProtoCallFrame*)
 {
     Interpreter::checkVMEntryPermission();
     return encodeResult(nullptr, nullptr);
 }
 
-extern "C" void llint_dump_value(EncodedJSValue value);
-extern "C" void llint_dump_value(EncodedJSValue value)
+extern "C" void SYSV_ABI llint_dump_value(EncodedJSValue value);
+extern "C" void SYSV_ABI llint_dump_value(EncodedJSValue value)
 {
     dataLogLn(JSValue::decode(value));
 }
 
-extern "C" NO_RETURN_DUE_TO_CRASH void llint_crash()
+extern "C" NO_RETURN_DUE_TO_CRASH void SYSV_ABI llint_crash()
 {
     CRASH();
 }

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -36,15 +36,15 @@ struct ProtoCallFrame;
 
 namespace LLInt {
 
-extern "C" void logWasmPrologue(uint64_t i, uint64_t* fp, uint64_t* sp)  REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair llint_trace_operand(CallFrame*, const JSInstruction*, int fromWhere, int operand) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair llint_trace_value(CallFrame*, const JSInstruction*, int fromWhere, VirtualRegister operand) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair llint_default_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair llint_virtual_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" void llint_write_barrier_slow(CallFrame*, JSCell*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" void SYSV_ABI logWasmPrologue(uint64_t i, uint64_t* fp, uint64_t* sp)  REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_trace_operand(CallFrame*, const JSInstruction*, int fromWhere, int operand) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_trace_value(CallFrame*, const JSInstruction*, int fromWhere, VirtualRegister operand) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_default_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_virtual_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" void SYSV_ABI llint_write_barrier_slow(CallFrame*, JSCell*) REFERENCED_FROM_ASM WTF_INTERNAL;
 
 #define LLINT_SLOW_PATH_DECL(name) \
-    extern "C" UGPRPair llint_##name(CallFrame* callFrame, const JSInstruction* pc)
+    extern "C" UGPRPair SYSV_ABI llint_##name(CallFrame* callFrame, const JSInstruction* pc)
 
 #define LLINT_SLOW_PATH_HIDDEN_DECL(name) \
     LLINT_SLOW_PATH_DECL(name) REFERENCED_FROM_ASM WTF_INTERNAL
@@ -155,13 +155,13 @@ LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_log_shadow_chicken_prologue);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_log_shadow_chicken_tail);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_out_of_line_jump_target);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_arityCheck);
-extern "C" UGPRPair llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue unused) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue unused) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
 #if ENABLE(C_LOOP)
-extern "C" UGPRPair llint_stack_check_at_vm_entry(VM*, Register*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_stack_check_at_vm_entry(VM*, Register*) REFERENCED_FROM_ASM WTF_INTERNAL;
 #endif
-extern "C" UGPRPair llint_check_vm_entry_permission(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" NO_RETURN_DUE_TO_CRASH void llint_crash() REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_check_vm_entry_permission(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" NO_RETURN_DUE_TO_CRASH void SYSV_ABI llint_crash() REFERENCED_FROM_ASM WTF_INTERNAL;
 
 } } // namespace JSC::LLInt

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -36,11 +36,11 @@ struct ProtoCallFrame;
 typedef int64_t EncodedJSValue;
 
 extern "C" {
-    EncodedJSValue vmEntryToJavaScript(void*, VM*, ProtoCallFrame*);
-    EncodedJSValue vmEntryToNative(void*, VM*, ProtoCallFrame*);
-    EncodedJSValue vmEntryCustomGetter(JSGlobalObject*, EncodedJSValue, PropertyName, void*);
-    void vmEntryCustomSetter(JSGlobalObject*, EncodedJSValue, EncodedJSValue, PropertyName, void*);
-    EncodedJSValue vmEntryHostFunction(JSGlobalObject*, CallFrame*, void*);
+    EncodedJSValue SYSV_ABI vmEntryToJavaScript(void*, VM*, ProtoCallFrame*);
+    EncodedJSValue SYSV_ABI vmEntryToNative(void*, VM*, ProtoCallFrame*);
+    EncodedJSValue SYSV_ABI vmEntryCustomGetter(JSGlobalObject*, EncodedJSValue, PropertyName, void*);
+    void SYSV_ABI vmEntryCustomSetter(JSGlobalObject*, EncodedJSValue, EncodedJSValue, PropertyName, void*);
+    EncodedJSValue SYSV_ABI vmEntryHostFunction(JSGlobalObject*, CallFrame*, void*);
 
 #if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
     EncodedJSValue vmEntryToJavaScriptWith0Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -290,16 +290,11 @@ if JSVALUE64
         const PB = csr7
         const numberTag = csr8
         const notCellMask = csr9
-    elsif X86_64
+    elsif X86_64 or X86_64_WIN
         const metadataTable = csr1
         const PB = csr2
         const numberTag = csr3
         const notCellMask = csr4
-    elsif X86_64_WIN
-        const metadataTable = csr3
-        const PB = csr4
-        const numberTag = csr5
-        const notCellMask = csr6
     elsif C_LOOP or C_LOOP_WIN
         const PB = csr0
         const numberTag = csr1
@@ -551,12 +546,7 @@ macro llintOpWithProfile(opcodeName, opcodeStruct, fn)
     end)
 end
 
-
-if X86_64_WIN
-    const extraTempReg = t0
-else
-    const extraTempReg = t5
-end
+const extraTempReg = t5
 
 # Constants for reasoning about value representation.
 const TagOffset = constexpr TagOffset
@@ -870,16 +860,11 @@ macro preserveCalleeSavesUsedByLLInt()
         storepairq csr6, csr7, -32[cfr]
     elsif X86
     elsif X86_WIN
-    elsif X86_64
+    elsif X86_64 or X86_64_WIN
         storep csr4, -8[cfr]
         storep csr3, -16[cfr]
         storep csr2, -24[cfr]
         storep csr1, -32[cfr]
-    elsif X86_64_WIN
-        storep csr6, -8[cfr]
-        storep csr5, -16[cfr]
-        storep csr4, -24[cfr]
-        storep csr3, -32[cfr]
     elsif RISCV64
         storep csr9, -8[cfr]
         storep csr8, -16[cfr]
@@ -899,16 +884,11 @@ macro restoreCalleeSavesUsedByLLInt()
         loadpairq -16[cfr], csr8, csr9
     elsif X86
     elsif X86_WIN
-    elsif X86_64
+    elsif X86_64 or X86_64_WIN
         loadp -32[cfr], csr1
         loadp -24[cfr], csr2
         loadp -16[cfr], csr3
         loadp -8[cfr], csr4
-    elsif X86_64_WIN
-        loadp -32[cfr], csr3
-        loadp -24[cfr], csr4
-        loadp -16[cfr], csr5
-        loadp -8[cfr], csr6
     elsif RISCV64
         loadp -32[cfr], csr6
         loadp -24[cfr], csr7
@@ -931,20 +911,12 @@ macro copyCalleeSavesToEntryFrameCalleeSavesBuffer(entryFrame)
             storepaird csfr2, csfr3, 96[entryFrame]
             storepaird csfr4, csfr5, 112[entryFrame]
             storepaird csfr6, csfr7, 128[entryFrame]
-        elsif X86_64
+        elsif X86_64 or X86_64_WIN
             storeq csr0, [entryFrame]
             storeq csr1, 8[entryFrame]
             storeq csr2, 16[entryFrame]
             storeq csr3, 24[entryFrame]
             storeq csr4, 32[entryFrame]
-        elsif X86_64_WIN
-            storeq csr0, [entryFrame]
-            storeq csr1, 8[entryFrame]
-            storeq csr2, 16[entryFrame]
-            storeq csr3, 24[entryFrame]
-            storeq csr4, 32[entryFrame]
-            storeq csr5, 40[entryFrame]
-            storeq csr6, 48[entryFrame]
         elsif ARMv7
             storep csr0, [entryFrame]
             storep csr1, 4[entryFrame]
@@ -1004,20 +976,12 @@ macro restoreCalleeSavesFromVMEntryFrameCalleeSavesBuffer(vm, temp)
             loadpaird 96[temp], csfr2, csfr3
             loadpaird 112[temp], csfr4, csfr5
             loadpaird 128[temp], csfr6, csfr7
-        elsif X86_64
+        elsif X86_64 or X86_64_WIN
             loadq [temp], csr0
             loadq 8[temp], csr1
             loadq 16[temp], csr2
             loadq 24[temp], csr3
             loadq 32[temp], csr4
-        elsif X86_64_WIN
-            loadq [temp], csr0
-            loadq 8[temp], csr1
-            loadq 16[temp], csr2
-            loadq 24[temp], csr3
-            loadq 32[temp], csr4
-            loadq 40[temp], csr5
-            loadq 48[temp], csr6
         elsif ARMv7
             loadp [temp], csr0
             loadp 4[temp], csr1
@@ -1982,14 +1946,10 @@ else
     # The PC base is in t3, as this is what _llint_entry leaves behind through
     # initPCRelative(t3)
     macro setEntryAddressCommon(kind, index, label, map)
-        if X86_64
+        if X86_64 or X86_64_WIN
             leap (label - _%kind%_relativePCBase)[t3], t4
             move index, t5
             storep t4, [map, t5, 8]
-        elsif X86_64_WIN
-            leap (label - _%kind%_relativePCBase)[t3], t4
-            move index, t0
-            storep t4, [map, t0, 8]
         elsif X86 or X86_WIN
             leap (label - _%kind%_relativePCBase)[t3], t4
             move index, t5

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -41,7 +41,7 @@ require "config"
 # ebp => cfr
 # esp => sp
 #
-# On x86-64 non-windows
+# On x86-64 (windows and non-windows)
 #
 # rax => t0,     r0
 # rdi =>     a0
@@ -56,27 +56,6 @@ require "config"
 # r13 =>             csr2 (callee-save, PB)
 # r14 =>             csr3 (callee-save, tagTypeNumber)
 # r15 =>             csr4 (callee-save, tagMask)
-# rsp => sp
-# rbp => cfr
-# r11 =>                  (scratch)
-#
-# On x86-64 windows
-# Arguments need to be push/pop'd on the stack in addition to being stored in
-# the registers. Also, >8 return types are returned in a weird way.
-#
-# rax => t0,     r0
-# rcx => t5, a0
-# rdx => t1, a1, r1
-#  r8 => t2, a2
-#  r9 => t3, a3
-# r10 => t4
-# rbx =>             csr0 (callee-save, wasmInstance, unused in baseline)
-# rsi =>             csr1 (callee-save)
-# rdi =>    ws1, t6, csr2 (callee-save, wasmScratch)
-# r12 =>             csr3 (callee-save, metadataTable)
-# r13 =>             csr4 (callee-save, PB)
-# r14 =>             csr5 (callee-save, numberTag, memoryBase)
-# r15 =>             csr6 (callee-save, notCellMask, boundsCheckingSize)
 # rsp => sp
 # rbp => cfr
 # r11 =>                  (scratch)
@@ -278,37 +257,35 @@ class RegisterID
             when "t0", "r0", "ws0"
                 "eax"
             when "r1"
-                "edx" # t1 = a1 when isWin, t2 = a2 otherwise
+                "edx"
             when "a0", "wa0"
-                isWin ? "ecx" : "edi"
+                "edi"
             when "t1", "a1", "wa1"
-                isWin ? "edx" : "esi"
+                "esi"
             when "t2", "a2", "wa2"
-                isWin ? "r8" : "edx"
+                "edx"
             when "t3", "a3", "wa3"
-                isWin ? "r9" : "ecx"
+                "ecx"
             when "t4", "wa4"
-                isWin ? "r10" : "r8"
+                "r8"
             when "t5", "wa5"
-                isWin ? "ecx" : "r9"
+                "r9"
             when "t6", "ws1"
-                isWin ? "edi" : "r10"
+                "r10"
             when "csr0"
                 "ebx"
             when "csr1"
-                isWin ? "esi" : "r12"
+                "r12"
             when "csr2"
-                isWin ? "edi" : "r13"
+                "r13"
             when "csr3"
-                isWin ? "r12" : "r14"
-            when "csr4"
-                isWin ? "r13" : "r15"
-            when "csr5"
-                raise "cannot use register #{name} on X86-64" unless isWin
                 "r14"
-            when "csr6"
-                raise "cannot use register #{name} on X86-64" unless isWin
+            when "csr4"
                 "r15"
+            when "csr5"
+                raise "cannot use register #{name} on X86-64"
+            when "csr6"
+                raise "cannot use register #{name} on X86-64"
             when "cfr"
                 "ebp"
             when "sp"

--- a/Source/JavaScriptCore/runtime/MachineContext.h
+++ b/Source/JavaScriptCore/runtime/MachineContext.h
@@ -772,8 +772,8 @@ inline void*& llintInstructionPointer(PlatformRegisters& regs)
     static_assert(LLInt::LLIntPC == X86Registers::esi, "Wrong LLInt PC.");
     return reinterpret_cast<void*&>((uintptr_t&) regs.Esi);
 #elif CPU(X86_64)
-    static_assert(LLInt::LLIntPC == X86Registers::r10, "Wrong LLInt PC.");
-    return reinterpret_cast<void*&>((uintptr_t&) regs.R10);
+    static_assert(LLInt::LLIntPC == X86Registers::r8, "Wrong LLInt PC.");
+    return reinterpret_cast<void*&>((uintptr_t&) regs.R8);
 #else
 #error Unknown Architecture
 #endif

--- a/Source/JavaScriptCore/runtime/PutPropertySlot.h
+++ b/Source/JavaScriptCore/runtime/PutPropertySlot.h
@@ -34,7 +34,7 @@ namespace JSC {
 class JSObject;
 class JSFunction;
     
-using CustomAccessorValueFunc = FunctionPtr<CustomAccessorPtrTag, bool(JSGlobalObject*, EncodedJSValue, EncodedJSValue, PropertyName)>;
+using CustomAccessorValueFunc = FunctionPtr<CustomAccessorPtrTag, bool(JSGlobalObject*, EncodedJSValue, EncodedJSValue, PropertyName), FunctionAttributes::JITOperation>;
 
 class PutPropertySlot {
 public:

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1189,7 +1189,7 @@ inline Heap* WeakSet::heap() const
 }
 
 #if !ENABLE(C_LOOP)
-extern "C" void sanitizeStackForVMImpl(VM*);
+extern "C" void SYSV_ABI sanitizeStackForVMImpl(VM*);
 #endif
 
 JS_EXPORT_PRIVATE void sanitizeStackForVM(VM&);

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -91,6 +91,13 @@ public:
         : m_value(encodeFunc(ptr))
     { }
 
+#if OS(WINDOWS)
+    template<typename Out, typename... In>
+    constexpr CodePtr(Out(SYSV_ABI *ptr)(In...))
+        : m_value(encodeFunc(ptr))
+    { }
+#endif
+
 // MSVC doesn't seem to treat functions with different calling conventions as
 // different types; these methods already defined for fastcall, below.
 #if CALLING_CONVENTION_IS_STDCALL && !OS(WINDOWS)

--- a/Source/WTF/wtf/FunctionPtr.h
+++ b/Source/WTF/wtf/FunctionPtr.h
@@ -86,6 +86,12 @@ public:
         : m_ptr(encode(ptr))
     { }
 
+#if OS(WINDOWS)
+    constexpr FunctionPtr(Out(SYSV_ABI *ptr)(In...))
+        : m_ptr(encode(ptr))
+    { }
+#endif
+
 // MSVC doesn't seem to treat functions with different calling conventions as
 // different types; these methods already defined for fastcall, below.
 #if CALLING_CONVENTION_IS_STDCALL && !OS(WINDOWS)

--- a/Source/WTF/wtf/PlatformCallingConventions.h
+++ b/Source/WTF/wtf/PlatformCallingConventions.h
@@ -33,13 +33,18 @@
 
 /* Macros for specifing specific calling conventions. */
 
+#if OS(WINDOWS)
+#define SYSV_ABI __attribute__((sysv_abi))
+#else
+#define SYSV_ABI
+#endif
 
 #if CPU(X86) && COMPILER(MSVC)
 #define JSC_HOST_CALL_ATTRIBUTES __fastcall
 #elif CPU(X86) && COMPILER(GCC_COMPATIBLE)
 #define JSC_HOST_CALL_ATTRIBUTES __attribute__ ((fastcall))
 #else
-#define JSC_HOST_CALL_ATTRIBUTES
+#define JSC_HOST_CALL_ATTRIBUTES SYSV_ABI
 #endif
 
 #define JSC_ANNOTATE_HOST_FUNCTION(functionId, function)
@@ -83,6 +88,8 @@
 
 #if ENABLE(JIT) && CALLING_CONVENTION_IS_STDCALL
 #define JIT_OPERATION_ATTRIBUTES CDECL
+#elif OS(WINDOWS)
+#define JIT_OPERATION_ATTRIBUTES SYSV_ABI
 #else
 #define JIT_OPERATION_ATTRIBUTES
 #endif


### PR DESCRIPTION
#### 8f1711cf5f78246f4d8f77693eb046d370b293cc
<pre>
Use SystemV ABI for C++ entrypoints for JS LLInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=274064">https://bugs.webkit.org/show_bug.cgi?id=274064</a>

Reviewed by Yusuke Suzuki.

Switched register mapping on Windows to match the other x86-64 platforms
Added SystemV ABI function annotation to C++ entrypoints for JS LLInt
Disabed WebAssembly LLInt, as it doesn&apos;t work without JIT anyway, so we
can review the necessary changes there in another pull request.

* Source/JavaScriptCore/assembler/MaxFrameExtentForSlowPathCall.h:
* Source/JavaScriptCore/assembler/X86_64Registers.h:
* Source/JavaScriptCore/heap/MachineStackMarker.cpp:
(JSC::osRedZoneAdjustment):
* Source/JavaScriptCore/interpreter/VMEntryRecord.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::selectScratchGPR):
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::GPRInfo::toRegister):
(JSC::GPRInfo::toArgumentRegister):
(JSC::GPRInfo::toIndex):
(JSC::PreferredArgumentImpl::preferredArgumentJSR):
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::vmCalleeSaveRegisters):
(JSC::RegisterSetBuilder::llintBaselineCalleeSaveRegisters):
(JSC::RegisterSetBuilder::dfgCalleeSaveRegisters):
* Source/JavaScriptCore/llint/LLIntData.cpp:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_trace_operand):
(JSC::LLInt::llint_trace_value):
(JSC::LLInt::llint_default_call):
(JSC::LLInt::llint_virtual_call):
(JSC::LLInt::llint_slow_path_checkpoint_osr_exit_from_inlined_call):
(JSC::LLInt::llint_slow_path_checkpoint_osr_exit):
(JSC::LLInt::llint_throw_stack_overflow_error):
(JSC::LLInt::llint_stack_check_at_vm_entry):
(JSC::LLInt::llint_check_vm_entry_permission):
(JSC::LLInt::llint_dump_value):
(JSC::LLInt::llint_crash):
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/llint/LLIntThunks.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/offlineasm/x86.rb:
* Source/JavaScriptCore/runtime/MachineContext.h:
(JSC::MachineContext::llintInstructionPointer):
* Source/JavaScriptCore/runtime/PutPropertySlot.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/WTF/wtf/CodePtr.h:
(WTF::CodePtr::CodePtr):
* Source/WTF/wtf/FunctionPtr.h:
* Source/WTF/wtf/PlatformCallingConventions.h:

Canonical link: <a href="https://commits.webkit.org/278967@main">https://commits.webkit.org/278967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aee41b659c2f3b861ecda9e96eee22820805403

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2715 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42350 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26250 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2208 "Found 60 new test failures: editing/execCommand/primitive-value-cleanup-minimal.html, editing/execCommand/primitive-value.html, editing/execCommand/print.html, editing/execCommand/query-command-state.html, editing/execCommand/query-command-value-background-color.html, editing/execCommand/query-font-size-with-typing-style.html, editing/execCommand/query-font-size.html, editing/execCommand/query-format-block.html, editing/execCommand/query-text-alignment.html, editing/execCommand/query-text-decoration-with-typing-style.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/885 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45342 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56865 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51509 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49744 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49002 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29279 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63817 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7617 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28093 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12046 "Passed tests") | 
<!--EWS-Status-Bubble-End-->