### PR TITLE
Rendered text extraction should exclude Live Text

### DIFF
--- a/LayoutTests/fast/element-targeting/target-rendered-text-excludes-live-text-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-rendered-text-excludes-live-text-expected.txt
@@ -1,0 +1,8 @@
+
+This test requires WebKitTestRunner
+
+PASS text is "{320,240}"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/element-targeting/target-rendered-text-excludes-live-text.html
+++ b/LayoutTests/fast/element-targeting/target-rendered-text-excludes-live-text.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+div:has(img) {
+    border: 1px solid tomato;
+    display: inline-block;
+    width: 320px;
+    height: 240px;
+}
+</style>
+</head>
+<body>
+    <div><img src="../images/resources/dice.png"></img></div>
+    <p>This test requires WebKitTestRunner</p>
+    <div id="console"></div>
+</body>
+<script>
+jsTestIsAsync = true;
+addEventListener("load", async () => {
+    const image = document.querySelector("img");
+    internals.installImageOverlay(image, [
+        {
+            topLeft : new DOMPointReadOnly(0.5, 0.5),
+            topRight : new DOMPointReadOnly(1, 0.5),
+            bottomRight : new DOMPointReadOnly(1, 1),
+            bottomLeft : new DOMPointReadOnly(0.5, 1),
+            children: [{
+                text : "Hello",
+                topLeft : new DOMPointReadOnly(0.5, 0.5),
+                topRight : new DOMPointReadOnly(1, 0.5),
+                bottomRight : new DOMPointReadOnly(1, 1),
+                bottomLeft : new DOMPointReadOnly(0.5, 1),
+            }],
+        }
+    ]);
+    text = await UIHelper.requestRenderedTextForFrontmostTarget(100, 100);
+    shouldBeEqualToString("text", "{320,240}");
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -37,6 +37,7 @@
 #include "HTMLImageElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
+#include "ImageOverlay.h"
 #include "LocalFrame.h"
 #include "Page.h"
 #include "RenderBox.h"
@@ -528,6 +529,9 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
             continue;
 
         if (descendant.style().opacity() < minOpacityToConsiderVisible)
+            continue;
+
+        if (RefPtr node = descendant.node(); node && ImageOverlay::isInsideOverlay(*node))
             continue;
 
         if (CheckedPtr textRenderer = dynamicDowncast<RenderText>(descendant); textRenderer && textRenderer->hasRenderedText()) {


### PR DESCRIPTION
#### 098f678e610d8fe1301289362d2b8a49eedaae2f
<pre>
Rendered text extraction should exclude Live Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=274355">https://bugs.webkit.org/show_bug.cgi?id=274355</a>
<a href="https://rdar.apple.com/128213708">rdar://128213708</a>

Reviewed by Richard Robinson.

Exclude Live Text in UA shadow roots under image elements, for the purposes of extracting rendered
text.

* LayoutTests/fast/element-targeting/target-rendered-text-excludes-live-text-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-rendered-text-excludes-live-text.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedText):

Canonical link: <a href="https://commits.webkit.org/278961@main">https://commits.webkit.org/278961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc9a580044295b13cb0693cc34b265fdd29fdd29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2517 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/979 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56967 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49792 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49019 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11400 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->