### PR TITLE
[JSC] Fix jitCompileSIMDFunction when recompiling the same function with a compiled replacement in different mode

### DIFF
--- a/Source/JavaScriptCore/runtime/MemoryMode.h
+++ b/Source/JavaScriptCore/runtime/MemoryMode.h
@@ -28,15 +28,16 @@
 namespace JSC {
 
 // FIXME: We should support other modes. see: https://bugs.webkit.org/show_bug.cgi?id=162693
-enum class MemoryMode : uint8_t {
-    BoundsChecking,
+using MemoryModeType = uint8_t;
+enum class MemoryMode : MemoryModeType {
+    BoundsChecking = 0,
     Signaling,
 };
 
 static constexpr size_t numberOfMemoryModes = 2;
 
 enum class MemorySharingMode : uint8_t {
-    Default,
+    Default = 0,
     Shared,
 };
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -202,12 +202,12 @@ void BBQPlan::work(CompilationEffort effort)
                 IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
                 Locker locker { ipintCallee.tierUpCounter().m_lock };
                 ipintCallee.setReplacement(callee.copyRef(), mode());
-                ipintCallee.tierUpCounter().m_compilationStatus = IPIntTierUpCounter::CompilationStatus::Compiled;
+                ipintCallee.tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);
             } else {
                 LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
                 Locker locker { llintCallee.tierUpCounter().m_lock };
                 llintCallee.setReplacement(callee.copyRef(), mode());
-                llintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+                llintCallee.tierUpCounter().setCompilationStatus(mode(), LLIntTierUpCounter::CompilationStatus::Compiled);
             }
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -181,19 +181,19 @@ void OMGPlan::work(CompilationEffort)
             if (BBQCallee* bbqCallee = m_calleeGroup->bbqCallee(locker, m_functionIndex)) {
                 Locker locker { bbqCallee->tierUpCount()->getLock() };
                 bbqCallee->setReplacement(callee.copyRef());
-                bbqCallee->tierUpCount()->m_compilationStatusForOMG = TierUpCount::CompilationStatus::Compiled;
+                bbqCallee->tierUpCount()->setCompilationStatusForOMG(mode(), TierUpCount::CompilationStatus::Compiled);
             }
             if (Options::useWasmIPInt() && m_calleeGroup->m_ipintCallees) {
                 IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
                 Locker locker { ipintCallee.tierUpCounter().m_lock };
                 ipintCallee.setReplacement(callee.copyRef(), mode());
-                ipintCallee.tierUpCounter().m_compilationStatus = IPIntTierUpCounter::CompilationStatus::Compiled;
+                ipintCallee.tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);
             }
             if (!Options::useWasmIPInt() && m_calleeGroup->m_llintCallees) {
                 LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
                 Locker locker { llintCallee.tierUpCounter().m_lock };
                 llintCallee.setReplacement(callee.copyRef(), mode());
-                llintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+                llintCallee.tierUpCounter().setCompilationStatus(mode(), LLIntTierUpCounter::CompilationStatus::Compiled);
             }
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -162,14 +162,14 @@ void OSREntryPlan::work(CompilationEffort)
                 LLIntCallee* llintCallee = static_cast<LLIntCallee*>(m_callee.ptr());
                 Locker locker { llintCallee->tierUpCounter().m_lock };
                 llintCallee->setOSREntryCallee(callee.copyRef(), mode());
-                llintCallee->tierUpCounter().m_loopCompilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+                llintCallee->tierUpCounter().setLoopCompilationStatus(mode(), LLIntTierUpCounter::CompilationStatus::Compiled);
                 break;
             }
             case CompilationMode::IPIntMode: {
                 IPIntCallee* ipintCallee = static_cast<IPIntCallee*>(m_callee.ptr());
                 Locker locker { ipintCallee->tierUpCounter().m_lock };
                 ipintCallee->setOSREntryCallee(callee.copyRef(), mode());
-                ipintCallee->tierUpCounter().m_loopCompilationStatus = IPIntTierUpCounter::CompilationStatus::Compiled;
+                ipintCallee->tierUpCounter().setLoopCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);
                 break;
             }
             case CompilationMode::BBQMode: {
@@ -177,7 +177,7 @@ void OSREntryPlan::work(CompilationEffort)
                 Locker locker { bbqCallee->tierUpCount()->getLock() };
                 bbqCallee->setOSREntryCallee(callee.copyRef(), mode());
                 bbqCallee->tierUpCount()->osrEntryTriggers()[m_loopIndex] = TierUpCount::TriggerReason::CompilationDone;
-                bbqCallee->tierUpCount()->m_compilationStatusForOMGForOSREntry = TierUpCount::CompilationStatus::Compiled;
+                bbqCallee->tierUpCount()->setCompilationStatusForOMGForOSREntry(mode(), TierUpCount::CompilationStatus::Compiled);
                 break;
             }
             default:

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -63,7 +63,7 @@ public:
     void addCompletionTask(VM&, CompletionTask&&);
 
     void setMode(MemoryMode mode) { m_mode = mode; }
-    MemoryMode mode() const { return m_mode; }
+    ALWAYS_INLINE MemoryMode mode() const { return m_mode; }
 
     String errorMessage() const { return crossThreadCopy(m_errorMessage); }
 

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -129,7 +129,8 @@ static inline bool jitCompileAndSetHeuristics(Wasm::LLIntCallee* callee, Wasm::I
         return false;
     }
 
-    if (callee->replacement(instance->memory()->mode()))  {
+    MemoryMode memoryMode = instance->memory()->mode();
+    if (callee->replacement(memoryMode))  {
         dataLogLnIf(Options::verboseOSR(), "    Code was already compiled.");
         tierUpCounter.optimizeSoon();
         return true;
@@ -138,10 +139,10 @@ static inline bool jitCompileAndSetHeuristics(Wasm::LLIntCallee* callee, Wasm::I
     bool compile = false;
     {
         Locker locker { tierUpCounter.m_lock };
-        switch (tierUpCounter.m_compilationStatus) {
+        switch (tierUpCounter.compilationStatus(memoryMode)) {
         case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
             compile = true;
-            tierUpCounter.m_compilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
+            tierUpCounter.setCompilationStatus(memoryMode, Wasm::LLIntTierUpCounter::CompilationStatus::Compiling);
             break;
         case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
             tierUpCounter.optimizeAfterWarmUp();
@@ -158,7 +159,7 @@ static inline bool jitCompileAndSetHeuristics(Wasm::LLIntCallee* callee, Wasm::I
             plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
 #if ENABLE(WEBASSEMBLY_OMGJIT)
         else // No need to check OMG allow list: if we didn't want to compile this function, shouldJIT should have returned false.
-            plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), instance->memory()->mode(), Wasm::Plan::dontFinalize()));
+            plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), memoryMode, Wasm::Plan::dontFinalize()));
 #endif
 
         if (plan) {
@@ -170,14 +171,15 @@ static inline bool jitCompileAndSetHeuristics(Wasm::LLIntCallee* callee, Wasm::I
         }
     }
 
-    return !!callee->replacement(instance->memory()->mode());
+    return !!callee->replacement(memoryMode);
 }
 
 static inline bool jitCompileSIMDFunction(Wasm::LLIntCallee* callee, Wasm::Instance* instance)
 {
     Wasm::LLIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
 
-    if (callee->replacement(instance->memory()->mode()))  {
+    MemoryMode memoryMode = instance->memory()->mode();
+    if (callee->replacement(memoryMode))  {
         dataLogLnIf(Options::verboseOSR(), "    SIMD code was already compiled.");
         return true;
     }
@@ -185,16 +187,16 @@ static inline bool jitCompileSIMDFunction(Wasm::LLIntCallee* callee, Wasm::Insta
     bool compile = false;
     while (!compile) {
         Locker locker { tierUpCounter.m_lock };
-        switch (tierUpCounter.m_compilationStatus) {
+        switch (tierUpCounter.compilationStatus(memoryMode)) {
         case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
             compile = true;
-            tierUpCounter.m_compilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
+            tierUpCounter.setCompilationStatus(memoryMode, Wasm::LLIntTierUpCounter::CompilationStatus::Compiling);
             break;
         case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
-            // This spinlock is bad, but this is only temporary.
+            // FIXME: This spinlock is bad, but this is only temporary. https://bugs.webkit.org/show_bug.cgi?id=274326
             continue;
         case Wasm::LLIntTierUpCounter::CompilationStatus::Compiled:
-            RELEASE_ASSERT(!!callee->replacement(instance->memory()->mode()));
+            RELEASE_ASSERT(!!callee->replacement(memoryMode));
             return true;
         }
     }
@@ -206,15 +208,15 @@ static inline bool jitCompileSIMDFunction(Wasm::LLIntCallee* callee, Wasm::Insta
         plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
 #if ENABLE(WEBASSEMBLY_OMGJIT)
     else
-        plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), instance->memory()->mode(), Wasm::Plan::dontFinalize()));
+        plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), memoryMode, Wasm::Plan::dontFinalize()));
 #endif
 
     Wasm::ensureWorklist().enqueue(*plan);
     plan->waitForCompletion();
 
-    Locker locker { tierUpCounter.m_lock };
-    RELEASE_ASSERT(tierUpCounter.m_compilationStatus == Wasm::LLIntTierUpCounter::CompilationStatus::Compiled);
-    RELEASE_ASSERT(!!callee->replacement(instance->memory()->mode()));
+        Locker locker { tierUpCounter.m_lock };
+        RELEASE_ASSERT(tierUpCounter.compilationStatus(memoryMode) == Wasm::LLIntTierUpCounter::CompilationStatus::Compiled);
+        RELEASE_ASSERT(!!callee->replacement(memoryMode));
 
     return true;
 }
@@ -327,16 +329,17 @@ WASM_SLOW_PATH_DECL(loop_osr)
             WASM_RETURN_TWO(buffer, osrEntryCallee->entrypoint().taggedPtr());
         };
 
-        if (auto* osrEntryCallee = callee->osrEntryCallee(instance->memory()->mode()))
+        MemoryMode memoryMode = instance->memory()->mode();
+        if (auto* osrEntryCallee = callee->osrEntryCallee(memoryMode))
             return doOSREntry(osrEntryCallee);
 
         bool compile = false;
         {
             Locker locker { tierUpCounter.m_lock };
-            switch (tierUpCounter.m_loopCompilationStatus) {
+            switch (tierUpCounter.loopCompilationStatus(memoryMode)) {
             case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
                 compile = true;
-                tierUpCounter.m_loopCompilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
+                tierUpCounter.setLoopCompilationStatus(memoryMode, Wasm::LLIntTierUpCounter::CompilationStatus::Compiling);
                 break;
             case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
                 tierUpCounter.optimizeAfterWarmUp();
@@ -347,7 +350,7 @@ WASM_SLOW_PATH_DECL(loop_osr)
         }
 
         if (compile) {
-            Ref<Wasm::Plan> plan = adoptRef(*static_cast<Wasm::Plan*>(new Wasm::OSREntryPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), Ref<Wasm::Callee>(*callee), callee->functionIndex(), callee->hasExceptionHandlers(), osrEntryData.loopIndex, instance->memory()->mode(), Wasm::Plan::dontFinalize())));
+            Ref<Wasm::Plan> plan = adoptRef(*static_cast<Wasm::Plan*>(new Wasm::OSREntryPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), Ref<Wasm::Callee>(*callee), callee->functionIndex(), callee->hasExceptionHandlers(), osrEntryData.loopIndex, memoryMode, Wasm::Plan::dontFinalize())));
             Wasm::ensureWorklist().enqueue(plan.copyRef());
             if (UNLIKELY(!Options::useConcurrentJIT()))
                 plan->waitForCompletion();
@@ -355,7 +358,7 @@ WASM_SLOW_PATH_DECL(loop_osr)
                 tierUpCounter.optimizeAfterWarmUp();
         }
 
-        if (auto* osrEntryCallee = callee->osrEntryCallee(instance->memory()->mode()))
+        if (auto* osrEntryCallee = callee->osrEntryCallee(memoryMode))
             return doOSREntry(osrEntryCallee);
 
 #endif

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.cpp
@@ -38,6 +38,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TierUpCount);
 TierUpCount::TierUpCount()
 {
     setNewThreshold(Options::thresholdForOMGOptimizeAfterWarmUp());
+    m_compilationStatusForOMG.fill(CompilationStatus::NotCompiled);
+    m_compilationStatusForOMGForOSREntry.fill(CompilationStatus::NotCompiled);
 }
 
 TierUpCount::~TierUpCount() = default;

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.h
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.h
@@ -129,9 +129,15 @@ public:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
+    ALWAYS_INLINE CompilationStatus compilationStatusForOMG(MemoryMode mode) { return m_compilationStatusForOMG[static_cast<MemoryModeType>(mode)]; }
+    ALWAYS_INLINE void setCompilationStatusForOMG(MemoryMode mode, CompilationStatus status) { m_compilationStatusForOMG[static_cast<MemoryModeType>(mode)] = status; }
+
+    ALWAYS_INLINE CompilationStatus compilationStatusForOMGForOSREntry(MemoryMode mode) { return m_compilationStatusForOMGForOSREntry[static_cast<MemoryModeType>(mode)]; }
+    ALWAYS_INLINE void setCompilationStatusForOMGForOSREntry(MemoryMode mode, CompilationStatus status) { m_compilationStatusForOMGForOSREntry[static_cast<MemoryModeType>(mode)] = status; }
+
     Lock m_lock;
-    CompilationStatus m_compilationStatusForOMG { CompilationStatus::NotCompiled };
-    CompilationStatus m_compilationStatusForOMGForOSREntry { CompilationStatus::NotCompiled };
+    std::array<CompilationStatus, numberOfMemoryModes> m_compilationStatusForOMG;
+    std::array<CompilationStatus, numberOfMemoryModes> m_compilationStatusForOMGForOSREntry;
     SegmentedVector<TriggerReason, 16> m_osrEntryTriggers;
     Vector<uint32_t> m_outerLoops;
     Vector<std::unique_ptr<OSREntryData>> m_osrEntryData;


### PR DESCRIPTION
#### b53bf3051822348ead87b99a62f53bbcbe571ed8
<pre>
[JSC] Fix jitCompileSIMDFunction when recompiling the same function with a compiled replacement in different mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=274327">https://bugs.webkit.org/show_bug.cgi?id=274327</a>
<a href="https://rdar.apple.com/128141991">rdar://128141991</a>

Reviewed by Mark Lam and Yusuke Suzuki.

We might encounter a situation that a WASM SIMD function was previously compiled
with the fast memory in a Signaling mode, but failed and tried to recompile
the same function in a BoundsChecking mode. In that case, we should allow it
to be compiled.

To fix this issue, the compilation status should be tracked and updated for each
memory mode. This patch fixes all the potential issues among
WasmIPIntTierUpCounter.h, WasmLLIntTierUpCounter.h, and WasmTierUpCount.h.

* Source/JavaScriptCore/runtime/MemoryMode.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h:
(JSC::Wasm::IPIntTierUpCounter::IPIntTierUpCounter):
(JSC::Wasm::IPIntTierUpCounter::compilationStatus):
(JSC::Wasm::IPIntTierUpCounter::setCompilationStatus):
(JSC::Wasm::IPIntTierUpCounter::loopCompilationStatus):
(JSC::Wasm::IPIntTierUpCounter::setLoopCompilationStatus):
(): Deleted.
* Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h:
(JSC::Wasm::LLIntTierUpCounter::LLIntTierUpCounter):
(JSC::Wasm::LLIntTierUpCounter::compilationStatus):
(JSC::Wasm::LLIntTierUpCounter::setCompilationStatus):
(JSC::Wasm::LLIntTierUpCounter::loopCompilationStatus):
(JSC::Wasm::LLIntTierUpCounter::setLoopCompilationStatus):
(): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::triggerOMGReplacementCompile):
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmPlan.h:
(JSC::Wasm::Plan::mode const):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::jitCompileSIMDFunction):
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTierUpCount.cpp:
(JSC::Wasm::TierUpCount::TierUpCount):
* Source/JavaScriptCore/wasm/WasmTierUpCount.h:
(JSC::Wasm::TierUpCount::compilationStatusForOMG):
(JSC::Wasm::TierUpCount::setCompilationStatusForOMG):
(JSC::Wasm::TierUpCount::compilationStatusForOMGForOSREntry):
(JSC::Wasm::TierUpCount::setCompilationStatusForOMGForOSREntry):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/278957@main">https://commits.webkit.org/278957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea3336a6907752cfa5c3f8416c39c54c3002f313

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2764 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42368 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1765 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/934 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45397 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56922 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51559 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49764 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45025 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48980 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11398 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29308 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63866 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28145 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12060 "Passed tests") | 
<!--EWS-Status-Bubble-End-->