### PR TITLE
GlyphPage::fill() should take in a std::span

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -190,9 +190,9 @@ RenderingResourceIdentifier FontInternalAttributes::ensureRenderingResourceIdent
     return *renderingResourceIdentifier;
 }
 
-static bool fillGlyphPage(GlyphPage& pageToFill, UChar* buffer, unsigned bufferLength, const Font& font)
+static bool fillGlyphPage(GlyphPage& pageToFill, std::span<const UChar> buffer, const Font& font)
 {
-    bool hasGlyphs = pageToFill.fill(buffer, bufferLength);
+    bool hasGlyphs = pageToFill.fill(buffer);
 #if ENABLE(OPENTYPE_VERTICAL)
     if (hasGlyphs && font.verticalData())
         font.verticalData()->substituteWithVerticalGlyphs(&font, &pageToFill);
@@ -400,7 +400,7 @@ static RefPtr<GlyphPage> createAndFillGlyphPage(unsigned pageNumber, const Font&
     // for only 128 out of 256 characters.
     Ref glyphPage = GlyphPage::create(font);
 
-    bool haveGlyphs = fillGlyphPage(glyphPage, buffer.data(), bufferLength, font);
+    bool haveGlyphs = fillGlyphPage(glyphPage, buffer.span().first(bufferLength), font);
     if (!haveGlyphs)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -126,7 +126,7 @@ public:
     }
 
     // Implemented by the platform.
-    bool fill(UChar* characterBuffer, unsigned bufferLength);
+    bool fill(std::span<const UChar> characterBuffer);
 
 private:
     explicit GlyphPage(const Font& font)

--- a/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
@@ -36,30 +36,30 @@
 
 namespace WebCore {
 
-static bool shouldFillWithVerticalGlyphs(const UChar* buffer, unsigned bufferLength, const Font& font)
+static bool shouldFillWithVerticalGlyphs(std::span<const UChar> buffer, const Font& font)
 {
     if (!font.hasVerticalGlyphs())
         return false;
-    for (unsigned i = 0; i < bufferLength; ++i) {
-        if (!FontCascade::isCJKIdeograph(buffer[i]))
+    for (auto character : buffer) {
+        if (!FontCascade::isCJKIdeograph(character))
             return true;
     }
     return false;
 }
 
 
-bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
+bool GlyphPage::fill(std::span<const UChar> buffer)
 {
-    ASSERT(bufferLength == GlyphPage::size || bufferLength == 2 * GlyphPage::size);
+    ASSERT(buffer.size() == GlyphPage::size || buffer.size() == 2 * GlyphPage::size);
 
     const Font& font = this->font();
-    Vector<CGGlyph, 512> glyphs(bufferLength);
-    unsigned glyphStep = bufferLength / GlyphPage::size;
+    Vector<CGGlyph, 512> glyphs(buffer.size());
+    unsigned glyphStep = buffer.size() / GlyphPage::size;
 
-    if (shouldFillWithVerticalGlyphs(buffer, bufferLength, font))
-        CTFontGetVerticalGlyphsForCharacters(font.platformData().ctFont(), reinterpret_cast<UniChar*>(buffer), glyphs.data(), bufferLength);
+    if (shouldFillWithVerticalGlyphs(buffer, font))
+        CTFontGetVerticalGlyphsForCharacters(font.platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
     else
-        CTFontGetGlyphsForCharacters(font.platformData().ctFont(), reinterpret_cast<UniChar*>(buffer), glyphs.data(), bufferLength);
+        CTFontGetGlyphsForCharacters(font.platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
 
     bool haveGlyphs = false;
     for (unsigned i = 0; i < GlyphPage::size; ++i) {

--- a/Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
+bool GlyphPage::fill(std::span<const UChar> buffer)
 {
     const Font& font = this->font();
     cairo_scaled_font_t* scaledFont = font.platformData().scaledFont();
@@ -63,10 +63,10 @@ bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
     bool haveGlyphs = false;
     unsigned bufferOffset = 0;
     for (unsigned i = 0; i < GlyphPage::size; i++) {
-        if (bufferOffset == bufferLength)
+        if (bufferOffset == buffer.size())
             break;
         char32_t character;
-        U16_NEXT(buffer, bufferOffset, bufferLength, character);
+        U16_NEXT(buffer, bufferOffset, buffer.size(), character);
 
         Glyph glyph = FcFreeTypeCharIndex(face, FontCascade::treatAsSpace(character) ? space : character);
         // If the font doesn't support a Default_Ignorable character, replace it with zero with space.

--- a/Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp
@@ -34,14 +34,14 @@
 
 namespace WebCore {
 
-bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
+bool GlyphPage::fill(std::span<const UChar> buffer)
 {
     const Font& font = this->font();
     auto* skiaHarfBuzzFont = font.platformData().skiaHarfBuzzFont();
     if (!skiaHarfBuzzFont)
         return false;
 
-    StringView stringView(std::span(buffer, bufferLength));
+    StringView stringView(buffer);
     auto codePoints = stringView.codePoints();
     auto codePointsIterator = codePoints.begin();
 

--- a/Source/WebCore/platform/graphics/win/GlyphPageTreeNodeWin.cpp
+++ b/Source/WebCore/platform/graphics/win/GlyphPageTreeNodeWin.cpp
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
+bool GlyphPage::fill(std::span<const UChar> buffer)
 {
-    ASSERT(bufferLength == GlyphPage::size || bufferLength == 2 * GlyphPage::size);
+    ASSERT(buffer.size() == GlyphPage::size || buffer.size() == 2 * GlyphPage::size);
 
     const Font& font = this->font();
     bool haveGlyphs = false;
@@ -47,10 +47,10 @@ bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
     SelectObject(dc, font.platformData().hfont());
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=259205 Determine if the glyph is a color glyph or not.
-    if (bufferLength == GlyphPage::size) {
+    if (buffer.size() == GlyphPage::size) {
         WORD localGlyphBuffer[GlyphPage::size * 2];
-        DWORD result = GetGlyphIndices(dc, wcharFrom(buffer), bufferLength, localGlyphBuffer, GGI_MARK_NONEXISTING_GLYPHS);
-        bool success = result != GDI_ERROR && static_cast<unsigned>(result) == bufferLength;
+        DWORD result = GetGlyphIndices(dc, wcharFrom(buffer.data()), buffer.size(), localGlyphBuffer, GGI_MARK_NONEXISTING_GLYPHS);
+        bool success = result != GDI_ERROR && static_cast<unsigned>(result) == buffer.size();
 
         if (success) {
             for (unsigned i = 0; i < GlyphPage::size; i++) {
@@ -76,7 +76,7 @@ bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
             gcpResults.lStructSize = sizeof gcpResults;
             gcpResults.nGlyphs = 2;
             gcpResults.lpGlyphs = glyphs;
-            GetCharacterPlacement(dc, wcharFrom(buffer) + i * 2, 2, 0, &gcpResults, GCP_GLYPHSHAPE);
+            GetCharacterPlacement(dc, wcharFrom(buffer.data()) + i * 2, 2, 0, &gcpResults, GCP_GLYPHSHAPE);
             bool success = 1 == gcpResults.nGlyphs;
             if (success) {
                 auto glyph = glyphs[0];


### PR DESCRIPTION
#### 521e9dcd8ea9a86bf10afeb649c74128df3031d3
<pre>
GlyphPage::fill() should take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=274341">https://bugs.webkit.org/show_bug.cgi?id=274341</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::fillGlyphPage):
(WebCore::createAndFillGlyphPage):
* Source/WebCore/platform/graphics/GlyphPage.h:
* Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp:
(WebCore::shouldFillWithVerticalGlyphs):
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp:
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp:
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/win/GlyphPageTreeNodeWin.cpp:
(WebCore::GlyphPage::fill):

Canonical link: <a href="https://commits.webkit.org/278959@main">https://commits.webkit.org/278959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80526808cc311f224832aebb3d2cbaeef88e277c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2483 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42374 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2187 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49768 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45038 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48984 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29320 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7613 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->