### PR TITLE
[WebGPU] A12x devices and earlier allowed for creation of more samplers than supported by the HW

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2127,6 +2127,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274275.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274317.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274317.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274334.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274334.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274334-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274334-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-274334.html
+++ b/LayoutTests/fast/webgpu/fuzz-274334.html
@@ -1,0 +1,10816 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {label: '\u48e2\u03ac\ud27b\u0b1c\udae6\u0b88\u312e\ub534\u145b'},
+  requiredFeatures: [
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 56,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 64488,
+    maxStorageTexturesPerShaderStage: 30,
+    maxStorageBuffersPerShaderStage: 30,
+    maxDynamicStorageBuffersPerPipelineLayout: 51489,
+    maxDynamicUniformBuffersPerPipelineLayout: 13438,
+    maxBindingsPerBindGroup: 6765,
+    maxTextureArrayLayers: 1336,
+    maxTextureDimension1D: 9992,
+    maxTextureDimension2D: 12587,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 29,
+    maxUniformBufferBindingSize: 203205787,
+    maxUniformBuffersPerShaderStage: 39,
+    maxSampledTexturesPerShaderStage: 18,
+    maxInterStageShaderVariables: 88,
+    maxInterStageShaderComponents: 87,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+let sampler0 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.04,
+});
+let querySet0 = device0.createQuerySet({label: '\uecc0\udd54\u39f9\u14d7\u6b1c\u8c38', type: 'occlusion', count: 660});
+let texture0 = device0.createTexture({
+  label: '\u{1ffbf}\u35e2\u7cbf\u0e01\u{1f7cf}\u0a05',
+  size: {width: 640, height: 80, depthOrArrayLayers: 743},
+  mipLevelCount: 5,
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-10x5-unorm', 'astc-10x5-unorm', 'astc-10x5-unorm'],
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u3cd5\u093a\u57b3\uafa7\u5d46'});
+let textureView0 = texture0.createView({
+  label: '\ua455\u0858\u0ed7\u157a\u86b1\u7278\u002a',
+  dimension: '2d',
+  mipLevelCount: 3,
+  baseArrayLayer: 492,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let sampler1 = device0.createSampler({
+  label: '\u{1fc53}\ud305\u{1fa7f}\u{1fa84}\uefa9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 97.67,
+  maxAnisotropy: 1,
+});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u0029\ue554\u{1f6fc}\ue795\u66bc\uc6a2\u{1fd50}\u1f4e\u0185\u{1fd8a}\ueb36'});
+let querySet1 = device0.createQuerySet({label: '\ub613\u1af8\u261c\u225c\u1e5b\uaa69\u69d2', type: 'occlusion', count: 3465});
+let computePassEncoder1 = commandEncoder1.beginComputePass();
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(955, 783);
+let commandEncoder2 = device0.createCommandEncoder({});
+let sampler2 = device0.createSampler({
+  label: '\u{1fafd}\uc833\u0216',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.32,
+  lodMaxClamp: 99.40,
+  maxAnisotropy: 5,
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1fcab}\u4385\u0e0e\u03ed\u{1f915}\ub3dc\u216e\u0a0b\u03a2\u22a0\u0d8d',
+  entries: [{binding: 1530, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u{1fca7}\ue038\u{1fd2f}\u1b25\u526d',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let buffer0 = device0.createBuffer({size: 513978, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder3 = device0.createCommandEncoder({label: '\u{1f9df}\u1037\ubdee'});
+let texture1 = device0.createTexture({
+  size: {width: 640},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u2dfd\u0654\u{1f728}\u82d1\u058d\u{1ffd3}\u2c3e\u0927',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u44e2\u83fb\u0d95\uaa6e\u66d9\ua27e\u0567'});
+let texture2 = device0.createTexture({
+  size: {width: 150, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1fbd9}\u{1f74d}\u51f1\u{1fc74}\u0569\u95c5\u0d65\u0e57\uc087',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+buffer0.unmap();
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+try {
+adapter0.label = '\ud1f7\u{1f856}\ua6e5\u{1f9c3}\ufdac\u09ed';
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({});
+let sampler3 = device0.createSampler({
+  label: '\u{1fe85}\ucd27\uf786\u{1fb01}\u0592',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.84,
+  maxAnisotropy: 15,
+});
+try {
+device0.queue.writeBuffer(buffer0, 180284, new BigUint64Array(41212), 35895, 600);
+} catch {}
+let textureView1 = texture2.createView({dimension: '2d-array', format: 'rg8uint', baseMipLevel: 2});
+let renderBundle0 = renderBundleEncoder0.finish();
+let sampler4 = device0.createSampler({
+  label: '\ucb2f\u0737\u{1f8a5}\u0771\u5db9\u52ed',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 47.15,
+  lodMaxClamp: 85.29,
+});
+try {
+commandEncoder3.clearBuffer(buffer0, 442012, 20260);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(116, 737);
+let video0 = await videoWithData();
+let shaderModule0 = device0.createShaderModule({
+  label: '\u9bfa\ufd86\u0749\uf698\u061a\u{1fc50}\u77ca',
+  code: `@group(2) @binding(1530)
+var<storage, read_write> function0: array<u32>;
+@group(3) @binding(1530)
+var<storage, read_write> function1: array<u32>;
+@group(0) @binding(1530)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(7, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(4) f1: vec4<f32>,
+  @location(2) f2: vec4<u32>,
+  @location(3) f3: vec4<i32>,
+  @location(1) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(19) a0: vec2<u32>, @location(14) a1: u32, @location(21) a2: f32, @location(16) a3: u32, @location(11) a4: vec4<f16>, @location(18) a5: vec4<f16>, @location(13) a6: vec3<f16>, @location(5) a7: vec4<f32>, @location(4) a8: vec2<u32>, @location(23) a9: f32, @location(1) a10: vec3<f32>, @location(3) a11: vec2<f32>, @location(12) a12: f32, @location(9) a13: vec4<f32>, @location(8) a14: vec3<u32>, @location(2) a15: u32, @location(10) a16: vec3<u32>, @location(15) a17: vec2<u32>, @location(20) a18: f32, @location(0) a19: vec3<f32>, @builtin(instance_index) a20: u32, @location(22) a21: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer1 = device0.createBuffer({
+  label: '\uc201\u{1f894}\u0a8d\u{1f7d9}\u1263\u0036\u729f\u12ca\u0d41\ud1f9',
+  size: 363354,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+});
+let renderBundle1 = renderBundleEncoder0.finish({});
+let imageData0 = new ImageData(220, 8);
+try {
+offscreenCanvas1.getContext('webgpu');
+} catch {}
+let textureView2 = texture1.createView({label: '\uba18\u{1f6b7}\u0026\u0cd4'});
+let pipeline0 = await device0.createRenderPipelineAsync({
+  label: '\u509d\u{1fdc6}\u4b84\u0fa6\u1c19\u{1f7bf}\u7e32',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x164e3ba1},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint'}, {format: 'rgba8unorm-srgb'}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2968,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 568, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 320, shaderLocation: 9},
+          {format: 'uint32x3', offset: 1276, shaderLocation: 19},
+          {format: 'uint8x4', offset: 16, shaderLocation: 2},
+          {format: 'uint16x2', offset: 1236, shaderLocation: 16},
+          {format: 'uint32x4', offset: 36, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 238, shaderLocation: 12},
+          {format: 'float16x2', offset: 432, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 368, shaderLocation: 5},
+          {format: 'uint32', offset: 136, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 300, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 912, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 120, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 448, shaderLocation: 20},
+          {format: 'uint16x4', offset: 1148, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 2792,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 80, shaderLocation: 14},
+          {format: 'float16x2', offset: 308, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 428, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 594, shaderLocation: 23},
+          {format: 'float16x4', offset: 836, shaderLocation: 21},
+          {format: 'float32x3', offset: 508, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+});
+let commandBuffer0 = commandEncoder2.finish();
+let textureView3 = texture0.createView({baseMipLevel: 2, baseArrayLayer: 723, arrayLayerCount: 13});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u0e96\u1a3c\u0e64\u1b89\ubcad\u0c9b\u{1f6e7}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\u{1fcd6}\u89a0\u{1fd29}\u0750\u5e45\ua11f\u{1f9a0}\u516c\u0255\u713e\u0243';
+} catch {}
+let commandBuffer1 = commandEncoder5.finish({label: '\u60e2\u{1fe14}\u{1fdbd}\u090a\u5aea\u{1fd6b}\uaf3c'});
+let textureView4 = texture1.createView({label: '\u2098\u14c7\u6b07\u904c\u8777\u{1f968}\u9218\uc098', aspect: 'all'});
+let renderBundle2 = renderBundleEncoder1.finish();
+let sampler5 = device0.createSampler({
+  label: '\uac61\ucf8e\u4d23\u4152',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.70,
+  lodMaxClamp: 86.70,
+  maxAnisotropy: 15,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u03f8');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\uab57\u5e25\u0529\u82ac\u07f6\u2c0f',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+try {
+  await promise0;
+} catch {}
+gc();
+let commandBuffer2 = commandEncoder3.finish({label: '\ubeee\u5c41\udc6f\u57d4\u0182\u333a'});
+let texture3 = device0.createTexture({
+  label: '\ued83\u8c24',
+  size: [1200, 192, 1],
+  mipLevelCount: 4,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView5 = texture3.createView({
+  label: '\u04b7\u{1fc93}\udea5\ub41f\u{1f691}\u5ff4\u57a1\u823e',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({label: '\u0fb8\u{1ff18}\u{1f9c1}\u9acf'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u5bf3\u0aba\u01d4\u0a99\u02e1',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let texture4 = device0.createTexture({
+  label: '\u37d7\u0831\u2b0c\u177b\uefaf',
+  size: [22],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+let textureView6 = texture3.createView({label: '\u07db\u73c7\u{1f94d}\u74c8\ub1d9\ue2af\u0c01\u426b', mipLevelCount: 1});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 506 */
+  offset: 462,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 22, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: {x: 5, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(8)), /* required buffer size: 874 */
+{offset: 874, bytesPerRow: 672}, {width: 284, height: 35, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({label: '\u{1fcef}\u8b24\u3f98\uec0e\uba9c\u8356\uf724'});
+let textureView7 = texture4.createView({aspect: 'all'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\ucf96\u1803\u{1fabe}\u91e9\u{1fec2}\ubedc\u0459',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+});
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4540, new BigUint64Array(8981), 4546, 1324);
+} catch {}
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.28,
+  lodMaxClamp: 62.33,
+  maxAnisotropy: 9,
+});
+let pipeline2 = await device0.createRenderPipelineAsync({
+  label: '\u0309\u06a4\u{1fb5b}\uadf9\u{1fddc}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 2946481896,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 32576,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 3700, shaderLocation: 16},
+          {format: 'float32x2', offset: 10136, shaderLocation: 23},
+          {format: 'uint16x4', offset: 5656, shaderLocation: 14},
+          {format: 'float32x3', offset: 4692, shaderLocation: 5},
+          {format: 'uint8x4', offset: 5796, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 9056,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 4116, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 456, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 3540, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 524, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 608, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 402, shaderLocation: 22},
+          {format: 'float16x4', offset: 668, shaderLocation: 9},
+          {format: 'float32x2', offset: 648, shaderLocation: 20},
+          {format: 'uint32x2', offset: 472, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 12052,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 3716, shaderLocation: 21},
+          {format: 'uint32x2', offset: 1808, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 392, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 25356, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5896,
+        attributes: [
+          {format: 'snorm8x4', offset: 2080, shaderLocation: 12},
+          {format: 'float32x4', offset: 1056, shaderLocation: 18},
+          {format: 'uint8x2', offset: 222, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 6460, attributes: [{format: 'uint32x3', offset: 1476, shaderLocation: 19}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw'},
+});
+offscreenCanvas1.width = 756;
+let offscreenCanvas2 = new OffscreenCanvas(639, 659);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let querySet2 = device0.createQuerySet({
+  label: '\u0b3e\u0e33\u8d60\uec6a\u81ea\u{1ff6a}\u0b23\u{1f606}\u{1f8a1}\u{1fae2}\u7aab',
+  type: 'occlusion',
+  count: 1546,
+});
+let texture5 = device0.createTexture({
+  size: [600],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let texture6 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle3 = renderBundleEncoder1.finish();
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 45660 */
+  offset: 45660,
+  bytesPerRow: 256,
+  rowsPerImage: 157,
+  buffer: buffer0,
+}, {width: 28, height: 6, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+  label: '\ue6ba\u07c9\u00e6\ude77\u{1f821}\u{1f8b4}\u08f5\u04f0',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let commandEncoder7 = device0.createCommandEncoder();
+let texture7 = device0.createTexture({
+  label: '\u{1f98c}\u9554\u15ca\u0776\u6507\ud978',
+  size: [300, 48, 1],
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1fd65}\u4dec\u{1fff0}\u0e27\u21f1\u{1f7f1}\u{1f621}\u0c61\u{1f904}\ueda6\u{1f7a8}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let sampler7 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 39.23,
+  lodMaxClamp: 46.01,
+});
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: {x: 1, y: 6, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(0)), /* required buffer size: 6232 */
+{offset: 53, bytesPerRow: 349, rowsPerImage: 77}, {width: 123, height: 18, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(884, 639);
+let commandEncoder8 = device0.createCommandEncoder({label: '\uebea\ud4b1\u0bea\u0a99'});
+let sampler8 = device0.createSampler({
+  label: '\u{1fd5e}\u0b32',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.60,
+  lodMaxClamp: 57.65,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 101, y: 459 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder5.label;
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 115, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 400 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13472 */
+  offset: 13472,
+  buffer: buffer1,
+}, {width: 100, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1f816}\u0965'});
+let textureView8 = texture0.createView({
+  label: '\u0d2e\u0b5a\u{1ff7a}\ub8fc\u4b31\ubcd9\u{1f8db}\uc7f0\u2149',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 398,
+});
+let renderBundle4 = renderBundleEncoder1.finish({label: '\u321c\u19af\u{1faa0}\u0d76\u0bc3\u03d3\u039d'});
+try {
+renderBundleEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder7.pushDebugGroup('\u898a');
+} catch {}
+let promise1 = device0.createComputePipelineAsync({
+  label: '\u9a2e\u0b2a\u12e2\u6fa9\u8b14\u{1f950}\u{1fc17}\u0743\u9557',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let textureView9 = texture7.createView({label: '\u084a\u{1f96f}\u9cd2\u{1fb48}\u{1fb0b}\u9ddc', format: 'rgba8unorm', baseMipLevel: 2});
+let externalTexture0 = device0.importExternalTexture({label: '\u929d\ub997\u{1f818}\u{1fdb2}', source: video0, colorSpace: 'srgb'});
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 31, y: 12, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer1, 25208, 15592);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 42, y: 131 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer2 = device0.createBuffer({label: '\u{1f7e4}\u0f45', size: 658554, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let externalTexture1 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 48, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 46868 */
+  offset: 42036,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 56, height: 19, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer0, 455816, 56252);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder7.popDebugGroup();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let computePassEncoder3 = commandEncoder6.beginComputePass();
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 103860);
+} catch {}
+let pipeline4 = device0.createComputePipeline({
+  label: '\u1af6\ufbb8\u0e76\u0017\u66b9\uc625\u7e21\u51f4\u0bd5',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u18d2\u0d89\u64da\u{1fc1c}'});
+let commandBuffer3 = commandEncoder8.finish({label: '\u{1f886}\u{1f89a}\u{1ff90}\u{1fb04}\u{1f95c}\u{1fc9a}\u598b\uc055\u904d'});
+let texture8 = device0.createTexture({
+  size: [176, 96, 196],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+try {
+renderBundleEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer2, 171632, buffer0, 20460, 113932);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 106320, new DataView(new ArrayBuffer(36656)), 19345, 5404);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u2718\u1ddb\u{1f8f3}\u{1f735}\u{1ffc5}',
+  entries: [{binding: 1494, visibility: 0, sampler: { type: 'filtering' }}],
+});
+let texture9 = device0.createTexture({
+  label: '\u0b7d\u3e23\u04ec\u{1fa25}',
+  size: [1280],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let pipeline5 = device0.createComputePipeline({
+  label: '\u4bf4\ucea4\u{1f753}\u9da0\u68b7\ufc53',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup0 = device0.createBindGroup({label: '\uf3f3\ub35e', layout: bindGroupLayout1, entries: [{binding: 1494, resource: sampler2}]});
+let computePassEncoder4 = commandEncoder9.beginComputePass({label: '\u{1f96f}\ud6ca\u{1f6a1}'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\ucad2\u08e6\ubd82\ub45c\u{1f6f5}\u6572\u2cb1\u0401\u0f16',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer1, 233512, 112780);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u1204');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 27, y: 15 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+  label: '\u09ee\udaca\ub796',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup1 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 1494, resource: sampler1}]});
+let commandBuffer4 = commandEncoder1.finish({label: '\u9c8e\u979d\u2149\u{1f7b8}\u{1facf}\u05a6'});
+let textureView10 = texture4.createView({label: '\u351b\u7f57\u02b9\u5c85\u963c\u2363\u69b9\ud2a0\u0a45', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'], depthReadOnly: true});
+let promise2 = buffer0.mapAsync(GPUMapMode.READ, 0, 192256);
+try {
+device0.queue.writeBuffer(buffer1, 27664, new BigUint64Array(2586), 1223, 332);
+} catch {}
+let pipeline7 = device0.createComputePipeline({
+  label: '\u{1fc5e}\u{1f929}\ub504\ud1cc\uc85a\u24f6\u0cb6\uaae8\u0a49\uc60f',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline8 = device0.createRenderPipeline({
+  label: '\u875b\ua4c3\u{1f8d2}\ud1e7\u0011\u4a49\u603a\u1898',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3712,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 848, shaderLocation: 15},
+          {format: 'uint8x4', offset: 1440, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 216, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 172, shaderLocation: 20},
+          {format: 'uint32x4', offset: 372, shaderLocation: 16},
+          {format: 'float32x2', offset: 492, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 18548,
+        attributes: [
+          {format: 'float32x3', offset: 2712, shaderLocation: 0},
+          {format: 'uint32', offset: 5988, shaderLocation: 10},
+          {format: 'uint16x4', offset: 4048, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 4092, shaderLocation: 11},
+          {format: 'float32x3', offset: 11928, shaderLocation: 12},
+          {format: 'uint16x4', offset: 104, shaderLocation: 4},
+          {format: 'float32x3', offset: 1832, shaderLocation: 23},
+          {format: 'float32x2', offset: 5868, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 404, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 3136, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 28, shaderLocation: 13},
+          {format: 'uint32x2', offset: 540, shaderLocation: 19},
+          {format: 'unorm16x2', offset: 4400, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 2732, shaderLocation: 1},
+          {format: 'uint8x2', offset: 784, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let canvas0 = document.createElement('canvas');
+try {
+window.someLabel = device0.label;
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2593,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 6303,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer3 = device0.createBuffer({size: 46261, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView11 = texture7.createView({format: 'rgba8unorm', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler9 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.04,
+  lodMaxClamp: 92.36,
+  maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder6.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+commandEncoder10.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10404 */
+  offset: 10404,
+  rowsPerImage: 297,
+  buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer1, 132316, 223072);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  label: '\u0931\u56eb\u9549\u0b15',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'keep', passOp: 'increment-clamp'},
+    stencilReadMask: 3504114541,
+    stencilWriteMask: 598939705,
+    depthBias: -1290126271,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13688,
+        attributes: [
+          {format: 'snorm8x4', offset: 316, shaderLocation: 12},
+          {format: 'float32x3', offset: 520, shaderLocation: 23},
+          {format: 'float16x4', offset: 324, shaderLocation: 9},
+          {format: 'uint32x3', offset: 308, shaderLocation: 2},
+          {format: 'uint32x3', offset: 2032, shaderLocation: 15},
+          {format: 'float32x3', offset: 348, shaderLocation: 22},
+          {format: 'uint8x2', offset: 3034, shaderLocation: 19},
+          {format: 'uint8x2', offset: 13686, shaderLocation: 14},
+          {format: 'float32', offset: 832, shaderLocation: 0},
+          {format: 'float32', offset: 852, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 2968, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 1304, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 5318, shaderLocation: 18},
+          {format: 'uint16x4', offset: 2672, shaderLocation: 10},
+          {format: 'uint32', offset: 2120, shaderLocation: 8},
+          {format: 'float32x2', offset: 3556, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 14816,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x4', offset: 8752, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 488, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 260, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 3304, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 8136, attributes: [{format: 'uint32x2', offset: 416, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let video1 = await videoWithData();
+try {
+adapter0.label = '\u2b9d\u042f\u{1fcc3}';
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture10 = device0.createTexture({
+  label: '\u289d\u167f',
+  size: {width: 160, height: 20, depthOrArrayLayers: 4},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint'],
+});
+let texture11 = gpuCanvasContext0.getCurrentTexture();
+let textureView12 = texture11.createView({label: '\u8e2b\u0b0e\u{1f628}\u0c18\u{1fc8b}\u106c', dimension: '2d-array'});
+let computePassEncoder5 = commandEncoder11.beginComputePass({});
+let renderBundle5 = renderBundleEncoder6.finish({});
+try {
+renderBundleEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer3, 11592, buffer1, 125776, 29336);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder10.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 580 widthInBlocks: 145 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11232 */
+  offset: 9884,
+  bytesPerRow: 768,
+  buffer: buffer1,
+}, {width: 145, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 15, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 54, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let pipeline10 = await promise1;
+let texture12 = device0.createTexture({
+  label: '\u23ac\u61b3\u7ad2\u9880\u8568',
+  size: [1280, 160, 38],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u9c8e\u{1f6c0}\uf65a',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+});
+let promise4 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext1 = offscreenCanvas2.getContext('webgpu');
+let buffer4 = device0.createBuffer({size: 269974, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandBuffer5 = commandEncoder10.finish({});
+let texture13 = device0.createTexture({
+  label: '\ubaa1\u{1fd09}\u7bcd\u845b\u{1ffab}\u{1f805}\u0c57\uccc8\u1720\ucf19\u0caf',
+  size: [160, 20, 79],
+  mipLevelCount: 7,
+  format: 'astc-5x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-5x4-unorm'],
+});
+let renderBundle6 = renderBundleEncoder6.finish();
+try {
+renderBundleEncoder4.setPipeline(pipeline0);
+} catch {}
+let promise5 = buffer4.mapAsync(GPUMapMode.WRITE, 0, 9896);
+try {
+commandEncoder7.copyBufferToBuffer(buffer3, 42328, buffer1, 188816, 1784);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 34 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 33438 */
+  offset: 33438,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 3, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 76 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5402 */
+  offset: 5402,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {width: 38, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+offscreenCanvas3.getContext('webgl2');
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 1530, resource: externalTexture0}]});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u0b6c\ufcae\ue0a1\u6cf3\ue17d\u{1f7d7}\ue4e5\u4073\u0019\u{1f82d}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(8, buffer3, 17584);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 33056 */
+  offset: 29216,
+  bytesPerRow: 256,
+  rowsPerImage: 1,
+  buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 16});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer0, 372832, 47092);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder();
+let querySet3 = device0.createQuerySet({
+  label: '\u9750\ub107\u595f\u65fe\u{1fcf5}\u8ae8\uede9\u9477\u0e07\u0f1f\u9056',
+  type: 'occlusion',
+  count: 2486,
+});
+let commandBuffer6 = commandEncoder7.finish({label: '\ub5ec\u{1f65a}\u0ecd\u6072\ubd73\uceed\u00de\u{1f792}\ud004\u0cf5\u618a'});
+let textureView13 = texture8.createView({label: '\udfae\ucb00\u79b0\u0cc3'});
+let externalTexture2 = device0.importExternalTexture({label: '\u35e5\ufc0c\u028d\ub05b', source: video1, colorSpace: 'srgb'});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let pipeline11 = await device0.createComputePipelineAsync({
+  label: '\u185e\u{1fb7c}\u0dca\ue95b\uc88b',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline12 = device0.createRenderPipeline({
+  label: '\u791e\uad5c\u1948\uc354\uc0a1\ufb75\u0079\u25b1\u0148',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xc7805196},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4076,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 1040, shaderLocation: 22},
+          {format: 'float32', offset: 1536, shaderLocation: 12},
+          {format: 'uint32x2', offset: 420, shaderLocation: 15},
+          {format: 'float16x2', offset: 936, shaderLocation: 20},
+          {format: 'float32x4', offset: 1980, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 1456, shaderLocation: 3},
+          {format: 'float32x4', offset: 304, shaderLocation: 0},
+          {format: 'uint32x4', offset: 892, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 12372,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 4064, shaderLocation: 21},
+          {format: 'float32x2', offset: 1084, shaderLocation: 13},
+          {format: 'float16x2', offset: 3672, shaderLocation: 5},
+          {format: 'uint32', offset: 5024, shaderLocation: 2},
+          {format: 'uint32x3', offset: 12, shaderLocation: 16},
+          {format: 'uint16x2', offset: 704, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 3584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 392, shaderLocation: 11},
+          {format: 'uint32x2', offset: 988, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 72, shaderLocation: 23},
+          {format: 'uint32', offset: 724, shaderLocation: 19},
+          {format: 'uint16x4', offset: 20, shaderLocation: 14},
+          {format: 'float16x2', offset: 1068, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 396, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+});
+video0.height = 218;
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u9254\u{1f6a7}\u{1ff34}\uc6b5',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1, bindGroupLayout1],
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u015d\u0346\u0324\u620b\u3bc5\u{1fd33}\u99ed'});
+try {
+renderBundleEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 33648 */
+  offset: 25732,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {width: 59, height: 16, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(967, 64);
+let commandEncoder14 = device0.createCommandEncoder({label: '\u1029\u{1f793}'});
+let textureView14 = texture3.createView({dimension: '2d-array', baseMipLevel: 2, baseArrayLayer: 0});
+let renderBundle7 = renderBundleEncoder4.finish();
+try {
+computePassEncoder5.setBindGroup(6, bindGroup1);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(4, bindGroup2, new Uint32Array(1509), 308, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(2, buffer3, 0, 37554);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer3, 8000, buffer1, 97736, 5208);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 145, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 440 widthInBlocks: 110 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16268 */
+  offset: 16268,
+  buffer: buffer1,
+}, {width: 110, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 39, y: 6, z: 114},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer0, 84012, 146168);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 794 */
+{offset: 794, bytesPerRow: 535}, {width: 130, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView15 = texture13.createView({
+  label: '\u0c5e\uf1aa\u{1f752}\u2d29\ubb3d\u{1ff95}\ueb8b\u462d\u0f5c\u0cd8',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 43,
+});
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 164 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4236 */
+  offset: 4236,
+  bytesPerRow: 512,
+  rowsPerImage: 101,
+  buffer: buffer3,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 6, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 41, height: 9, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer0, 304384, 196752);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandBuffer7 = commandEncoder12.finish();
+let textureView16 = texture7.createView({
+  label: '\ud02b\u07b2\u0ed6',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'rgba8unorm',
+  baseMipLevel: 2,
+});
+let computePassEncoder6 = commandEncoder14.beginComputePass({label: '\u0ef0\ufe71\u32ac\u543b\u7570\u5be6\u{1f954}'});
+let renderBundle8 = renderBundleEncoder7.finish({});
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 10208, new DataView(new ArrayBuffer(57267)), 51665, 592);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 1045 */
+{offset: 571, bytesPerRow: 234}, {width: 3, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\ucb4f\ub311\u0e3d\u0941\u6a7b\ue2bf\ua387',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u0c30\u41f8\u3396\u0ae3\u3e2b\u01f3\u03cc',
+  entries: [{binding: 6255, visibility: 0, sampler: { type: 'non-filtering' }}],
+});
+let bindGroup3 = device0.createBindGroup({
+  label: '\uf03f\u{1fb9b}\u0e85\udd0d',
+  layout: bindGroupLayout3,
+  entries: [{binding: 6255, resource: sampler4}],
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u365a\u0d58'});
+let querySet4 = device0.createQuerySet({
+  label: '\u{1fbe6}\ud9c3\u0c81\u005c\u4425\u020b\u{1f732}\u965f\u3c53\u{1fa0b}\u20cc',
+  type: 'occlusion',
+  count: 3636,
+});
+let commandBuffer8 = commandEncoder15.finish();
+let sampler10 = device0.createSampler({
+  label: '\u{1f9ae}\u30a0',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.08,
+  compare: 'never',
+  maxAnisotropy: 10,
+});
+let pipeline14 = device0.createRenderPipeline({
+  label: '\u081c\u{1f8c1}',
+  layout: pipelineLayout1,
+  multisample: {mask: 0x1e47e090},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 5928, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 18144,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 1016, shaderLocation: 9},
+          {format: 'uint8x4', offset: 4756, shaderLocation: 10},
+          {format: 'uint16x4', offset: 9400, shaderLocation: 16},
+          {format: 'float32x2', offset: 6052, shaderLocation: 13},
+          {format: 'float32x2', offset: 3964, shaderLocation: 12},
+          {format: 'uint8x4', offset: 15588, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 2572, shaderLocation: 22},
+          {format: 'uint16x2', offset: 7872, shaderLocation: 15},
+          {format: 'uint16x2', offset: 1000, shaderLocation: 8},
+          {format: 'float32x2', offset: 4072, shaderLocation: 3},
+          {format: 'uint32x4', offset: 4936, shaderLocation: 2},
+          {format: 'float32x3', offset: 5272, shaderLocation: 5},
+          {format: 'uint32x2', offset: 4468, shaderLocation: 4},
+          {format: 'float32', offset: 1832, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 1020, shaderLocation: 21},
+          {format: 'uint32', offset: 3080, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 4140, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 5196, shaderLocation: 23},
+          {format: 'float32x2', offset: 10132, shaderLocation: 20},
+          {format: 'snorm8x2', offset: 5242, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 680, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let texture14 = device0.createTexture({
+  size: {width: 176},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32sint'],
+});
+let textureView17 = texture7.createView({
+  label: '\u{1fee7}\u5f00\u24c8\u1279\u03e8\ua28c',
+  dimension: '2d-array',
+  format: 'rgba8unorm',
+  baseMipLevel: 2,
+});
+let computePassEncoder7 = commandEncoder13.beginComputePass({label: '\u16cf\u04c7\u{1fc46}\u{1faa1}\u3cbb\u376b\u231a\uf941\u019d\u01f8'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer3, 45468, buffer1, 321092, 64);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4436, new DataView(new ArrayBuffer(2535)), 1751, 356);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 2, y: 7 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise3;
+} catch {}
+gc();
+let videoFrame0 = new VideoFrame(canvas0, {timestamp: 0});
+let shaderModule1 = device0.createShaderModule({
+  label: '\u040b\u306f\u01b8\u798b',
+  code: `@group(1) @binding(1494)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(1530)
+var<storage, read_write> global1: array<u32>;
+@group(2) @binding(1494)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S0 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(6) f0: i32,
+  @location(0) f1: vec3<u32>,
+  @location(2) f2: vec2<u32>,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: vec4<i32>,
+  @location(3) f5: i32
+}
+
+@fragment
+fn fragment0(@location(54) a0: vec4<f16>, @location(36) a1: f32, @location(40) a2: f16, @builtin(front_facing) a3: bool, @builtin(sample_index) a4: u32, @builtin(sample_mask) a5: u32, a6: S0) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(54) f0: vec4<f16>,
+  @location(36) f1: f32,
+  @builtin(position) f2: vec4<f32>,
+  @location(40) f3: f16
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let textureView18 = texture4.createView({});
+let renderBundle9 = renderBundleEncoder2.finish({label: '\u{1f97e}\udfbe\u0d67\u2405\u6ba2\u{1fad2}\u602f'});
+let pipeline15 = device0.createRenderPipeline({
+  label: '\u7d1e\ud1e6\u1b5c\udb3c\u{1fcfb}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3832,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 108, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', unclippedDepth: true},
+});
+let texture15 = device0.createTexture({
+  label: '\u0b41\u0892\u220f',
+  size: {width: 2388, height: 128, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint'],
+});
+let textureView19 = texture0.createView({baseMipLevel: 4, baseArrayLayer: 533, arrayLayerCount: 92});
+let computePassEncoder8 = commandEncoder13.beginComputePass();
+let renderBundle10 = renderBundleEncoder0.finish({label: '\u{1fb95}\u4e18\u8eb7\u0163\ud43b\uc065\u3d79\u{1ffe6}\ua8b1\u38d7\u749e'});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder4.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer3, 0, 14204);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({
+  label: '\u5a35\u{1fcdb}\u244c\ueac8\u7b77\u{1f743}\u0d7d\u{1ffe4}\uf423',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let commandEncoder16 = device0.createCommandEncoder({label: '\u0cf3\u0c88\u0b45\uc975\u49a8\u2847\u82b8\u0cac\u9e1c\u0861'});
+let texture16 = device0.createTexture({
+  size: [640],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let renderBundle11 = renderBundleEncoder4.finish();
+let sampler11 = device0.createSampler({
+  label: '\u1e76\u0025\u{1ff72}\u{1fce6}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 12,
+});
+try {
+commandEncoder16.copyBufferToBuffer(buffer4, 121280, buffer0, 471780, 19048);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer0, 307844, 14076);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+offscreenCanvas4.getContext('bitmaprenderer');
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u{1fb4f}\ue564\uade1',
+  code: `@group(2) @binding(1530)
+var<storage, read_write> field0: array<u32>;
+@group(1) @binding(1530)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(1530)
+var<storage, read_write> n0: array<u32>;
+@group(3) @binding(1530)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<u32>,
+  @location(2) f2: vec3<u32>,
+  @location(3) f3: i32,
+  @location(4) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<f32>, @location(13) a1: i32, @location(18) a2: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let texture17 = device0.createTexture({
+  label: '\ue71c\u4ba3\u714d\u4540\uf7f0',
+  size: {width: 176, height: 96, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let texture18 = gpuCanvasContext0.getCurrentTexture();
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u{1ff13}\u0eb1\u{1fa67}\ue13e\uc032\u093d\uec07',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  sampleCount: 1,
+});
+let renderBundle12 = renderBundleEncoder10.finish({label: '\u9ed8\u7c2e\u3c0d\u127a'});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.09,
+  lodMaxClamp: 87.45,
+});
+try {
+computePassEncoder6.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 34 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6720 */
+  offset: 6720,
+  rowsPerImage: 278,
+  buffer: buffer1,
+}, {width: 17, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u{1f7e4}');
+} catch {}
+let img0 = await imageWithData(133, 120, '#e1a3942b', '#b482a3e0');
+let bindGroup4 = device0.createBindGroup({
+  label: '\u{1f861}\u{1f6e1}\u34c8\u{1fda2}\ua2b5\u3142\ua425\u{1fcd5}\u{1fe88}\u01f6',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1494, resource: sampler4}],
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  label: '\u{1fe37}\u{1f7e7}\u0cc9\ub730\u12db\ud146\uf2a3\u070a',
+  size: [320, 40, 1],
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let textureView20 = texture4.createView({label: '\ua0dd\u{1f75c}\u0e85\u4c08'});
+let computePassEncoder9 = commandEncoder17.beginComputePass();
+let externalTexture4 = device0.importExternalTexture({label: '\u0233\u{1ff06}\u0208\u3330\u05da\uedf7\ua587\u07d3\u0d60\u0501\u0afa', source: videoFrame0});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup2, new Uint32Array(4311), 3943, 0);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer3, 43572, 2678);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer3, 28112, buffer0, 471208, 15032);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 22108, new DataView(new ArrayBuffer(57179)), 49872, 720);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 67, y: 19 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise2;
+} catch {}
+let canvas1 = document.createElement('canvas');
+let imageData1 = new ImageData(52, 256);
+try {
+canvas1.getContext('webgpu');
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  label: '\u4ebd\ua612\u0b85\u1c3c\ua490\ua7e4\u344a\u0b65\u5d6b\u{1fceb}\uf896',
+  layout: bindGroupLayout3,
+  entries: [{binding: 6255, resource: sampler1}],
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\u0dab\u3f87\u82f0\u{1f738}\u0bf6\u20ea\u05d5\uaef2\u0741'});
+let texture20 = device0.createTexture({
+  label: '\u9fa8\ub450',
+  size: {width: 22},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView21 = texture6.createView({label: '\u0781\u7f66\uc90b\u0495\u{1f9e6}\u0d21\uba59\u704b\ub88d', dimension: '2d-array'});
+let renderBundle13 = renderBundleEncoder10.finish({label: '\u0ea0\u{1fae5}\u6a3a\uf61b\u{1feca}'});
+let externalTexture5 = device0.importExternalTexture({
+  label: '\ub27d\u77b0\u9f61\u0044\u0e52\u648b\u{1fef4}\u0723\u682b\u{1fbe0}',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup1, new Uint32Array(6929), 2188, 0);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline0);
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  label: '\u0b4a\u0278\u48f2\u29cc\u{1fddc}\u079d\u0cca\u8483\uea25',
+  layout: 'auto',
+  multisample: {mask: 0x596e6eac},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba8unorm-srgb'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4508,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 196, shaderLocation: 13},
+          {format: 'float16x2', offset: 396, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 16184,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 3588, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(video0);
+let video2 = await videoWithData();
+let commandEncoder19 = device0.createCommandEncoder({});
+let commandBuffer9 = commandEncoder18.finish({});
+let texture21 = device0.createTexture({
+  label: '\u5b5b\u2f28\u0c95\u{1faee}\u457a\u0486\u{1fc5b}\u32e9',
+  size: [160],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture22 = gpuCanvasContext0.getCurrentTexture();
+let textureView22 = texture3.createView({label: '\u61b6\u0d0e\ucd8b\u221c\u3b1d\u463f\u49bc\ua25a', dimension: '2d-array', mipLevelCount: 3});
+let externalTexture6 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 43140 */
+  offset: 43140,
+  rowsPerImage: 3,
+  buffer: buffer3,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline19 = await device0.createRenderPipelineAsync({
+  label: '\ua9a1\uafe8\u{1ffa4}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg16sint', writeMask: GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 23956,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x3', offset: 4452, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 5536, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 9780, attributes: []},
+      {arrayStride: 1492, attributes: [{format: 'float32', offset: 384, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+try {
+  await promise5;
+} catch {}
+let img1 = await imageWithData(72, 294, '#076bf94a', '#19693504');
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'], depthReadOnly: true});
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5276 */
+  offset: 4192,
+  bytesPerRow: 512,
+  rowsPerImage: 104,
+  buffer: buffer1,
+}, {width: 30, height: 3, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 180, y: 102 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline20 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let bindGroup6 = device0.createBindGroup({
+  label: '\uc06b\u053b\ub658\u0124',
+  layout: bindGroupLayout0,
+  entries: [{binding: 1530, resource: externalTexture4}],
+});
+let texture23 = device0.createTexture({
+  label: '\u06f8\u{1f7f2}\u{1f634}\u0125\u9b8f',
+  size: [88],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8uint'],
+});
+try {
+computePassEncoder5.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 44756 */
+  offset: 44756,
+  buffer: buffer3,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21540 */
+  offset: 21540,
+  buffer: buffer1,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync({
+  label: '\u{1faa6}\u{1ffbb}',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x15a031f4},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.RED}, {format: 'rg16sint'}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 5320, attributes: [{format: 'float32x4', offset: 3900, shaderLocation: 2}]}],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+let video3 = await videoWithData();
+try {
+canvas0.getContext('2d');
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\u0c77\u525c\u41ff\ubf37\u0fc8\u7019\u0b3f\u{1ffce}'});
+let computePassEncoder10 = commandEncoder16.beginComputePass({label: '\u{1fe30}\u{1ff6b}\u6aa0\u{1f9d0}\u007d\u9521\u3de3\u{1f773}\u5b08'});
+try {
+renderBundleEncoder8.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer3, 0);
+} catch {}
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 608 widthInBlocks: 152 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32888 */
+  offset: 32280,
+  buffer: buffer1,
+}, {width: 152, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\u02e5\u0228\u0b3e\u0415\u3ac2\u80ea\u7934\u02ed',
+  code: `@group(2) @binding(1494)
+var<storage, read_write> local1: array<u32>;
+@group(1) @binding(1494)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(2, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<u32>,
+  @location(0) f1: vec3<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(3) f3: vec2<i32>,
+  @location(1) f4: vec3<i32>,
+  @location(6) f5: vec3<u32>,
+  @location(4) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(22) f0: vec4<i32>,
+  @location(16) f1: u32,
+  @builtin(vertex_index) f2: u32,
+  @location(19) f3: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S1, @location(11) a1: f32, @location(23) a2: vec2<f32>, @location(13) a3: vec4<u32>, @location(5) a4: vec2<u32>, @location(14) a5: vec2<u32>, @location(6) a6: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView23 = texture16.createView({label: '\uf731\u{1fc9f}\u6a49\u{1f9a7}\u4fee', baseArrayLayer: 0});
+let computePassEncoder11 = commandEncoder20.beginComputePass({label: '\u7ed5\u3e05\u027a\u06fb\u05ee\ua2dc'});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(9, buffer3);
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\u{1fe77}\u7ac4\u2750',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup7 = device0.createBindGroup({label: '\u39e5\u08bf\ucfd0', layout: bindGroupLayout3, entries: [{binding: 6255, resource: sampler4}]});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 126});
+let commandBuffer10 = commandEncoder19.finish({label: '\u97b9\ub731\u7492\u{1ff26}\ub0dc\u05de'});
+let textureView24 = texture19.createView({label: '\u{1ffee}\u24cb', dimension: '2d-array'});
+let externalTexture7 = device0.importExternalTexture({
+  label: '\u605c\u{1f72b}\u61ec\ue92f\u{1fc79}\u66af\u{1fd2c}\u7d86\ud7cb',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder6.setBindGroup(5, bindGroup6, new Uint32Array(5026), 2645, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(4, bindGroup7);
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+  label: '\ucd89\u{1fe1c}\u{1ff3c}\u00fd\u5a5f\u0c6b\u0827\ub472\u0efa',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline24 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x89cd7ddb},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4432,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 3484, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 21588,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x2', offset: 15100, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 7612,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 724, shaderLocation: 18}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', unclippedDepth: false},
+});
+let video4 = await videoWithData();
+let imageData2 = new ImageData(252, 116);
+let commandEncoder21 = device0.createCommandEncoder({label: '\u{1fe93}\u0ceb\u{1f794}\ub0bb'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\uf512\u{1fc7a}\u9c32\u75e6\u520c\u{1ff87}\u004a\ufbf8',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+});
+try {
+computePassEncoder10.setBindGroup(5, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer3);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(527, 795);
+let computePassEncoder12 = commandEncoder21.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(6, bindGroup6, []);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer9, commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 62492, new Float32Array(26556), 24599, 1316);
+} catch {}
+let pipeline25 = await device0.createComputePipelineAsync({
+  label: '\u1d2b\u138a',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder22 = device0.createCommandEncoder({label: '\u{1fbd3}\u352a\ue572\u8431\u{1fa9f}\u1041\u0b67'});
+let textureView25 = texture9.createView({label: '\u02b4\u43b8\u3480\u7e55\u14bb\u8a30\u{1f822}\u01de\u09fb\u0980', baseArrayLayer: 0});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(4, bindGroup3, new Uint32Array(5708), 3303, 0);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(504, undefined);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer2, 183468, buffer0, 152780, 171960);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+renderBundleEncoder12.pushDebugGroup('\u0ea8');
+} catch {}
+let pipeline26 = device0.createComputePipeline({
+  label: '\u09df\u55c4\udd22\ub461\u5be1\u099d\u00a1\u0456\u{1fbec}\u0fb9',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline27 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {mask: 0x4004a474},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-src'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 24972, attributes: []},
+      {
+        arrayStride: 1540,
+        attributes: [
+          {format: 'float32', offset: 728, shaderLocation: 18},
+          {format: 'float32x2', offset: 440, shaderLocation: 6},
+          {format: 'sint32x2', offset: 436, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let commandEncoder23 = device0.createCommandEncoder();
+let texture24 = device0.createTexture({
+  label: '\u878a\u0b55\ue880\u0e07\u9df1\u5ef6\uf7cd\u079f',
+  size: {width: 1194},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView26 = texture1.createView({label: '\u0723\uf696\u{1fbae}\u0781\u0a60\u2b2a\u00ab'});
+let renderBundle14 = renderBundleEncoder9.finish();
+let sampler13 = device0.createSampler({
+  label: '\u0777\u05e0',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.82,
+  maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder8.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline14);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(82352, 9028);
+try {
+commandEncoder22.copyBufferToBuffer(buffer2, 532384, buffer0, 249800, 44760);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11716 */
+  offset: 11712,
+  buffer: buffer3,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline28 = device0.createComputePipeline({
+  label: '\u0ae0\ua69f\u0975\u40ce\u56ae',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline29 = device0.createRenderPipeline({
+  label: '\u0e96\u013a\u{1fe50}\u1f44\u{1f98d}\u0c38\u81a4',
+  layout: pipelineLayout2,
+  multisample: {mask: 0xa8f3e2fc},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint'}, {format: 'r16uint'}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 2441343391,
+    stencilWriteMask: 3222705127,
+    depthBiasSlopeScale: 526.0234114475494,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 27896, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 3836,
+        attributes: [
+          {format: 'float16x2', offset: 1580, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 464, shaderLocation: 23},
+          {format: 'uint32x2', offset: 2328, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 68, shaderLocation: 11},
+          {format: 'uint16x4', offset: 324, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 4368,
+        attributes: [
+          {format: 'sint32', offset: 280, shaderLocation: 22},
+          {format: 'uint32x3', offset: 284, shaderLocation: 14},
+          {format: 'uint16x2', offset: 424, shaderLocation: 5},
+          {format: 'uint8x4', offset: 2164, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+});
+let videoFrame1 = new VideoFrame(videoFrame0, {timestamp: 0});
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup5, new Uint32Array(921), 431, 0);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9944 */
+  offset: 688,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 37, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer1, 22836, 263660);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 148, y: 7 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture25 = device0.createTexture({
+  label: '\u{1fd08}\u{1fc63}\u0940',
+  size: {width: 1194, height: 64, depthOrArrayLayers: 166},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView27 = texture24.createView({label: '\u{1f9fa}\u0720\u66f3\u087b\u0ab9\u0a0b\u{1f838}\u{1fdfd}'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u2c54\u{1fcf7}\u4c4e',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+commandEncoder22.copyBufferToBuffer(buffer4, 181564, buffer0, 499080, 13916);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 892 */
+  offset: 892,
+  buffer: buffer3,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let video5 = await videoWithData();
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout2, bindGroupLayout0, bindGroupLayout3]});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u{1fcc9}\u4bf5\u{1f803}\u5ff1\u0c75\u464f\u{1ff93}\u6d63\u8545'});
+let commandBuffer11 = commandEncoder24.finish({label: '\u00ab\uc3d9'});
+let texture26 = gpuCanvasContext0.getCurrentTexture();
+let textureView28 = texture0.createView({dimension: '2d', baseMipLevel: 3, baseArrayLayer: 110});
+let externalTexture8 = device0.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer1, 199700, 113412);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 0, new Float32Array(14579), 9254, 516);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame2 = new VideoFrame(img0, {timestamp: 0});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u5dec\u9690\u0c59'});
+let texture27 = device0.createTexture({
+  size: [22, 12, 95],
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView29 = texture16.createView({label: '\u0372\u9503\u3158', arrayLayerCount: 1});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0287\u0237\uca71\u{1f963}\u0e6d\u0608\u{1fc72}\u18c3\u88ff',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+});
+try {
+renderBundleEncoder5.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer0, 73408, 197652);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 458, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 111 */
+{offset: 111}, {width: 133, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 522, y: 608 },
+  flipY: true,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1fe1d}\u{1fa0b}\u0160\u6279\u0281\u{1fde8}\u2fe0\u09c7'});
+try {
+renderBundleEncoder13.setBindGroup(4, bindGroup6, new Uint32Array(1850), 116, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer4]);
+} catch {}
+let externalTexture9 = device0.importExternalTexture({
+  label: '\ubc54\ud0a9\u{1f815}\u039b\u19d9\u01ed\uab0e\u0c29\ufd77\u05b0\ue6f9',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder5.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer3, 44032);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2412 */
+  offset: 2412,
+  rowsPerImage: 119,
+  buffer: buffer3,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer8, commandBuffer6, commandBuffer11]);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let canvas3 = document.createElement('canvas');
+let buffer5 = device0.createBuffer({size: 135990, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u328d\u0237\ueaed'});
+let renderBundle15 = renderBundleEncoder10.finish({label: '\u30fa\u937e\u{1f736}\u08af\u7e55\u018a\u{1ff43}\u4d0c\uc777\ub55d'});
+try {
+computePassEncoder4.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer3, 10032, 10496);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7060 */
+  offset: 7060,
+  buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 192, y: 23 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+  label: '\u{1f710}\u{1f88f}',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', passOp: 'invert'},
+    stencilBack: {failOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 970657061,
+    stencilWriteMask: 1484594323,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1340,
+        attributes: [
+          {format: 'uint8x4', offset: 8, shaderLocation: 6},
+          {format: 'uint16x2', offset: 1336, shaderLocation: 5},
+          {format: 'uint16x4', offset: 96, shaderLocation: 13},
+          {format: 'uint32x4', offset: 184, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 740, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 45740,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 7708, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 9072, shaderLocation: 11},
+          {format: 'sint32x4', offset: 236, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 13840, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder28 = device0.createCommandEncoder({label: '\u8156\ud2ca\u0de0\u7994'});
+let texture28 = device0.createTexture({
+  label: '\u087c\uc6d2\u{1fc3c}\u0452\u069b\u02cd\u{1f88f}',
+  size: [1280, 160, 38],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let texture29 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder11.setBindGroup(5, bindGroup6, new Uint32Array(3834), 679, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(2, buffer3, 0);
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(103128, 296);
+let promise8 = device0.queue.onSubmittedWorkDone();
+let pipeline31 = device0.createRenderPipeline({
+  label: '\u{1fd95}\u{1f852}\u38d9\uc191',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'invert'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 2105322046,
+    stencilWriteMask: 2882327752,
+    depthBias: 1871615120,
+    depthBiasSlopeScale: 154.98144447893523,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 17420,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 10992, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+let img2 = await imageWithData(274, 46, '#c6585c68', '#1be6df1c');
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u0f6c\u{1fb3f}',
+  entries: [
+    {
+      binding: 4160,
+      visibility: 0,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d' },
+    },
+    {binding: 5244, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 2527,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u0376\u0071\u{1f651}\u5baa\ubf3c\u25e2'});
+let textureView30 = texture4.createView({
+  label: '\u2505\ubeb3\u0979\u{1f961}\ufc9b\u{1ff25}',
+  aspect: 'all',
+  format: 'rg8uint',
+  arrayLayerCount: 1,
+});
+let computePassEncoder13 = commandEncoder29.beginComputePass({label: '\ue86f\u{1f9b4}\u{1f78c}\u{1fe90}\u528f\ufb9e'});
+try {
+renderBundleEncoder5.setVertexBuffer(1, buffer3, 0, 32448);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer5, 128900, buffer1, 71448, 3472);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder12.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 109, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 48 */
+{offset: 48}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 207, y: 110 },
+  flipY: false,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+  label: '\u{1f9a4}\u6335\uafd1\ucbdb\u{1f8ee}\u{1fcfb}\u04ef\ue07a\uddee\u56d7',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+try {
+  await promise8;
+} catch {}
+try {
+canvas2.getContext('webgl');
+} catch {}
+let texture30 = device0.createTexture({
+  label: '\u4176\ub4ce\ub2fc\u080b\u{1f926}\u{1ff6f}\uec70\u{1fdd0}\u0006\u5f17',
+  size: {width: 600, height: 96, depthOrArrayLayers: 195},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+let renderBundle16 = renderBundleEncoder6.finish();
+try {
+renderBundleEncoder5.draw(983445413, 959863833, 588210028);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let pipeline33 = device0.createRenderPipeline({
+  label: '\u11be\u0591\u6fca\u0f55\ub716\u982b',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0xbc3ec647},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 1809987209,
+    stencilWriteMask: 1781392148,
+    depthBias: -1294580409,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 258.6703788004626,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [{arrayStride: 5380, attributes: [{format: 'unorm8x4', offset: 48, shaderLocation: 2}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let imageData3 = new ImageData(180, 132);
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u364f\u09d4\u1a63\u0e24\u{1fcb8}',
+  entries: [
+    {binding: 4420, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 981,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u077e\u6e7a\u326b\u8c85\u{1fbb3}\u{1f683}\u4f40\u0e67\u0ef9\u04d3\u27d4',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+let sampler14 = device0.createSampler({
+  label: '\u{1fead}\u{1fe1b}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.26,
+  lodMaxClamp: 30.48,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1);
+} catch {}
+let pipeline34 = device0.createComputePipeline({
+  label: '\u3b13\u32cc\u66c5\u968d\u4e95\u0d0c',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+try {
+  await promise4;
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1fa95}\u6523\u88c6\u2bac\u{1f79f}'});
+let textureView31 = texture20.createView({label: '\u{1ff4d}\uad02\ufe0e', aspect: 'all', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(491716839, 336435239, 519526736, -1124731482);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14008 */
+  offset: 14008,
+  rowsPerImage: 276,
+  buffer: buffer5,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 496 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 41744 */
+  offset: 41744,
+  buffer: buffer0,
+}, {width: 124, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer0, 22028, 283388);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 58},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2858993 */
+{offset: 8, bytesPerRow: 401, rowsPerImage: 264}, {width: 160, height: 10, depthOrArrayLayers: 28});
+} catch {}
+let texture31 = device0.createTexture({
+  label: '\u6bf3\u5059\u0da9\u{1f9b1}\u0ff6\u0145\u{1fa41}',
+  size: {width: 640, height: 80, depthOrArrayLayers: 1097},
+  mipLevelCount: 9,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture32 = gpuCanvasContext0.getCurrentTexture();
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\ueb8d\uae9e\u08a5\u01e9\uc0d3\u0202\u{1f6a3}\u2733\u5d3c\u60fb',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+});
+try {
+renderBundleEncoder5.draw(54962106, 219595796, 559691461, 296991883);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(689085558, 304789818, 230161604, 642919033, 684088899);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 34484);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22268 */
+  offset: 22268,
+  bytesPerRow: 256,
+  rowsPerImage: 139,
+  buffer: buffer3,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 23, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 104 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 61042 */
+  offset: 20386,
+  bytesPerRow: 256,
+  rowsPerImage: 150,
+  buffer: buffer0,
+}, {width: 104, height: 9, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 211, y: 10 },
+  flipY: true,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture33 = device0.createTexture({
+  size: {width: 88, height: 48, depthOrArrayLayers: 1213},
+  mipLevelCount: 6,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView32 = texture27.createView({
+  label: '\u{1fc02}\uf762\u{1f84f}\u{1f964}\u01fa',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 44,
+});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 198460);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 31476);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline27);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 54 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 49820 */
+  offset: 49766,
+  buffer: buffer0,
+}, {width: 27, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData4 = new ImageData(24, 124);
+try {
+window.someLabel = texture1.label;
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u{1fa3a}\u3abe',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout5, bindGroupLayout5, bindGroupLayout5, bindGroupLayout2, bindGroupLayout3, bindGroupLayout5],
+});
+let texture34 = device0.createTexture({
+  label: '\u15ff\uf8dd\u{1f7fd}\uacc0\u0ac8\ud226',
+  size: {width: 298},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder14 = commandEncoder26.beginComputePass({label: '\u53ef\u1034\u62ed\u7d3f\u{1ffef}\u043a\u0600\u5c36\uee5e\u3d34\u06dd'});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(82888303, 569856819);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 57492);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(8, buffer3, 4596);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let buffer6 = device0.createBuffer({
+  label: '\uec46\uf679\uc61c\u0f55\u4686\udbc5',
+  size: 248254,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture35 = device0.createTexture({
+  label: '\u{1fb9b}\ud460\u44c1\u0d82\u7386\u0be7\ua589',
+  size: {width: 640, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let computePassEncoder15 = commandEncoder22.beginComputePass({label: '\u1a34\u{1f67e}'});
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer2, 324868, buffer0, 315240, 164352);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 3460});
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer3, 15756, 5299);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer5, 8412, buffer1, 70028, 10144);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 42 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7530 */
+  offset: 7530,
+  buffer: buffer0,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 33, y: 13, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 16, y: 138 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise10 = device0.createComputePipelineAsync({
+  label: '\u0fda\u853f\u0907\u{1f6f7}\u549a',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let offscreenCanvas6 = new OffscreenCanvas(426, 281);
+let shaderModule4 = device0.createShaderModule({
+  label: '\u0ccc\u{1ff5e}\u827f\ub17c\ueeac\ua764\ue868',
+  code: `@group(1) @binding(1530)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(1530)
+var<storage, read_write> parameter0: array<u32>;
+@group(3) @binding(1530)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(8, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @location(48) f0: vec3<f32>,
+  @location(74) f1: vec2<i32>,
+  @location(84) f2: vec4<u32>,
+  @location(49) f3: f16,
+  @location(21) f4: u32,
+  @location(13) f5: i32,
+  @location(70) f6: vec2<f16>,
+  @location(10) f7: vec2<u32>,
+  @location(46) f8: vec2<i32>,
+  @location(57) f9: vec2<f16>,
+  @location(1) f10: vec4<f16>,
+  @location(19) f11: u32,
+  @builtin(sample_mask) f12: u32,
+  @location(56) f13: u32,
+  @location(6) f14: f16,
+  @location(28) f15: vec2<u32>,
+  @builtin(front_facing) f16: bool,
+  @location(50) f17: vec3<f16>,
+  @location(2) f18: f16
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(3) f1: vec3<i32>,
+  @location(2) f2: u32,
+  @location(4) f3: vec4<f32>,
+  @location(0) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(a0: S2, @location(24) a1: vec2<f32>, @location(4) a2: vec2<f16>, @location(31) a3: vec3<u32>, @location(34) a4: vec4<f32>, @location(8) a5: vec3<u32>, @location(76) a6: vec2<i32>, @location(82) a7: vec4<i32>, @location(0) a8: vec3<u32>, @location(58) a9: vec4<f16>, @location(45) a10: f16, @location(55) a11: vec3<f16>, @location(39) a12: vec4<f16>, @location(37) a13: vec2<f16>, @location(65) a14: vec3<i32>, @location(77) a15: vec2<f16>, @location(83) a16: vec3<f32>, @location(36) a17: f32, @location(15) a18: vec3<i32>, @location(64) a19: i32, @location(80) a20: u32, @location(78) a21: vec3<f16>, @builtin(position) a22: vec4<f32>, @builtin(sample_index) a23: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(64) f4: i32,
+  @location(57) f5: vec2<f16>,
+  @location(6) f6: f16,
+  @location(34) f7: vec4<f32>,
+  @location(2) f8: f16,
+  @location(19) f9: u32,
+  @location(50) f10: vec3<f16>,
+  @location(28) f11: vec2<u32>,
+  @location(49) f12: f16,
+  @location(84) f13: vec4<u32>,
+  @location(45) f14: f16,
+  @location(21) f15: u32,
+  @location(1) f16: vec4<f16>,
+  @location(58) f17: vec4<f16>,
+  @location(76) f18: vec2<i32>,
+  @location(70) f19: vec2<f16>,
+  @location(13) f20: i32,
+  @location(36) f21: f32,
+  @builtin(position) f22: vec4<f32>,
+  @location(39) f23: vec4<f16>,
+  @location(31) f24: vec3<u32>,
+  @location(8) f25: vec3<u32>,
+  @location(10) f26: vec2<u32>,
+  @location(55) f27: vec3<f16>,
+  @location(82) f28: vec4<i32>,
+  @location(83) f29: vec3<f32>,
+  @location(78) f30: vec3<f16>,
+  @location(24) f31: vec2<f32>,
+  @location(65) f32: vec3<i32>,
+  @location(37) f33: vec2<f16>,
+  @location(0) f34: vec3<u32>,
+  @location(4) f35: vec2<f16>,
+  @location(48) f36: vec3<f32>,
+  @location(77) f37: vec2<f16>,
+  @location(74) f38: vec2<i32>,
+  @location(80) f39: u32,
+  @location(56) f40: u32,
+  @location(15) f41: vec3<i32>,
+  @location(46) f42: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout6 = device0.createBindGroupLayout({label: '\u956f\u{1f8c5}\u{1fd93}', entries: []});
+let commandBuffer12 = commandEncoder25.finish({label: '\u{1fd77}\ue3f0\u0637\u0763'});
+let texture36 = device0.createTexture({
+  label: '\u273d\ua1f9\u1633\u{1f886}\u2b3b\uedbc',
+  size: {width: 597, height: 32, depthOrArrayLayers: 459},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView33 = texture2.createView({dimension: '2d-array', baseMipLevel: 2});
+let externalTexture10 = device0.importExternalTexture({label: '\u999d\u4cb3\u7bd1\u1994\u{1f853}\uc156', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder8.draw(737298919, 271213432, 963128296, 1016383155);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(235478045, 64728679, 380624097, -478791665, 580107093);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer1, 67528);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 11216);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 23064 */
+  offset: 23064,
+  rowsPerImage: 205,
+  buffer: buffer5,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let buffer7 = device0.createBuffer({
+  label: '\u1297\u{1fb10}\u02db\u32a7',
+  size: 6723,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u8446\u8e55\u08f1\ud55b\uf130\u{1fb4d}\u47f6\ud41d\u06d9\u0824',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let externalTexture11 = device0.importExternalTexture({label: '\u9b0c\u5faf', source: video4});
+try {
+computePassEncoder4.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(51166306, 410092748);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer1, 23992);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5160 */
+  offset: 5160,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 3, y: 17 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas5.getContext('webgpu');
+let textureView34 = texture33.createView({dimension: '2d', baseMipLevel: 5, baseArrayLayer: 506});
+let computePassEncoder16 = commandEncoder14.beginComputePass({label: '\u0911\u64d1\ubc29\u09d9\uf96d'});
+let externalTexture12 = device0.importExternalTexture({label: '\uf89d\u{1f760}\u8bf7\u72e7\u0614\u97b6\u065f', source: video1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 63856);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline27);
+} catch {}
+let pipeline35 = await promise10;
+gc();
+let buffer8 = device0.createBuffer({
+  size: 167149,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle17 = renderBundleEncoder11.finish({label: '\uff37\u7a4a\u4370\u0b75\u{1ffc5}\u0176\u00f9\u2fd2\u0d90'});
+try {
+renderBundleEncoder8.drawIndexed(1060892158, 809854819, 4565386, 162921797, 1129575559);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer6, 138432, buffer1, 358816, 684);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5120 */
+  offset: 5120,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 151, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 464, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 136, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 832, new DataView(new ArrayBuffer(54246)), 6229, 588);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView35 = texture3.createView({
+  label: '\u5a73\u01d3\u0e62\u0e7b\u0f17\ue271\u1cce\u{1fff7}\u0b17',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let computePassEncoder17 = commandEncoder30.beginComputePass({label: '\u5d88\u78bc\u29fd\u460f\u07cc\u096c\u534e\u1172'});
+try {
+renderBundleEncoder12.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.draw(345981025, 1144391419);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 97, y: 179 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = device0.createComputePipeline({
+  label: '\ucfd3\u{1f7f6}\u0053\u7222',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let textureView36 = texture21.createView({label: '\ufb84\u34c5\u413f\u8bc4\ucbfd\u{1ffb3}\u0976\u0332\u9494\u087a\u6641', mipLevelCount: 1});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\u0819\u7e4b\u0fa5\u4308\u6f07\u095c\u0697\u1e3c\u0645',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer3, 0, 31918);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise9;
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u281f\u857f',
+  code: `@group(0) @binding(6255)
+var<storage, read_write> n1: array<u32>;
+@group(3) @binding(6255)
+var<storage, read_write> local2: array<u32>;
+@group(1) @binding(2593)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(62) f0: vec3<f32>,
+  @location(8) f1: u32,
+  @location(43) f2: vec3<u32>,
+  @location(74) f3: vec2<u32>,
+  @location(33) f4: vec2<f32>,
+  @location(42) f5: vec3<u32>,
+  @location(5) f6: vec2<f16>,
+  @location(19) f7: f32,
+  @location(24) f8: vec3<u32>,
+  @location(16) f9: vec4<u32>,
+  @location(70) f10: vec3<i32>,
+  @location(22) f11: vec2<i32>,
+  @location(67) f12: vec4<f32>,
+  @location(13) f13: vec4<i32>,
+  @location(50) f14: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec3<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(2) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec2<f32>, @location(68) a1: vec2<u32>, a2: S3, @location(64) a3: i32, @location(84) a4: vec4<f16>, @location(18) a5: vec4<i32>, @builtin(position) a6: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(16) f43: vec4<u32>,
+  @location(70) f44: vec3<i32>,
+  @location(68) f45: vec2<u32>,
+  @location(33) f46: vec2<f32>,
+  @location(19) f47: f32,
+  @location(13) f48: vec4<i32>,
+  @location(22) f49: vec2<i32>,
+  @location(50) f50: vec2<i32>,
+  @location(84) f51: vec4<f16>,
+  @location(74) f52: vec2<u32>,
+  @location(43) f53: vec3<u32>,
+  @location(5) f54: vec2<f16>,
+  @location(8) f55: u32,
+  @location(11) f56: vec2<f32>,
+  @location(64) f57: i32,
+  @location(18) f58: vec4<i32>,
+  @builtin(position) f59: vec4<f32>,
+  @location(42) f60: vec3<u32>,
+  @location(24) f61: vec3<u32>,
+  @location(67) f62: vec4<f32>,
+  @location(62) f63: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: f32, @location(23) a1: vec2<f32>, @location(12) a2: vec4<f32>, @location(10) a3: vec3<i32>, @location(19) a4: vec2<u32>, @location(20) a5: vec4<i32>, @location(18) a6: vec3<f32>, @location(16) a7: vec4<i32>, @location(13) a8: u32, @location(3) a9: i32, @location(7) a10: u32, @location(0) a11: u32, @location(2) a12: vec4<i32>, @location(21) a13: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let querySet7 = device0.createQuerySet({label: '\uc082\u{1fca1}\uc299\u000d\uaade\ufbf3\u7312\ue9ff\u0411', type: 'occlusion', count: 3731});
+let textureView37 = texture29.createView({label: '\ub5d5\u0307\ucf5f\ufc14', dimension: '2d-array'});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 11648);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer1, 60132);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer8, 'uint16', 111246, 52673);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(9, buffer8, 0, 55660);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer0, 209396, 22564);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker('\u61d1');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+offscreenCanvas6.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder();
+let texture37 = device0.createTexture({
+  label: '\u0df3\u{1f783}\u{1ff35}\u{1f8c0}\u{1fddf}\ua56d\u{1f967}',
+  size: {width: 600, height: 96, depthOrArrayLayers: 1643},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture14 = device0.importExternalTexture({label: '\u06c7\u9b66\u9a20\uce46\ud44c\u{1fa3e}\u6713', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder8.drawIndexed(601542701, 457798787, 638725251, -465895016, 657157726);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer8, 'uint32', 40152, 6867);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline8);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 126, y: 4, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 143, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(229234), /* required buffer size: 229234 */
+{offset: 818, bytesPerRow: 276, rowsPerImage: 162}, {width: 41, height: 18, depthOrArrayLayers: 6});
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u32d4\u4692\u{1f93a}\u{1f79d}\u{1f799}\u{1feee}\u486f'});
+let texture38 = device0.createTexture({
+  label: '\u7d73\uf1fc\u07ab\u2e1b\u{1fb08}\ud11b\u0f99\u{1ff86}\u5643\u6da9',
+  size: [44, 24, 1],
+  mipLevelCount: 4,
+  format: 'eac-rg11unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['eac-rg11unorm'],
+});
+let textureView38 = texture25.createView({label: '\u{1fd21}\ud6c5\u{1f956}\u38f5', baseMipLevel: 6});
+let renderBundle18 = renderBundleEncoder6.finish({});
+let externalTexture15 = device0.importExternalTexture({label: '\u5701\u2989\u3556\u0dd6', source: videoFrame2});
+try {
+computePassEncoder14.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer8, 71092);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer6, 108440, buffer0, 257108, 54540);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer1, 132296, 141924);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let pipeline37 = device0.createComputePipeline({
+  label: '\ubd3c\u{1f8f3}\ueb4b',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let textureView39 = texture22.createView({label: '\ua963\u0020\u15f3\u7dbb\u0d24\u022c\u3b77\u1a86\ub121\u8a0a', baseArrayLayer: 0});
+let externalTexture16 = device0.importExternalTexture({
+  label: '\u8096\u7f80\u0456\uabd2\u{1ff67}\u{1f910}\u7210\u{1ff72}\ufe52\u{1ff40}\u0ff9',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer1, 187180);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 106712);
+} catch {}
+try {
+commandEncoder31.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 15, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 204 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7260 */
+  offset: 7260,
+  buffer: buffer0,
+}, {width: 51, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer0, 347584, 92016);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker('\udfcc');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 20, y: 48 },
+  flipY: false,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture39 = device0.createTexture({
+  label: '\uc9cf\u14bc\u58f5',
+  size: [640, 80, 1],
+  mipLevelCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let textureView40 = texture6.createView({label: '\u25f6\u{1fcac}\u45ef', dimension: '2d-array', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder18 = commandEncoder28.beginComputePass({});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u56f6\ua1bf',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder18.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder5.draw(119725772, 365674369);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer2, 299900, buffer0, 511608, 1912);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder();
+let renderBundle19 = renderBundleEncoder16.finish({label: '\u04df\u1e00\ubc3a\u0aee'});
+try {
+renderBundleEncoder8.drawIndexed(168870587, 472084291, 680565792);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 996 widthInBlocks: 249 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23188 */
+  offset: 23188,
+  buffer: buffer0,
+}, {width: 249, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer0, 255912, 212408);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline38 = await device0.createRenderPipelineAsync({
+  label: '\uae3c\ue9cd\u12b6\u0b3b\u0cb8',
+  layout: pipelineLayout4,
+  multisample: {mask: 0x34f4c7a9},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'always', failOp: 'keep', depthFailOp: 'increment-clamp', passOp: 'keep'},
+    stencilBack: {failOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 3103795284,
+    depthBias: 33528475,
+    depthBiasSlopeScale: 994.598385409595,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 2072,
+        attributes: [
+          {format: 'uint8x2', offset: 158, shaderLocation: 16},
+          {format: 'float32x4', offset: 796, shaderLocation: 11},
+          {format: 'float32x2', offset: 860, shaderLocation: 19},
+          {format: 'uint32x2', offset: 1184, shaderLocation: 14},
+          {format: 'float16x2', offset: 780, shaderLocation: 23},
+          {format: 'sint8x2', offset: 574, shaderLocation: 22},
+          {format: 'uint32x2', offset: 84, shaderLocation: 6},
+          {format: 'uint16x2', offset: 444, shaderLocation: 13},
+          {format: 'uint8x4', offset: 992, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+document.body.prepend(video2);
+let textureView41 = texture13.createView({
+  label: '\ufb66\u8720',
+  format: 'astc-5x4-unorm',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 50,
+  arrayLayerCount: 4,
+});
+try {
+renderBundleEncoder5.draw(805328140, 978552115, 53116069, 410608525);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 15724);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8728 */
+  offset: 8728,
+  rowsPerImage: 133,
+  buffer: buffer5,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 33008 */
+  offset: 33008,
+  buffer: buffer0,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 192 */
+{offset: 188}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout7 = pipeline8.getBindGroupLayout(3);
+let commandEncoder35 = device0.createCommandEncoder({label: '\u5c61\u00f7\u299c'});
+let querySet8 = device0.createQuerySet({label: '\u06b9\u06a6\u0ca7\u043a\ub7e3\u1333\u2db6\u8612', type: 'occlusion', count: 1194});
+let renderBundle20 = renderBundleEncoder13.finish({label: '\u082b\uc9af\u{1ff50}\ubcd8'});
+let externalTexture17 = device0.importExternalTexture({label: '\u{1fcdf}\ua3bb\u0945\u083e\u04ab\u7458', source: video2});
+try {
+renderBundleEncoder5.draw(360083602, 723831763, 63508829, 704906415);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline8);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let querySet9 = device0.createQuerySet({label: '\uac5a\u0f61\u344e\u{1fac4}', type: 'occlusion', count: 679});
+let textureView42 = texture38.createView({label: '\ue968\u059b\u{1fdbd}\ufc9f\u05b6\u5a61\u166e', dimension: '2d-array', baseMipLevel: 3});
+let renderBundle21 = renderBundleEncoder6.finish({});
+try {
+renderBundleEncoder5.setBindGroup(5, bindGroup6, new Uint32Array(511), 354, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 59788);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 32512);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 460 widthInBlocks: 115 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3648 */
+  offset: 3648,
+  buffer: buffer1,
+}, {width: 115, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder32.clearBuffer(buffer7, 2164, 2380);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 25, y: 59 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+  label: '\uc231\u4cb3\u01f9\u5082\u044b',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint'}, {format: 'r16uint'}, {format: 'r32sint', writeMask: 0}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17668,
+        attributes: [
+          {format: 'float32x2', offset: 4280, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 7160, shaderLocation: 6},
+          {format: 'sint32x2', offset: 16088, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+});
+try {
+  await promise7;
+} catch {}
+gc();
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1869});
+let texture40 = device0.createTexture({
+  label: '\u5e80\u0fda',
+  size: [22, 12, 156],
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+});
+let textureView43 = texture17.createView({
+  label: '\ubd92\u2fb7\u8748\u4d86\ud7b9\u195e\u0c12\u{1fd7f}\u0e68\u0b93',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let sampler15 = device0.createSampler({
+  label: '\ud430\ud129\u09a8\u0e7b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 48.16,
+  maxAnisotropy: 20,
+});
+try {
+commandEncoder33.copyBufferToBuffer(buffer4, 197716, buffer7, 532, 1848);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer7, 5500, 284);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u9e35');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 16, y: 8 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let textureView44 = texture33.createView({
+  label: '\u{1fb15}\ue07c\ue2d8\u{1f994}\u07bd',
+  mipLevelCount: 3,
+  baseArrayLayer: 722,
+  arrayLayerCount: 6,
+});
+try {
+renderBundleEncoder5.draw(296615396, 91175828);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 19120);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 34580);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(9, buffer3, 4168);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer0, 453452, 39628);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 236280, new Int16Array(18823), 499, 7052);
+} catch {}
+let texture41 = device0.createTexture({
+  size: [600, 96, 251],
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder17.setBindGroup(4, bindGroup6, new Uint32Array(9072), 2890, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(752817194, 168501952, 957270821, 256090068);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 564, new BigUint64Array(64391), 8239, 84);
+} catch {}
+let pipeline40 = await device0.createRenderPipelineAsync({
+  label: '\u{1f8e5}\u5e23\ub46e\u7058\u9c43\ue29d\ud1c6\ub981\u1a9d\u{1f80c}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x98156e8d},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 1104, shaderLocation: 1},
+          {format: 'float32x4', offset: 44, shaderLocation: 3},
+          {format: 'float32x4', offset: 540, shaderLocation: 12},
+          {format: 'float32x2', offset: 436, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 17456,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 764, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 1136, shaderLocation: 9},
+          {format: 'uint8x4', offset: 2044, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 9756, shaderLocation: 0},
+          {format: 'uint32x4', offset: 1256, shaderLocation: 2},
+          {format: 'uint32x2', offset: 428, shaderLocation: 8},
+          {format: 'uint32x2', offset: 4536, shaderLocation: 15},
+          {format: 'float32', offset: 2484, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 3336,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 256, shaderLocation: 22},
+          {format: 'float16x2', offset: 244, shaderLocation: 5},
+          {format: 'uint32x2', offset: 1244, shaderLocation: 4},
+          {format: 'uint8x4', offset: 68, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 1344, shaderLocation: 11},
+          {format: 'uint32x2', offset: 384, shaderLocation: 16},
+          {format: 'float32x3', offset: 720, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 848,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 520, shaderLocation: 14}],
+      },
+      {arrayStride: 56, attributes: []},
+      {arrayStride: 4012, attributes: []},
+      {arrayStride: 23392, attributes: []},
+      {arrayStride: 7344, stepMode: 'instance', attributes: []},
+      {arrayStride: 17416, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5520,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x4', offset: 1464, shaderLocation: 21}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let imageData5 = new ImageData(180, 192);
+let pipelineLayout5 = device0.createPipelineLayout({label: '\ue2af\ua121\u5e14\u0bf6\u{1fc2d}\u05d1\u29bc', bindGroupLayouts: []});
+let commandEncoder36 = device0.createCommandEncoder({label: '\u0196\u1251\uddca\u730e\u{1fb8c}\u0186\u0fa5'});
+let texture42 = device0.createTexture({
+  label: '\u{1fba9}\ud027\ud201\u8232\u6d98',
+  size: {width: 44, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView45 = texture13.createView({
+  label: '\u0994\u51ea\u848d\u0950\u06a3\u9ca8\u0c1b\u9bcd\u00a3\ucb1a\uf125',
+  format: 'astc-5x4-unorm',
+  baseMipLevel: 5,
+  baseArrayLayer: 62,
+  arrayLayerCount: 4,
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.50,
+  maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder12.setVertexBuffer(3, buffer3, 14172, 21190);
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.WRITE, 0, 94036);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer8, 8300, buffer0, 382708, 83596);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 140972, new Float32Array(25452), 12980, 900);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 986 */
+{offset: 870, bytesPerRow: 232, rowsPerImage: 157}, {width: 58, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline41 = await device0.createComputePipelineAsync({
+  label: '\u{1fe36}\u9599\u70c2\u00b5\u2044\u7f29\u0fd7\u0fd6\u21e3\u{1f61c}\u0032',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let pipeline42 = device0.createRenderPipeline({
+  label: '\u942a\u5631\u43aa\u0751',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x2552d05f},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 934601132,
+    depthBias: 762125001,
+    depthBiasSlopeScale: 96.47450005793019,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 37404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 6912, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 1360, shaderLocation: 0},
+          {format: 'uint32x4', offset: 136, shaderLocation: 10},
+          {format: 'float32x3', offset: 4412, shaderLocation: 20},
+          {format: 'uint8x2', offset: 15702, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 14582, shaderLocation: 1},
+          {format: 'float32x3', offset: 10756, shaderLocation: 3},
+          {format: 'float32x4', offset: 1356, shaderLocation: 18},
+          {format: 'uint32x3', offset: 6600, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 21716, shaderLocation: 9},
+          {format: 'uint32', offset: 13984, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 3012, shaderLocation: 5},
+          {format: 'uint32x2', offset: 9552, shaderLocation: 19},
+          {format: 'uint8x2', offset: 4146, shaderLocation: 4},
+          {format: 'float16x2', offset: 2164, shaderLocation: 13},
+          {format: 'float32x3', offset: 584, shaderLocation: 23},
+          {format: 'float16x4', offset: 3440, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 1348,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 184, shaderLocation: 14},
+          {format: 'float32', offset: 876, shaderLocation: 12},
+          {format: 'uint16x4', offset: 392, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 21648, stepMode: 'vertex', attributes: []},
+      {arrayStride: 24500, attributes: [{format: 'snorm16x4', offset: 4732, shaderLocation: 22}]},
+    ],
+  },
+});
+document.body.prepend(video5);
+gc();
+let img3 = await imageWithData(170, 11, '#3ed97a18', '#e87c95e3');
+let bindGroup8 = device0.createBindGroup({label: '\uab8a\u{1ff35}\u{1fe6d}\ua6ad\ud975', layout: bindGroupLayout6, entries: []});
+let texture43 = device0.createTexture({
+  size: {width: 1200},
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\ue09b\u0312\u33a7\u6377\u{1ffc6}\u1738',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder18.setBindGroup(5, bindGroup7, new Uint32Array(9789), 534, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(922118967, 1224538684, 1104151128);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 22136);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer8, 'uint16', 126370);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer1, 58720, 129680);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 65504, new Float32Array(48445), 27419, 5380);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer9 = device0.createBuffer({
+  label: '\u0a55\u0a6e\uc19c\ubef0\u6fbe\u3bf4\u{1fe56}',
+  size: 79040,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder37 = device0.createCommandEncoder();
+let commandBuffer13 = commandEncoder32.finish({label: '\uf29e\u934c\u{1faf4}\u2d5a\u{1fcbd}\u0acd\u087e\u{1fb0e}'});
+let computePassEncoder19 = commandEncoder17.beginComputePass({label: '\u8700\ub99d\ue381\u0a35\u055f'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 103324);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 6328 */
+  offset: 6328,
+  buffer: buffer3,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder38 = device0.createCommandEncoder({label: '\u{1ff6a}\uf379\u5fa9\u0bbb\u8b2c\uf027\u0296\u0c54'});
+let textureView46 = texture29.createView({label: '\u0dbe\u{1fcc6}\u0339\u1e4f\uae70\u0fa7\u8f7e\u0cc1', dimension: '2d'});
+try {
+computePassEncoder5.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder5.draw(1224344598);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 74712);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 39, y: 223 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\u36bc\u{1fd10}\u{1f72b}\u4311\u{1fec6}'});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 2267});
+let textureView47 = texture16.createView({label: '\u{1f615}\u{1f8b0}\u8b8a\u01ca\u057b'});
+let renderBundle22 = renderBundleEncoder4.finish({});
+try {
+renderBundleEncoder3.setBindGroup(4, bindGroup5, new Uint32Array(6277), 2116, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 150296);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 60088);
+} catch {}
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 2, y: 8, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 204 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2400 */
+  offset: 2400,
+  bytesPerRow: 256,
+  buffer: buffer7,
+}, {width: 51, height: 23, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer0, 168848, 38740);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline43 = device0.createRenderPipeline({
+  label: '\u0a8f\uefb8\u7044\ue88a\uec30\u963c\u04d8\ucbc8\u0fa7\ue053\u01b6',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xfa5bbaa2},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: 0}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 2158738466,
+    depthBias: -1831291223,
+    depthBiasSlopeScale: 66.90048783513345,
+    depthBiasClamp: 481.7727038017366,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9056,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 48, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 968, shaderLocation: 1},
+          {format: 'uint32x3', offset: 1456, shaderLocation: 0},
+          {format: 'uint16x2', offset: 1488, shaderLocation: 13},
+          {format: 'float32x3', offset: 528, shaderLocation: 18},
+          {format: 'sint8x4', offset: 4180, shaderLocation: 16},
+          {format: 'sint8x2', offset: 618, shaderLocation: 2},
+          {format: 'sint32x2', offset: 3364, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 980, shaderLocation: 23},
+          {format: 'sint32x3', offset: 688, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 3336, shaderLocation: 21},
+          {format: 'uint32x2', offset: 5832, shaderLocation: 19},
+          {format: 'float32x4', offset: 7444, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 20116, attributes: [{format: 'uint8x4', offset: 436, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let textureView48 = texture26.createView({label: '\u0d16\u{1f77e}\u0b10\ueb46\uce93', aspect: 'all'});
+try {
+computePassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 37556);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer8, 0, 152208);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 992 */
+  offset: 992,
+  buffer: buffer5,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 136},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 36, y: 2, z: 31},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 580013 */
+{offset: 255, bytesPerRow: 464, rowsPerImage: 294}, {width: 111, height: 74, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u97b3\ud50a\u30e6',
+  entries: [
+    {binding: 3513, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 3816,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 4504,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture44 = device0.createTexture({
+  label: '\u{1fd1a}\u531f\u46e2',
+  size: {width: 320, height: 40, depthOrArrayLayers: 9},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder5.drawIndexed(18048131, 609067837);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 345024);
+} catch {}
+let arrayBuffer2 = buffer6.getMappedRange(0, 48472);
+let promise12 = buffer0.mapAsync(GPUMapMode.READ, 0, 364900);
+try {
+commandEncoder34.copyBufferToBuffer(buffer2, 467876, buffer0, 49792, 66212);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 125372, new BigUint64Array(52710), 33141, 8152);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({label: '\u006c\u{1ff28}\u{1ffdd}\u094c\ube4f\uac4c', entries: []});
+let querySet12 = device0.createQuerySet({label: '\u{1ff4b}\u9206\u{1f6c3}', type: 'occlusion', count: 3904});
+try {
+  await promise12;
+} catch {}
+let video6 = await videoWithData();
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u06ab\u{1fa7a}\u8f91\u00ef',
+  entries: [
+    {binding: 3794, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 3065,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 3245,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup9 = device0.createBindGroup({layout: bindGroupLayout6, entries: []});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u05c7\u4a1c\uacd0\ue078\u0c40',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(6, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 42896);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 37, y: 48, z: 43},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 274, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 39, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 918 */
+{offset: 918}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 26, y: 8 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img4 = await imageWithData(176, 95, '#eed2d5fe', '#430e4101');
+let commandEncoder40 = device0.createCommandEncoder({label: '\u9f73\uae33\u85e4\u66ae\u02d5\u{1f6df}\u0925'});
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 91.66,
+  lodMaxClamp: 93.69,
+  compare: 'greater',
+});
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 58788 */
+  offset: 58788,
+  buffer: buffer5,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 80684, new BigUint64Array(40920), 38934, 120);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 79, y: 0 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+  label: '\u7553\u1394\u{1fef0}\ud9f0\u4f3e\u{1f8bb}\u93a7\ubfdc\u02ee\u6eea\u{1fd32}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let imageBitmap0 = await createImageBitmap(canvas0);
+let bindGroup10 = device0.createBindGroup({label: '\u0a91\u{1fa2a}', layout: bindGroupLayout6, entries: []});
+let querySet13 = device0.createQuerySet({label: '\u34cb\u0762', type: 'occlusion', count: 3313});
+let texture45 = device0.createTexture({
+  label: '\u0749\u64ca\u0c67\u05b8',
+  size: {width: 176},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView49 = texture43.createView({label: '\uf9f1\u09aa\u{1fde4}\uab53\u6578\u{1f75d}\u0e4f'});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 81.56,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder19.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(6, bindGroup9, new Uint32Array(1959), 1555, 0);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 5,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 54 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 31618 */
+  offset: 31618,
+  buffer: buffer1,
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let buffer10 = device0.createBuffer({
+  label: '\u{1fda1}\u666d\u{1fb7b}\u0432\u{1f836}\u0ac7\u0788',
+  size: 86007,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder41 = device0.createCommandEncoder({label: '\u2675\uf055\u7054'});
+let querySet14 = device0.createQuerySet({label: '\u0d7c\u0d2c\uc35e\u0911', type: 'occlusion', count: 3870});
+let commandBuffer14 = commandEncoder21.finish({label: '\u8f64\u60c2\u0de3'});
+let externalTexture18 = device0.importExternalTexture({label: '\u5518\u0001', source: video5, colorSpace: 'srgb'});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder5.draw(560637802, 1050161321, 240349602, 609789258);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(806384968, 1167124074);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 161404);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer8, 'uint32', 32652, 22863);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer10, 10708, 21948);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let bindGroup11 = device0.createBindGroup({label: '\u0423\u2581\u0b3b', layout: bindGroupLayout9, entries: []});
+let buffer11 = device0.createBuffer({size: 130648, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let renderBundle23 = renderBundleEncoder20.finish({label: '\u{1fc56}\u14ab\u{1fddc}\ua883\uf2b6\u0224\u{1fcd8}\u0913\u{1faa5}\u50d6\u623f'});
+let sampler19 = device0.createSampler({
+  label: '\u0ff0\u019d\u029f',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 60.71,
+  lodMaxClamp: 84.04,
+});
+try {
+renderBundleEncoder5.drawIndexed(1050774697, 1064584766, 1182291793, 1044040776);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 115492);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline39);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer6, 100324, buffer0, 356048, 105132);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 0, y: 99 },
+  flipY: false,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline45 = device0.createRenderPipeline({
+  label: '\u6f74\u{1fbe0}\u0e04\u{1fde9}\u072b\u0e15\u{1f7f0}\u{1f9e3}\u4ca2',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x34fa6102},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg16sint'}, {format: 'r16uint'}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'constant'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilWriteMask: 3725860122,
+    depthBiasSlopeScale: 182.2974757756392,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3212,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1976, shaderLocation: 18},
+          {format: 'sint16x2', offset: 748, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 420, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 1974});
+let texture46 = device0.createTexture({
+  label: '\u0483\u8a7c',
+  size: [1280, 160, 38],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView50 = texture20.createView({label: '\u{1fd24}\u{1f71a}\ufcf9\u3615'});
+let computePassEncoder20 = commandEncoder36.beginComputePass();
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture19 = device0.importExternalTexture({
+  label: '\u0583\u0bb3\u60e0\u{1fc4f}\ub320\u04ca\u03e5\u0874',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.drawIndexed(586429773, 1138564825);
+} catch {}
+let pipeline46 = device0.createComputePipeline({
+  label: '\u6622\ue6a5\u{1f987}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline47 = device0.createRenderPipeline({
+  label: '\u01af\u1a33\u7d55\u{1fb49}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xa9ac43b7},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'keep', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 2261336113,
+    stencilWriteMask: 1636930340,
+    depthBiasClamp: 744.2829714273001,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 57544, stepMode: 'instance', attributes: []},
+      {arrayStride: 8392, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 8244, attributes: []},
+      {
+        arrayStride: 8536,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 3896, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 31440,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 7924, shaderLocation: 18},
+          {format: 'sint32x4', offset: 29900, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let commandEncoder43 = device0.createCommandEncoder({label: '\u{1fd5c}\u8a44\u0e83\u{1ffec}\u{1fb66}\u{1fbe1}\u{1f8f2}\u01e0\u0ae0\u{1fd10}'});
+let querySet16 = device0.createQuerySet({label: '\u0205\u{1f9da}\u0d3d\u0cdd\u0fc8', type: 'occlusion', count: 2205});
+let texture47 = device0.createTexture({
+  label: '\u00e2\u{1f8df}\u2eb3\u{1fb28}\u25f3\ufb70\u{1f90f}\u4ccf\u3d0e',
+  size: [160, 20, 1],
+  mipLevelCount: 5,
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm', 'astc-8x5-unorm'],
+});
+let externalTexture20 = device0.importExternalTexture({
+  label: '\u674a\u7acb\u57bc\u5987\u{1f6d9}\u01bd\u0ac3\u{1fd4d}\u149f\u2ae1',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 9220);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(8, buffer3, 0);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 110416 */
+  offset: 844,
+  bytesPerRow: 256,
+  rowsPerImage: 107,
+  buffer: buffer5,
+}, {
+  texture: texture25,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 5});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+computePassEncoder15.pushDebugGroup('\ud2fd');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let shaderModule6 = device0.createShaderModule({
+  label: '\ud639\u0fce',
+  code: `@group(1) @binding(1494)
+var<storage, read_write> function5: array<u32>;
+@group(2) @binding(1494)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @builtin(sample_mask) f0: u32,
+  @location(9) f1: vec3<i32>,
+  @location(84) f2: f32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(3) f3: vec4<i32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(59) a0: i32, @location(7) a1: vec2<u32>, @location(52) a2: vec3<u32>, @location(82) a3: vec4<f32>, @location(53) a4: vec2<u32>, @location(0) a5: vec3<f32>, @location(67) a6: vec4<u32>, @location(36) a7: vec3<f16>, @location(21) a8: vec4<f32>, @location(1) a9: vec4<u32>, @location(13) a10: vec2<u32>, @location(37) a11: f16, a12: S5) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(18) f0: i32,
+  @location(6) f1: vec2<i32>,
+  @location(4) f2: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(0) f64: vec3<f32>,
+  @location(53) f65: vec2<u32>,
+  @builtin(position) f66: vec4<f32>,
+  @location(8) f67: u32,
+  @location(21) f68: vec4<f32>,
+  @location(67) f69: vec4<u32>,
+  @location(1) f70: vec4<u32>,
+  @location(9) f71: vec3<i32>,
+  @location(59) f72: i32,
+  @location(84) f73: f32,
+  @location(36) f74: vec3<f16>,
+  @location(52) f75: vec3<u32>,
+  @location(7) f76: vec2<u32>,
+  @location(82) f77: vec4<f32>,
+  @location(13) f78: vec2<u32>,
+  @location(37) f79: f16
+}
+
+@vertex
+fn vertex0(a0: S4, @location(13) a1: vec2<u32>, @location(0) a2: f16, @location(22) a3: i32, @location(10) a4: vec3<f32>, @location(17) a5: vec2<f32>, @location(11) a6: f32, @location(3) a7: vec4<f32>, @location(8) a8: vec4<u32>, @location(21) a9: f16, @builtin(vertex_index) a10: u32, @location(5) a11: vec2<f32>, @location(14) a12: vec2<f16>, @location(23) a13: vec4<i32>, @location(12) a14: vec4<u32>, @location(2) a15: vec2<u32>, @location(7) a16: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup12 = device0.createBindGroup({
+  label: '\u14ed\u0f5d\u8180\u08a5',
+  layout: bindGroupLayout7,
+  entries: [{binding: 1530, resource: externalTexture15}],
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u0d9e\u48bb\u68a7\u{1fa6c}\u0650\u30ac\u{1f970}\ude29\u10fa',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup2, new Uint32Array(377), 109, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 15472 */
+  offset: 15472,
+  rowsPerImage: 82,
+  buffer: buffer10,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 608, new DataView(new ArrayBuffer(13783)), 10183, 48);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 246 */
+{offset: 246, bytesPerRow: 304, rowsPerImage: 108}, {width: 87, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.label = '\u76c1\u03ae\u0752\u{1faf8}\u034e';
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u6daf\uc1a1\u0c9a\u59cc\u9f49\ue734\u0710\ufc68\u{1febe}\u336a\u{1fce4}',
+  code: `@group(1) @binding(1530)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(1530)
+var<storage, read_write> function6: array<u32>;
+@group(2) @binding(1530)
+var<storage, read_write> global4: array<u32>;
+@group(3) @binding(1530)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(2) f1: vec3<u32>,
+  @location(3) f2: vec4<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: vec2<i32>,
+  @location(6) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @builtin(instance_index) f0: u32
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<u32>, @location(10) a1: i32, @builtin(vertex_index) a2: u32, @location(0) a3: vec4<u32>, @location(2) a4: vec4<u32>, @location(12) a5: vec4<f16>, @location(9) a6: vec2<u32>, a7: S6, @location(22) a8: i32, @location(3) a9: vec2<f32>, @location(16) a10: f32, @location(7) a11: u32, @location(14) a12: vec3<i32>, @location(18) a13: vec4<u32>, @location(1) a14: vec3<i32>, @location(6) a15: vec2<f16>, @location(5) a16: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u716d\uadc9\u1a90\u{1f770}\u0b2b\u3304', bindGroupLayouts: []});
+let buffer12 = device0.createBuffer({
+  label: '\uad97\u0852\u46a7\u758b\u0a88\u{1f870}',
+  size: 152317,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder45 = device0.createCommandEncoder();
+let commandBuffer15 = commandEncoder16.finish({label: '\ue3eb\u{1fd43}\u72b1\uee63\u0035\ua347\u9b5d\u{1f882}\u{1f983}'});
+try {
+renderBundleEncoder5.draw(882276210, 1076417888);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer8, 'uint16', 140712, 710);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 19378 */
+  offset: 19362,
+  rowsPerImage: 268,
+  buffer: buffer10,
+}, {width: 8, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 220, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet13, 218, 1222, buffer10, 60416);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 8, y: 96 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise15 = device0.createComputePipelineAsync({
+  label: '\u8d17\u4666\u713e\u1c61\u0c80',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let offscreenCanvas7 = new OffscreenCanvas(938, 805);
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u0bfe\u0d0f\u{1fe1a}\u0fe5\u{1fb24}',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout2],
+});
+let commandEncoder46 = device0.createCommandEncoder();
+let textureView51 = texture19.createView({aspect: 'all'});
+let computePassEncoder21 = commandEncoder40.beginComputePass({});
+try {
+renderBundleEncoder5.drawIndexed(260665632);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 68804);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer4, 198376, buffer0, 20324, 47632);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 1,
+  origin: {x: 5, y: 4, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer2), /* required buffer size: 2915 */
+{offset: 661, bytesPerRow: 230, rowsPerImage: 108}, {width: 92, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 81, y: 9 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video1);
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 898});
+let textureView52 = texture5.createView({label: '\u0e63\u1b14'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\ub1a9\u{1fd22}\u{1fa9b}\u{1f6ca}\u4735\u{1fac2}\ue1a7',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let renderBundle24 = renderBundleEncoder18.finish({label: '\u86c5\u{1fd88}\u7b7c\u0d5d\ufb1e'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(25913768, 1142600488, 627106518, -273832594, 1228253612);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer11, 28800);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer3, 24180, 2902);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder15.popDebugGroup();
+} catch {}
+try {
+commandEncoder33.insertDebugMarker('\u{1f6a0}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 209, y: 2, z: 31},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer0), /* required buffer size: 1217939 */
+{offset: 843, bytesPerRow: 376, rowsPerImage: 228}, {width: 90, height: 45, depthOrArrayLayers: 15});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 204, y: 31 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(101, 439);
+let video7 = await videoWithData();
+let textureView53 = texture1.createView({
+  label: '\uf274\u1bcf\u508b\u67b4\u0e56\u9576\u10e8\u0998\uc19a\u639b\u{1febf}',
+  baseMipLevel: 0,
+  baseArrayLayer: 0,
+});
+let sampler20 = device0.createSampler({
+  label: '\u50b4\u7208',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.54,
+  lodMaxClamp: 56.40,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder8.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder5.draw(140036734);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(3, buffer3, 13184, 6920);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 1988 widthInBlocks: 994 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 70698 */
+  offset: 70698,
+  bytesPerRow: 2048,
+  buffer: buffer5,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 49, y: 33, z: 0},
+  aspect: 'all',
+}, {width: 994, height: 12, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 23},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 268688 */
+  offset: 28048,
+  bytesPerRow: 256,
+  rowsPerImage: 235,
+  buffer: buffer1,
+}, {width: 5, height: 0, depthOrArrayLayers: 5});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder14.insertDebugMarker('\u916a');
+} catch {}
+let pipeline48 = device0.createRenderPipeline({
+  label: '\ua07b\u08dc\u{1fbd2}\u0538\u0105\ubb53\u1092\u0ebf\u{1fcdc}',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x83cd16e},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'always', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2576342120,
+    stencilWriteMask: 615273121,
+    depthBias: 1372866703,
+    depthBiasSlopeScale: 197.69497796302556,
+    depthBiasClamp: 945.2748890481064,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 24468,
+        attributes: [
+          {format: 'sint32x4', offset: 5920, shaderLocation: 22},
+          {format: 'uint8x4', offset: 9560, shaderLocation: 16},
+          {format: 'uint32x3', offset: 16036, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 524,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 120, shaderLocation: 6},
+          {format: 'uint32', offset: 104, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 6024,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 860, shaderLocation: 19},
+          {format: 'uint16x4', offset: 2388, shaderLocation: 5},
+          {format: 'float16x2', offset: 348, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 1700, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let img5 = await imageWithData(67, 237, '#be5909d7', '#7f11ee79');
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\ud10f\u4f7b\u{1fc04}\u699d\u09e1\u{1f9f4}\u{1f8ba}',
+  entries: [
+    {
+      binding: 1344,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1992,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let textureView54 = texture6.createView({label: '\u8cc2\ub4d4', dimension: '2d-array', format: 'bgra8unorm'});
+try {
+renderBundleEncoder22.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder5.draw(393893659, 258005631, 428146361, 391422160);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(232721611, 921311292);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 6784);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer2, 183516, buffer7, 5856, 692);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 1176 widthInBlocks: 588 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 69646 */
+  offset: 68470,
+  buffer: buffer8,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 452, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 588, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 7, y: 5, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 13, y: 8, z: 1},
+  aspect: 'all',
+},
+{width: 138, height: 9, depthOrArrayLayers: 3});
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u090a');
+} catch {}
+document.body.prepend(video0);
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u{1fa59}\u{1ff1c}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let externalTexture21 = device0.importExternalTexture({label: '\u8f46\u0f56', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.draw(196447438, 417413844);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 71988);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer1, 100056, 253780);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u087c');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer2), /* required buffer size: 367 */
+{offset: 367}, {width: 751, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 77, y: 3 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder();
+let texture48 = device0.createTexture({
+  size: {width: 1200, height: 192, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView55 = texture33.createView({baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 958, arrayLayerCount: 93});
+let renderBundle25 = renderBundleEncoder4.finish({label: '\u0706\u0d34\u6b82\u0e82\ubfca\u0c3d'});
+try {
+renderBundleEncoder5.draw(932230315, 640730782, 503482169, 904243049);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 26668);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 473 */
+{offset: 473, bytesPerRow: 273}, {width: 8, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\u0e2c\u50e0\uf1d5\ud8cb\u{1fe17}\u936c'});
+let textureView56 = texture47.createView({
+  label: '\ua7a7\uc4c8\u0082\u30f8\u3a46\u0b6e\u{1ff63}\u084e\u01a9\u{1f90e}',
+  dimension: '2d-array',
+  format: 'astc-8x5-unorm',
+  baseMipLevel: 3,
+});
+let computePassEncoder22 = commandEncoder45.beginComputePass({label: '\u0b3b\ubbe2\u944d\u896f\u0a52\u{1fd83}'});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup4, new Uint32Array(1317), 835, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline44);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(240, undefined);
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer7, 6136, 348);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 456 */
+{offset: 456}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3485,
+      visibility: 0,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView57 = texture39.createView({label: '\u8fc5\uc71e\u02c6\u0e05'});
+let renderBundle26 = renderBundleEncoder24.finish({label: '\u{1fb6a}\u0070\u026e\u82a6'});
+let sampler21 = device0.createSampler({
+  label: '\u0c97\u015e\u{1fbdf}\u0c36',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 7.142,
+  lodMaxClamp: 98.86,
+});
+try {
+renderBundleEncoder5.drawIndexed(255507413, 452245493, 142224177, -642748429, 634157070);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline39);
+} catch {}
+let arrayBuffer3 = buffer6.getMappedRange(48472, 9388);
+try {
+  await buffer7.mapAsync(GPUMapMode.READ, 0, 2104);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16568 */
+  offset: 16568,
+  bytesPerRow: 0,
+  buffer: buffer4,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer7, 5052, 1288);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 38, y: 79 },
+  flipY: false,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer16 = commandEncoder42.finish();
+let textureView58 = texture2.createView({label: '\u05af\udb78\u07da\u1b70\u31a5\u0258', baseMipLevel: 1});
+try {
+renderBundleEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9726 */
+  offset: 9726,
+  buffer: buffer10,
+}, {width: 11, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet1, 1645, 595, buffer10, 75520);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 474 */
+{offset: 366, bytesPerRow: 327}, {width: 54, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 94, y: 35 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+  await promise13;
+} catch {}
+let img6 = await imageWithData(255, 201, '#80bed013', '#f9ea0ca6');
+let commandEncoder49 = device0.createCommandEncoder({label: '\u1cb9\u89d3\u{1fc9b}\ue988\uf3d2\u{1f814}\uc260\u3764\u1c11\u{1f6df}\u46b0'});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 153, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 130, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer12, commandBuffer16, commandBuffer15]);
+} catch {}
+let externalTexture22 = device0.importExternalTexture({
+  label: '\u089e\u07e8\u{1fdd5}\u0ab3\u{1fae5}\u8093\u12f5\u{1fb89}',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder5.draw(306789891, 30665638, 840491106, 646695226);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 29608);
+} catch {}
+let promise16 = buffer4.mapAsync(GPUMapMode.WRITE, 0, 138712);
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 361, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 176, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline49 = device0.createComputePipeline({
+  label: '\ub35a\u852f\u449c\u045a\u5bdf\u92d9',
+  layout: 'auto',
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+try {
+offscreenCanvas8.getContext('webgl');
+} catch {}
+let texture49 = device0.createTexture({
+  label: '\u075b\u{1f7a4}\u1ddb\u0b2c\u{1f62e}',
+  size: {width: 1194, height: 64, depthOrArrayLayers: 1},
+  mipLevelCount: 11,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let computePassEncoder23 = commandEncoder35.beginComputePass({label: '\u0a35\u58dd\u29e3\u02c4\u0139'});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup10, new Uint32Array(494), 22, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(558661977);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer11, 12124);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer8, 37988, 106091);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 390 widthInBlocks: 195 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 17698 */
+  offset: 17698,
+  rowsPerImage: 220,
+  buffer: buffer5,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 195, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 209, y: 21, z: 7},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 281099 */
+{offset: 103, bytesPerRow: 344, rowsPerImage: 257}, {width: 73, height: 46, depthOrArrayLayers: 4});
+} catch {}
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u{1f863}\u6640',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder19.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 130632);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer11, 'uint16', 35682, 10337);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer12, 72820, buffer7, 6244, 228);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 123, y: 7, z: 8},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4336 widthInBlocks: 1084 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16072 */
+  offset: 16072,
+  bytesPerRow: 4352,
+  buffer: buffer10,
+}, {width: 1084, height: 81, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 183, y: 31, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer1, 106084, 104576);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let img7 = await imageWithData(255, 240, '#45c3284e', '#9d2b6e6c');
+let commandEncoder50 = device0.createCommandEncoder();
+let querySet18 = device0.createQuerySet({
+  label: '\u03d0\u3ef4\ud786\u0a67\u0430\u0920\u9ba6\u4962\u06c6\u0c17\u{1f842}',
+  type: 'occlusion',
+  count: 1483,
+});
+try {
+renderBundleEncoder5.draw(9344457);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(290887137, 72217639);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 111976);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(10, buffer3, 3068, 27189);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 992 */
+  offset: 992,
+  buffer: buffer10,
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline50 = device0.createComputePipeline({
+  label: '\uf2af\u08ea\u012f\u{1f733}\u6f5a\u{1f674}\u26bb\u{1f9e5}\u0bf7\u6d9e\u{1fdb5}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline51 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 47317071,
+    stencilWriteMask: 1407286387,
+    depthBias: 0,
+    depthBiasSlopeScale: 526.2779157707347,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 32764,
+        attributes: [
+          {format: 'uint32x3', offset: 1520, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 6410, shaderLocation: 3},
+          {format: 'uint16x4', offset: 19792, shaderLocation: 21},
+          {format: 'uint32x3', offset: 6732, shaderLocation: 18},
+          {format: 'uint8x4', offset: 9496, shaderLocation: 5},
+          {format: 'sint8x2', offset: 32762, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 4516, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 34600,
+        attributes: [
+          {format: 'unorm8x2', offset: 13934, shaderLocation: 16},
+          {format: 'sint16x4', offset: 5764, shaderLocation: 10},
+          {format: 'float16x4', offset: 9928, shaderLocation: 6},
+          {format: 'sint32', offset: 6444, shaderLocation: 1},
+          {format: 'float16x4', offset: 11664, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 6392, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7744,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 540, shaderLocation: 14},
+          {format: 'uint32x2', offset: 784, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 16748,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 836, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 14048,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 2740, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let bindGroupLayout13 = pipeline47.getBindGroupLayout(1);
+let bindGroup13 = device0.createBindGroup({
+  label: '\u8e8b\u0fc1\ucd8c\u{1fa98}\uef06\ufa96\u0509\u{1fce4}',
+  layout: bindGroupLayout7,
+  entries: [{binding: 1530, resource: externalTexture10}],
+});
+let textureView59 = texture16.createView({label: '\u{1fd5c}\u489e\u{1fc8d}\u01b8\u09a3\u02bd\u{1ff87}\u{1feb2}\uaf37'});
+let sampler22 = device0.createSampler({
+  label: '\u0801\u3d16\u095f\u3fe7\u6093',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 55.59,
+  lodMaxClamp: 99.09,
+});
+try {
+renderBundleEncoder21.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer2, 133320, buffer0, 99168, 239772);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 48, y: 15, z: 35},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView60 = texture15.createView({label: '\u1721\ub408\u{1fec9}\ubd2f\u03fb', baseArrayLayer: 0});
+let renderBundle27 = renderBundleEncoder7.finish({});
+let sampler23 = device0.createSampler({
+  label: '\u{1ff79}\u708f\u0b08',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.932,
+  lodMaxClamp: 47.22,
+});
+let externalTexture23 = device0.importExternalTexture({label: '\u3bee\u022d\u17c1\u04a7\u{1fea6}\u0077\u0773\u{1f85b}', source: video7, colorSpace: 'srgb'});
+try {
+computePassEncoder5.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder5.draw(711532884, 914247374, 247616357, 56273324);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 9376 */
+  offset: 9376,
+  buffer: buffer5,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({label: '\u{1ffbf}\u{1fff9}'});
+let commandBuffer17 = commandEncoder49.finish();
+let textureView61 = texture27.createView({label: '\u0cb1\u4caf\u035a', dimension: '2d', aspect: 'all', baseArrayLayer: 72});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 61, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 524 widthInBlocks: 131 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8736 */
+  offset: 8736,
+  bytesPerRow: 768,
+  buffer: buffer1,
+}, {width: 131, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 21644, new Float32Array(17816), 492, 148);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer1), /* required buffer size: 164 */
+{offset: 164, bytesPerRow: 193}, {width: 21, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame3 = new VideoFrame(offscreenCanvas6, {timestamp: 0});
+let texture50 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 2668);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 162976 */
+  offset: 100000,
+  bytesPerRow: 256,
+  rowsPerImage: 123,
+  buffer: buffer8,
+}, {
+  texture: texture41,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 2, y: 17, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 284 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18540 */
+  offset: 5968,
+  bytesPerRow: 768,
+  rowsPerImage: 254,
+  buffer: buffer1,
+}, {width: 71, height: 17, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 92, y: 9, z: 0},
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet4, 3121, 243, buffer10, 59392);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView62 = texture42.createView({label: '\u1942\u{1fe1c}\u{1f8dc}', aspect: 'all', baseMipLevel: 2});
+try {
+renderBundleEncoder5.drawIndexed(924571669);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 6368);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 80476);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(9, buffer8);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer1, 282716, 7888);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline52 = await device0.createRenderPipelineAsync({
+  label: '\u8954\u2125\u{1fa56}\u71b8\u{1f843}\u0da6',
+  layout: pipelineLayout5,
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 1835944646,
+    stencilWriteMask: 3232146003,
+    depthBias: 2085529829,
+    depthBiasSlopeScale: 482.9006492328899,
+    depthBiasClamp: 664.1888196463711,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 41412,
+        attributes: [
+          {format: 'float32x2', offset: 20632, shaderLocation: 12},
+          {format: 'sint32x2', offset: 7692, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 25644, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 32016,
+        attributes: [
+          {format: 'uint16x4', offset: 12064, shaderLocation: 9},
+          {format: 'uint16x4', offset: 4604, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 21708,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 1936, shaderLocation: 16},
+          {format: 'uint16x4', offset: 3864, shaderLocation: 5},
+          {format: 'sint32x4', offset: 5424, shaderLocation: 14},
+          {format: 'sint16x2', offset: 1708, shaderLocation: 10},
+          {format: 'uint32x2', offset: 72, shaderLocation: 2},
+          {format: 'uint32x2', offset: 2064, shaderLocation: 0},
+          {format: 'uint16x2', offset: 10600, shaderLocation: 21},
+          {format: 'uint32x2', offset: 6116, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 12196,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 9800, shaderLocation: 1},
+          {format: 'float32x4', offset: 348, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+gc();
+let commandEncoder52 = device0.createCommandEncoder({label: '\u1c8c\u3b43\u01ef\ue695\u01d1'});
+let texture51 = device0.createTexture({
+  label: '\u7fb1\u259b\ua3e6',
+  size: [600, 96, 1],
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView63 = texture13.createView({
+  label: '\u0ec2\u307d\u8afe\u98be\u0766\u7ea6',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 32,
+  arrayLayerCount: 45,
+});
+let computePassEncoder24 = commandEncoder44.beginComputePass({});
+let renderBundle28 = renderBundleEncoder10.finish({label: '\u{1fbd3}\u7a10\u{1fb5f}\uc1c9\uda2c\u8d42\uf555\u4460\u0839'});
+let externalTexture24 = device0.importExternalTexture({
+  label: '\u{1faee}\uf0cf\u040d\u38f9\u8cb3\u2d6f\u{1fcb6}\u0953\u06d7\u0213',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder5.draw(31761179);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(66329705, 161594878, 723979714, 948186381, 1018009704);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 376, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas9 = new OffscreenCanvas(355, 415);
+let commandEncoder53 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({label: '\u01ff\u{1fca5}\u746c\u070f', type: 'occlusion', count: 232});
+let texture52 = gpuCanvasContext0.getCurrentTexture();
+let textureView64 = texture25.createView({
+  label: '\u{1f75c}\ucb35\u3f12\u42d8\u0343\u{1fe91}',
+  format: 'rg16sint',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+});
+let renderBundle29 = renderBundleEncoder23.finish({label: '\u4c9b\u098d\u9f36\u68ea\u{1fbce}\u{1fe77}\ubdd5\u{1fc2a}\u955b\u0814\uc4bc'});
+try {
+renderBundleEncoder15.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder5.draw(558601149, 1073996789, 687115751, 959243896);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer0, 410840, 3216);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let externalTexture25 = device0.importExternalTexture({label: '\u0c8d\u37fb\u{1fa15}\ubd5c', source: video6, colorSpace: 'srgb'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder5.draw(769508725, 842142325, 107003956, 693128236);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer8, 'uint16', 82258, 64639);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer8, 0, 62937);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer6, 222076, buffer10, 19944, 7068);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 55788 */
+  offset: 55788,
+  buffer: buffer8,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10656 */
+  offset: 10604,
+  buffer: buffer10,
+}, {width: 13, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 547 */
+{offset: 547, rowsPerImage: 25}, {width: 163, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline53 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 727197643,
+    stencilWriteMask: 583111330,
+    depthBiasClamp: 988.168367261042,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 556,
+        attributes: [
+          {format: 'uint16x4', offset: 116, shaderLocation: 2},
+          {format: 'uint8x2', offset: 48, shaderLocation: 4},
+          {format: 'uint32x2', offset: 8, shaderLocation: 8},
+          {format: 'float32', offset: 0, shaderLocation: 21},
+          {format: 'snorm8x4', offset: 40, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 18, shaderLocation: 11},
+          {format: 'float32', offset: 52, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 6532,
+        attributes: [
+          {format: 'uint8x4', offset: 568, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 3380, shaderLocation: 12},
+          {format: 'float16x4', offset: 5544, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 1820, shaderLocation: 20},
+          {format: 'uint32x4', offset: 1328, shaderLocation: 19},
+          {format: 'uint16x4', offset: 2148, shaderLocation: 16},
+          {format: 'float32', offset: 1284, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 2384, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint8x2', offset: 30292, shaderLocation: 14},
+          {format: 'uint32x3', offset: 64476, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 3664, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 1684, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 41872, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 920, shaderLocation: 23},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+offscreenCanvas7.width = 1505;
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout6, entries: []});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u8f88\u0130\u8197\u02f4\u987d\u0cfa'});
+let textureView65 = texture17.createView({aspect: 'all', baseMipLevel: 4});
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 516 widthInBlocks: 129 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12312 */
+  offset: 12312,
+  bytesPerRow: 768,
+  buffer: buffer1,
+}, {width: 129, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer7, 3820, 2372);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 13660, new Float32Array(56999), 47695, 7344);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer2), /* required buffer size: 591 */
+{offset: 591, bytesPerRow: 60}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 886});
+let texture53 = device0.createTexture({
+  label: '\udbf3\u07ac\u2220\u{1fb5f}\u0efe',
+  size: {width: 640},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView66 = texture1.createView({label: '\u8b44\u7904\u3bb7\u{1f829}\u7c06\u{1fa9f}\u{1f884}\u648c\u{1fbd9}\u{1fcd0}\ua382'});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder5.draw(480791402, 42260, 746038255, 412667292);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer3, 25196, buffer10, 69832, 15136);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1360 widthInBlocks: 340 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 65776 */
+  offset: 65776,
+  buffer: buffer10,
+}, {width: 340, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas9.getContext('webgpu');
+let offscreenCanvas10 = new OffscreenCanvas(184, 475);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u19fb\uc605\u5870\u{1fdc2}\u{1fcd6}\uc43b\u0c81\u{1f67b}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+});
+let externalTexture26 = device0.importExternalTexture({
+  label: '\u{1fdd5}\u{1f6ef}\uca91\u{1fdf6}\u928c\ua3a6\u{1fbb3}\u0f9c',
+  source: video7,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup8, new Uint32Array(7367), 7068, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline14);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  label: '\u066a\ub4e7\u0107\ub74e\u55aa\u0130\u0863\u72ba\u07b8\u9450',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: 0}, {format: 'rgba8unorm-srgb', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 384223809,
+    stencilWriteMask: 2190220319,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm16x4', offset: 59492, shaderLocation: 16},
+          {format: 'float32x4', offset: 6420, shaderLocation: 6},
+          {format: 'uint8x2', offset: 18720, shaderLocation: 7},
+          {format: 'uint16x4', offset: 180, shaderLocation: 9},
+          {format: 'uint16x2', offset: 5512, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 11844,
+        attributes: [
+          {format: 'snorm16x4', offset: 2792, shaderLocation: 3},
+          {format: 'sint8x4', offset: 10208, shaderLocation: 14},
+          {format: 'uint8x2', offset: 140, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 52008,
+        attributes: [
+          {format: 'sint8x4', offset: 5356, shaderLocation: 10},
+          {format: 'uint32', offset: 4356, shaderLocation: 0},
+          {format: 'sint16x2', offset: 3552, shaderLocation: 1},
+          {format: 'uint16x2', offset: 3492, shaderLocation: 18},
+          {format: 'sint8x4', offset: 7212, shaderLocation: 22},
+          {format: 'uint32x3', offset: 4788, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 15472, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let buffer13 = device0.createBuffer({
+  label: '\u0429\u34e3\u3225\u0fbb\ucd91',
+  size: 103866,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let computePassEncoder25 = commandEncoder13.beginComputePass();
+let renderBundle30 = renderBundleEncoder16.finish({label: '\u{1f7dd}\u0b60\u676a\u{1f7aa}\u0663'});
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 40672);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 19364);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer8, 130344, 28707);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 42, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet7, 561, 422, buffer10, 9472);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 7520, new DataView(new ArrayBuffer(61933)), 28625, 16848);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 2048 */
+{offset: 884, rowsPerImage: 213}, {width: 582, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline55 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let pipeline56 = device0.createRenderPipeline({
+  label: '\uec72\uc42e\u5288',
+  layout: pipelineLayout7,
+  multisample: {mask: 0x2a809c21},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 2179728820,
+    stencilWriteMask: 2039824236,
+    depthBias: -573077692,
+    depthBiasSlopeScale: 811.5269791949223,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1536,
+        attributes: [
+          {format: 'uint8x2', offset: 16, shaderLocation: 2},
+          {format: 'float32x4', offset: 16, shaderLocation: 9},
+          {format: 'float16x2', offset: 544, shaderLocation: 0},
+          {format: 'float32', offset: 676, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 128, shaderLocation: 5},
+          {format: 'float32', offset: 172, shaderLocation: 20},
+          {format: 'uint8x2', offset: 360, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 296, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 9084,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 4008, shaderLocation: 4},
+          {format: 'uint32', offset: 8936, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 31808,
+        attributes: [
+          {format: 'float32', offset: 464, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 856, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 3756, shaderLocation: 11},
+          {format: 'uint16x4', offset: 11592, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 4200, shaderLocation: 13},
+          {format: 'uint8x4', offset: 3320, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 5376, shaderLocation: 22}],
+      },
+      {
+        arrayStride: 19152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 1376, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 2244, shaderLocation: 23},
+          {format: 'float32x2', offset: 2132, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 18324,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 12448, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+offscreenCanvas7.getContext('webgl');
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\ucba0\u02d7\u4408',
+  layout: bindGroupLayout5,
+  entries: [{binding: 4420, resource: externalTexture8}, {binding: 981, resource: textureView59}],
+});
+let commandEncoder55 = device0.createCommandEncoder({label: '\u1c51\u0cbe\u1e23\u{1fc0e}\u3c6b\u1706\u60d6\u{1f646}\u3db6\u0f00\uc019'});
+try {
+computePassEncoder19.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder5.draw(1008692517, 692608217, 791040851, 653648269);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 56344);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer8, 0, 45614);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 26, y: 6 },
+  flipY: true,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u3e97\u{1f9fc}\u347b\ucbb7\uf46b\u0c66\u4f16\u1948',
+  layout: bindGroupLayout3,
+  entries: [{binding: 6255, resource: sampler22}],
+});
+let texture54 = gpuCanvasContext2.getCurrentTexture();
+let textureView67 = texture53.createView({});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\uccc4\u5293\u0ed0\u0461\u8dbb',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+});
+try {
+computePassEncoder17.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer8, 'uint32');
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer0, 154984, 118764);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 27448, new DataView(new ArrayBuffer(63911)), 26903, 1148);
+} catch {}
+let promise19 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise18;
+} catch {}
+gc();
+let texture55 = device0.createTexture({
+  label: '\u02b7\ub4b3\u7251\u{1fada}\u08a4\u{1f7c6}\uc39a\u{1f95b}\u{1f6b1}',
+  size: {width: 298, height: 16, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint'],
+});
+let externalTexture27 = device0.importExternalTexture({
+  label: '\u5926\u0a6e\u{1f723}\u{1ffb7}\u0d1e\u22e0\u895b\u{1fe0b}',
+  source: video3,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder5.draw(175141185, 633559678, 770126478, 1209921189);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 41888);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1392 widthInBlocks: 696 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 33776 */
+  offset: 33776,
+  bytesPerRow: 1536,
+  rowsPerImage: 279,
+  buffer: buffer1,
+}, {width: 696, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 55, y: 13, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 1},
+  aspect: 'all',
+},
+{width: 58, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 5344, new Float32Array(33914), 14851, 1512);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 6, y: 5 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\u{1f996}\u0935\u1c79\u{1fd32}\ud67c',
+  layout: bindGroupLayout3,
+  entries: [{binding: 6255, resource: sampler21}],
+});
+let commandEncoder56 = device0.createCommandEncoder({label: '\u041a\uf2c2\u{1f7ad}\ube6f'});
+let textureView68 = texture4.createView({mipLevelCount: 1});
+let computePassEncoder26 = commandEncoder46.beginComputePass({});
+let renderBundle31 = renderBundleEncoder19.finish();
+try {
+computePassEncoder11.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer11, 37192);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer7, 1620, 3028);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+renderBundleEncoder22.pushDebugGroup('\u2827');
+} catch {}
+try {
+  await promise16;
+} catch {}
+let imageBitmap1 = await createImageBitmap(offscreenCanvas7);
+let bindGroupLayout14 = pipeline3.getBindGroupLayout(1);
+let texture56 = device0.createTexture({
+  label: '\u07c1\uc6c0\ua30b\u{1fa4a}\u{1fee2}\ua527\uece1\u{1fd9c}\u{1f88f}',
+  size: [320, 40, 9],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let renderBundle32 = renderBundleEncoder21.finish({label: '\u09bd\u6e9e\u051b\u44c7\u897f\u0346\u00d1\u0691\u9abe\u{1f961}\uecb0'});
+let externalTexture28 = device0.importExternalTexture({label: '\u{1f622}\u8fa5\u0958\u9e60', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(1109122790);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer10, 52004, 11840);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(72)), /* required buffer size: 978 */
+{offset: 976, rowsPerImage: 40}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u7dc0\u0f99',
+  entries: [
+    {
+      binding: 6280,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 4936,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup18 = device0.createBindGroup({
+  label: '\u0893\u0e7d\u6018\u{1fe6b}\u6d37\u02a0\u021a',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1494, resource: sampler9}],
+});
+let texture57 = device0.createTexture({
+  label: '\u{1f89f}\u08cb\u0019\ufb47\u8412\u9470\u0c29\u{1f8ab}\u0787\u6ea1',
+  size: [150, 24, 1],
+  mipLevelCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint'],
+});
+let renderBundle33 = renderBundleEncoder9.finish({});
+let externalTexture29 = device0.importExternalTexture({label: '\u03e6\u{1fc33}\u7382\u0db5', source: video4, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.setBindGroup(6, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup16, new Uint32Array(3066), 2429, 0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer3, 0, 4915);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer8, 129608, buffer10, 70240, 2256);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder55.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 30, y: 3, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 488 widthInBlocks: 244 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 22148 */
+  offset: 20124,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {width: 244, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 7, depthOrArrayLayers: 1});
+} catch {}
+let pipeline57 = device0.createRenderPipeline({
+  label: '\u0b94\u{1fbbe}\u082e\u{1fbcf}\u90ea\uea5c\udda2\u{1fc7c}\u05e3\u6fb3\ud59e',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x8d5de931},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', failOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 2130665333,
+    stencilWriteMask: 1741280454,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 9904, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5940,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 328, shaderLocation: 23}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+document.body.prepend(video4);
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\u{1fe16}\u57fe\u{1f6ae}\u3cb6\uc5d5\u7938',
+  entries: [
+    {binding: 751, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 4059,
+      visibility: 0,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 715, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder57 = device0.createCommandEncoder();
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 2705});
+let commandBuffer18 = commandEncoder47.finish({label: '\u9ee4\u69b9'});
+let texture58 = device0.createTexture({
+  label: '\u0114\u03c6\u9eb0\u{1fdd4}\u0d2c\u{1f9b5}\u3705\u0a23\u0ab3',
+  size: [1280],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView69 = texture6.createView({
+  label: '\uba40\u9bcd\u7976\ub63f\u{1fc1f}\u{1f6d6}\u{1fbcc}\u0ac0',
+  format: 'bgra8unorm',
+  baseMipLevel: 0,
+});
+try {
+renderBundleEncoder5.drawIndexed(281765647, 1070543389, 253658881, 158153798, 1057263637);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 122240);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  buffer: buffer13,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(querySet4, 2131, 1183, buffer10, 12288);
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\ub3ad');
+} catch {}
+try {
+  await promise17;
+} catch {}
+let videoFrame4 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let commandEncoder58 = device0.createCommandEncoder();
+let querySet22 = device0.createQuerySet({label: '\u0fda\udb6f\u2605\u070d\u4983', type: 'occlusion', count: 3335});
+let textureView70 = texture55.createView({label: '\u3326\u{1fae9}\u0769\u1607\uc1e0\u7230\u4834', baseMipLevel: 1});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb']});
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 43192);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer3, 25336, buffer0, 274648, 584);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24920 */
+  offset: 24920,
+  buffer: buffer13,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38724 */
+  offset: 38724,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet22, 684, 874, buffer10, 33792);
+} catch {}
+try {
+renderBundleEncoder22.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 164172, new Int16Array(52063), 15723, 908);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture59 = device0.createTexture({
+  label: '\u15b4\u02a5\u0ad4',
+  size: {width: 600},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+try {
+computePassEncoder3.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup18, new Uint32Array(8528), 6585, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(973841786, 532798242, 594808295, -154950368, 970247776);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer2, 368232, buffer1, 103420, 77280);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+  label: '\u0dd6\u707c\u491f\ud6d2\u{1fe8d}\u2fdd',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x1722e61c},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8unorm-srgb'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilReadMask: 1083443285,
+    stencilWriteMask: 2057062582,
+    depthBias: 1558257166,
+    depthBiasSlopeScale: 867.147508119042,
+    depthBiasClamp: 306.3855425420118,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 46412,
+        attributes: [
+          {format: 'float32x2', offset: 27152, shaderLocation: 5},
+          {format: 'uint32x4', offset: 2916, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 8812,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 282, shaderLocation: 0},
+          {format: 'sint16x2', offset: 2996, shaderLocation: 6},
+          {format: 'uint8x4', offset: 504, shaderLocation: 7},
+          {format: 'float32x4', offset: 212, shaderLocation: 3},
+          {format: 'uint16x4', offset: 2488, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 1530, shaderLocation: 17},
+          {format: 'sint8x2', offset: 720, shaderLocation: 22},
+          {format: 'float16x4', offset: 340, shaderLocation: 14},
+          {format: 'uint32', offset: 540, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 2460, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 16888,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 2892, shaderLocation: 23}],
+      },
+      {
+        arrayStride: 33748,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 2276, shaderLocation: 11},
+          {format: 'uint16x4', offset: 8612, shaderLocation: 13},
+          {format: 'uint32x2', offset: 2396, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint16x4', offset: 17268, shaderLocation: 18}]},
+      {
+        arrayStride: 12356,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 492, shaderLocation: 21}],
+      },
+    ],
+  },
+});
+let gpuCanvasContext5 = offscreenCanvas10.getContext('webgpu');
+let videoFrame5 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let shaderModule8 = device0.createShaderModule({
+  label: '\u{1faf0}\u{1f8ac}\ubb79\ucc1c\u36a9\u{1fdef}\u0831\u0dd2\ub5c5\u74b9\udd8c',
+  code: `@group(2) @binding(1530)
+var<storage, read_write> global6: array<u32>;
+@group(1) @binding(6303)
+var<storage, read_write> function7: array<u32>;
+@group(3) @binding(6255)
+var<storage, read_write> n3: array<u32>;
+@group(0) @binding(6255)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(3) f3: i32,
+  @location(1) f4: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder60 = device0.createCommandEncoder({label: '\u5aa4\u44a9\u0164\u0696'});
+let textureView71 = texture6.createView({
+  label: '\u1b76\u0f78\ufef0\uf68f\ud3bc\u0ca5\udcb8\u0511\u19d0',
+  format: 'bgra8unorm-srgb',
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\ub11c\u0e35\u9c85',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let sampler24 = device0.createSampler({
+  label: '\u{1fb8f}\u30be',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 21.39,
+  lodMaxClamp: 37.24,
+});
+try {
+renderBundleEncoder5.draw(1051270128);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 104160);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer8, 'uint16', 5356, 106182);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer3, 0, 21897);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer0, 166792, 320832);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder54.insertDebugMarker('\u432d');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 57936, new DataView(new ArrayBuffer(43083)), 7475, 4184);
+} catch {}
+let textureView72 = texture30.createView({format: 'rgba8unorm', baseMipLevel: 2});
+try {
+renderBundleEncoder5.draw(1149698838, 517044321, 841507741, 137474620);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 45148);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer11, 'uint32', 22812, 27648);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline27);
+} catch {}
+let arrayBuffer4 = buffer6.getMappedRange(57864, 8376);
+try {
+commandEncoder60.copyBufferToTexture({
+  /* bytesInLastRow: 660 widthInBlocks: 165 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21080 */
+  offset: 21080,
+  rowsPerImage: 236,
+  buffer: buffer12,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 165, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer2), /* required buffer size: 813 */
+{offset: 809, bytesPerRow: 124}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let externalTexture30 = device0.importExternalTexture({label: '\u0c9d\u9824\u4dbb\u89a7\ue778\ue138\u0b78', source: video5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.draw(717650511, 1174521395, 394632629, 41599072);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 1240 widthInBlocks: 155 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24568 */
+  offset: 10528,
+  bytesPerRow: 1280,
+  buffer: buffer8,
+}, {
+  texture: texture49,
+  mipLevel: 2,
+  origin: {x: 116, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 155, height: 11, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1404, new BigUint64Array(45273), 6267, 2788);
+} catch {}
+let pipeline59 = await promise19;
+gc();
+try {
+canvas4.getContext('bitmaprenderer');
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  label: '\udfca\u0cd0\u4ea0\ua2c7\u950e\uebec\u0ffe',
+  layout: bindGroupLayout13,
+  entries: [{binding: 1530, resource: externalTexture23}],
+});
+let commandBuffer19 = commandEncoder54.finish({label: '\u0f65\u952f\u0700\u0432'});
+let texture60 = device0.createTexture({
+  label: '\u088e\u{1fd20}\u04ac\u4960\u0b5a\u06bd\u4c92\u3120\u0130\u0dae',
+  size: {width: 88, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView73 = texture44.createView({label: '\u9dca\u0858\ue74d\u{1f87e}', baseMipLevel: 5});
+let sampler25 = device0.createSampler({
+  label: '\u{1ffb0}\u4dc9\ud36f\u99d9\u0f9c\u05a2\u3851\u0fc8\u0d80\u0a0c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.7736,
+  lodMaxClamp: 40.28,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(4, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 63308);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer8, 1132);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 170, y: 5, z: 143},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer3), /* required buffer size: 13638875 */
+{offset: 59, bytesPerRow: 213, rowsPerImage: 116}, {width: 100, height: 0, depthOrArrayLayers: 553});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 38, y: 47 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 19, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 35, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = await promise15;
+let imageBitmap2 = await createImageBitmap(img6);
+let shaderModule9 = device0.createShaderModule({
+  label: '\u{1fd3a}\u4927\u9714\ud359\u{1f8e2}\ue9f4\u80a0\u{1f742}\u7145',
+  code: `@group(1) @binding(6303)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(3816)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(4504)
+var<storage, read_write> local5: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(0) f3: vec4<u32>,
+  @location(3) f4: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(39) a0: vec3<f32>, @location(27) a1: vec3<f16>, @location(53) a2: vec4<f16>, @location(78) a3: vec2<f32>, @location(55) a4: vec4<i32>, @location(13) a5: f32, @location(45) a6: vec3<f32>, @location(64) a7: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(8) f0: vec3<u32>,
+  @location(0) f1: vec2<f16>,
+  @location(15) f2: vec3<f16>,
+  @location(9) f3: vec4<f16>,
+  @location(19) f4: vec3<f32>,
+  @location(13) f5: vec3<f32>,
+  @location(22) f6: f32,
+  @location(21) f7: vec3<u32>,
+  @location(2) f8: f16,
+  @location(6) f9: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(55) f80: vec4<i32>,
+  @builtin(position) f81: vec4<f32>,
+  @location(81) f82: vec3<f32>,
+  @location(51) f83: f32,
+  @location(85) f84: vec2<f16>,
+  @location(10) f85: vec2<u32>,
+  @location(15) f86: vec3<u32>,
+  @location(27) f87: vec3<f16>,
+  @location(64) f88: vec3<f32>,
+  @location(72) f89: vec2<f16>,
+  @location(13) f90: f32,
+  @location(78) f91: vec2<f32>,
+  @location(20) f92: vec4<u32>,
+  @location(45) f93: vec3<f32>,
+  @location(49) f94: u32,
+  @location(70) f95: vec3<u32>,
+  @location(68) f96: u32,
+  @location(46) f97: vec4<f32>,
+  @location(87) f98: vec4<i32>,
+  @location(67) f99: vec4<i32>,
+  @location(65) f100: vec4<f16>,
+  @location(42) f101: i32,
+  @location(82) f102: vec4<i32>,
+  @location(80) f103: vec4<u32>,
+  @location(39) f104: vec3<f32>,
+  @location(47) f105: vec2<f16>,
+  @location(9) f106: vec2<u32>,
+  @location(41) f107: u32,
+  @location(53) f108: vec4<f16>,
+  @location(1) f109: vec3<f16>,
+  @location(83) f110: vec3<f16>,
+  @location(43) f111: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f32>, @location(3) a1: vec3<f16>, @builtin(instance_index) a2: u32, @location(14) a3: vec3<u32>, @location(20) a4: vec2<f32>, @location(1) a5: vec2<f16>, @location(18) a6: f32, a7: S7) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder61 = device0.createCommandEncoder({label: '\u{1f92c}\u0924\uaddf\ubb9f\u03f3'});
+let textureView74 = texture42.createView({
+  label: '\ude05\u0ccf\u66f8\u47c2\u0bcf\ufc9e\u0ebd\u05df\u7c54\u0c5f\u2ced',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let sampler26 = device0.createSampler({
+  label: '\u0723\u{1f73f}\uda5b',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 66.34,
+  lodMaxClamp: 84.65,
+});
+let externalTexture31 = device0.importExternalTexture({label: '\u707d\u07ee\u{1fb56}\u47b7\u47a0', source: video0});
+try {
+renderBundleEncoder5.draw(359290827, 294001142);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 98992);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(3063, undefined, 3732531649, 357667004);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer6, 151380, buffer0, 35592, 81256);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 77, y: 6, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(45650), /* required buffer size: 45650 */
+{offset: 124, bytesPerRow: 860, rowsPerImage: 271}, {width: 403, height: 53, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u1729\u7ad9\u879b\ud7d5\u0398\u{1fa33}\u0d90\ubf4d\u7d3e',
+  bindGroupLayouts: [bindGroupLayout8],
+});
+let commandEncoder62 = device0.createCommandEncoder({label: '\udbb5\u1920\u04c7\u{1fa93}\u5d7d\u51dd\u26b3\ua6c7\u{1f644}\u{1f9d2}\ufd8e'});
+let textureView75 = texture43.createView({label: '\u0454\u15f5\ua730\u2532\u8b0f\u06c9\u4371\ua087', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+renderBundleEncoder5.drawIndexed(938195325, 1097123189, 1170703900, 1017505366);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17, commandBuffer19, commandBuffer18]);
+} catch {}
+let promise20 = device0.createComputePipelineAsync({
+  label: '\uf548\u613b',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline61 = device0.createRenderPipeline({
+  label: '\u2cfe\u67bf\u8b29',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1060,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 308, shaderLocation: 14},
+          {format: 'uint16x4', offset: 460, shaderLocation: 21},
+          {format: 'uint32x3', offset: 316, shaderLocation: 9},
+          {format: 'uint32x4', offset: 472, shaderLocation: 18},
+          {format: 'uint32', offset: 200, shaderLocation: 2},
+          {format: 'float32x3', offset: 528, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 120, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 440, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 5228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 3392, shaderLocation: 10},
+          {format: 'sint32x3', offset: 696, shaderLocation: 22},
+          {format: 'uint8x2', offset: 1190, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 19948, attributes: []},
+      {
+        arrayStride: 24568,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 504, shaderLocation: 16},
+          {format: 'uint8x4', offset: 5948, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 20676,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 472, shaderLocation: 0},
+          {format: 'sint16x2', offset: 4848, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let offscreenCanvas11 = new OffscreenCanvas(565, 839);
+let commandEncoder63 = device0.createCommandEncoder();
+let texture61 = device0.createTexture({
+  label: '\u04ef\ue793\u0d92',
+  size: [44, 24, 1],
+  mipLevelCount: 2,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8uint'],
+});
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup18, new Uint32Array(6884), 96, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(803278759, 912821171, 429132427, 516104644);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(833730874, 470646116, 591670867);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer11, 'uint32', 104428, 8108);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer8, 104876, 40436);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 1996 widthInBlocks: 499 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8840 */
+  offset: 8840,
+  buffer: buffer12,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 499, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer0, 192092, 236240);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup20 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 1530, resource: externalTexture17}]});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.40,
+  compare: 'greater',
+});
+try {
+computePassEncoder18.setBindGroup(4, bindGroup0, new Uint32Array(9364), 9129, 0);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(6, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder5.draw(327379316, 498268861, 119311789, 877039001);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline39);
+} catch {}
+let arrayBuffer5 = buffer7.getMappedRange(1624, 20);
+try {
+commandEncoder57.copyBufferToBuffer(buffer4, 232408, buffer10, 82368, 740);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder56.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 181, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 512 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15472 */
+  offset: 15472,
+  buffer: buffer10,
+}, {width: 128, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer7, 1488, 1932);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet12, 3114, 257, buffer10, 79872);
+} catch {}
+let videoFrame6 = new VideoFrame(canvas1, {timestamp: 0});
+let shaderModule10 = device0.createShaderModule({
+  label: '\u913c\u0b7a\u{1ff12}\u2abf\u6cc7\u{1f673}\u2141\ufb4c',
+  code: `@group(6) @binding(4420)
+var<storage, read_write> local6: array<u32>;
+@group(4) @binding(6303)
+var<storage, read_write> type1: array<u32>;
+@group(3) @binding(981)
+var<storage, read_write> parameter3: array<u32>;
+@group(3) @binding(4420)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(981)
+var<storage, read_write> function9: array<u32>;
+@group(5) @binding(6255)
+var<storage, read_write> type2: array<u32>;
+@group(0) @binding(1494)
+var<storage, read_write> field2: array<u32>;
+@group(4) @binding(2593)
+var<storage, read_write> field3: array<u32>;
+@group(6) @binding(981)
+var<storage, read_write> local7: array<u32>;
+@group(2) @binding(4420)
+var<storage, read_write> global7: array<u32>;
+
+@compute @workgroup_size(2, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(3) f1: vec3<i32>,
+  @location(4) f2: vec4<f32>,
+  @location(0) f3: vec3<u32>,
+  @location(2) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec4<i32>, @location(1) a1: vec2<f16>, @location(2) a2: vec3<f32>, @location(18) a3: vec3<i32>, @location(6) a4: vec3<f32>, @location(7) a5: vec2<i32>, @location(0) a6: vec2<i32>, @location(22) a7: vec3<f32>, @location(3) a8: i32, @location(11) a9: vec4<f32>, @location(17) a10: vec4<f32>, @location(19) a11: vec3<f32>, @location(8) a12: i32, @location(10) a13: vec2<i32>, @location(15) a14: f16, @location(14) a15: vec3<u32>, @location(23) a16: vec4<u32>, @builtin(vertex_index) a17: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder27 = commandEncoder62.beginComputePass({label: '\u0d59\udae6\u0092\u{1f712}\u5ce2\u{1faa2}\u{1fb5a}\u{1fe67}\u0cbd\uccb0'});
+try {
+computePassEncoder26.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: {x: 1, y: 8, z: 0},
+  aspect: 'all',
+},
+{width: 36, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer10, 69276, 12212);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+  label: '\u{1fe49}\u{1fca6}\u433d\u6cfc',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas12 = new OffscreenCanvas(871, 642);
+let commandEncoder64 = device0.createCommandEncoder({label: '\u0dc5\u03be\u0ff7\u{1ffd7}\uc780\uca48\u0e2b\u5e3f\u3bc4'});
+let renderBundle34 = renderBundleEncoder27.finish({label: '\u0157\uf14d\u{1f916}\uedf5\ufac8\u33e7\ube60\u9150'});
+try {
+renderBundleEncoder5.draw(1177424598, 581667609, 1064092053, 675371702);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(366285739, 1136833401, 1095644137, 626615389, 1039781271);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer3, 0, 2523);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 0, 42804);
+} catch {}
+let pipeline62 = await device0.createRenderPipelineAsync({
+  label: '\u1fc0\u0622\u3b9f\u34cc\u0397\u{1fa45}\u{1fde2}',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0xa51b5725},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 35944,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 1436, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+let offscreenCanvas13 = new OffscreenCanvas(276, 393);
+let bindGroup21 = device0.createBindGroup({label: '\u{1fb85}\ubc6e', layout: bindGroupLayout1, entries: [{binding: 1494, resource: sampler0}]});
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({
+  label: '\u03c4\ude3c\u5b91\u0ab8\u{1fd37}\u9a7f\u{1fce5}\u7786\u{1fd1d}\u254f',
+  size: [88],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView76 = texture42.createView({baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 0});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u4317\u12ce\u0ab6',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler28 = device0.createSampler({
+  label: '\u0549\u{1fb27}\udcbc\u6271\u9383\u6e49\u{1f7df}\u0cbf\u0f99\u2988\u0fc0',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.63,
+  lodMaxClamp: 98.40,
+  maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 155472);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 35, y: 155 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise14;
+} catch {}
+let canvas5 = document.createElement('canvas');
+let shaderModule11 = device0.createShaderModule({
+  label: '\u{1fb71}\u0ee3\u{1fc16}\u26e7',
+  code: `@group(0) @binding(3816)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(6303)
+var<storage, read_write> parameter4: array<u32>;
+@group(0) @binding(3513)
+var<storage, read_write> function10: array<u32>;
+@group(0) @binding(4504)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(4) f1: vec4<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(2) f3: u32,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(7) f0: f16,
+  @location(18) f1: vec4<i32>,
+  @location(2) f2: vec2<u32>,
+  @location(4) f3: f16,
+  @location(15) f4: vec4<i32>,
+  @location(21) f5: vec2<i32>,
+  @location(9) f6: i32,
+  @location(1) f7: vec3<f32>,
+  @location(12) f8: vec3<f16>,
+  @location(11) f9: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec2<i32>, @location(6) a1: vec2<f16>, @location(14) a2: vec3<i32>, @builtin(vertex_index) a3: u32, @location(0) a4: vec3<f16>, @location(8) a5: i32, @location(3) a6: vec2<i32>, @location(5) a7: vec3<u32>, @location(10) a8: u32, @location(16) a9: vec2<f16>, @location(23) a10: vec3<f32>, a11: S8) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup22 = device0.createBindGroup({
+  label: '\u6f7c\u05d2\u2784\u083c\uf687\u0a98\u0fd5\uc2ee\u0318',
+  layout: bindGroupLayout7,
+  entries: [{binding: 1530, resource: externalTexture27}],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup20, new Uint32Array(7962), 4568, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(1078392221, 994429757, 977237463, 574657940);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 136668);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(8, buffer8, 164980, 1079);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer8, 102836, buffer1, 167412, 3264);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet13, 407, 1, buffer10, 4352);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 13 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise22 = device0.createRenderPipelineAsync({
+  label: '\ua53b\u7a1c\u0c15\u7ed4\u0a47\ue86b\u3843\u{1ff6a}\u2394\u449e\u8847',
+  layout: 'auto',
+  multisample: {mask: 0x48525eb5},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'keep', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    depthBias: -939802962,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 668,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 28, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 6},
+          {format: 'sint8x4', offset: 84, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+});
+let gpuCanvasContext6 = canvas5.getContext('webgpu');
+let canvas6 = document.createElement('canvas');
+let texture63 = device0.createTexture({
+  label: '\u6ce7\u2da2\uf2b7\u75eb\uabee',
+  size: [150],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView77 = texture61.createView({
+  label: '\u5b6e\u6870\u1703\u{1f947}\u0c3c\ub1cf\u0756\u{1fed1}\u3f98\u047c\u0b71',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup6, new Uint32Array(6993), 1584, 0);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup14, []);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(779006025, 776038152, 270222099, 783545409, 850878946);
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1150 widthInBlocks: 575 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1048 */
+  offset: 1048,
+  buffer: buffer10,
+}, {width: 575, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer1, 29436, 245228);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet15, 651, 714, buffer10, 62208);
+} catch {}
+let imageBitmap3 = await createImageBitmap(img5);
+let bindGroup23 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 6255, resource: sampler4}]});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u{1ff2b}\ud6f4\u1d6b\u0e6b'});
+let textureView78 = texture26.createView({
+  label: '\ude57\u8e02\u8632\u7c78\u059a\u02cc\u0a27\u{1f720}\u6731\ue425\u{1ff78}',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb',
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u2dc7\ubc12\u5834\u{1f7d2}\u0ce8\u02ef\u{1f85c}\u{1f9b4}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle35 = renderBundleEncoder4.finish();
+try {
+computePassEncoder15.setBindGroup(4, bindGroup4, new Uint32Array(4391), 3576, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 15400);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline39);
+} catch {}
+try {
+buffer6.destroy();
+} catch {}
+let querySet23 = device0.createQuerySet({label: '\uab6d\u0c9e\u5ee8\uac24\ue1a4\ucf2d\u8e3a\u04ca\uf09b', type: 'occlusion', count: 2376});
+let commandBuffer20 = commandEncoder65.finish({label: '\u{1f6a4}\u0cdb\ua061\u{1fb0c}'});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\u{1fb3f}\u{1fa56}\u00c5\ua09e\u0748\u53a7\u0835',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle36 = renderBundleEncoder4.finish({label: '\ue99e\u8572\u{1f9b7}\u72dd\u{1fef3}'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 52820);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 20896);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer8, 91820, buffer7, 4100, 1660);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let pipeline63 = device0.createComputePipeline({
+  label: '\u0c9b\u71ff\u041e\u{1f989}\u278c\u7e93\ub87b\u9ceb\u7832\u{1f665}\u8c9d',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2842,
+      visibility: 0,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView79 = texture37.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder5.draw(971579834, 1080628513, 437220862, 565030249);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(278107690);
+} catch {}
+offscreenCanvas12.width = 499;
+let commandEncoder67 = device0.createCommandEncoder({label: '\u3510\u975b\u{1f7e6}\u6049\u090e\ueee7\u1d47\u{1f791}'});
+let querySet24 = device0.createQuerySet({label: '\uc2a6\uce4b\u0ad5\u5e1b\u097d\u{1fdf5}\u072a\ub5c4', type: 'occlusion', count: 2471});
+let externalTexture32 = device0.importExternalTexture({label: '\u02ea\u{1fb78}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(54343411);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 19296);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 145596, new Int16Array(27865), 23691, 436);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 312, y: 80 },
+  flipY: false,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 64, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let pipeline64 = await device0.createComputePipelineAsync({
+  label: '\ufdd6\u67f1\u2a1a\u20bc',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let sampler29 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 2.650,
+  lodMaxClamp: 29.55,
+});
+try {
+computePassEncoder15.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(427082153, 98433808, 1147920395);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 75108 */
+  offset: 75108,
+  buffer: buffer10,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 3,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 461 */
+{offset: 461}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let imageBitmap4 = await createImageBitmap(img2);
+try {
+canvas6.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder();
+let textureView80 = texture12.createView({
+  label: '\u07f6\ua955\u045e\u3782\ufca0\u0e8d\u{1f880}\u{1f74d}',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let renderBundle37 = renderBundleEncoder6.finish({});
+try {
+renderBundleEncoder5.drawIndexed(738409163, 1035487430);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 612 widthInBlocks: 153 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6216 */
+  offset: 6216,
+  buffer: buffer5,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 153, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 24, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 25, y: 82 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder69 = device0.createCommandEncoder({label: '\u7a1e\u025f\u05bd\u8002'});
+let commandBuffer21 = commandEncoder34.finish({label: '\u31a0\u0c00\u0618\u0c92\ua5d4\u{1fb33}'});
+let texture64 = device0.createTexture({
+  label: '\ua1d6\u3e03\u546e\u68c3\uf147\u8235\uc01e',
+  size: [320, 40, 168],
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint', 'rg8uint'],
+});
+let renderBundle38 = renderBundleEncoder16.finish({label: '\u0d53\uaca4\u7ce0\u5245\ufe01\u08ed\u04a4\u44fb\u{1faa9}\u8868\u9ff3'});
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer11, 8356);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 198 widthInBlocks: 99 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12794 */
+  offset: 12794,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture3,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 99, height: 20, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 96596, new BigUint64Array(33087), 2505, 7372);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let pipeline65 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11384,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x4', offset: 3348, shaderLocation: 16}],
+      },
+      {
+        arrayStride: 40504,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 17254, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 12908, shaderLocation: 23},
+          {format: 'float32x2', offset: 300, shaderLocation: 19},
+          {format: 'sint8x2', offset: 4034, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 8306, shaderLocation: 11},
+          {format: 'uint32x2', offset: 7232, shaderLocation: 6},
+          {format: 'uint32x2', offset: 3724, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 11072,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 332, shaderLocation: 5}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u0316\u4146\u582f\u0857\u2d6d\u0992\ue931',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+commandEncoder37.resolveQuerySet(querySet9, 663, 6, buffer10, 37888);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 25, y: 37 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline66 = await device0.createRenderPipelineAsync({
+  label: '\uef2d\u4166\u0bcc\uc515\u0c62\u03e2\u477c\u0564\u5e17',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint'}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 556530109,
+    stencilWriteMask: 2267235253,
+    depthBias: 1815059020,
+    depthBiasSlopeScale: 326.1545800933313,
+    depthBiasClamp: -90.32837387968978,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 13188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 284, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 3888, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 5492,
+        attributes: [
+          {format: 'sint8x2', offset: 578, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 344, shaderLocation: 2},
+          {format: 'sint32x4', offset: 3460, shaderLocation: 0},
+          {format: 'sint32x2', offset: 1336, shaderLocation: 3},
+          {format: 'uint32x3', offset: 676, shaderLocation: 23},
+          {format: 'float16x2', offset: 184, shaderLocation: 19},
+          {format: 'float32', offset: 5340, shaderLocation: 17},
+          {format: 'float16x2', offset: 664, shaderLocation: 1},
+          {format: 'float32x4', offset: 1812, shaderLocation: 6},
+          {format: 'sint32', offset: 764, shaderLocation: 10},
+          {format: 'sint16x2', offset: 468, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 22040,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 5936, shaderLocation: 22},
+          {format: 'sint8x4', offset: 352, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 3456,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 116, shaderLocation: 11},
+          {format: 'sint8x4', offset: 44, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let bindGroupLayout18 = pipeline16.getBindGroupLayout(1);
+let commandEncoder70 = device0.createCommandEncoder({});
+let externalTexture33 = device0.importExternalTexture({
+  label: '\u0b04\u{1f754}\u07d3\u0a5a\u{1fea6}\u09e2\u6887\u8c1f\u6e4e',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup19, new Uint32Array(4857), 4388, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(5, bindGroup3, new Uint32Array(3860), 143, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer2, 43992, buffer0, 485612, 13144);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture61,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 10734 */
+  offset: 8172,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {width: 1, height: 11, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer0, 481584, 7104);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet13, 105, 1498, buffer10, 1280);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 1968);
+} catch {}
+try {
+commandEncoder70.copyBufferToBuffer(buffer5, 23412, buffer10, 26268, 17520);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: {x: 14, y: 0, z: 28},
+  aspect: 'all',
+}, new DataView(arrayBuffer1), /* required buffer size: 1862069 */
+{offset: 421, bytesPerRow: 346, rowsPerImage: 298}, {width: 42, height: 17, depthOrArrayLayers: 19});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 600, height: 96, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 13, y: 0 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 227, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 22, height: 96, depthOrArrayLayers: 0});
+} catch {}
+let pipeline67 = device0.createComputePipeline({
+  label: '\uec11\u3cf1\u0a61\u2dec\u42df\u0d4f\u{1fb3b}\u9a3c\u370d\uf13b',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder71 = device0.createCommandEncoder();
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 1947});
+let commandBuffer22 = commandEncoder60.finish({label: '\u807a\u0f3b\u0721\u0383\u0829\ue818\ud7d8\u0856\ucc41'});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup14, []);
+} catch {}
+try {
+renderBundleEncoder5.draw(1117369171, 1111944056);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 2770});
+let textureView81 = texture4.createView({label: '\ub574\u3ca8\u0f44\u{1fa78}\u2f0c\u{1f8bf}\u045b\u042a'});
+let computePassEncoder28 = commandEncoder63.beginComputePass({label: '\u00f7\u15e4\u3548\ua801\u03aa\uef31\u07eb\u4164\ub552'});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\uded1\uec42\u0c76\u9d8a\udc0b\u{1f98e}\u0540\u9451\ubdae\u4d69\u59f0',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder8.draw(185902335);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(245875969, 794376314, 214554006, -839098182, 78493661);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer1, 14356);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 12, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer7, 5808, 564);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 31, y: 54 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let commandEncoder72 = device0.createCommandEncoder({label: '\u8c47\u{1f92f}\u52af\u05cc\u0a03'});
+try {
+renderBundleEncoder33.setVertexBuffer(7, buffer3);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer5, 61992, buffer1, 58944, 38768);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet26, 112, 43, buffer10, 16640);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer21, commandBuffer20]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 68676, new DataView(new ArrayBuffer(49599)), 22827, 3244);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 1,
+  origin: {x: 89, y: 0, z: 3},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 3992443 */
+{offset: 507, bytesPerRow: 1234, rowsPerImage: 247}, {width: 295, height: 24, depthOrArrayLayers: 14});
+} catch {}
+let pipeline68 = device0.createComputePipeline({
+  label: '\u0f16\ue819',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video1);
+let commandEncoder73 = device0.createCommandEncoder({label: '\u5aef\u0865\u0df6'});
+let arrayBuffer6 = buffer7.getMappedRange(1776, 260);
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 12, y: 11, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 224 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 45816 */
+  offset: 32280,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {width: 56, height: 27, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer0, 38268, 265512);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline69 = device0.createRenderPipeline({
+  label: '\u2f47\u7c53',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilWriteMask: 1076503970,
+    depthBias: -894750923,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 2320, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1636,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x2', offset: 12, shaderLocation: 18},
+          {format: 'sint32x2', offset: 620, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 1608, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+let imageBitmap5 = await createImageBitmap(offscreenCanvas3);
+let renderBundle39 = renderBundleEncoder27.finish({label: '\u1cc9\ucded\uc0ba'});
+try {
+renderBundleEncoder34.setBindGroup(6, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder5.draw(620748452, 72577601, 141087103, 116028788);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer8, 36648);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(5, buffer3, 12980, 8178);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet12, 1888, 612, buffer10, 63488);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u3f95\u0775\u2c8d\u{1fed6}\u05ed\uceee'});
+let textureView82 = texture18.createView({label: '\uced4\u5adf', baseArrayLayer: 0});
+try {
+computePassEncoder19.setBindGroup(6, bindGroup9, new Uint32Array(6108), 2434, 0);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(5, buffer8, 95228, 63557);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer12, 66664, buffer0, 128484, 22864);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas5,
+  origin: { x: 7, y: 11 },
+  flipY: true,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas13.getContext('webgpu');
+let img8 = await imageWithData(106, 76, '#2b2ea123', '#8d53eca3');
+let videoFrame7 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let texture65 = device0.createTexture({
+  label: '\u9783\u{1f9a3}\ub2bf\u7243',
+  size: {width: 176},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder28.setBindGroup(5, bindGroup0, new Uint32Array(3468), 2063, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(1216105858);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer11, 13932);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline19);
+} catch {}
+gc();
+let shaderModule12 = device0.createShaderModule({
+  label: '\u086d\u{1fe5b}\u7c99\u{1f837}\ucdd1\ud745\u1ccf\u07e1\u0171\ua082\uae78',
+  code: `@group(2) @binding(1530)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(6255)
+var<storage, read_write> n5: array<u32>;
+@group(1) @binding(2593)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(58) f0: vec2<i32>,
+  @location(74) f1: vec3<f16>,
+  @location(76) f2: vec4<u32>,
+  @builtin(sample_index) f3: u32,
+  @location(36) f4: f32,
+  @location(43) f5: vec4<i32>,
+  @location(50) f6: vec2<f32>,
+  @location(80) f7: vec2<f32>,
+  @location(20) f8: vec4<f32>,
+  @location(59) f9: f32,
+  @location(44) f10: vec4<i32>,
+  @location(51) f11: vec2<f32>,
+  @location(73) f12: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: u32,
+  @location(3) f1: vec4<i32>,
+  @location(0) f2: vec4<u32>,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(a0: S10, @location(38) a1: vec2<u32>, @location(34) a2: u32, @location(35) a3: vec3<u32>, @builtin(sample_mask) a4: u32, @location(41) a5: f32, @location(8) a6: f32, @location(17) a7: i32, @location(63) a8: vec3<f16>, @location(67) a9: vec4<f32>, @location(12) a10: f32, @location(69) a11: f16, @location(31) a12: vec2<f16>, @location(75) a13: vec4<i32>, @location(0) a14: vec2<u32>, @location(26) a15: vec3<f16>, @location(9) a16: vec3<i32>, @location(65) a17: u32, @location(48) a18: vec4<f32>, @location(61) a19: vec3<i32>, @location(30) a20: u32, @location(39) a21: vec4<f16>, @location(7) a22: vec3<f16>, @location(64) a23: f16, @location(3) a24: vec3<f32>, @location(21) a25: vec3<f32>, @builtin(position) a26: vec4<f32>, @builtin(front_facing) a27: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(7) f0: vec3<f16>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec4<u32>,
+  @location(6) f3: vec4<f32>,
+  @builtin(vertex_index) f4: u32,
+  @location(9) f5: vec2<f32>,
+  @location(0) f6: vec2<u32>,
+  @location(17) f7: vec4<f32>,
+  @location(19) f8: f32,
+  @location(23) f9: u32,
+  @location(18) f10: vec3<f16>,
+  @location(21) f11: vec3<u32>,
+  @location(4) f12: vec2<f16>,
+  @location(3) f13: f32,
+  @builtin(instance_index) f14: u32,
+  @location(16) f15: vec4<f32>,
+  @location(20) f16: u32,
+  @location(22) f17: vec3<i32>,
+  @location(12) f18: u32,
+  @location(10) f19: vec4<f16>,
+  @location(11) f20: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(26) f112: vec3<f16>,
+  @location(17) f113: i32,
+  @location(69) f114: f16,
+  @location(80) f115: vec2<f32>,
+  @location(59) f116: f32,
+  @location(58) f117: vec2<i32>,
+  @location(67) f118: vec4<f32>,
+  @location(36) f119: f32,
+  @location(50) f120: vec2<f32>,
+  @location(20) f121: vec4<f32>,
+  @location(3) f122: vec3<f32>,
+  @location(76) f123: vec4<u32>,
+  @location(64) f124: f16,
+  @location(7) f125: vec3<f16>,
+  @location(8) f126: f32,
+  @location(12) f127: f32,
+  @location(34) f128: u32,
+  @location(35) f129: vec3<u32>,
+  @location(0) f130: vec2<u32>,
+  @location(38) f131: vec2<u32>,
+  @location(43) f132: vec4<i32>,
+  @location(39) f133: vec4<f16>,
+  @location(75) f134: vec4<i32>,
+  @location(31) f135: vec2<f16>,
+  @location(41) f136: f32,
+  @location(44) f137: vec4<i32>,
+  @location(48) f138: vec4<f32>,
+  @location(51) f139: vec2<f32>,
+  @location(73) f140: vec3<i32>,
+  @location(74) f141: vec3<f16>,
+  @location(30) f142: u32,
+  @builtin(position) f143: vec4<f32>,
+  @location(9) f144: vec3<i32>,
+  @location(65) f145: u32,
+  @location(63) f146: vec3<f16>,
+  @location(61) f147: vec3<i32>,
+  @location(21) f148: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: u32, @location(13) a1: vec3<f32>, @location(14) a2: vec3<i32>, a3: S9, @location(8) a4: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder75 = device0.createCommandEncoder({label: '\ua60d\u87fe\u04ea\uf675\u{1f861}\u3d9b\u09de\u16e9\u9257'});
+let querySet27 = device0.createQuerySet({label: '\ud6be\u6421\u014e\u92c3\u1710\u907e', type: 'occlusion', count: 294});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\ubc93\u01fd\u{1f90d}\ua8c8',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer11, 13528);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 3088 widthInBlocks: 772 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18496 */
+  offset: 18496,
+  bytesPerRow: 3328,
+  buffer: buffer5,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 170, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 772, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(querySet10, 1135, 601, buffer10, 59904);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(803, 923);
+try {
+offscreenCanvas14.getContext('webgl2');
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u{1fd13}\ud7dc\ud29d\u4568\udda2\u05fa\u088c\u0d5e\ue18f\ua085',
+  code: `@group(1) @binding(2593)
+var<storage, read_write> field4: array<u32>;
+@group(0) @binding(3816)
+var<storage, read_write> n6: array<u32>;
+@group(1) @binding(6303)
+var<storage, read_write> parameter6: array<u32>;
+@group(0) @binding(4504)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(3513)
+var<storage, read_write> field5: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec3<u32>,
+  @location(3) f3: vec2<i32>,
+  @location(2) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(7) f0: vec2<f16>,
+  @location(4) f1: vec4<i32>,
+  @location(13) f2: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec4<u32>, @location(14) a1: vec2<u32>, @location(22) a2: vec3<i32>, a3: S11, @location(15) a4: vec2<f32>, @location(21) a5: vec2<u32>, @location(9) a6: vec3<u32>, @location(19) a7: u32, @location(1) a8: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout19 = device0.createBindGroupLayout({label: '\u63bc\ubc4e', entries: []});
+try {
+computePassEncoder0.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup21, new Uint32Array(8905), 7473, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 28560);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer11, 'uint16', 18216, 67519);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture61,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7580 */
+  offset: 7580,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {width: 4, height: 5, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet20, 7, 163, buffer10, 37120);
+} catch {}
+try {
+renderBundleEncoder12.insertDebugMarker('\ub869');
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  label: '\u0b86\u{1fd55}\u{1fd82}\u161f',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1494, resource: sampler3}],
+});
+let texture66 = device0.createTexture({
+  label: '\u7a7f\u0e9f\u881f\u07c3\uf371',
+  size: [298, 16, 1],
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView83 = texture53.createView({label: '\u9409\u144f\u{1fa53}\u{1f73f}\u{1fee6}\u16df\u0f1e'});
+let computePassEncoder29 = commandEncoder57.beginComputePass({label: '\uff97\u{1fb08}\u04c5'});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder5.draw(229561874, 392398491, 171620501, 92987112);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(315117686);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer1, 102308);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer8);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer5), /* required buffer size: 287366 */
+{offset: 86, bytesPerRow: 36, rowsPerImage: 105}, {width: 9, height: 0, depthOrArrayLayers: 77});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img9 = await imageWithData(186, 182, '#3fa3d89a', '#4c5fc274');
+let bindGroup25 = device0.createBindGroup({
+  label: '\uf844\u09a5\u{1f72a}\u05ee\u0b4a\u083b\u{1f9a1}\u02f7',
+  layout: bindGroupLayout7,
+  entries: [{binding: 1530, resource: externalTexture12}],
+});
+let commandEncoder76 = device0.createCommandEncoder();
+let querySet28 = device0.createQuerySet({
+  label: '\u{1ff08}\u09a7\u{1f916}\u0970\u056b\uffe3\u086c\u37de\u0572\u1095',
+  type: 'occlusion',
+  count: 2952,
+});
+let textureView84 = texture11.createView({label: '\u1a0e\ud322\u{1fb27}\u{1fe80}\u{1f78a}', dimension: '2d-array'});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder5.draw(788848702, 776074138, 569796759, 1133821890);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer11, 17280);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(9, buffer3);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 544 widthInBlocks: 136 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 66736 */
+  offset: 30864,
+  bytesPerRow: 768,
+  buffer: buffer4,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 136, height: 47, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 656 widthInBlocks: 164 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8688 */
+  offset: 8688,
+  buffer: buffer10,
+}, {width: 164, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 12},
+  aspect: 'all',
+},
+{width: 549, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u{1fd1d}\u{1fc59}',
+  entries: [
+    {
+      binding: 5098,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder77 = device0.createCommandEncoder();
+let sampler30 = device0.createSampler({
+  label: '\u30b9\uf89b\ub2d2\u4248\u{1f6ca}\udd3f\u3698\u30a1\u0378\u680c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.54,
+  lodMaxClamp: 99.77,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(5, bindGroup2, new Uint32Array(7747), 661, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(450139675, 782317263, 185586957, -926358288, 1031245962);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer1, 199960);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2, buffer8);
+} catch {}
+let arrayBuffer7 = buffer9.getMappedRange(28368, 28);
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 296, y: 23, z: 0},
+  aspect: 'all',
+},
+{width: 176, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({label: '\ud8ee\u{1f823}\u0e75\u469b\u0937\u90a5\u{1f8c5}\u3135\u0a90\u0b60\u{1fd8f}'});
+let textureView85 = texture28.createView({label: '\ua1a5\u{1f69f}\u5c7a\u9f18', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundle40 = renderBundleEncoder10.finish({});
+let sampler31 = device0.createSampler({
+  label: '\u{1fb3a}\u3b6e\u04d0\u3400\u1f37\u{1fe4d}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 15.29,
+  lodMaxClamp: 76.64,
+});
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(2, buffer8, 165660);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer3, 41800, buffer10, 78316, 2660);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28416 */
+  offset: 28416,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 313, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 55, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder75.resolveQuerySet(querySet10, 1702, 163, buffer10, 52480);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 55648, new Float32Array(27403), 13581, 1936);
+} catch {}
+let pipeline70 = device0.createRenderPipeline({
+  label: '\uc29d\u{1f9c0}\u0858\ufef3\u5dda\u0fa5\u095e\u094b\u{1fd68}\u3b9e\u8c0a',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'zero', depthFailOp: 'keep'},
+    stencilReadMask: 4208725088,
+    depthBiasSlopeScale: 665.1810062704798,
+    depthBiasClamp: 203.21572361718387,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7912,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 2180, shaderLocation: 14},
+          {format: 'float32x3', offset: 28, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 5932, shaderLocation: 15},
+          {format: 'uint16x2', offset: 4368, shaderLocation: 8},
+          {format: 'float32', offset: 844, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 1736, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 160, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 17076,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1108, shaderLocation: 22},
+          {format: 'uint8x4', offset: 8192, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 10, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 4272, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 16520,
+        attributes: [
+          {format: 'float32', offset: 4056, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 112, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 1516, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 1924,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x4', offset: 308, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let img10 = await imageWithData(292, 56, '#1dc7ee69', '#91834449');
+try {
+renderBundleEncoder5.draw(717647796);
+} catch {}
+let arrayBuffer8 = buffer0.getMappedRange(0, 125536);
+try {
+commandEncoder64.copyBufferToBuffer(buffer6, 204868, buffer0, 497464, 14916);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet25, 287, 305, buffer10, 67072);
+} catch {}
+let buffer14 = device0.createBuffer({
+  label: '\u41fc\u0dc5\u{1f60b}\u8e6c\u8f1a\ucf42\u68da\ud5f7',
+  size: 88836,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let texture67 = device0.createTexture({
+  label: '\uda6d\u{1fdfd}\u08e0\ufcff',
+  size: {width: 1194, height: 64, depthOrArrayLayers: 656},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView86 = texture45.createView({label: '\u412a\u0894\ua7b6\u8153\u0443\u186e'});
+let sampler32 = device0.createSampler({
+  label: '\u802b\u5a85\u{1ff9c}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 61.45,
+  lodMaxClamp: 90.65,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer11, 130632);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer8, 'uint32', 78032, 77838);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 603, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+},
+{width: 35, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder27.resolveQuerySet(querySet14, 2221, 743, buffer10, 6912);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let pipeline71 = device0.createComputePipeline({
+  label: '\u62db\u{1fc6b}\ucdd3',
+  layout: 'auto',
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let video9 = await videoWithData();
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2872,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 1149,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 859, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u0304\u07cd\uccab\u071f\u3199\ud103', bindGroupLayouts: [bindGroupLayout0]});
+let texture68 = device0.createTexture({
+  label: '\u{1fe01}\u0aed\u80fe\u{1fa5a}\u3e1b\u0839\u{1fd44}\u{1fd90}\u6172',
+  size: [160, 20, 4],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView87 = texture14.createView({label: '\ubd37\u1012\u0d0c\u{1fbb0}\ue313\u1afa'});
+let externalTexture34 = device0.importExternalTexture({source: video3});
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer11, 18584);
+} catch {}
+try {
+renderBundleEncoder28.insertDebugMarker('\u73e2');
+} catch {}
+let textureView88 = texture32.createView({label: '\u0ba5\u095b\uf0ba\u{1ff82}\ua767\u{1ff1d}', format: 'rgba8unorm-srgb'});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\u0c4e\uc24b\u{1fc6b}\uc268\uaf8a\u8fcf\uee5c\u2788\u151a\udd7f',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(292550645, 1135744198, 488250687, 353696790, 100844734);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer8, 62552, buffer7, 3760, 624);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let pipeline72 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  multisample: {mask: 0xb790eb4a},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 515786769,
+    stencilWriteMask: 1637728573,
+    depthBias: -197295034,
+    depthBiasSlopeScale: 83.22962205333849,
+    depthBiasClamp: 641.5379644370298,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 12032, attributes: [{format: 'unorm16x4', offset: 5696, shaderLocation: 2}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let gpuCanvasContext8 = offscreenCanvas11.getContext('webgpu');
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let renderBundle41 = renderBundleEncoder13.finish({label: '\u4326\udf8b\u9f0a'});
+let sampler33 = device0.createSampler({
+  label: '\u0785\u956e\u906d\u84de\u367f\u0265\u0ab0\u{1fd7a}\u7bba\u8147',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.25,
+  lodMaxClamp: 68.26,
+});
+try {
+renderBundleEncoder15.setPipeline(pipeline65);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer8, 152140, buffer14, 39732, 1268);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 106, y: 66 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame8 = new VideoFrame(video9, {timestamp: 0});
+let textureView89 = texture42.createView({
+  label: '\u02e3\u234f\u9616\u787e\u0343\uafc2\ude9c\u0f23\u008c\u411f\u0fbd',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let sampler34 = device0.createSampler({
+  label: '\u{1f946}\ue080\u{1f6c7}\u7429\u0dd8\u425b\u016d',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 74.73,
+});
+try {
+renderBundleEncoder37.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline73 = await promise22;
+offscreenCanvas7.height = 219;
+let promise25 = adapter0.requestAdapterInfo();
+let textureView90 = texture67.createView({label: '\ue606\u{1f8bc}\uffd9\u0de4\u0254\u{1ff09}', mipLevelCount: 1});
+let computePassEncoder30 = commandEncoder39.beginComputePass();
+let renderBundle42 = renderBundleEncoder9.finish({label: '\u191a\u0f08\u6325'});
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer11, 14924);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 172 widthInBlocks: 86 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12262 */
+  offset: 12262,
+  bytesPerRow: 256,
+  buffer: buffer8,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 215, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 86, height: 75, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 291, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 80, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 80600, new DataView(new ArrayBuffer(33885)), 3504, 880);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 1,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(80)), /* required buffer size: 171513 */
+{offset: 73, bytesPerRow: 400, rowsPerImage: 210}, {width: 120, height: 9, depthOrArrayLayers: 3});
+} catch {}
+let pipeline74 = device0.createRenderPipeline({
+  label: '\uf699\uf586\uad50\uac9f\u{1fdc5}\u8aca\uf3fa\u0951',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilReadMask: 2719145049,
+    stencilWriteMask: 493167115,
+    depthBias: -2008653279,
+    depthBiasSlopeScale: 753.9374082333197,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 12284,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x4', offset: 6844, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 216, shaderLocation: 18},
+          {format: 'sint16x2', offset: 4044, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder79 = device0.createCommandEncoder({label: '\u0ac7\u92ea\u07ec\u0745\u{1f770}\u0977\udcbb\ubaf0'});
+let querySet29 = device0.createQuerySet({
+  label: '\u9a69\u0a4c\u0685\uec1c\u{1f89e}\u1591\ub2af\u962f\u{1f6be}\u{1ff10}',
+  type: 'occlusion',
+  count: 3010,
+});
+let externalTexture35 = device0.importExternalTexture({label: '\u{1fb53}\u{1fef6}\u0b93\ub536\u30ee', source: video2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder5.drawIndexed(342096521);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer2, 581464, buffer14, 7216, 16072);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 2,
+  origin: {x: 34, y: 7, z: 5},
+  aspect: 'all',
+},
+{width: 175, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker('\u52cd');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer8), /* required buffer size: 397 */
+{offset: 397, bytesPerRow: 321}, {width: 73, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let pipeline75 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint'}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8unorm-srgb', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 2932303587,
+    stencilWriteMask: 1415785312,
+    depthBias: 1523325914,
+    depthBiasSlopeScale: 4.140863212310592,
+    depthBiasClamp: 580.1298049438051,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 46472, shaderLocation: 4},
+          {format: 'uint32x3', offset: 28792, shaderLocation: 9},
+          {format: 'float32', offset: 28484, shaderLocation: 7},
+          {format: 'uint32x2', offset: 8844, shaderLocation: 21},
+          {format: 'sint16x4', offset: 18200, shaderLocation: 13},
+          {format: 'uint8x2', offset: 6304, shaderLocation: 19},
+          {format: 'uint16x2', offset: 17256, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 5788,
+        attributes: [
+          {format: 'uint16x4', offset: 488, shaderLocation: 14},
+          {format: 'uint32', offset: 2668, shaderLocation: 1},
+          {format: 'sint32x4', offset: 860, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 44360, attributes: []},
+      {arrayStride: 64488, stepMode: 'instance', attributes: []},
+      {arrayStride: 18140, stepMode: 'instance', attributes: []},
+      {arrayStride: 8408, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'float16x2', offset: 8976, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', unclippedDepth: true},
+});
+document.body.prepend(canvas0);
+let textureView91 = texture1.createView({label: '\u6d0b\ua18c\u{1f807}\uf140\u{1f799}\u269e\u0fb5\u330f\ub483\ud7e5\u08ea'});
+try {
+computePassEncoder17.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer1, 134828);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer8, 'uint32');
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer13.mapAsync(GPUMapMode.WRITE, 102400, 372);
+} catch {}
+try {
+commandEncoder64.copyBufferToBuffer(buffer6, 178088, buffer1, 130852, 69456);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 132 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 15522 */
+  offset: 14622,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 19, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 848 */
+{offset: 848}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 597, height: 32, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 1,
+  origin: {x: 16, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({label: '\ufc16\u{1fb59}\u{1fd45}\u840e\u{1fe09}\uc69a\u05b3\u0ac9\u9c07'});
+let textureView92 = texture15.createView({label: '\u{1fa11}\u25e7\u98f6\u747b\u{1fce6}\u5c60\u24e6', mipLevelCount: 1});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\udde2\u0ed5\u8f19\u{1f95b}',
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+});
+let externalTexture36 = device0.importExternalTexture({label: '\u53cb\u4bba\ua4b1\u{1f6dc}\u{1f641}\u03a9', source: video7, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder8.drawIndirect(buffer8, 23108);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline39);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer3, 0);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 10, y: 34, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\ufc4a\u4257\u2c3c\u0c64\u{1f763}\u{1f980}\u{1f909}\u{1fcd3}\u9f31',
+  size: 579385,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'rg16sint', 'r16uint', 'r32sint', 'rgba8unorm-srgb'],
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder24.setBindGroup(6, bindGroup22, new Uint32Array(2387), 2367, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder5.draw(1037672419, 720445798);
+} catch {}
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 426 widthInBlocks: 213 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21436 */
+  offset: 17938,
+  bytesPerRow: 512,
+  buffer: buffer10,
+}, {width: 213, height: 7, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 58196, new Int16Array(62403), 22530, 3600);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\uf9c2\u{1ff31}',
+  code: `@group(1) @binding(1530)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(1530)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: u32,
+  @location(0) f1: vec3<u32>,
+  @location(3) f2: vec2<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, a1: S13, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(14) f0: vec2<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(8) f2: i32,
+  @location(15) f3: vec2<u32>,
+  @location(17) f4: vec2<f16>,
+  @location(1) f5: vec3<f32>,
+  @location(7) f6: i32,
+  @location(9) f7: vec2<f32>,
+  @location(22) f8: vec4<i32>,
+  @location(6) f9: vec3<f16>,
+  @location(12) f10: vec2<i32>,
+  @location(5) f11: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<u32>, @location(13) a1: vec4<i32>, a2: S12, @location(18) a3: i32, @location(10) a4: vec3<f32>, @location(3) a5: vec2<i32>, @location(16) a6: vec2<f32>, @location(20) a7: vec3<u32>, @location(19) a8: vec2<f32>, @location(2) a9: i32, @location(11) a10: vec3<f16>, @location(4) a11: vec2<u32>, @location(23) a12: vec2<u32>, @builtin(instance_index) a13: u32, @builtin(vertex_index) a14: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder81 = device0.createCommandEncoder({label: '\uafb9\u{1f793}\u276b\u{1f8a1}\u2aed\u6f22'});
+let querySet30 = device0.createQuerySet({label: '\uddf1\u604a\u6e68\u0441\u030d\u1bd0\u7e95\u{1fd03}\u{1faa8}', type: 'occlusion', count: 1790});
+let renderBundle43 = renderBundleEncoder34.finish({});
+let sampler35 = device0.createSampler({
+  label: '\u{1f8aa}\ua712\u{1fc2f}',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 65.75,
+  lodMaxClamp: 80.35,
+});
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 812 widthInBlocks: 203 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 47808 */
+  offset: 47808,
+  bytesPerRow: 1024,
+  rowsPerImage: 153,
+  buffer: buffer12,
+}, {
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 203, height: 28, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 48, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 7, y: 1 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 44, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer23 = commandEncoder67.finish();
+let renderBundle44 = renderBundleEncoder33.finish();
+let sampler36 = device0.createSampler({
+  label: '\u07a5\u6241\u0d86\u07f2\u{1ffaf}\u7e5c\u062d\u3e77\u39f5',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 12.76,
+  lodMaxClamp: 91.54,
+});
+try {
+renderBundleEncoder12.setPipeline(pipeline19);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer8, 10868, buffer1, 253996, 96060);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16676 */
+  offset: 16676,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 86},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 109, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer7, 1236, 4312);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4936, new DataView(new ArrayBuffer(52800)), 9656, 16336);
+} catch {}
+let imageBitmap6 = await createImageBitmap(videoFrame6);
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\uf929\u99fd',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout15, bindGroupLayout4, bindGroupLayout5, bindGroupLayout5],
+});
+let buffer16 = device0.createBuffer({
+  label: '\u75d5\u0794\u6fa0\u99ff\u0733',
+  size: 169596,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let textureView93 = texture17.createView({label: '\uf126\u01f5\u{1fae1}\u03ce\u5d6e\uedb3\u0044\ua802', dimension: '2d-array', baseMipLevel: 4});
+let externalTexture37 = device0.importExternalTexture({label: '\u{1fc0a}\u0d89\udce6\ub3cf', source: video5, colorSpace: 'srgb'});
+try {
+computePassEncoder3.setBindGroup(4, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup6, new Uint32Array(8479), 5282, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer16, 18236);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer11, 'uint32', 61112, 48822);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 727},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder81.clearBuffer(buffer16, 135012);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline76 = device0.createComputePipeline({
+  label: '\u0439\u06bf\u{1fa4f}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let imageData6 = new ImageData(244, 204);
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\u0fd1\u5c7c\u40a4\u7317\u0068\u07b1\u4af0\u09ce',
+  entries: [
+    {
+      binding: 5145,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 4881,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer17 = device0.createBuffer({size: 148800, usage: GPUBufferUsage.VERTEX});
+try {
+renderBundleEncoder14.setBindGroup(6, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer8, 8496);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 283800, 68980);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(querySet22, 3271, 21, buffer10, 31744);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 53958 */
+{offset: 412, bytesPerRow: 558}, {width: 134, height: 96, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video2);
+let offscreenCanvas15 = new OffscreenCanvas(926, 177);
+let imageData7 = new ImageData(120, 148);
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\ue638\uaf96\uc57b\u0e38\u7aff\u05ee',
+  entries: [
+    {
+      binding: 1809,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 3954,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 647,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let textureView94 = texture66.createView({label: '\u325d\u0deb\u0618\u02db\u9153\u7f3a', dimension: '2d-array', baseMipLevel: 1});
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.56,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(6, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer14, 1592);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 11760 */
+  offset: 11760,
+  rowsPerImage: 129,
+  buffer: buffer10,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder68.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet0, 486, 136, buffer10, 40704);
+} catch {}
+try {
+device0.queue.submit([commandBuffer23]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas13,
+  origin: { x: 47, y: 315 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline77 = device0.createComputePipeline({
+  label: '\u0211\u1d3d',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+offscreenCanvas9.width = 1568;
+let bindGroup26 = device0.createBindGroup({
+  label: '\u48b3\uaf2c\u{1f617}\u{1f8e6}\u5a27\u{1f99a}\u{1f675}\u{1f740}',
+  layout: bindGroupLayout19,
+  entries: [],
+});
+try {
+renderBundleEncoder40.setBindGroup(5, bindGroup7, new Uint32Array(7569), 1999, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(1229026211, 456149075, 978386523, 1188072787);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(81622257, 847120194, 474473385);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1700 widthInBlocks: 425 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17820 */
+  offset: 17820,
+  buffer: buffer10,
+}, {width: 425, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 672 */
+{offset: 668}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let renderBundle45 = renderBundleEncoder37.finish({label: '\u4188\u0d9c'});
+let sampler38 = device0.createSampler({
+  label: '\u845d\ue159\u0ef3\u0181\ua50c\uc5e2\u1d80\u{1fe61}\u{1fb6a}\uea52\u01ac',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.17,
+  lodMaxClamp: 92.41,
+  maxAnisotropy: 9,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer4, 118328, buffer14, 21368, 47420);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let commandBuffer24 = commandEncoder81.finish({label: '\u0a4c\u{1fe13}\u0d94\ufd2f'});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 161956);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(10, buffer3, 6140, 28680);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 51792 */
+  offset: 51792,
+  rowsPerImage: 254,
+  buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer16, 113436, 12048);
+dissociateBuffer(device0, buffer16);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -39,9 +39,7 @@ namespace WebGPU {
 static constexpr auto maxVertexBuffers = 12;
 static constexpr uint32_t maxBindGroups = 11;
 
-static constexpr auto tier1LimitForBuffersAndTextures = 1;
 static constexpr auto tier2LimitForBuffersAndTextures = 4;
-static constexpr auto tier1LimitForSamplers = 1;
 static constexpr auto tier2LimitForSamplers = 2;
 static constexpr uint64_t defaultMaxBufferSize = 268435456;
 
@@ -119,168 +117,6 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
 #endif
 
     return features;
-}
-
-static HardwareCapabilities apple3(id<MTLDevice> device)
-{
-    auto baseCapabilities = WebGPU::baseCapabilities(device);
-
-    baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
-    baseCapabilities.canPresentRGB10A2PixelFormats = false;
-
-    auto features = WebGPU::baseFeatures(device, baseCapabilities);
-
-    features.append(WGPUFeatureName_TextureCompressionETC2);
-    features.append(WGPUFeatureName_TextureCompressionASTC);
-
-    std::sort(features.begin(), features.end());
-
-    return {
-        {
-            .maxTextureDimension1D =    16384,
-            .maxTextureDimension2D =    16384,
-            .maxTextureDimension3D =    2048,
-            .maxTextureArrayLayers =    2048,
-            .maxBindGroups =    maxBindGroups,
-            .maxBindGroupsPlusVertexBuffers = 30,
-            .maxBindingsPerBindGroup =  10000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
-            .maxSampledTexturesPerShaderStage =    maxBindGroups * tier1LimitForBuffersAndTextures,
-            .maxSamplersPerShaderStage =    maxBindGroups * tier1LimitForSamplers,
-            .maxStorageBuffersPerShaderStage =    maxBindGroups * tier1LimitForBuffersAndTextures,
-            .maxStorageTexturesPerShaderStage =    maxBindGroups * tier1LimitForBuffersAndTextures,
-            .maxUniformBuffersPerShaderStage =    maxBindGroups * tier1LimitForBuffersAndTextures,
-            .maxUniformBufferBindingSize =    0, // To be filled in by the caller.
-            .maxStorageBufferBindingSize =    0, // To be filled in by the caller.
-            .minUniformBufferOffsetAlignment =    32,
-            .minStorageBufferOffsetAlignment =    32,
-            .maxVertexBuffers =    maxVertexBuffers,
-            .maxBufferSize = maxBufferSize(device),
-            .maxVertexAttributes =    30,
-            .maxVertexBufferArrayStride =    multipleOf4(largeReasonableLimit()),
-            .maxInterStageShaderComponents =    64,
-            .maxInterStageShaderVariables =    124,
-            .maxColorAttachments =    8,
-            .maxColorAttachmentBytesPerSample = 32,
-            .maxComputeWorkgroupStorageSize =    16 * KB,
-            .maxComputeInvocationsPerWorkgroup =    512,
-            .maxComputeWorkgroupSizeX =    512,
-            .maxComputeWorkgroupSizeY =    512,
-            .maxComputeWorkgroupSizeZ =    512,
-            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
-        },
-        WTFMove(features),
-        baseCapabilities,
-    };
-}
-
-static HardwareCapabilities apple4(id<MTLDevice> device)
-{
-    auto baseCapabilities = WebGPU::baseCapabilities(device);
-
-    baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
-    baseCapabilities.canPresentRGB10A2PixelFormats = false;
-
-    auto features = WebGPU::baseFeatures(device, baseCapabilities);
-
-    features.append(WGPUFeatureName_TextureCompressionETC2);
-    features.append(WGPUFeatureName_TextureCompressionASTC);
-
-    std::sort(features.begin(), features.end());
-
-    return {
-        {
-            .maxTextureDimension1D =    16384,
-            .maxTextureDimension2D =    16384,
-            .maxTextureDimension3D =    2048,
-            .maxTextureArrayLayers =    2048,
-            .maxBindGroups =    maxBindGroups,
-            .maxBindGroupsPlusVertexBuffers = 30,
-            .maxBindingsPerBindGroup =  10000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
-            .maxSampledTexturesPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxSamplersPerShaderStage =    maxBindGroups * tier2LimitForSamplers,
-            .maxStorageBuffersPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxStorageTexturesPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxUniformBuffersPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxUniformBufferBindingSize =    0, // To be filled in by the caller.
-            .maxStorageBufferBindingSize =    0, // To be filled in by the caller.
-            .minUniformBufferOffsetAlignment =    32,
-            .minStorageBufferOffsetAlignment =    32,
-            .maxVertexBuffers =    maxVertexBuffers,
-            .maxBufferSize =    maxBufferSize(device),
-            .maxVertexAttributes =    30,
-            .maxVertexBufferArrayStride =    multipleOf4(largeReasonableLimit()),
-            .maxInterStageShaderComponents =    124,
-            .maxInterStageShaderVariables =    124,
-            .maxColorAttachments =    8,
-            .maxColorAttachmentBytesPerSample = 64,
-            .maxComputeWorkgroupStorageSize =    32 * KB,
-            .maxComputeInvocationsPerWorkgroup =    1024,
-            .maxComputeWorkgroupSizeX =    1024,
-            .maxComputeWorkgroupSizeY =    1024,
-            .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
-        },
-        WTFMove(features),
-        baseCapabilities,
-    };
-}
-
-static HardwareCapabilities apple5(id<MTLDevice> device)
-{
-    auto baseCapabilities = WebGPU::baseCapabilities(device);
-
-    baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
-    baseCapabilities.canPresentRGB10A2PixelFormats = false;
-
-    auto features = WebGPU::baseFeatures(device, baseCapabilities);
-
-    features.append(WGPUFeatureName_TextureCompressionETC2);
-    features.append(WGPUFeatureName_TextureCompressionASTC);
-
-    std::sort(features.begin(), features.end());
-
-    return {
-        {
-            .maxTextureDimension1D =    16384,
-            .maxTextureDimension2D =    16384,
-            .maxTextureDimension3D =    2048,
-            .maxTextureArrayLayers =    2048,
-            .maxBindGroups =    maxBindGroups,
-            .maxBindGroupsPlusVertexBuffers = 30,
-            .maxBindingsPerBindGroup =  10000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
-            .maxSampledTexturesPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxSamplersPerShaderStage =    maxBindGroups * tier2LimitForSamplers,
-            .maxStorageBuffersPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxStorageTexturesPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxUniformBuffersPerShaderStage =    maxBindGroups * tier2LimitForBuffersAndTextures,
-            .maxUniformBufferBindingSize =    0, // To be filled in by the caller.
-            .maxStorageBufferBindingSize =    0, // To be filled in by the caller.
-            .minUniformBufferOffsetAlignment =    32,
-            .minStorageBufferOffsetAlignment =    32,
-            .maxVertexBuffers =    maxVertexBuffers,
-            .maxBufferSize =    maxBufferSize(device),
-            .maxVertexAttributes =    30,
-            .maxVertexBufferArrayStride =    multipleOf4(largeReasonableLimit()),
-            .maxInterStageShaderComponents =    124,
-            .maxInterStageShaderVariables = 124,
-            .maxColorAttachments = 8,
-            .maxColorAttachmentBytesPerSample = 64,
-            .maxComputeWorkgroupStorageSize =    32 * KB,
-            .maxComputeInvocationsPerWorkgroup =    1024,
-            .maxComputeWorkgroupSizeX =    1024,
-            .maxComputeWorkgroupSizeY =    1024,
-            .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
-        },
-        WTFMove(features),
-        baseCapabilities,
-    };
 }
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
@@ -536,14 +372,6 @@ static std::optional<HardwareCapabilities> rawHardwareCapabilities(id<MTLDevice>
         result->baseCapabilities = mergeBaseCapabilities(result->baseCapabilities, capabilities.baseCapabilities);
     };
 
-    // The feature set tables do not list limits for MTLGPUFamilyCommon1, MTLGPUFamilyCommon2, or MTLGPUFamilyCommon3.
-    // MTLGPUFamilyApple1 and MTLGPUFamilyApple2 are not supported.
-    if ([device supportsFamily:MTLGPUFamilyApple3])
-        merge(apple3(device));
-    if ([device supportsFamily:MTLGPUFamilyApple4])
-        merge(apple4(device));
-    if ([device supportsFamily:MTLGPUFamilyApple5])
-        merge(apple5(device));
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     if ([device supportsFamily:MTLGPUFamilyApple6])
         merge(apple6(device));


### PR DESCRIPTION
#### a19c25f387d25390c062e22d4b56e32a275ef274
<pre>
[WebGPU] A12x devices and earlier allowed for creation of more samplers than supported by the HW
<a href="https://bugs.webkit.org/show_bug.cgi?id=274334">https://bugs.webkit.org/show_bug.cgi?id=274334</a>
&lt;radar://128065020&gt;

Reviewed by Dan Glastonbury.

Apple4 and Apple5 devices have Tier 1 AB support, not tier 2, but
their limits were set according to tier 1 limits.

These are mostly older phones and iPads (iPhone XS, 2018 iPad Pro),
so we can instead use the default WebGPU limits which many websites
may use in any case.

Apple3 is not supported by WebGPU core, rather only WebGPU compat mode, which we
don&apos;t have any validation for right now.

* LayoutTests/fast/webgpu/fuzz-274334-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274334.html: Added.
* LayoutTests/TestExpectations
Add regression test.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::rawHardwareCapabilities):
(WebGPU::apple3): Deleted.
(WebGPU::apple4): Deleted.
(WebGPU::apple5): Deleted.
Use default limits for Apple3/4/5

Canonical link: <a href="https://commits.webkit.org/279016@main">https://commits.webkit.org/279016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e84c735e50f79bbe5e46808c0fc9ac149f9a31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55533 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2680 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29213 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23593 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2373 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1141 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57129 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45218 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11420 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->