### PR TITLE
[GLIB] Generate serialization for DMABuf classes

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2837,6 +2837,11 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/InbandTextTrackPrivate.serialization.in
 
+    platform/graphics/gbm/DMABufColorSpace.serialization.in
+    platform/graphics/gbm/DMABufFormat.serialization.in
+    platform/graphics/gbm/DMABufObject.serialization.in
+    platform/graphics/gbm/DMABufReleaseFlag.serialization.in
+
     platform/mediastream/MDNSRegisterError.serialization.in
 
     platform/network/ProtectionSpaceBase.serialization.in

--- a/Source/WebCore/platform/graphics/gbm/DMABufColorSpace.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufColorSpace.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Metrological Group B.V.
- * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2022-2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/platform/graphics/gbm/DMABufColorSpace.serialization.in
+++ b/Source/WebCore/platform/graphics/gbm/DMABufColorSpace.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/DMABufColorSpace.h>
+enum class WebCore::DMABufColorSpace : uint32_t {
+    Invalid,
+    SRGB,
+    BT601,
+    BT709,
+    BT2020,
+    SMPTE240M,
+};

--- a/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Metrological Group B.V.
- * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2022-2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,10 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+
+namespace IPC {
+template<typename T, typename U> struct ArgumentCoder;
+}
 
 namespace WebCore {
 
@@ -129,6 +133,15 @@ struct DMABufFormat {
         FourCC fourcc { FourCC::Invalid };
         unsigned horizontalSubsampling { 0 };
         unsigned verticalSubsampling { 0 };
+
+    private:
+        Plane(const FourCC& fourcc, const unsigned& hsValue, const unsigned& vsValue)
+            : fourcc(fourcc)
+            , horizontalSubsampling(hsValue)
+            , verticalSubsampling(vsValue)
+        { }
+
+        friend struct IPC::ArgumentCoder<Plane, void>;
     };
     std::array<Plane, c_maxPlanes> planes;
 };

--- a/Source/WebCore/platform/graphics/gbm/DMABufFormat.serialization.in
+++ b/Source/WebCore/platform/graphics/gbm/DMABufFormat.serialization.in
@@ -1,0 +1,73 @@
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/DMABufFormat.h>
+struct WebCore::DMABufFormat {
+    WebCore::DMABufFormat::FourCC fourcc;
+    unsigned numPlanes;
+
+    std::array<WebCore::DMABufFormat::Plane, 4> planes;
+};
+
+[Nested] enum class WebCore::DMABufFormat::FourCC : uint32_t {
+    Invalid,
+    R8,
+    GR88,
+    R16,
+    GR32,
+    XRGB8888,
+    XBGR8888,
+    RGBX8888,
+    BGRX8888,
+    ARGB8888,
+    ABGR8888,
+    RGBA8888,
+    BGRA8888,
+    RGB888,
+    BGR888,
+    I420,
+    YV12,
+    A420,
+    NV12,
+    NV21,
+    YUY2,
+    YVYU,
+    UYVY,
+    VYUY,
+    VUYA,
+    AYUV,
+    Y444,
+    Y41B,
+    Y42B,
+    P010,
+    P016,
+};
+
+[Nested] struct WebCore::DMABufFormat::Plane {
+    WebCore::DMABufFormat::FourCC fourcc;
+    unsigned horizontalSubsampling;
+    unsigned verticalSubsampling;
+};
+
+[Nested] enum class WebCore::DMABufFormat::Modifier : uint64_t {
+    Invalid,
+};

--- a/Source/WebCore/platform/graphics/gbm/DMABufObject.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufObject.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Metrological Group B.V.
- * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2022-2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,20 +40,6 @@
 namespace WebCore {
 
 struct DMABufObject {
-    WTF_MAKE_NONCOPYABLE(DMABufObject);
-
-    DMABufObject(uintptr_t handle)
-        : handle(handle)
-    { }
-
-    ~DMABufObject() = default;
-
-    DMABufObject(DMABufObject&&) = default;
-    DMABufObject& operator=(DMABufObject&&) = default;
-
-    template<class Encoder> void encode(Encoder&) &&;
-    template<class Decoder> static std::optional<DMABufObject> decode(Decoder&);
-
     uintptr_t handle { 0 };
     DMABufFormat format { };
     DMABufColorSpace colorSpace { DMABufColorSpace::Invalid };
@@ -66,73 +52,5 @@ struct DMABufObject {
     std::array<bool, DMABufFormat::c_maxPlanes> modifierPresent { false, false, false, false };
     std::array<uint64_t, DMABufFormat::c_maxPlanes> modifierValue { 0, 0, 0, 0 };
 };
-
-template<class Encoder>
-void DMABufObject::encode(Encoder& encoder) &&
-{
-    encoder << handle << uint32_t(format.fourcc) << uint32_t(colorSpace) << width << height
-        << WTFMove(releaseFlag) << WTFMove(fd) << offset << stride << modifierPresent << modifierValue;
-}
-
-template<class Decoder>
-std::optional<DMABufObject> DMABufObject::decode(Decoder& decoder)
-{
-    auto handle = decoder.template decode<uintptr_t>();
-    if (!handle)
-        return std::nullopt;
-
-    auto fourcc = decoder.template decode<uint32_t>();
-    if (!fourcc)
-        return std::nullopt;
-
-    auto colorSpace = decoder.template decode<uint32_t>();
-    if (!colorSpace)
-        return std::nullopt;
-
-    auto width = decoder.template decode<uint32_t>();
-    if (!width)
-        return std::nullopt;
-
-    auto height = decoder.template decode<uint32_t>();
-    if (!height)
-        return std::nullopt;
-
-    auto releaseFlag = decoder.template decode<DMABufReleaseFlag>();
-    if (!releaseFlag)
-        return std::nullopt;
-
-    auto fd = decoder.template decode<std::array<UnixFileDescriptor, DMABufFormat::c_maxPlanes>>();
-    if (!fd)
-        return std::nullopt;
-
-    auto offset = decoder.template decode<std::array<size_t, DMABufFormat::c_maxPlanes>>();
-    if (!offset)
-        return std::nullopt;
-
-    auto stride = decoder.template decode<std::array<uint32_t, DMABufFormat::c_maxPlanes>>();
-    if (!stride)
-        return std::nullopt;
-
-    auto modifierPresent = decoder.template decode<std::array<bool, DMABufFormat::c_maxPlanes>>();
-    if (!modifierPresent)
-        return std::nullopt;
-
-    auto modifierValue = decoder.template decode<std::array<uint64_t, DMABufFormat::c_maxPlanes>>();
-    if (!modifierValue)
-        return std::nullopt;
-
-    DMABufObject dmabufObject(*handle);
-    dmabufObject.format = DMABufFormat::create(*fourcc);
-    dmabufObject.colorSpace = DMABufColorSpace { *colorSpace };
-    dmabufObject.width = *width;
-    dmabufObject.height = *height;
-    dmabufObject.releaseFlag = WTFMove(*releaseFlag);
-    dmabufObject.fd = WTFMove(*fd);
-    dmabufObject.offset = WTFMove(*offset);
-    dmabufObject.stride = WTFMove(*stride);
-    dmabufObject.modifierPresent = WTFMove(*modifierPresent);
-    dmabufObject.modifierValue = WTFMove(*modifierValue);
-    return dmabufObject;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/DMABufObject.serialization.in
+++ b/Source/WebCore/platform/graphics/gbm/DMABufObject.serialization.in
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+header: <WebCore/DMABufObject.h>
+[CustomHeader] struct WebCore::DMABufObject {
+    uintptr_t handle;
+    WebCore::DMABufFormat format;
+    WebCore::DMABufColorSpace colorSpace;
+    uint32_t width;
+    uint32_t height;
+    WebCore::DMABufReleaseFlag releaseFlag;
+    std::array<UnixFileDescriptor, WebCore::DMABufFormat::c_maxPlanes> fd;
+    std::array<size_t, WebCore::DMABufFormat::c_maxPlanes> offset;
+    std::array<uint32_t, WebCore::DMABufFormat::c_maxPlanes> stride;
+    std::array<bool, WebCore::DMABufFormat::c_maxPlanes> modifierPresent;
+    std::array<uint64_t, WebCore::DMABufFormat::c_maxPlanes> modifierValue;
+}

--- a/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Metrological Group B.V.
- * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2022-2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,14 @@ struct DMABufReleaseFlag {
     {
         fd = { eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK), UnixFileDescriptor::Adopt };
     }
+
+    DMABufReleaseFlag(const UnixFileDescriptor& fd)
+        : fd(fd.duplicate())
+    { }
+
+    DMABufReleaseFlag(UnixFileDescriptor&& fd)
+        : fd(fd.duplicate())
+    { }
 
     ~DMABufReleaseFlag() = default;
 

--- a/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.serialization.in
+++ b/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.serialization.in
@@ -1,0 +1,27 @@
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/DMABufReleaseFlag.h>
+struct WebCore::DMABufReleaseFlag {
+    UnixFileDescriptor fd;
+};
+

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -621,6 +621,10 @@ set(WebCore_GENERATED_SERIALIZATION_IN_FILES
 
 set(WebCore_SERIALIZATION_IN_FILES
     ActivityState.serialization.in
+    DMABufColorSpace.serialization.in
+    DMABufFormat.serialization.in
+    DMABufObject.serialization.in
+    DMABufReleaseFlag.serialization.in
     DragActions.serialization.in
     InbandTextTrackPrivate.serialization.in
     IndexedDB.serialization.in

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -129,7 +129,7 @@ public:
     template<typename T>
     std::optional<T> decode()
     {
-        std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>, void>::decode(*this) };
+        std::optional<T> t { ArgumentCoder<std::remove_cvref_t<T>>::decode(*this) };
         if (UNLIKELY(!t))
             markInvalid();
         return t;

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -77,7 +77,7 @@ public:
     template<typename T>
     Encoder& operator<<(T&& t)
     {
-        ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
+        ArgumentCoder<std::remove_cvref_t<T>>::encode(*this, std::forward<T>(t));
         return *this;
     }
 


### PR DESCRIPTION
#### 4b241532961e42451c9ef18ea8d68bc9a993a934
<pre>
[GLIB] Generate serialization for DMABuf classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=274328">https://bugs.webkit.org/show_bug.cgi?id=274328</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).
* Added new serialization description files for `DMABufColorSpace`,
  `DMABufFormat`, `DMABufObject` and `DMABufReleaseFlag`.
* Removed custom encode/decode methods in `DMABufObject`.
* Fixed argument coder templates in `Encoder.h` and `Decoder.h` by
  removing unnecessary `void` parameters.
* Updated `CMakeLists.txt` in WebCore and WebKit to include DMABuf
  serialization files.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/platform/graphics/gbm/DMABufColorSpace.h:
* Source/WebCore/platform/graphics/gbm/DMABufColorSpace.serialization.in: Added.
* Source/WebCore/platform/graphics/gbm/DMABufFormat.h:
(WebCore::DMABufFormat::Plane::Plane):
* Source/WebCore/platform/graphics/gbm/DMABufFormat.serialization.in: Added.
* Source/WebCore/platform/graphics/gbm/DMABufObject.h:
(WebCore::DMABufObject::DMABufObject): Deleted.
(WebCore::DMABufObject::encode): Deleted.
(WebCore::DMABufObject::decode): Deleted.
* Source/WebCore/platform/graphics/gbm/DMABufObject.serialization.in: Added.
* Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h:
(WebCore::DMABufReleaseFlag::DMABufReleaseFlag):
* Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.serialization.in: Added.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decode):
* Source/WebKit/Platform/IPC/Encoder.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b241532961e42451c9ef18ea8d68bc9a993a934

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52073 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31400 "Hash 4b241532 for PR 28725 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4487 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55346 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2785 "Hash 4b241532 for PR 28725 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54377 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37781 "Failed to checkout and rebase branch from PR 28725") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2493 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42378 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/2785 "Hash 4b241532 for PR 28725 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54167 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/37781 "Failed to checkout and rebase branch from PR 28725") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/4487 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23449 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/37781 "Failed to checkout and rebase branch from PR 28725") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/4487 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/955 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/37781 "Failed to checkout and rebase branch from PR 28725") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/4487 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56943 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27191 "Hash 4b241532 for PR 28725 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/2493 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49773 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28428 "Hash 4b241532 for PR 28725 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/4487 "Hash 4b241532 for PR 28725 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48993 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29336 "Hash 4b241532 for PR 28725 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28169 "Hash 4b241532 for PR 28725 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->