### PR TITLE
120Hz requestAnimationFrame is not supported on iPhone Pros, it is supported on iPad Pros

### DIFF
--- a/Source/WebKit/Platform/cocoa/CAFrameRateRangeUtilities.h
+++ b/Source/WebKit/Platform/cocoa/CAFrameRateRangeUtilities.h
@@ -41,6 +41,7 @@ static CAFrameRateRange highFrameRateRange()
 
 static CAHighFrameRateReason webAnimationHighFrameRateReason = CAHighFrameRateReasonMake(WEBKIT_HIGH_FRAME_RATE_REASON_COMPONENT, 1);
 static CAHighFrameRateReason keyboardScrollingAnimationHighFrameRateReason = CAHighFrameRateReasonMake(WEBKIT_HIGH_FRAME_RATE_REASON_COMPONENT, 2);
+static CAHighFrameRateReason preferPageRenderingUpdatesNear60FPSDisabledHighFrameRateReason = CAHighFrameRateReasonMake(WEBKIT_HIGH_FRAME_RATE_REASON_COMPONENT, 3);
 
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "CAFrameRateRangeUtilities.h"
 #import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
@@ -79,9 +80,14 @@ static void* displayRefreshRateObservationContext = &displayRefreshRateObservati
             [_displayLink.display addObserver:self forKeyPath:@"refreshRate" options:NSKeyValueObservingOptionNew context:displayRefreshRateObservationContext];
             _displayLink.paused = YES;
 
-            if (drawingAreaProxy && !drawingAreaProxy->page().preferences().preferPageRenderingUpdatesNear60FPSEnabled())
+            if (drawingAreaProxy && !drawingAreaProxy->page().preferences().preferPageRenderingUpdatesNear60FPSEnabled()) {
+#if HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
+                [_displayLink setPreferredFrameRateRange:WebKit::highFrameRateRange()];
+                [_displayLink setHighFrameRateReason:WebKit::preferPageRenderingUpdatesNear60FPSDisabledHighFrameRateReason];
+#else
                 _displayLink.preferredFramesPerSecond = (1.0 / _displayLink.maximumRefreshRate);
-            else
+#endif
+            } else
                 _displayLink.preferredFramesPerSecond = DisplayLinkFramesPerSecond;
         }
     }


### PR DESCRIPTION
#### 596b3b01497f3bd3b3ea653ec79ffc69d6f68b30
<pre>
120Hz requestAnimationFrame is not supported on iPhone Pros, it is supported on iPad Pros
<a href="https://bugs.webkit.org/show_bug.cgi?id=272165">https://bugs.webkit.org/show_bug.cgi?id=272165</a>
<a href="https://rdar.apple.com/126067757">rdar://126067757</a>

Reviewed by Simon Fraser.

In 273122@main we opted into higher frame rate animations when performed by Core Animation on
qualifying hardware. In 274234@main we did the same for scrolling animations resulting from
interacting with the keyboard (such as pressing the space bar).

We must do the same thing with the `CADisplayLink` created in `RemoteLayerTreeDrawingAreaProxyIOS`
which drives page rendering updates.

* Source/WebKit/Platform/cocoa/CAFrameRateRangeUtilities.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):

Canonical link: <a href="https://commits.webkit.org/278949@main">https://commits.webkit.org/278949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76e4cf2b67c6c636341cb63d0a04f8acd726533f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42339 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26236 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56852 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49730 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44945 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48929 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29253 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7610 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->