### PR TITLE
Update FileSystem::writeToFile() to take in a std::span

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -348,7 +348,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     SHA1 sha1;
     sha1.addBytes(m_cachedBytecode->span());
     sha1.computeHash(computedHash);
-    FileSystem::writeToFile(tempFD, computedHash.data(), sizeof(computedHash));
+    FileSystem::writeToFile(tempFD, computedHash);
 
     fsync(tempFD);
     rename(tempFileName, cacheFileName);

--- a/Source/JavaScriptCore/runtime/CachePayload.h
+++ b/Source/JavaScriptCore/runtime/CachePayload.h
@@ -43,6 +43,7 @@ public:
 
     JS_EXPORT_PRIVATE const uint8_t* data() const;
     JS_EXPORT_PRIVATE size_t size() const;
+    std::span<const uint8_t> span() const { return { data(), size() }; }
 
 private:
     CachePayload(std::variant<FileSystem::MappedFileData, std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>>&&);

--- a/Source/JavaScriptCore/runtime/CachedBytecode.cpp
+++ b/Source/JavaScriptCore/runtime/CachedBytecode.cpp
@@ -73,17 +73,17 @@ void CachedBytecode::commitUpdates(const ForEachUpdateCallback& callback) const
                 ptrdiff_t codeBlockOffset = functionUpdate.m_base + kindOffset + CachedWriteBarrierOffsets::ptrOffset() + CachedPtrOffsets::offsetOffset();
                 ptrdiff_t offsetPayload = static_cast<ptrdiff_t>(offset) - codeBlockOffset;
                 static_assert(std::is_same<decltype(VariableLengthObjectBase::m_offset), ptrdiff_t>::value);
-                callback(codeBlockOffset, &offsetPayload, sizeof(ptrdiff_t));
+                callback(codeBlockOffset, { reinterpret_cast<const uint8_t*>(&offsetPayload), sizeof(ptrdiff_t) });
             }
 
             {
                 ptrdiff_t metadataOffset = functionUpdate.m_base + CachedFunctionExecutableOffsets::metadataOffset();
-                callback(metadataOffset, &functionUpdate.m_metadata, sizeof(functionUpdate.m_metadata));
+                callback(metadataOffset, { reinterpret_cast<const uint8_t*>(&functionUpdate.m_metadata), sizeof(functionUpdate.m_metadata) });
             }
         }
 
         ASSERT(payload);
-        callback(offset, payload->data(), payload->size());
+        callback(offset, payload->span());
         offset += payload->size();
     }
     ASSERT(static_cast<size_t>(offset) == m_size);

--- a/Source/JavaScriptCore/runtime/CachedBytecode.h
+++ b/Source/JavaScriptCore/runtime/CachedBytecode.h
@@ -61,7 +61,7 @@ public:
     JS_EXPORT_PRIVATE void addGlobalUpdate(Ref<CachedBytecode>);
     JS_EXPORT_PRIVATE void addFunctionUpdate(const UnlinkedFunctionExecutable*, CodeSpecializationKind, Ref<CachedBytecode>);
 
-    using ForEachUpdateCallback = Function<void(off_t, const void*, size_t)>;
+    using ForEachUpdateCallback = Function<void(off_t, std::span<const uint8_t>)>;
     JS_EXPORT_PRIVATE void commitUpdates(const ForEachUpdateCallback&) const;
 
     std::span<const uint8_t> span() const { return { data(), size() }; }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -180,7 +180,7 @@ private:
         }
 
         for (const auto& page : m_pages) {
-            int bytesWritten = FileSystem::writeToFile(m_fd, page.buffer(), page.size());
+            int bytesWritten = FileSystem::writeToFile(m_fd, page.span());
             if (bytesWritten == -1) {
                 error = BytecodeCacheError::StandardError(errno);
                 return nullptr;
@@ -225,6 +225,9 @@ private:
 
         uint8_t* buffer() const { return m_buffer.get(); }
         size_t size() const { return static_cast<size_t>(m_offset); }
+
+        std::span<uint8_t> mutableSpan() { return { m_buffer.get(), size() }; }
+        std::span<const uint8_t> span() const { return { m_buffer.get(), size() }; }
 
         bool getOffset(const void* address, ptrdiff_t& result) const
         {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -453,7 +453,7 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
 
         CString utf8String = jsonData.utf8();
 
-        FileSystem::writeToFile(fileHandle, utf8String.data(), utf8String.length());
+        FileSystem::writeToFile(fileHandle, utf8String.span());
         FileSystem::closeFile(fileHandle);
         dataLogLn("Dumped sampling profiler samples to ", tempFilePath);
     }

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -87,7 +87,7 @@ static void dumpWasmSource(const Vector<uint8_t>& source)
         return;
     }
     dataLogLn("Dumping ", source.size(), " wasm source bytes to ", WTF::makeString(span(file), (count - 1), ".wasm"_s));
-    FileSystem::writeToFile(fileHandle, source.data(), source.size());
+    FileSystem::writeToFile(fileHandle, source.span());
     FileSystem::closeFile(fileHandle);
 }
 #endif

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -272,7 +272,7 @@ bool appendFileContentsToFileHandle(const String& path, PlatformFileHandle& targ
         if (readBytes < 0)
             return false;
 
-        if (writeToFile(target, buffer.data(), readBytes) != readBytes)
+        if (writeToFile(target, buffer.span().first(readBytes)) != readBytes)
             return false;
 
         if (readBytes < bufferSize)
@@ -524,7 +524,7 @@ std::optional<Salt> readOrMakeSalt(const String& path)
     if (!FileSystem::isHandleValid(file))
         return { };
 
-    bool success = static_cast<std::size_t>(FileSystem::writeToFile(file, salt.data(), salt.size())) == salt.size();
+    bool success = static_cast<std::size_t>(FileSystem::writeToFile(file, salt)) == salt.size();
     FileSystem::closeFile(file);
     if (!success)
         return { };
@@ -577,7 +577,7 @@ int overwriteEntireFile(const String& path, std::span<const uint8_t> span)
     if (!FileSystem::isHandleValid(fileHandle))
         return -1;
 
-    return FileSystem::writeToFile(fileHandle, span.data(), span.size());
+    return FileSystem::writeToFile(fileHandle, span);
 }
 
 void deleteAllFilesModifiedSince(const String& directory, WallTime time)

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -168,7 +168,7 @@ WTF_EXPORT_PRIVATE long long seekFile(PlatformFileHandle, long long offset, File
 WTF_EXPORT_PRIVATE bool truncateFile(PlatformFileHandle, long long offset);
 WTF_EXPORT_PRIVATE bool flushFile(PlatformFileHandle);
 // Returns number of bytes actually read if successful, -1 otherwise.
-WTF_EXPORT_PRIVATE int64_t writeToFile(PlatformFileHandle, const void* data, size_t length);
+WTF_EXPORT_PRIVATE int64_t writeToFile(PlatformFileHandle, std::span<const uint8_t> data);
 // Returns number of bytes actually written if successful, -1 otherwise.
 WTF_EXPORT_PRIVATE int64_t readFromFile(PlatformFileHandle, void* data, size_t length);
 

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -134,10 +134,10 @@ bool flushFile(PlatformFileHandle handle)
     return !fsync(handle);
 }
 
-int64_t writeToFile(PlatformFileHandle handle, const void* data, size_t length)
+int64_t writeToFile(PlatformFileHandle handle, std::span<const uint8_t> data)
 {
     do {
-        auto bytesWritten = write(handle, data, length);
+        auto bytesWritten = write(handle, data.data(), data.size());
         if (bytesWritten >= 0)
             return bytesWritten;
     } while (errno == EINTR);

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -275,13 +275,13 @@ bool flushFile(PlatformFileHandle)
     return false;
 }
 
-int64_t writeToFile(PlatformFileHandle handle, const void* data, size_t length)
+int64_t writeToFile(PlatformFileHandle handle, std::span<const uint8_t> data)
 {
     if (!isHandleValid(handle))
         return -1;
 
     DWORD bytesWritten;
-    bool success = WriteFile(handle, data, length, &bytesWritten, nullptr);
+    bool success = WriteFile(handle, data.data(), data.size(), &bytesWritten, nullptr);
 
     if (!success)
         return -1;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
@@ -144,7 +144,7 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::write(BufferSource&&
     if (!requestSpaceForWrite(*options.at, buffer.length()))
         return Exception { ExceptionCode::QuotaExceededError };
 
-    int result = FileSystem::writeToFile(m_file.handle(), buffer.data(), buffer.length());
+    int result = FileSystem::writeToFile(m_file.handle(), buffer.span());
     if (result == -1)
         return Exception { ExceptionCode::InvalidStateError, "Failed to write to file"_s };
 

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
@@ -104,7 +104,7 @@ static RetainPtr<NSURL> writeToTemporaryFile(WebCore::Model& modelSource)
     auto [filePath, fileHandle] = FileSystem::openTemporaryFile("ModelFile"_s, ".usdz"_s);
     ASSERT(FileSystem::isHandleValid(fileHandle));
 
-    size_t byteCount = FileSystem::writeToFile(fileHandle, modelSource.data()->makeContiguous()->data(), modelSource.data()->size());
+    size_t byteCount = FileSystem::writeToFile(fileHandle, modelSource.data()->makeContiguous()->span());
     ASSERT_UNUSED(byteCount, byteCount == modelSource.data()->size());
     FileSystem::closeFile(fileHandle);
 

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -162,7 +162,7 @@ void GCController::dumpHeapForVM(VM& vm)
 
     CString utf8String = jsonData.utf8();
 
-    FileSystem::writeToFile(fileHandle, utf8String.data(), utf8String.length());
+    FileSystem::writeToFile(fileHandle, utf8String.span());
     FileSystem::closeFile(fileHandle);
     WTFLogAlways("Dumped GC heap to %s%s", tempFilePath.utf8().data(), isMainThread() ? ""_s : " for Worker");
 }

--- a/Source/WebCore/contentextensions/SerializedNFA.cpp
+++ b/Source/WebCore/contentextensions/SerializedNFA.cpp
@@ -40,7 +40,7 @@ bool writeAllToFile(FileSystem::PlatformFileHandle file, const T& container)
     size_t bytesLength = container.size() * sizeof(container[0]);
     auto end = bytes + bytesLength;
     while (bytes < end) {
-        auto written = FileSystem::writeToFile(file, bytes, bytesLength);
+        auto written = FileSystem::writeToFile(file, { bytes, bytesLength });
         if (written == -1)
             return false;
         bytes += written;

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1292,7 +1292,7 @@ bool ApplicationCacheStorage::writeDataToUniqueFileInDirectory(FragmentedSharedB
     
     int64_t writtenBytes = 0;
     data.forEachSegment([&](auto segment) {
-        writtenBytes += FileSystem::writeToFile(handle, segment.data(), segment.size());
+        writtenBytes += FileSystem::writeToFile(handle, segment);
     });
     FileSystem::closeFile(handle);
     

--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -109,12 +109,12 @@ int FileHandle::read(void* data, int length)
     return FileSystem::readFromFile(m_fileHandle, data, length);
 }
 
-int FileHandle::write(const void* data, int length)
+int FileHandle::write(std::span<const uint8_t> data)
 {
     if (!open())
         return -1;
 
-    return FileSystem::writeToFile(m_fileHandle, data, length);
+    return FileSystem::writeToFile(m_fileHandle, data);
 }
 
 bool FileHandle::printf(const char* format, ...)
@@ -132,7 +132,7 @@ bool FileHandle::printf(const char* format, ...)
 
     va_end(args);
 
-    return write(buffer.data(), stringLength) >= 0;
+    return write({ reinterpret_cast<const uint8_t*>(buffer.data()), stringLength }) >= 0;
 }
 
 void FileHandle::close()

--- a/Source/WebCore/platform/FileHandle.h
+++ b/Source/WebCore/platform/FileHandle.h
@@ -49,8 +49,8 @@ public:
 
     bool open(const String& path, FileSystem::FileOpenMode);
     bool open();
-    int read(void* data, int length);
-    int write(const void* data, int length);
+    int read(void* data, int length); // FIXME: Should use a std::span.
+    int write(std::span<const uint8_t> data);
     bool printf(const char* format, ...) WTF_ATTRIBUTE_PRINTF(2, 3);
     void close();
 

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -76,7 +76,7 @@ static String transcodeImage(const String& path, const String& destinationUTI, c
     CGDataConsumerCallbacks callbacks = {
         [](void* info, const void* buffer, size_t count) -> size_t {
             auto handle = *static_cast<FileSystem::PlatformFileHandle*>(info);
-            return FileSystem::writeToFile(handle, buffer, count);
+            return FileSystem::writeToFile(handle, { static_cast<const uint8_t*>(buffer), count });
         },
         nullptr
     };

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -369,7 +369,7 @@ static bool writeFilePathsOrDataBuffersToFile(const Vector<std::pair<String, Ref
     for (auto& part : filePathsOrDataBuffers) {
         if (part.second) {
             int length = part.second->size();
-            if (FileSystem::writeToFile(file, part.second->data(), length) != length) {
+            if (FileSystem::writeToFile(file, part.second->span()) != length) {
                 LOG_ERROR("Failed writing a Blob to temporary file");
                 return false;
             }

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -84,7 +84,7 @@ bool writeOriginToFile(const String& filePath, const ClientOrigin& origin)
 
     WTF::Persistence::Encoder encoder;
     encoder << origin;
-    FileSystem::writeToFile(originFileHandle, encoder.buffer(), encoder.bufferSize());
+    FileSystem::writeToFile(originFileHandle, encoder.span());
     return true;
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5355,7 +5355,7 @@ String Internals::createTemporaryFile(const String& name, const String& contents
         return nullString();
 
     auto contentsUTF8 = contents.utf8();
-    FileSystem::writeToFile(file, contentsUTF8.data(), contentsUTF8.length());
+    FileSystem::writeToFile(file, contentsUTF8.span());
 
     FileSystem::closeFile(file);
 

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -104,7 +104,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
         }
         if (size) {
             iterateOverBufferAndWriteData([&](std::span<const uint8_t> span) {
-                FileSystem::writeToFile(handle, span.data(), span.size());
+                FileSystem::writeToFile(handle, span);
                 return true;
             });
         }

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -465,7 +465,7 @@ void NetworkDataTaskBlob::download()
 bool NetworkDataTaskBlob::writeDownload(std::span<const uint8_t> data)
 {
     ASSERT(isDownload());
-    int bytesWritten = FileSystem::writeToFile(m_downloadFile, data.data(), data.size());
+    int bytesWritten = FileSystem::writeToFile(m_downloadFile, data);
     if (static_cast<size_t>(bytesWritten) != data.size()) {
         didFailDownload(cancelledError(m_firstRequest));
         return false;

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -178,7 +178,7 @@ void NetworkDataTaskDataURL::downloadDecodedData(Vector<uint8_t>&& data)
     downloadManager.dataTaskBecameDownloadTask(m_pendingDownloadID, WTFMove(download));
     downloadPtr->didCreateDestination(m_pendingDownloadLocation);
 
-    if (-1 == FileSystem::writeToFile(downloadDestinationFile, static_cast<void*>(data.data()), data.size())) {
+    if (-1 == FileSystem::writeToFile(downloadDestinationFile, data.span())) {
         FileSystem::closeFile(downloadDestinationFile);
         FileSystem::deleteFile(m_pendingDownloadLocation);
 #if USE(CURL)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -190,7 +190,7 @@ void ServiceWorkerDownloadTask::didReceiveData(const IPC::SharedBufferReference&
     if (m_downloadFile == FileSystem::invalidPlatformFileHandle)
         return;
 
-    size_t bytesWritten = FileSystem::writeToFile(m_downloadFile, data.data(), data.size());
+    size_t bytesWritten = FileSystem::writeToFile(m_downloadFile, data.span());
 
     if (bytesWritten != data.size()) {
         didFailDownload();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -638,8 +638,8 @@ void Cache::dumpContentsToFile()
     if (!isHandleValid(fd))
         return;
 
-    static const char prologue[] = "{\n\"entries\": [\n";
-    writeToFile(fd, prologue, strlen(prologue));
+    constexpr auto prologue = "{\n\"entries\": [\n"_s;
+    writeToFile(fd, prologue.span8());
 
     struct Totals {
         unsigned count { 0 };
@@ -661,7 +661,7 @@ void Cache::dumpContentsToFile()
                 "\"averageWorth\": ", totals.count ? totals.worth / totals.count : 0, "\n"
                 "}\n}\n"
             ).utf8();
-            writeToFile(fd, writeData.data(), writeData.length());
+            writeToFile(fd, writeData.span());
             closeFile(fd);
             return;
         }
@@ -675,8 +675,7 @@ void Cache::dumpContentsToFile()
         StringBuilder json;
         entry->asJSON(json, info);
         json.append(",\n"_s);
-        auto writeData = json.toString().utf8();
-        writeToFile(fd, writeData.data(), writeData.length());
+        writeToFile(fd, json.toString().utf8().span());
     });
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
@@ -79,7 +79,7 @@ void IOChannel::write(size_t offset, const Data& data, WTF::WorkQueueBase& queue
 {
     queue.dispatch([this, protectedThis = Ref { *this }, offset, data, completionHandler = WTFMove(completionHandler)] {
         FileSystem::seekFile(m_fileDescriptor, offset, FileSystem::FileSeekOrigin::Beginning);
-        int err = FileSystem::writeToFile(m_fileDescriptor, data.data(), data.size());
+        int err = FileSystem::writeToFile(m_fileDescriptor, data.span());
         err = err < 0 ? err : 0;
         completionHandler(err);
     });

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -199,7 +199,7 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&& b
         RELEASE_ASSERT(download);
         uint64_t bytesWritten = 0;
         for (auto& segment : buffer.get()) {
-            if (-1 == FileSystem::writeToFile(m_downloadDestinationFile, segment.segment->data(), segment.segment->size())) {
+            if (-1 == FileSystem::writeToFile(m_downloadDestinationFile, segment.segment->span())) {
                 download->didFail(ResourceError(CURLE_WRITE_ERROR, m_response.url()), { });
                 invalidateAndCancel();
                 return;

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -221,7 +221,7 @@ void BackgroundFetchStoreManager::storeFetchResponseBodyChunk(const String& iden
         FileSystem::PlatformFileHandle handle = FileSystem::openFile(filePath, FileSystem::FileOpenMode::ReadWrite);
         if (FileSystem::isHandleValid(handle)) {
             // FIXME: Cover the case of partial write.
-            auto writtenSize = FileSystem::writeToFile(handle, data->data(), data->size());
+            auto writtenSize = FileSystem::writeToFile(handle, data->span());
             if (static_cast<size_t>(writtenSize) == data->size())
                 result = StoreResult::OK;
             FileSystem::closeFile(handle);

--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -58,7 +58,7 @@ void writeToDisk(std::unique_ptr<KeyedEncoder>&& encoder, String&& path)
     if (handle == FileSystem::invalidPlatformFileHandle)
         return;
 
-    auto writtenBytes = FileSystem::writeToFile(handle, rawData->data(), rawData->size());
+    auto writtenBytes = FileSystem::writeToFile(handle, rawData->span());
     FileSystem::unlockAndCloseFile(handle);
 
     if (writtenBytes != static_cast<int64_t>(rawData->size()))

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -146,7 +146,7 @@ void WebMemorySampler::initializeSandboxedLogFile(SandboxExtension::Handle&& sam
 void WebMemorySampler::writeHeaders()
 {
     auto processDetails = makeString("Process: ", processName(), " Pid: ", getCurrentProcessID(), '\n').utf8();
-    FileSystem::writeToFile(m_sampleLogFile, processDetails.data(), processDetails.length());
+    FileSystem::writeToFile(m_sampleLogFile, processDetails.span());
 }
 
 void WebMemorySampler::sampleTimerFired()
@@ -180,7 +180,7 @@ void WebMemorySampler::appendCurrentMemoryUsageToFile(FileSystem::PlatformFileHa
     statString.append('\n');
 
     CString utf8String = statString.toString().utf8();
-    FileSystem::writeToFile(m_sampleLogFile, utf8String.data(), utf8String.length());
+    FileSystem::writeToFile(m_sampleLogFile, utf8String.span());
 }
 
 }

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -240,7 +240,7 @@ static bool writeDataToFile(const WebKit::NetworkCache::Data& fileData, Platform
 {
     bool success = true;
     fileData.apply([fd, &success](std::span<const uint8_t> span) {
-        if (writeToFile(fd, span.data(), span.size()) == -1) {
+        if (writeToFile(fd, span) == -1) {
             success = false;
             return false;
         }
@@ -364,10 +364,10 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
         return makeUnexpected(ContentRuleListStore::Error::CompileFailed);
     }
     
-    char invalidHeader[CurrentVersionFileHeaderSize];
-    memset(invalidHeader, 0xFF, sizeof(invalidHeader));
+    std::array<uint8_t, CurrentVersionFileHeaderSize> invalidHeader;
+    memset(invalidHeader.data(), 0xFF, invalidHeader.size());
     // This header will be rewritten in CompilationClient::finalize.
-    if (writeToFile(temporaryFileHandle, invalidHeader, sizeof(invalidHeader)) == -1) {
+    if (writeToFile(temporaryFileHandle, invalidHeader) == -1) {
         WTFLogAlways("Content Rule List compiling failed: Writing header to file failed.");
         closeFile(temporaryFileHandle);
         return makeUnexpected(ContentRuleListStore::Error::CompileFailed);
@@ -592,7 +592,7 @@ void ContentRuleListStore::invalidateContentRuleListVersion(const WTF::String& i
         return;
 
     ContentRuleListMetaData invalidHeader = {0, 0, 0, 0, 0, 0};
-    auto bytesWritten = writeToFile(file, &invalidHeader, sizeof(invalidHeader));
+    auto bytesWritten = writeToFile(file, { reinterpret_cast<const uint8_t*>(&invalidHeader), sizeof(invalidHeader) });
     ASSERT_UNUSED(bytesWritten, bytesWritten == sizeof(invalidHeader));
     closeFile(file);
 }

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -39,10 +39,12 @@
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/UTIUtilities.h>
-#import <pal/ios/QuickLookSoftLink.h>
 #import <pal/spi/cocoa/FoundationSPI.h>
 #import <pal/spi/ios/QuickLookSPI.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
+
+#import <pal/ios/QuickLookSoftLink.h>
 
 #if HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)
 #import "ARKitSoftLink.h"
@@ -355,7 +357,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
 - (void)completeLoad
 {
     ASSERT(_fileHandle != FileSystem::invalidPlatformFileHandle);
-    size_t byteCount = FileSystem::writeToFile(_fileHandle, [_data bytes], [_data length]);
+    size_t byteCount = FileSystem::writeToFile(_fileHandle, span(_data.get()));
     FileSystem::closeFile(_fileHandle);
 
     if (byteCount != _data.get().length) {

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -109,7 +109,7 @@ void WebInspectorUIProxy::showSavePanelForSingleFile(HWND parentWindow, Vector<W
 
         auto content = saveDatas[0].content.utf8();
         auto contentSize = content.length();
-        auto bytesWritten = FileSystem::writeToFile(fd, content.data(), contentSize);
+        auto bytesWritten = FileSystem::writeToFile(fd, content.span());
         if (bytesWritten == -1 || bytesWritten != contentSize) {
             auto message = systemErrorMessage(GetLastError());
             if (message.isEmpty())

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -231,7 +231,7 @@ void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(
         auto [filePath, fileHandle] = FileSystem::openTemporaryFile("QuickLook"_s, suffix);
         ASSERT(FileSystem::isHandleValid(fileHandle));
 
-        size_t byteCount = FileSystem::writeToFile(fileHandle, buffer->data(), buffer->size());
+        size_t byteCount = FileSystem::writeToFile(fileHandle, buffer->span());
         ASSERT_UNUSED(byteCount, byteCount == buffer->size());
         FileSystem::closeFile(fileHandle);
 

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -108,7 +108,7 @@ SOFT_LINK_CLASS(AssetViewer, ASVInlinePreview);
     if (file <= 0)
         return NO;
 
-    auto byteCount = static_cast<std::size_t>(FileSystem::writeToFile(file, model.data()->data(), model.data()->size()));
+    auto byteCount = static_cast<std::size_t>(FileSystem::writeToFile(file, model.data()->span()));
     ASSERT_UNUSED(byteCount, byteCount == model.data()->size());
     FileSystem::closeFile(file);
     _filePath = filePath;

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -115,7 +115,7 @@ void ARKitInlinePreviewModelPlayerMac::createFile(WebCore::Model& modelSource)
     if (file <= 0)
         return;
 
-    FileSystem::writeToFile(file, modelSource.data()->makeContiguous()->data(), modelSource.data()->size());
+    FileSystem::writeToFile(file, modelSource.data()->makeContiguous()->span());
     FileSystem::closeFile(file);
     m_filePath = filePath;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -34,13 +34,13 @@
 
 namespace TestWebKitAPI {
 
-const char* FileSystemTestData = "This is a test";
+constexpr auto FileSystemTestData = "This is a test"_s;
 
 static void createTestFile(const String& path)
 {
     auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate);
     EXPECT_TRUE(FileSystem::isHandleValid(fileHandle));
-    FileSystem::writeToFile(fileHandle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(fileHandle, FileSystemTestData.span8());
     FileSystem::closeFile(fileHandle);
 };
 
@@ -55,7 +55,7 @@ public:
         auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
         m_tempFilePath = result.first;
         auto handle = result.second;
-        FileSystem::writeToFile(handle, FileSystemTestData, strlen(FileSystemTestData));
+        FileSystem::writeToFile(handle, FileSystemTestData.span8());
         FileSystem::closeFile(handle);
 
         m_tempFileSymlinkPath = FileSystem::createTemporaryFile("tempTestFile-symlink"_s);
@@ -236,7 +236,7 @@ TEST_F(FileSystemTest, openExistingFileTruncate)
     // Check the existing file WAS truncated when the operation succeded.
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), 0);
     // Write data to it and check the file size grows.
-    FileSystem::writeToFile(handle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(handle, FileSystemTestData.span8());
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), strlen(FileSystemTestData));
     FileSystem::closeFile(handle);
 }
@@ -256,8 +256,8 @@ TEST_F(FileSystemTest, openExistingFileReadWrite)
     // ReadWrite mode shouldn't truncate the contents of the file.
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), strlen(FileSystemTestData));
     // Write data to it and check the file size grows.
-    FileSystem::writeToFile(handle, FileSystemTestData, strlen(FileSystemTestData));
-    FileSystem::writeToFile(handle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(handle, FileSystemTestData.span8());
+    FileSystem::writeToFile(handle, FileSystemTestData.span8());
     EXPECT_EQ(FileSystem::fileSize(tempFilePath()), strlen(FileSystemTestData) * 2);
     FileSystem::closeFile(handle);
 }
@@ -450,7 +450,7 @@ TEST_F(FileSystemTest, deleteEmptyDirectoryContainingDSStoreFile)
     // Create .DSStore file.
     auto dsStorePath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), ".DS_Store"_s);
     auto dsStoreHandle = FileSystem::openFile(dsStorePath, FileSystem::FileOpenMode::Truncate);
-    FileSystem::writeToFile(dsStoreHandle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(dsStoreHandle, FileSystemTestData.span8());
     FileSystem::closeFile(dsStoreHandle);
     EXPECT_TRUE(FileSystem::fileExists(dsStorePath));
 
@@ -466,14 +466,14 @@ TEST_F(FileSystemTest, deleteEmptyDirectoryOnNonEmptyDirectory)
     // Create .DSStore file.
     auto dsStorePath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), ".DS_Store"_s);
     auto dsStoreHandle = FileSystem::openFile(dsStorePath, FileSystem::FileOpenMode::Truncate);
-    FileSystem::writeToFile(dsStoreHandle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(dsStoreHandle, FileSystemTestData.span8());
     FileSystem::closeFile(dsStoreHandle);
     EXPECT_TRUE(FileSystem::fileExists(dsStorePath));
 
     // Create a dummy file.
     auto dummyFilePath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "dummyFile"_s);
     auto dummyFileHandle = FileSystem::openFile(dummyFilePath, FileSystem::FileOpenMode::Truncate);
-    FileSystem::writeToFile(dummyFileHandle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(dummyFileHandle, FileSystemTestData.span8());
     FileSystem::closeFile(dummyFileHandle);
     EXPECT_TRUE(FileSystem::fileExists(dummyFilePath));
 
@@ -541,7 +541,7 @@ TEST_F(FileSystemTest, moveDirectory)
     EXPECT_TRUE(FileSystem::makeAllDirectories(temporaryTestFolder));
     auto testFilePath = FileSystem::pathByAppendingComponent(temporaryTestFolder, "testFile"_s);
     auto fileHandle = FileSystem::openFile(testFilePath, FileSystem::FileOpenMode::Truncate);
-    FileSystem::writeToFile(fileHandle, FileSystemTestData, strlen(FileSystemTestData));
+    FileSystem::writeToFile(fileHandle, FileSystemTestData.span8());
     FileSystem::closeFile(fileHandle);
 
     EXPECT_TRUE(FileSystem::fileExists(testFilePath));
@@ -750,7 +750,7 @@ static void runGetFileModificationTimeTest(const String& path, Function<std::opt
     // Modify the file.
     auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite);
     EXPECT_TRUE(FileSystem::isHandleValid(fileHandle));
-    FileSystem::writeToFile(fileHandle, "foo", strlen("foo"));
+    FileSystem::writeToFile(fileHandle, "foo"_span);
     FileSystem::closeFile(fileHandle);
 
     auto newModificationTime = fileModificationTime(path);

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -59,7 +59,7 @@ public:
         auto handle = result.second;
         ASSERT_NE(handle, FileSystem::invalidPlatformFileHandle);
 
-        int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().data(), FileMonitorTestData.length());
+        int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().span());
         ASSERT_NE(rc, -1);
         
         FileSystem::closeFile(handle);
@@ -347,7 +347,7 @@ TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)
         auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate);
         ASSERT_NE(handle, FileSystem::invalidPlatformFileHandle);
 
-        int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().data(), FileMonitorTestData.length());
+        int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().span());
         ASSERT_NE(rc, -1);
 
         auto firstCommand = createCommand(tempFilePath(), FileMonitorRevisedData);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
@@ -38,7 +38,7 @@ void FragmentedSharedBufferTest::SetUp()
     // create temp file
     auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
     m_tempFilePath = result.first;
-    FileSystem::writeToFile(result.second, testData(), strlen(testData()));
+    FileSystem::writeToFile(result.second, testData().span8());
     FileSystem::closeFile(result.second);
 
     m_tempEmptyFilePath = FileSystem::createTemporaryFile("tempEmptyTestFile"_s);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.h
@@ -34,7 +34,7 @@ public:
     void SetUp() override;
     void TearDown() override;
 
-    static const char* testData() { return "This is a test"; }
+    static ASCIILiteral testData() { return "This is a test"_s; }
     const String& tempFilePath() { return m_tempFilePath; }
     const String& tempEmptyFilePath() { return m_tempEmptyFilePath; }
 


### PR DESCRIPTION
#### e173385dac3703f5d92018a5f4cc1619bf00cefc
<pre>
Update FileSystem::writeToFile() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=274333">https://bugs.webkit.org/show_bug.cgi?id=274333</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSScript.mm:
(-[JSScript writeCache:]):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/CachePayload.h:
(JSC::CachePayload::span const):
* Source/JavaScriptCore/runtime/CachedBytecode.cpp:
(JSC::CachedBytecode::commitUpdates const):
* Source/JavaScriptCore/runtime/CachedBytecode.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::releaseMapped):
(JSC::Encoder::Page::mutableSpan):
(JSC::Encoder::Page::span const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::dumpWasmSource):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::appendFileContentsToFileHandle):
(WTF::FileSystemImpl::readOrMakeSalt):
(WTF::FileSystemImpl::overwriteEntireFile):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::writeToFile):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::writeToFile):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::write):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm:
(WebCore::writeToTemporaryFile):
* Source/WebCore/bindings/js/GCController.cpp:
(WebCore::GCController::dumpHeapForVM):
* Source/WebCore/contentextensions/SerializedNFA.cpp:
(WebCore::ContentExtensions::writeAllToFile):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::writeDataToUniqueFileInDirectory):
* Source/WebCore/platform/FileHandle.cpp:
(WebCore::FileHandle::write):
(WebCore::FileHandle::printf):
* Source/WebCore/platform/FileHandle.h:
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::transcodeImage):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::writeFilePathsOrDataBuffersToFile):
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::writeOriginToFile):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::createTemporaryFile):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::writeDownload):
* Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp:
(WebKit::NetworkDataTaskDataURL::downloadDecodedData):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::didReceiveData):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::dumpContentsToFile):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp:
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveData):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::storeFetchResponseBodyChunk):
* Source/WebKit/Shared/PersistencyUtils.cpp:
(WebKit::writeToDisk):
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::writeHeaders):
(WebKit::WebMemorySampler::appendCurrentMemoryUsageToFile):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::writeSandboxDataToCacheFile):
(WebKit::compileAndCacheSandboxProfile):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::writeDataToFile):
(API::compiledToFile):
(API::ContentRuleListStore::invalidateContentRuleListVersion):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::showSavePanelForSingleFile):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::prepareQuickLookImageURL const):
* Source/WebKit/UIProcess/ios/WKModelView.mm:
(-[WKModelView createFileForModel:]):
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:
(WebKit::ARKitInlinePreviewModelPlayerMac::createFile):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::createTestFile):
(TestWebKitAPI::FileSystemTest::tempFilePath const): Deleted.
(TestWebKitAPI::FileSystemTest::tempFileSymlinkPath const): Deleted.
(TestWebKitAPI::FileSystemTest::tempEmptyFolderPath const): Deleted.
(TestWebKitAPI::FileSystemTest::tempEmptyFolderSymlinkPath const): Deleted.
(TestWebKitAPI::FileSystemTest::tempEmptyFilePath const): Deleted.
(TestWebKitAPI::FileSystemTest::spaceContainingFilePath const): Deleted.
(TestWebKitAPI::FileSystemTest::bangContainingFilePath const): Deleted.
(TestWebKitAPI::FileSystemTest::quoteContainingFilePath const): Deleted.
(TestWebKitAPI::TEST_F): Deleted.
(TestWebKitAPI::runGetFileModificationTimeTest): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp:
(TestWebKitAPI::FragmentedSharedBufferTest::SetUp):
* Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.h:
(TestWebKitAPI::FragmentedSharedBufferTest::testData):

Canonical link: <a href="https://commits.webkit.org/278941@main">https://commits.webkit.org/278941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5085feae2256cc25fdd4d9308d907483250d698

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1753 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54129 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28980 "1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23432 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2167 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/917 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/45380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56899 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51542 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27150 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45003 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63849 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7605 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28128 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12054 "Passed tests") | 
<!--EWS-Status-Bubble-End-->