### PR TITLE
REGRESSION (278815@main): [ MacOS iOS Debug ] TestWebKitAPI.AdvancedPrivacyProtections.AddNoiseToWebAudioAPIs is a consistent failure

### DIFF
--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -136,6 +136,16 @@ void ThreadGlobalData::initializeFontCache()
     m_fontCache = makeUnique<FontCache>();
 }
 
+#if ENABLE(WEB_AUDIO)
+
+void ThreadGlobalData::initializeAudioNoiseInjectionMultiplierTable()
+{
+    ASSERT(!m_audioNoiseInjectionMultiplierTable);
+    m_audioNoiseInjectionMultiplierTable = makeUniqueWithoutFastMallocCheck<AudioNoiseInjectionMultiplierTable>();
+}
+
+#endif
+
 } // namespace WebCore
 
 namespace PAL {

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -45,6 +45,10 @@ struct CachedResourceRequestInitiatorTypes;
 struct EventNames;
 struct MIMETypeRegistryThreadGlobalData;
 
+#if ENABLE(WEB_AUDIO)
+using AudioNoiseInjectionMultiplierTable = std::array<float, 262144>;
+#endif
+
 class ThreadGlobalData : public PAL::ThreadGlobalData {
     WTF_MAKE_NONCOPYABLE(ThreadGlobalData);
     WTF_MAKE_FAST_ALLOCATED;
@@ -105,6 +109,15 @@ public:
     FontCache* fontCacheIfExists() { return m_fontCache.get(); }
     FontCache* fontCacheIfNotDestroyed() { return m_destroyed ? nullptr : &fontCache(); }
 
+#if ENABLE(WEB_AUDIO)
+    AudioNoiseInjectionMultiplierTable& audioNoiseInjectionMultiplierTable()
+    {
+        if (!m_audioNoiseInjectionMultiplierTable)
+            initializeAudioNoiseInjectionMultiplierTable();
+        return *m_audioNoiseInjectionMultiplierTable;
+    }
+#endif
+
 private:
     bool m_destroyed { false };
 
@@ -114,6 +127,10 @@ private:
     WEBCORE_EXPORT void initializeMimeTypeRegistryThreadGlobalData();
     WEBCORE_EXPORT void initializeFontCache();
 
+#if ENABLE(WEB_AUDIO)
+    WEBCORE_EXPORT void initializeAudioNoiseInjectionMultiplierTable();
+#endif
+
     std::unique_ptr<CachedResourceRequestInitiatorTypes> m_cachedResourceRequestInitiatorTypes;
     std::unique_ptr<EventNames> m_eventNames;
     std::unique_ptr<ThreadTimers> m_threadTimers;
@@ -121,6 +138,10 @@ private:
     JSC::JSGlobalObject* m_currentState { nullptr };
     std::unique_ptr<MIMETypeRegistryThreadGlobalData> m_MIMETypeRegistryThreadGlobalData;
     std::unique_ptr<FontCache> m_fontCache;
+
+#if ENABLE(WEB_AUDIO)
+    std::unique_ptr<AudioNoiseInjectionMultiplierTable> m_audioNoiseInjectionMultiplierTable;
+#endif
 
 #ifndef NDEBUG
     bool m_isMainThread;


### PR DESCRIPTION
#### 3e8d5002ff19f2172ad0bd3c6ed1299a8c214815
<pre>
REGRESSION (278815@main): [ MacOS iOS Debug ] TestWebKitAPI.AdvancedPrivacyProtections.AddNoiseToWebAudioAPIs is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=274266">https://bugs.webkit.org/show_bug.cgi?id=274266</a>
<a href="https://rdar.apple.com/128209071">rdar://128209071</a>

Reviewed by NOBODY (OOPS!).

Allocations are forbidden here for performance reasons:

```
void AudioDestinationNode::renderQuantum(…)
{
    …

    // For performance reasons, we forbid heap allocations while doing rendering on the audio thread.
    // Heap allocations that cannot be avoided or have not been fixed yet can be allowed using
    // DisableMallocRestrictionsForCurrentThreadScope scope variables.
    ForbidMallocUseForCurrentThreadScope forbidMallocUse;
```

…but in private browsing mode, we intentionally inject random noise into the audio buffer upon
readback at the cost of performance, in order to make it significantly more difficult to infer
details about the underlying OS or hardware through a Web Audio fingerprint.

Refactor this code so that the noise multiplier table is a `std::array` that&apos;s only allocated once
(in the initial call to `applyNoise`), and reuse it on subsequent requests to apply noise.

* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::ThreadGlobalData::initializeAudioNoiseInjectionMultiplierTable):
* Source/WebCore/platform/ThreadGlobalData.h:
(WebCore::ThreadGlobalData::audioNoiseInjectionMultiplierTable):
* Source/WebCore/platform/audio/AudioUtilities.cpp:
(WebCore::AudioUtilities::applyNoise):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e8d5002ff19f2172ad0bd3c6ed1299a8c214815

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55295 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2441 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54117 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23420 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2127 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/905 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56887 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44972 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->