### PR TITLE
[JSC] Enable 16bit CLoop Win

### DIFF
--- a/Source/JavaScriptCore/generator/Opcode.rb
+++ b/Source/JavaScriptCore/generator/Opcode.rb
@@ -236,12 +236,6 @@ private:
     static bool checkImpl(BytecodeGenerator* gen#{typed_reference_args}#{metadata_param})
     {
         UNUSED_PARAM(gen);
-#if OS(WINDOWS) && ENABLE(C_LOOP)
-        // FIXME: Disable wide16 optimization for Windows CLoop
-        // https://bugs.webkit.org/show_bug.cgi?id=198283
-        if (__size == OpcodeSize::Wide16)
-            return false;
-#endif
         return #{map_fields_with_size("", "__size", &:fits_check).join "\n            && "}
             && (__size == OpcodeSize::Narrow ? #{Argument.new("opcodeID", opcodeIDType, 0).fits_check(Size::Narrow)} : #{Argument.new("opcodeID", opcodeIDType, 0).fits_check(Size::Wide16)})
             && (__size == OpcodeSize::Wide16 ? #{op_wide16.fits_check(Size::Narrow)} : true)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -467,11 +467,6 @@ _%label%:
         break
     end
 
-# FIXME: We cannot enable wide16 bytecode in Windows CLoop. With MSVC, as CLoop::execute gets larger code
-# size, CLoop::execute gets higher stack height requirement. This makes CLoop::execute takes 160KB stack
-# per call, causes stack overflow error easily. For now, we disable wide16 optimization for Windows CLoop.
-# https://bugs.webkit.org/show_bug.cgi?id=198283
-if not C_LOOP_WIN
 _%label%_wide16:
     prologue()
     fn(wide16)
@@ -479,7 +474,6 @@ _%label%_wide16:
         break
         break
     end
-end
 
 _%label%_wide32:
     prologue()
@@ -1083,21 +1077,15 @@ end
 
 macro defineReturnLabel(opcodeName, size)
     macro defineNarrow()
-        if not C_LOOP_WIN
-            _%opcodeName%_return_location:
-        end
+        _%opcodeName%_return_location:
     end
 
     macro defineWide16()
-        if not C_LOOP_WIN
-            _%opcodeName%_return_location_wide16:
-        end
+        _%opcodeName%_return_location_wide16:
     end
 
     macro defineWide32()
-        if not C_LOOP_WIN
-            _%opcodeName%_return_location_wide32:
-        end
+        _%opcodeName%_return_location_wide32:
     end
 
     size(defineNarrow, defineWide16, defineWide32, macro (f) f() end)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -196,8 +196,6 @@ macro cCall4(function)
         push a0
         call function
         addp 16, sp
-    elsif C_LOOP or C_LOOP_WIN
-        error
     else
         error
     end


### PR DESCRIPTION
#### 2c77a224cdd2b33ca4eefc35c20a2cc9aace0963
<pre>
[JSC] Enable 16bit CLoop Win
<a href="https://bugs.webkit.org/show_bug.cgi?id=198283">https://bugs.webkit.org/show_bug.cgi?id=198283</a>
<a href="https://rdar.apple.com/128344991">rdar://128344991</a>

Reviewed by Ross Kirsling.

This was MSVC workaround. Now we only support clang-cl, so we do not need this workaround.

* Source/JavaScriptCore/generator/Opcode.rb:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:

Canonical link: <a href="https://commits.webkit.org/278968@main">https://commits.webkit.org/278968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a20ad08d7d6c2df538ecffe837f83e556bca8276

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55404 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42419 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23490 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26360 "Failed to checkout and rebase branch from PR 28767") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2261 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1013 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45478 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57001 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51639 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2454 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45100 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29402 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63945 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7618 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28234 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12097 "Passed tests") | 
<!--EWS-Status-Bubble-End-->