### PR TITLE
Optimize PublicSuffixStore

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -168,9 +168,9 @@ public:
     MappedTakeType take(iterator);
     MappedTakeType takeFirst();
 
-    // An alternate version of find() that finds the object by hashing and comparing
-    // with some other type, to avoid the cost of type conversion. HashTranslator
-    // must have the following function members:
+    // Alternate versions of find() / contains() / get() / remove() that find the object
+    // by hashing and comparing with some other type, to avoid the cost of type conversion.
+    // HashTranslator must have the following function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
     template<typename HashTranslator, typename T> iterator find(const T&);
@@ -180,13 +180,14 @@ public:
     template<typename HashTranslator, typename T> MappedPeekType inlineGet(const T&) const;
     template<typename HashTranslator, typename T> bool remove(const T&);
 
-    // An alternate version of add() that finds the object by hashing and comparing
+    // Alternate versions of add() / ensure() that find the object by hashing and comparing
     // with some other type, to avoid the cost of type conversion if the object is already
     // in the table. HashTranslator must have the following function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
     //   static translate(ValueType&, const T&, unsigned hashCode);
     template<typename HashTranslator, typename K, typename V> AddResult add(K&&, V&&);
+    template<typename HashTranslator, typename K, typename Functor> AddResult ensure(K&&, Functor&&);
 
     // Overloads for smart pointer keys that take the raw pointer type as the parameter.
     template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*);
@@ -265,6 +266,17 @@ struct HashMapTranslatorAdapter {
     {
         Translator::translate(location.key, key, hashCode);
         location.value = std::forward<V>(mapped);
+    }
+};
+
+template<typename ValueTraits, typename Translator>
+struct HashMapEnsureTranslatorAdapter {
+    template<typename T> static unsigned hash(const T& key) { return Translator::hash(key); }
+    template<typename T, typename U> static bool equal(const T& a, const U& b) { return Translator::equal(a, b); }
+    template<typename T, typename U, typename Functor> static void translate(T& location, U&& key, Functor&& functor, unsigned hashCode)
+    {
+        Translator::translate(location.key, key, hashCode);
+        location.value = functor();
     }
 };
 
@@ -437,6 +449,13 @@ template<typename HashTranslator, typename K, typename V>
 auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::add(K&& key, V&& value) -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), std::forward<V>(value));
+}
+
+template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
+template<typename HashTranslator, typename K, typename Functor>
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(K&& key, Functor&& functor) -> AddResult
+{
+    return m_impl.template addPassingHashCode<HashMapEnsureTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), std::forward<Functor>(functor));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>

--- a/Source/WTF/wtf/URLHelpers.h
+++ b/Source/WTF/wtf/URLHelpers.h
@@ -41,7 +41,7 @@ WTF_EXPORT_PRIVATE String userVisibleURL(const CString& URL);
 void loadIDNAllowedScriptList();
 void addScriptToIDNAllowedScriptList(const char* scriptName);
 void initializeDefaultIDNAllowedScriptList();
-std::optional<String> mapHostName(const String&, URLDecodeFunction);
+WTF_EXPORT_PRIVATE std::optional<String> mapHostName(const String&, URLDecodeFunction);
 String mapHostNames(const String&, URLDecodeFunction);
 
 } // namespace URLHelpers

--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -250,6 +250,12 @@ namespace WTF {
         {
             return equalIgnoringASCIICaseCommon(a, b);
         }
+
+        static void translate(String& location, StringView view, unsigned hash)
+        {
+            location = view.toString();
+            location.impl()->setHash(hash);
+        }
     };
 
     struct HashTranslatorASCIILiteral {

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -66,6 +66,7 @@ namespace WTF {
 class SymbolImpl;
 class SymbolRegistry;
 
+struct ASCIICaseInsensitiveStringViewHashTranslator;
 struct HashedUTF8CharactersTranslator;
 struct HashTranslatorASCIILiteral;
 struct LCharBufferTranslator;
@@ -185,6 +186,7 @@ class StringImpl : private StringImplShape {
     friend class SymbolImpl;
     friend class ExternalStringImpl;
 
+    friend struct WTF::ASCIICaseInsensitiveStringViewHashTranslator;
     friend struct WTF::HashedUTF8CharactersTranslator;
     friend struct WTF::HashTranslatorASCIILiteral;
     friend struct WTF::LCharBufferTranslator;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4108,8 +4108,8 @@ const URL& Document::urlForBindings() const
 
         auto areSameSiteIgnoringPublicSuffix = [](StringView domain, StringView otherDomain) {
             auto& publicSuffixStore = PublicSuffixStore::singleton();
-            auto domainString = publicSuffixStore.topPrivatelyControlledDomain(domain.toStringWithoutCopying());
-            auto otherDomainString = publicSuffixStore.topPrivatelyControlledDomain(otherDomain.toStringWithoutCopying());
+            auto domainString = publicSuffixStore.topPrivatelyControlledDomain(domain);
+            auto otherDomainString = publicSuffixStore.topPrivatelyControlledDomain(otherDomain);
             auto substringToSeparator = [](const String& string) -> String {
                 auto indexOfFirstSeparator = string.find('.');
                 if (indexOfFirstSeparator == notFound)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -101,7 +101,7 @@ static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentString
 static inline bool isYahooMail(Document& document)
 {
     auto host = document.topDocument().url().host();
-    return host.startsWith("mail."_s) && PublicSuffixStore::singleton().topPrivatelyControlledDomain(host.toString()).startsWith("yahoo."_s);
+    return host.startsWith("mail."_s) && PublicSuffixStore::singleton().topPrivatelyControlledDomain(host).startsWith("yahoo."_s);
 }
 #endif
 
@@ -242,7 +242,7 @@ bool Quirks::shouldHideSearchFieldResultsButton() const
     if (!needsQuirks())
         return false;
 
-    if (PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host().toString()).startsWith("google."_s))
+    if (PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host()).startsWith("google."_s))
         return true;
 #endif
     return false;
@@ -419,13 +419,13 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
 #if ENABLE(TOUCH_EVENTS)
 bool Quirks::isAmazon() const
 {
-    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host().toString()).startsWith("amazon."_s);
+    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host()).startsWith("amazon."_s);
 }
 
 bool Quirks::isGoogleMaps() const
 {
     auto& url = m_document->topDocument().url();
-    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(url.host().toString()).startsWith("google."_s) && startsWithLettersIgnoringASCIICase(url.path(), "/maps/"_s);
+    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(url.host()).startsWith("google."_s) && startsWithLettersIgnoringASCIICase(url.path(), "/maps/"_s);
 }
 
 // rdar://49124313

--- a/Source/WebCore/platform/PublicSuffixStore.cpp
+++ b/Source/WebCore/platform/PublicSuffixStore.cpp
@@ -28,8 +28,11 @@
 
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringHash.h>
 
 namespace WebCore {
+
+constexpr auto maxHostTopPrivatelyControlledDomainCache = 128;
 
 PublicSuffixStore& PublicSuffixStore::singleton()
 {
@@ -71,30 +74,31 @@ String PublicSuffixStore::publicSuffix(const URL& url) const
     return { };
 }
 
-String PublicSuffixStore::topPrivatelyControlledDomain(const String& host) const
+String PublicSuffixStore::topPrivatelyControlledDomain(StringView host) const
 {
     // FIXME: if host is a URL, we could drop these checks.
     if (host.isEmpty())
         return { };
 
     if (!host.containsOnlyASCII())
-        return host;
+        return host.toString();
 
     Locker locker { m_HostTopPrivatelyControlledDomainCacheLock };
-    auto hostCopy = crossThreadCopy(host);
-    auto result = m_hostTopPrivatelyControlledDomainCache.ensure(hostCopy, [&] {
-        const auto lowercaseHost = hostCopy.convertToASCIILowercase();
+    auto addResult = m_hostTopPrivatelyControlledDomainCache.ensure<ASCIICaseInsensitiveStringViewHashTranslator>(host, [&] {
+        const auto lowercaseHost = host.convertToASCIILowercase();
         if (lowercaseHost == "localhost"_s || URL::hostIsIPAddress(lowercaseHost))
             return lowercaseHost;
 
         return platformTopPrivatelyControlledDomain(lowercaseHost);
-    }).iterator->value.isolatedCopy();
+    });
 
-    constexpr auto maxHostTopPrivatelyControlledDomainCache = 128;
-    if (m_hostTopPrivatelyControlledDomainCache.size() > maxHostTopPrivatelyControlledDomainCache)
-        m_hostTopPrivatelyControlledDomainCache.remove(m_hostTopPrivatelyControlledDomainCache.random());
+    auto domain = addResult.iterator->value.isolatedCopy();
+    if (!addResult.isNewEntry) {
+        if (m_hostTopPrivatelyControlledDomainCache.size() > maxHostTopPrivatelyControlledDomainCache)
+            m_hostTopPrivatelyControlledDomainCache.remove(m_hostTopPrivatelyControlledDomainCache.random());
+    }
 
-    return result;
+    return domain;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -39,7 +39,7 @@ public:
     // https://url.spec.whatwg.org/#host-public-suffix
     WEBCORE_EXPORT bool isPublicSuffix(StringView domain) const;
     WEBCORE_EXPORT String publicSuffix(const URL&) const;
-    WEBCORE_EXPORT String topPrivatelyControlledDomain(const String& host) const;
+    WEBCORE_EXPORT String topPrivatelyControlledDomain(StringView host) const;
     WEBCORE_EXPORT void clearHostTopPrivatelyControlledDomainCache();
 
 #if PLATFORM(COCOA)
@@ -53,14 +53,14 @@ private:
     PublicSuffixStore() = default;
 
     bool platformIsPublicSuffix(StringView domain) const;
-    String platformTopPrivatelyControlledDomain(const String& host) const;
+    String platformTopPrivatelyControlledDomain(StringView host) const;
 
     mutable Lock m_HostTopPrivatelyControlledDomainCacheLock;
     mutable HashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);
 #if PLATFORM(COCOA)
     mutable Lock m_publicSuffixCacheLock;
     std::optional<HashSet<String, ASCIICaseInsensitiveHash>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
-    bool m_canAcceptCustomPublicSuffix WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock) { false };
+    bool m_canAcceptCustomPublicSuffix { false }; // Only used on the main thread.
 #endif
 };
 

--- a/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
+++ b/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
@@ -50,7 +50,7 @@ static String topPrivatelyControlledDomainInternal(const psl_ctx_t* psl, const c
     return String();
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& domain) const
+String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain) const
 {
     if (platformIsPublicSuffix(domain))
         return String();

--- a/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
@@ -39,7 +39,7 @@ bool PublicSuffixStore::platformIsPublicSuffix(StringView domain) const
     return soup_tld_domain_is_public_suffix(domain.convertToASCIILowercase().utf8().data());
 }
 
-static String permissiveTopPrivateDomain(const String& domain)
+static String permissiveTopPrivateDomain(StringView domain)
 {
     auto position = domain.length();
     bool foundDot = false;
@@ -50,15 +50,15 @@ static String permissiveTopPrivateDomain(const String& domain)
     while (position-- > 0) {
         if (domain[position] == '.') {
             if (foundDot)
-                return domain.substring(position + 1);
+                return domain.substring(position + 1).toString();
             foundDot = true;
         }
     }
 
-    return foundDot ? domain : String();
+    return foundDot ? domain.toString() : String();
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& domain) const
+String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain) const
 {
     CString domainUTF8 = domain.utf8();
 
@@ -84,7 +84,7 @@ String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& dom
         return String();
 
     if (g_error_matches(error.get(), SOUP_TLD_ERROR, SOUP_TLD_ERROR_IS_IP_ADDRESS))
-        return domain;
+        return domain.toString();
 
     ASSERT_NOT_REACHED();
     return String();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9717,7 +9717,7 @@ void WebPageProxy::resetStateAfterProcessTermination(ProcessTerminationReason re
 
 #if PLATFORM(IOS_FAMILY)
     if (m_process->isUnderMemoryPressure()) {
-        auto domain = WebCore::PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, currentURL()).host().toString());
+        auto domain = WebCore::PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, currentURL()).host());
         if (!domain.isEmpty())
             logDiagnosticMessageWithEnhancedPrivacy(WebCore::DiagnosticLoggingKeys::domainCausingJetsamKey(), domain, WebCore::ShouldSample::No);
     }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1212,7 +1212,7 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
     // FIXME: Perhaps this should consider ProcessTerminationReasons ExceededMemoryLimit, ExceededCPULimit, Unresponsive as well.
     if (pages.size() == 1 && reason == ProcessTerminationReason::Crash) {
         auto& page = pages[0];
-        auto domain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, page->currentURL()).host().toString());
+        auto domain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, page->currentURL()).host());
         if (!domain.isEmpty())
             page->logDiagnosticMessageWithEnhancedPrivacy(WebCore::DiagnosticLoggingKeys::domainCausingCrashKey(), domain, WebCore::ShouldSample::No);
     }
@@ -2015,7 +2015,7 @@ void WebProcessProxy::didExceedMemoryFootprintThreshold(size_t footprint)
     bool hasAllowedToRunInTheBackgroundActivity = false;
 
     for (auto& page : this->pages()) {
-        auto pageDomain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, page->currentURL()).host().toString());
+        auto pageDomain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, page->currentURL()).host());
         if (domain.isEmpty())
             domain = WTFMove(pageDomain);
         else if (domain != pageDomain)


### PR DESCRIPTION
#### 1becc19b6e5ecf20c63b152e5cd5591e1ab9566d
<pre>
Optimize PublicSuffixStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=274358">https://bugs.webkit.org/show_bug.cgi?id=274358</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/WTF/wtf/HashMap.h:
(WTF::HashMapEnsureTranslatorAdapter::hash):
(WTF::HashMapEnsureTranslatorAdapter::equal):
(WTF::HashMapEnsureTranslatorAdapter::translate):
(WTF::TableTraitsArg&gt;::ensure):
* Source/WTF/wtf/URLHelpers.h:
* Source/WTF/wtf/text/StringHash.h:
(WTF::ASCIICaseInsensitiveStringViewHashTranslator::translate):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::urlForBindings const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::isYahooMail):
(WebCore::Quirks::shouldHideSearchFieldResultsButton const):
(WebCore::Quirks::isAmazon const):
(WebCore::Quirks::isGoogleMaps const):
* Source/WebCore/platform/PublicSuffixStore.cpp:
(WebCore::PublicSuffixStore::topPrivatelyControlledDomain const):
* Source/WebCore/platform/PublicSuffixStore.h:
(WebCore::PublicSuffixStore::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::isPublicSuffixCF):
(WebCore::PublicSuffixStore::platformIsPublicSuffix const):
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
(WebCore::PublicSuffixStore::enablePublicSuffixCache):
(WebCore::PublicSuffixStore::addPublicSuffix):
* Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didExceedMemoryFootprintThreshold):

Canonical link: <a href="https://commits.webkit.org/278977@main">https://commits.webkit.org/278977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30753a7979caf9b1f871cf4edd46373ff5811ab3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42442 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54250 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29120 "Found 1 new test failure: http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23513 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51998 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1036 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45503 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57024 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51662 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2485 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49073 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29425 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/63969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7624 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28257 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/63969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->