### PR TITLE
Cleanup various "nil vs empty" confusions in serializaiton of some ObjC types

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.h
@@ -46,7 +46,7 @@ public:
 private:
     friend struct IPC::ArgumentCoder<CoreIPCPKContact, void>;
 
-    CoreIPCPKContact(CoreIPCPersonNameComponents&& name, String&& emailAddress, CoreIPCCNPhoneNumber&& phoneNumber, CoreIPCCNPostalAddress&& postalAddress, String&& supplementarySublocality)
+    CoreIPCPKContact(std::optional<CoreIPCPersonNameComponents>&& name, String&& emailAddress, std::optional<CoreIPCCNPhoneNumber>&& phoneNumber, std::optional<CoreIPCCNPostalAddress>&& postalAddress, String&& supplementarySublocality)
         : m_name(WTFMove(name))
         , m_emailAddress(WTFMove(emailAddress))
         , m_phoneNumber(WTFMove(phoneNumber))
@@ -55,10 +55,10 @@ private:
     {
     }
 
-    CoreIPCPersonNameComponents m_name;
+    std::optional<CoreIPCPersonNameComponents> m_name;
     String m_emailAddress;
-    CoreIPCCNPhoneNumber m_phoneNumber;
-    CoreIPCCNPostalAddress m_postalAddress;
+    std::optional<CoreIPCCNPhoneNumber> m_phoneNumber;
+    std::optional<CoreIPCCNPostalAddress> m_postalAddress;
     String m_supplementarySublocality;
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
@@ -33,26 +33,33 @@
 namespace WebKit {
 
 CoreIPCPKContact::CoreIPCPKContact(PKContact *contact)
-    : m_name(contact.name)
-    , m_emailAddress(contact.emailAddress)
-    , m_phoneNumber(contact.phoneNumber)
-    , m_postalAddress(contact.postalAddress)
+    : m_emailAddress(contact.emailAddress)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     , m_supplementarySublocality(contact.supplementarySubLocality)
 ALLOW_DEPRECATED_DECLARATIONS_END
 {
+    if (contact.name)
+        m_name = contact.name;
+    if (contact.phoneNumber)
+        m_phoneNumber = contact.phoneNumber;
+    if (contact.postalAddress)
+        m_postalAddress = contact.postalAddress;
 }
 
 RetainPtr<id> CoreIPCPKContact::toID() const
 {
     RetainPtr<PKContact> contact = adoptNS([[PAL::getPKContactClass() alloc] init]);
 
-    contact.get().name = (NSPersonNameComponents *)m_name.toID();
-    contact.get().emailAddress = (NSString *)m_emailAddress;
-    contact.get().phoneNumber = (CNPhoneNumber *)m_phoneNumber.toID();
-    contact.get().postalAddress = (CNPostalAddress *)m_postalAddress.toID();
+    if (m_name)
+        contact.get().name = (NSPersonNameComponents *)m_name->toID();
+    if (m_phoneNumber)
+        contact.get().phoneNumber = (CNPhoneNumber *)m_phoneNumber->toID();
+    if (m_postalAddress)
+        contact.get().postalAddress = (CNPostalAddress *)m_postalAddress->toID();
+
+    contact.get().emailAddress = nsStringNilIfNull(m_emailAddress);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    contact.get().supplementarySubLocality = (NSString *)m_supplementarySublocality;
+    contact.get().supplementarySubLocality = nsStringNilIfNull(m_supplementarySublocality);
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     return contact;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -26,10 +26,10 @@ webkit_platform_headers: "CoreIPCPassKit.h"
 secure_coding_header: <pal/cocoa/PassKitSoftLink.h>
 
 [CustomHeader, WebKitPlatform] class WebKit::CoreIPCPKContact {
-    WebKit::CoreIPCPersonNameComponents m_name;
+    std::optional<WebKit::CoreIPCPersonNameComponents> m_name;
     String m_emailAddress;
-    WebKit::CoreIPCCNPhoneNumber m_phoneNumber;
-    WebKit::CoreIPCCNPostalAddress m_postalAddress;
+    std::optional<WebKit::CoreIPCCNPhoneNumber> m_phoneNumber;
+    std::optional<WebKit::CoreIPCCNPostalAddress> m_postalAddress;
     String m_supplementarySublocality;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
@@ -46,11 +46,11 @@ CoreIPCPersonNameComponents::CoreIPCPersonNameComponents(NSPersonNameComponents 
 RetainPtr<id> CoreIPCPersonNameComponents::toID() const
 {
     auto components = adoptNS([NSPersonNameComponents new]);
-    components.get().namePrefix = (NSString *)m_namePrefix;
-    components.get().givenName = (NSString *)m_givenName;
-    components.get().middleName = (NSString *)m_middleName;
-    components.get().familyName = (NSString *)m_familyName;
-    components.get().nickname = (NSString *)m_nickname;
+    components.get().namePrefix = nsStringNilIfNull(m_namePrefix);
+    components.get().givenName = nsStringNilIfNull(m_givenName);
+    components.get().middleName = nsStringNilIfNull(m_middleName);
+    components.get().familyName = nsStringNilIfNull(m_familyName);
+    components.get().nickname = nsStringNilIfNull(m_nickname);
     if (m_phoneticRepresentation)
         components.get().phoneticRepresentation = m_phoneticRepresentation->toID().get();
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1096,9 +1096,22 @@ TEST(IPCSerialization, Basic)
     auto components = personNameComponentsForTesting();
     runTestNS({ components.get().phoneticRepresentation });
     runTestNS({ components.get() });
+    components.get().namePrefix = nil;
+    runTestNS({ components.get() });
+    components.get().givenName = nil;
+    runTestNS({ components.get() });
+    components.get().middleName = nil;
+    runTestNS({ components.get() });
+    components.get().familyName = nil;
+    runTestNS({ components.get() });
+    components.get().nickname = nil;
+    runTestNS({ components.get() });
 
 #if USE(PASSKIT) && !PLATFORM(WATCHOS)
     // CNPhoneNumber
+    // Digits must be non-null at init-time, but countryCode can be null.
+    // However, Contacts will calculate a default country code if you pass in a null one,
+    // so testing encode/decode of such an instance is pointless.
     RetainPtr<CNPhoneNumber> phoneNumber = [PAL::getCNPhoneNumberClass() phoneNumberWithDigits:@"4085551234" countryCode:@"us"];
     runTestNS({ phoneNumber.get() });
 
@@ -1109,7 +1122,18 @@ TEST(IPCSerialization, Basic)
     runTestNS({ address.get() });
 
     // PKContact
-    runTestNS({ pkContactForTesting().get() });
+    auto pkContact = pkContactForTesting();
+    runTestNS({ pkContact.get() });
+    pkContact.get().name = nil;
+    runTestNS({ pkContact.get() });
+    pkContact.get().postalAddress = nil;
+    runTestNS({ pkContact.get() });
+    pkContact.get().phoneNumber = nil;
+    runTestNS({ pkContact.get() });
+    pkContact.get().emailAddress = nil;
+    runTestNS({ pkContact.get() });
+    pkContact.get().supplementarySubLocality = nil;
+    runTestNS({ pkContact.get() });
 #endif // USE(PASSKIT) && !PLATFORM(WATCHOS)
 
 


### PR DESCRIPTION
#### 26b41e6069aaf52423f7f73664cf8c29aef70bd8
<pre>
Cleanup various &quot;nil vs empty&quot; confusions in serializaiton of some ObjC types
<a href="https://rdar.apple.com/128027011">rdar://128027011</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274342">https://bugs.webkit.org/show_bug.cgi?id=274342</a>

Reviewed by Alex Christensen.

Similar to what I fixed over in <a href="https://commits.webkit.org/277627@main">https://commits.webkit.org/277627@main</a>, various other ObjC serializers
have some &quot;nil vs empty&quot; confusion that can lead to various wonky side effects.

Let&apos;s support the different between nil and empty wherever we can spot it.

* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.h:
(WebKit::CoreIPCPKContact::CoreIPCPKContact):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm:
(WebKit::CoreIPCPKContact::CoreIPCPKContact):
(WebKit::CoreIPCPKContact::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:

* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm:
(WebKit::CoreIPCPersonNameComponents::toID const):

* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, Basic)):

Canonical link: <a href="https://commits.webkit.org/278966@main">https://commits.webkit.org/278966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f04da31d14c216baa0c825e3702c139e09f899d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2761 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42365 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1759 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23434 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56919 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49758 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45014 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48976 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11402 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29305 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->