### PR TITLE
MediaFragmentURIParser rejects valid NPT strings if 'hours' is defined using 1 digit

### DIFF
--- a/LayoutTests/media/media-fragments/TC0095-expected.txt
+++ b/LayoutTests/media/media-fragments/TC0095-expected.txt
@@ -1,0 +1,12 @@
+
+
+Title: TC0095
+Fragment: 't=0:00:03,0:00:07'
+Comment: The media is requested from a to b.
+EVENT(canplaythrough)
+EXPECTED (video.currentTime == '3') OK
+RUN(video.play())
+EVENT(pause)
+EXPECTED (video.currentTime - fragmentEndTime <= '0.75') OK
+END OF TEST
+

--- a/LayoutTests/media/media-fragments/TC0095.html
+++ b/LayoutTests/media/media-fragments/TC0095.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
+        <script src=media-fragments.js></script>
+    </head>
+    <body onload="start()">
+</html>

--- a/LayoutTests/media/media-fragments/media-fragments.js
+++ b/LayoutTests/media/media-fragments/media-fragments.js
@@ -72,7 +72,8 @@
         TC0091 : { start: 3, end: 7, valid: true, description: "Sprinkling &", fragment: "&t=3,7&", comment: "Sprinkling & is OK."},
         TC0092 : { start: null, end: null, valid: false, description: "Incorrect percent encoding", fragment: "t%3d10", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."},
         TC0093 : { start: null, end: null, valid: false, description: "Incorrect percent encoding", fragment: "t=10%26", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."},
-        TC0094 : { start: null, end: null, valid: false, description: "Trailing comma", fragment: "t=3,7,", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."}
+        TC0094 : { start: null, end: null, valid: false, description: "Trailing comma", fragment: "t=3,7,", comment: "UA knows that this is an invalid media fragment, so it will play the entire media resource."},
+        TC0095 : { start: 3, end: 7, valid: true, description: "NPT HH:MM:SS format. Single digit npt-hh.", fragment: "t=0:00:03,0:00:07", comment: "The media is requested from a to b."}
     };
 
     function pause()


### PR DESCRIPTION
#### 1b08c7ea9a82ee1ae8de6f2df1199abca0a2ded1
<pre>
MediaFragmentURIParser rejects valid NPT strings if &apos;hours&apos; is defined using 1 digit

<a href="https://bugs.webkit.org/show_bug.cgi?id=160199">https://bugs.webkit.org/show_bug.cgi?id=160199</a>

Reviewed by Eric Carlson.

This patch aligns WebKit with Blink / Chromium and web specification [1]:

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/139d93b86c305ec60e9f41890cefcb4972dd8e7f">https://chromium.googlesource.com/chromium/src/+/139d93b86c305ec60e9f41890cefcb4972dd8e7f</a>

[1] <a href="https://www.w3.org/TR/media-frags/#naming-time">https://www.w3.org/TR/media-frags/#naming-time</a>

&quot;Minutes and seconds must be specified as exactly two digits, hours and fractional seconds can be any number of digits.&quot;

As above, and also per RFC2326 [2], &apos;hours&apos; can be single digit.

[2] <a href="https://www.ietf.org/rfc/rfc2326.txt">https://www.ietf.org/rfc/rfc2326.txt</a>

Refer:

&gt; npt-hh       =   1*DIGIT     ; any positive number

* Source/WebCore/html/MediaFragmentURIParser.cpp:
(MediaFragmentURIParser::parseNPTTime):
* LayoutTests/media/media-fragments/TC0095.html: Add Test Case
* LayoutTests/media/media-fragments/TC0095-expected.txt: Add Test Case Expectation
* LayoutTests/media/media-fragments/media-fragments.js: Update Test script

Canonical link: <a href="https://commits.webkit.org/278951@main">https://commits.webkit.org/278951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/378e1c4530500441665a50caa780dcce285f5a7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54360 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/37790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42369 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1764 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23440 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26285 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49763 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->