### PR TITLE
Rebaseline intl tests for latest ICU

### DIFF
--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -239,7 +239,7 @@ shouldBe(Intl.DateTimeFormat('en').resolvedOptions().second, undefined);
 shouldBe(Intl.DateTimeFormat('en').resolvedOptions().timeZoneName, undefined);
 
 // Locale-sensitive format().
-shouldBe(Intl.DateTimeFormat('ar', { timeZone: 'America/Denver' }).format(1451099872641), '٢٥‏/١٢‏/٢٠١٥');
+shouldBeOneOf(Intl.DateTimeFormat('ar', { timeZone: 'America/Denver' }).format(1451099872641), ['٢٥‏/١٢‏/٢٠١٥', '25‏/12‏/2015']);
 shouldBe(Intl.DateTimeFormat('de', { timeZone: 'America/Denver' }).format(1451099872641), '25.12.2015');
 shouldBe(Intl.DateTimeFormat('ja', { timeZone: 'America/Denver' }).format(1451099872641), '2015/12/25');
 shouldBe(Intl.DateTimeFormat('pt', { timeZone: 'America/Denver' }).format(1451099872641), '25/12/2015');
@@ -298,7 +298,7 @@ shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Pacific/Auckland' }).format(1451
 // Gets default calendar and numberingSystem from locale.
 shouldBe(Intl.DateTimeFormat('ar-sa').resolvedOptions().locale, 'ar-SA');
 shouldBe(Intl.DateTimeFormat('fa-IR').resolvedOptions().calendar, 'persian');
-shouldBe(Intl.DateTimeFormat('ar').resolvedOptions().numberingSystem, 'arab');
+shouldBeOneOf(Intl.DateTimeFormat('ar').resolvedOptions().numberingSystem, ['arab','latn']);
 
 shouldBe(Intl.DateTimeFormat('en', { calendar: 'dangi' }).resolvedOptions().calendar, 'dangi');
 shouldBe(Intl.DateTimeFormat('en-u-ca-bogus').resolvedOptions().locale, 'en');

--- a/JSTests/stress/intl-numberformat.js
+++ b/JSTests/stress/intl-numberformat.js
@@ -3,6 +3,12 @@ function shouldBe(actual, expected) {
         throw new Error(`expected ${expected} but got ${actual}`);
 }
 
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
+}
+
+
 function shouldNotThrow(func) {
     func();
 }
@@ -460,7 +466,7 @@ shouldThrow(() => Intl.NumberFormat.prototype.resolvedOptions.call(5), TypeError
 // BigInt tests
 shouldBe(Intl.NumberFormat().format(0n), '0');
 shouldBe(Intl.NumberFormat().format(BigInt(1)), '1');
-shouldBe(Intl.NumberFormat('ar').format(123456789n), '١٢٣٬٤٥٦٬٧٨٩');
+shouldBeOneOf(Intl.NumberFormat('ar').format(123456789n), ['١٢٣٬٤٥٦٬٧٨٩','123,456,789']);
 shouldBe(Intl.NumberFormat('zh-Hans-CN-u-nu-hanidec').format(123456789n), '一二三,四五六,七八九');
 shouldBe(Intl.NumberFormat('en', { maximumSignificantDigits: 3 }).format(123456n), '123,000');
 


### PR DESCRIPTION
#### 9a2f01e883bb3b393d9a8d17532c7c462ef52cb3
<pre>
Rebaseline intl tests for latest ICU
<a href="https://bugs.webkit.org/show_bug.cgi?id=274339">https://bugs.webkit.org/show_bug.cgi?id=274339</a>
<a href="https://rdar.apple.com/128296361">rdar://128296361</a>

Unreviewed, rebaseline intl tests.

* JSTests/stress/intl-datetimeformat.js:
* JSTests/stress/intl-numberformat.js:
(shouldBeOneOf):

Canonical link: <a href="https://commits.webkit.org/278954@main">https://commits.webkit.org/278954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68a8feb7278a18b178b0e0b32054b327c5a9cf3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55287 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2728 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42351 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1746 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26254 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/898 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45355 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56880 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51522 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49743 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48949 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29270 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63830 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7611 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28106 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12049 "Found 10 new JSC stress test failures: stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.bytecode-cache, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.default, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.dfg-eager, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.dfg-eager-no-cjit-validate, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.eager-jettison-no-cjit, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.lockdown, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.mini-mode, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-cjit-collect-continuously, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-cjit-validate-phases, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->