### PR TITLE
Pass invalidation handler to ExtensionProcess::grantCapability

### DIFF
--- a/Source/WebKit/Platform/cocoa/AssertionCapability.h
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.h
@@ -44,6 +44,8 @@ public:
     // ExtensionCapability
     String environmentIdentifier() const final { return m_environmentIdentifier; }
 
+    BlockPtr<void()> didInvalidateBlock() const { return m_didInvalidateBlock; }
+
 private:
     String m_environmentIdentifier;
     String m_domain;

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -479,9 +479,8 @@ void ProcessAssertion::acquireSync()
     RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion::acquireSync Trying to take RBS assertion '%{public}s' for process with PID=%d", this, m_reason.utf8().data(), m_pid);
 #if USE(EXTENSIONKIT)
     if (m_process && m_capability && m_capability->hasPlatformCapability()) {
-        auto capability = m_capability->platformCapability();
         Locker locker { s_capabilityLock };
-        auto grant = m_process->grantCapability(capability);
+        auto grant = m_process->grantCapability(m_capability->platformCapability(), m_capability->didInvalidateBlock());
         m_grant.setPlatformGrant(WTFMove(grant));
         if (m_grant.isValid()) {
             RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion() Successfully granted capability", this);

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -69,7 +69,7 @@ public:
 private:
     explicit LaunchGrant(ExtensionProcess&);
 
-    RetainPtr<BEProcessCapabilityGrant> m_grant;
+    ExtensionCapabilityGrant m_grant;
 };
 #endif
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -28,6 +28,7 @@
 #include "ExtensionCapability.h"
 #include "ExtensionCapabilityGrant.h"
 
+#include <wtf/BlockPtr.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 
@@ -48,8 +49,6 @@ using ExtensionProcessVariant = std::variant<RetainPtr<BEWebContentProcess>, Ret
 using ExtensionProcessVariant = std::variant<RetainPtr<BEWebContentProcess>, RetainPtr<BENetworkingProcess>, RetainPtr<BERenderingProcess>>;
 #endif
 
-class ExtensionCapability;
-
 class ExtensionProcess {
 public:
     ExtensionProcess(BEWebContentProcess *);
@@ -61,8 +60,7 @@ public:
 
     void invalidate() const;
     OSObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
-    RetainPtr<BEProcessCapabilityGrant> grantCapability(BEProcessCapability *) const;
-    PlatformGrant grantCapability(const PlatformCapability&) const;
+    PlatformGrant grantCapability(const PlatformCapability&, BlockPtr<void()>&& invalidationHandler = ^{ }) const;
     RetainPtr<UIInteraction> createVisibilityPropagationInteraction() const;
 
 private:

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -32,6 +32,10 @@
 #import "ExtensionKitSPI.h"
 #import <BrowserEngineKit/BrowserEngineKit.h>
 
+#if __has_include(<WebKitAdditions/BEKAdditions.h>)
+#import <WebKitAdditions/BEKAdditions.h>
+#endif
+
 namespace WebKit {
 
 ExtensionProcess::ExtensionProcess(BEWebContentProcess *process)
@@ -73,18 +77,7 @@ OSObjectPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
     return xpcConnection;
 }
 
-RetainPtr<BEProcessCapabilityGrant> ExtensionProcess::grantCapability(BEProcessCapability *capability) const
-{
-    NSError *error = nil;
-    RetainPtr<BEProcessCapabilityGrant> grant;
-    WTF::switchOn(m_process, [&] (auto& process) {
-        grant = [process grantCapability:capability error:&error];
-    }, [] (const RetainPtr<_SEExtensionProcess>&) {
-    });
-    return grant;
-}
-
-PlatformGrant ExtensionProcess::grantCapability(const PlatformCapability& capability) const
+PlatformGrant ExtensionProcess::grantCapability(const PlatformCapability& capability, BlockPtr<void()>&& invalidationHandler) const
 {
     NSError *error = nil;
     PlatformGrant grant;
@@ -102,7 +95,11 @@ PlatformGrant ExtensionProcess::grantCapability(const PlatformCapability& capabi
     });
 #else
     WTF::switchOn(m_process, [&] (auto& process) {
+#if __has_include(<WebKitAdditions/BEKAdditions.h>)
+        GRANT_ADDITIONS
+#else
         grant = [process grantCapability:capability.get() error:&error];
+#endif
     });
 #endif
     return grant;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -58,10 +58,11 @@
 #endif
 
 #if USE(EXTENSIONKIT)
+#import "AssertionCapability.h"
+#import "ExtensionKitSPI.h"
 #import <BrowserEngineKit/BENetworkingProcess.h>
 #import <BrowserEngineKit/BERenderingProcess.h>
 #import <BrowserEngineKit/BEWebContentProcess.h>
-#import "ExtensionKitSPI.h"
 
 #if USE(LEGACY_EXTENSIONKIT_SPI)
 SOFT_LINK_FRAMEWORK_OPTIONAL(ServiceExtensions);
@@ -195,13 +196,14 @@ Ref<LaunchGrant> LaunchGrant::create(ExtensionProcess& process)
 
 LaunchGrant::LaunchGrant(ExtensionProcess& process)
 {
-    BEProcessCapability* capability = [BEProcessCapability foreground];
-    m_grant = process.grantCapability(capability);
+    AssertionCapability capability(emptyString(), emptyString(), "Foreground"_s);
+    auto grant = process.grantCapability(capability.platformCapability());
+    m_grant.setPlatformGrant(WTFMove(grant));
 }
 
 LaunchGrant::~LaunchGrant()
 {
-    [m_grant invalidate];
+    m_grant.invalidate();
 }
 #endif
 


### PR DESCRIPTION
#### 11913004d540d2edc9ab32dffa2e1c15624e73cb
<pre>
Pass invalidation handler to ExtensionProcess::grantCapability
<a href="https://bugs.webkit.org/show_bug.cgi?id=274331">https://bugs.webkit.org/show_bug.cgi?id=274331</a>
<a href="https://rdar.apple.com/126825362">rdar://126825362</a>

Reviewed by Chris Dumez.

In order for the invalidation handler to be called when the grant is invalidated, we need to
pass the invalidation handler to ExtensionProcess::grantCapability.

* Source/WebKit/Platform/cocoa/AssertionCapability.h:
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::ProcessAssertion):
(WebKit::ProcessAssertion::acquireSync):
(WebKit::Function&lt;void):
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm:
(WebKit::ExtensionProcess::grantCapability const):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::LaunchGrant::LaunchGrant):
(WebKit::LaunchGrant::~LaunchGrant):
* Source/WebKit/UIProcess/ProcessAssertion.h:

Canonical link: <a href="https://commits.webkit.org/279428@main">https://commits.webkit.org/279428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4e26e49a8c6d718895594043b762867b877ffe6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4206 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/40300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3988 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2753 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55578 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31021 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24482 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2362 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58355 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3704 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46411 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30772 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7870 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->