### PR TITLE
`m_maxMessageSize` should be `infinity()` instead of `max()` in `RTCSctpTransport.h`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxMessageSize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxMessageSize-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Determine the local side send limitation (canSendSize) by offering a max-message-size of 0
-FAIL Remote offer SDP missing max-message-size attribute assert_equals: Missing SDP attribute and a non-zero canSendSize should give an maxMessageSize of min(65536, canSendSize) expected 65536 but got 1.7976931348623157e+308
-FAIL max-message-size with a (non-zero) value provided by the remote peer assert_equals: maxMessageSize should be the value provided by the remote peer (as long as it is less than canSendSize) expected 1 but got 1.7976931348623157e+308
-FAIL Renegotiate max-message-size with various values provided by the remote peer assert_equals: maxMessageSize should be the value provided by the remote peer (as long as it is less than canSendSize) expected 1 but got 1.7976931348623157e+308
-FAIL max-message-size with a (non-zero) value larger than canSendSize provided by the remote peer promise_test: Unhandled rejection with value: object "SyntaxError: Invalid SCTP max message size."
+FAIL Remote offer SDP missing max-message-size attribute assert_equals: Missing SDP attribute and a canSendSize of 0 should give an maxMessageSize of 65536 expected 65536 but got Infinity
+FAIL max-message-size with a (non-zero) value provided by the remote peer assert_equals: maxMessageSize should be the value provided by the remote peer (as long as it is less than canSendSize) expected 1 but got Infinity
+FAIL Renegotiate max-message-size with various values provided by the remote peer assert_equals: maxMessageSize should be the value provided by the remote peer (as long as it is less than canSendSize) expected 1 but got Infinity
+PASS max-message-size with a (non-zero) value larger than canSendSize provided by the remote peer
 

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +73,8 @@ private:
     UniqueRef<RTCSctpTransportBackend> m_backend;
     Ref<RTCDtlsTransport> m_transport;
     RTCSctpTransportState m_state { RTCSctpTransportState::Connecting };
-    double m_maxMessageSize { std::numeric_limits<double>::max() };
+    // https://w3c.github.io/webrtc-pc/#dfn-update-the-data-max-message-size
+    double m_maxMessageSize { std::numeric_limits<double>::infinity() };
     std::optional<unsigned short> m_maxChannels;
 };
 


### PR DESCRIPTION
#### 868f20242ed99710a9ff9d17d12cbb124619920f
<pre>
`m_maxMessageSize` should be `infinity()` instead of `max()` in `RTCSctpTransport.h`

<a href="https://bugs.webkit.org/show_bug.cgi?id=274025">https://bugs.webkit.org/show_bug.cgi?id=274025</a>
<a href="https://rdar.apple.com/problem/128306030">rdar://problem/128306030</a>

Reviewed by Youenn Fablet.

This patch aligns WebKit with web specification [1]:

[1] <a href="https://w3c.github.io/webrtc-pc/#dfn-update-the-data-max-message-size">https://w3c.github.io/webrtc-pc/#dfn-update-the-data-max-message-size</a>

&quot;If both remoteMaxMessageSize and canSendSize are 0, set
[[MaxMessageSize]] to the positive Infinity value.&quot;

* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
(double m_maxMessageSize):
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxMessageSize-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/279039@main">https://commits.webkit.org/279039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d368c1a6ca8b8a8aba11468fb80638bc9b6442b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42383 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56950 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49779 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11428 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->