### PR TITLE
[Unified Text Replacement] Refactor `m_textIndicatorCharacterRanges` to be a HashMap

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -48,6 +48,7 @@ class Editor;
 namespace WebKit {
 
 enum class WebUnifiedTextReplacementSessionDataReplacementType : uint8_t;
+enum class TextIndicatorStyle : uint8_t;
 
 enum class RemoveAllMarkersForSession : uint8_t { No, Yes };
 
@@ -85,15 +86,22 @@ public:
     void removeTransparentMarkersForSession(const WTF::UUID&, RemoveAllMarkersForSession);
 
 private:
+    struct TextIndicatorCharacterRange {
+        WTF::UUID uuid;
+        WebCore::CharacterRange range;
+    };
+
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(const WebCore::SimpleRange&) const;
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerByUUID(const WebCore::SimpleRange& outerRange, const WTF::UUID& replacementUUID) const;
 
-    void replaceContentsOfRangeInSessionInternal(const WTF::UUID&, const WebCore::SimpleRange&, WTF::Function<void(WebCore::Editor&)>&&);
-    void replaceContentsOfRangeInSession(const WTF::UUID&, const WebCore::SimpleRange&, const String&);
-    void replaceContentsOfRangeInSession(const WTF::UUID&, const WebCore::SimpleRange&, WebCore::DocumentFragment&);
+    void replaceContentsOfRangeInSessionInternal(const WebUnifiedTextReplacementSessionData&, const WebCore::SimpleRange&, WTF::Function<void(WebCore::Editor&)>&&);
+    void replaceContentsOfRangeInSession(const WebUnifiedTextReplacementSessionData&, const WebCore::SimpleRange&, const String&);
+    void replaceContentsOfRangeInSession(const WebUnifiedTextReplacementSessionData&, const WebCore::SimpleRange&, WebCore::DocumentFragment&);
 
     void textReplacementSessionPerformEditActionForPlainText(WebCore::Document&, const WebUnifiedTextReplacementSessionData&, WebTextReplacementData::EditAction);
     void textReplacementSessionPerformEditActionForRichText(WebCore::Document&, const WebUnifiedTextReplacementSessionData&, WebTextReplacementData::EditAction);
+
+    WTF::UUID createTextIndicator(const WebCore::SimpleRange&, TextIndicatorStyle);
 
     template<WebUnifiedTextReplacementSessionData::ReplacementType Type>
     void didEndTextReplacementSession(const WebUnifiedTextReplacementSessionData&, bool accepted);
@@ -102,15 +110,13 @@ private:
 
     WeakPtr<WebPage> m_webPage;
 
-    using TextIndicatorCharacterRange = std::pair<WTF::UUID, WebCore::CharacterRange>;
-    Vector<std::pair<WTF::UUID, Vector<TextIndicatorCharacterRange>>> m_textIndicatorCharacterRangesForSessions;
-
     // FIXME: Unify these states into a single `State` struct.
     HashMap<WTF::UUID, Ref<WebCore::Range>> m_contextRanges;
     HashMap<WTF::UUID, WebUnifiedTextReplacementSessionData::ReplacementType> m_replacementTypes;
     HashMap<WTF::UUID, int> m_replacementLocationOffsets;
     HashMap<WTF::UUID, Ref<WebCore::DocumentFragment>> m_originalDocumentNodes;
     HashMap<WTF::UUID, Ref<WebCore::DocumentFragment>> m_replacedDocumentNodes;
+    HashMap<WTF::UUID, Vector<TextIndicatorCharacterRange>> m_textIndicatorCharacterRanges;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### d48be59b226a3da86b16e3948e08db42c6637263
<pre>
[Unified Text Replacement] Refactor `m_textIndicatorCharacterRanges` to be a HashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=274357">https://bugs.webkit.org/show_bug.cgi?id=274357</a>
<a href="https://rdar.apple.com/128336962">rdar://128336962</a>

Reviewed by Abrar Rahman Protyasha.

Work towards improved type safety and consistency by refactoring `m_textIndicatorCharacterRanges`
to be a HashMap, like the other state instance variables.

* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession&lt;WebUnifiedTextReplacementSessionData::ReplacementType::PlainText&gt;):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::textReplacementSessionPerformEditActionForPlainText):
(WebKit::UnifiedTextReplacementController::textReplacementSessionPerformEditActionForRichText):
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForUUID):
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForSession):
(WebKit::UnifiedTextReplacementController::contextRangeForSessionOrRangeWithUUID const):
(WebKit::UnifiedTextReplacementController::createTextIndicator):
(WebKit::UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal):
(WebKit::UnifiedTextReplacementController::replaceContentsOfRangeInSession):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:

Canonical link: <a href="https://commits.webkit.org/278978@main">https://commits.webkit.org/278978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/079d23846ffd600e7933abdda3215c2b4fc7cf6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2822 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42407 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26334 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/992 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56980 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49030 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29374 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7625 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->