### PR TITLE
[WTF] Start removing GCC_COMPATIBLE

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -352,11 +352,7 @@ void WTFCrash()
 #else
     *(int *)(uintptr_t)0xbbadbeef = 0;
     // More reliable, but doesn't say BBADBEEF.
-#if COMPILER(GCC) || COMPILER(CLANG)
     __builtin_trap();
-#else
-    ((void(*)())nullptr)();
-#endif // COMPILER(GCC_COMPATIBLE)
 #endif // ASAN_ENABLED
 }
 #else

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -101,11 +101,7 @@
 #define VERBOSE_RELEASE_LOG ENABLE(JOURNALD_LOG)
 #endif
 
-#if COMPILER(GCC_COMPATIBLE)
 #define WTF_PRETTY_FUNCTION __PRETTY_FUNCTION__
-#else
-#define WTF_PRETTY_FUNCTION __FUNCTION__
-#endif
 
 #if COMPILER(MINGW)
 /* By default MinGW emits warnings when C99 format attributes are used, even if __USE_MINGW_ANSI_STDIO is defined */

--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -407,7 +407,7 @@ ALWAYS_INLINE constexpr void BitSet<bitSetSize, WordType>::forEachSetBit(const F
             continue;
         size_t base = i * wordSize;
 
-#if COMPILER(GCC_COMPATIBLE) && (CPU(X86_64) || CPU(ARM64))
+#if CPU(X86_64) || CPU(ARM64)
         // We should only use ctz() when we know that ctz() is implementated using
         // a fast hardware instruction. Otherwise, this will actually result in
         // worse performance.
@@ -443,7 +443,7 @@ ALWAYS_INLINE constexpr void BitSet<bitSetSize, WordType>::forEachSetBit(size_t 
     auto iterate = [&](WordType word, size_t i) ALWAYS_INLINE_LAMBDA {
         size_t base = i * wordSize;
 
-#if COMPILER(GCC_COMPATIBLE) && (CPU(X86_64) || CPU(ARM64))
+#if CPU(X86_64) || CPU(ARM64)
         // We should only use ctz() when we know that ctz() is implementated using
         // a fast hardware instruction. Otherwise, this will actually result in
         // worse performance.

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -290,7 +290,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
 
     static inline bool add(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
     {
-#if COMPILER(GCC_COMPATIBLE)
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
@@ -301,7 +300,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
             return true;
 #if !HAVE(INT128_T)
         }
-#endif
 #endif
         if (signsMatch(lhs, rhs)) {
             if (lhs >= 0) {
@@ -319,7 +317,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
 
     static inline bool sub(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
     {
-#if COMPILER(GCC_COMPATIBLE)
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
@@ -330,7 +327,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
             return true;
 #if !HAVE(INT128_T)
         }
-#endif
 #endif
         if (!signsMatch(lhs, rhs)) {
             if (lhs >= 0) {
@@ -404,7 +400,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
     static inline bool add(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
     {
         ResultType temp;
-#if COMPILER(GCC_COMPATIBLE)
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
@@ -414,7 +409,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
             return true;
 #if !HAVE(INT128_T)
         }
-#endif
 #endif
         temp = lhs + rhs;
         if (temp < lhs)
@@ -426,7 +420,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
     static inline bool sub(LHS lhs, RHS rhs, ResultType& result) WARN_UNUSED_RETURN
     {
         ResultType temp;
-#if COMPILER(GCC_COMPATIBLE)
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
@@ -436,7 +429,6 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
             return true;
 #if !HAVE(INT128_T)
         }
-#endif
 #endif
         temp = lhs - rhs;
         if (temp > lhs)
@@ -489,40 +481,20 @@ template <typename LHS, typename RHS, typename ResultType> struct ArithmeticOper
 template <typename ResultType> struct ArithmeticOperations<int, unsigned, ResultType, true, false> {
     static inline bool add(int64_t lhs, int64_t rhs, ResultType& result)
     {
-#if COMPILER(GCC_COMPATIBLE)
         ResultType temp;
         if (__builtin_add_overflow(lhs, rhs, &temp))
             return false;
         result = temp;
         return true;
-#else
-        int64_t temp = lhs + rhs;
-        if (temp < std::numeric_limits<ResultType>::min())
-            return false;
-        if (temp > std::numeric_limits<ResultType>::max())
-            return false;
-        result = static_cast<ResultType>(temp);
-        return true;
-#endif
     }
     
     static inline bool sub(int64_t lhs, int64_t rhs, ResultType& result)
     {
-#if COMPILER(GCC_COMPATIBLE)
         ResultType temp;
         if (__builtin_sub_overflow(lhs, rhs, &temp))
             return false;
         result = temp;
         return true;
-#else
-        int64_t temp = lhs - rhs;
-        if (temp < std::numeric_limits<ResultType>::min())
-            return false;
-        if (temp > std::numeric_limits<ResultType>::max())
-            return false;
-        result = static_cast<ResultType>(temp);
-        return true;
-#endif
     }
 
     static inline bool multiply(int64_t lhs, int64_t rhs, ResultType& result)

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -199,7 +199,7 @@
 
 /* In GCC functions marked with no_sanitize_address cannot call functions that are marked with always_inline and not marked with no_sanitize_address.
  * Therefore we need to give up on the enforcement of ALWAYS_INLINE when bulding with ASAN. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67368 */
-#if !defined(ALWAYS_INLINE) && COMPILER(GCC_COMPATIBLE) && defined(NDEBUG) && !COMPILER(MINGW) && !(COMPILER(GCC) && ASAN_ENABLED)
+#if !defined(ALWAYS_INLINE) && defined(NDEBUG) && !COMPILER(MINGW) && !(COMPILER(GCC) && ASAN_ENABLED)
 #define ALWAYS_INLINE inline __attribute__((__always_inline__))
 #endif
 
@@ -270,7 +270,7 @@
 
 /* LIKELY */
 
-#if !defined(LIKELY) && COMPILER(GCC_COMPATIBLE)
+#if !defined(LIKELY)
 #define LIKELY(x) __builtin_expect(!!(x), 1)
 #endif
 
@@ -280,7 +280,7 @@
 
 /* NEVER_INLINE */
 
-#if !defined(NEVER_INLINE) && COMPILER(GCC_COMPATIBLE)
+#if !defined(NEVER_INLINE)
 #define NEVER_INLINE __attribute__((__noinline__))
 #endif
 
@@ -331,7 +331,7 @@
 #endif
 
 /* RETURNS_NONNULL */
-#if !defined(RETURNS_NONNULL) && COMPILER(GCC_COMPATIBLE)
+#if !defined(RETURNS_NONNULL)
 #define RETURNS_NONNULL __attribute__((returns_nonnull))
 #endif
 
@@ -373,7 +373,7 @@
 
 /* PURE_FUNCTION */
 
-#if !defined(PURE_FUNCTION) && COMPILER(GCC_COMPATIBLE)
+#if !defined(PURE_FUNCTION)
 #define PURE_FUNCTION __attribute__((__pure__))
 #endif
 
@@ -383,7 +383,7 @@
 
 /* WK_UNUSED_INSTANCE_VARIABLE */
 
-#if !defined(WK_UNUSED_INSTANCE_VARIABLE) && COMPILER(GCC_COMPATIBLE)
+#if !defined(WK_UNUSED_INSTANCE_VARIABLE)
 #define WK_UNUSED_INSTANCE_VARIABLE __attribute__((unused))
 #endif
 
@@ -403,7 +403,7 @@
 
 /* UNUSED_TYPE_ALIAS */
 
-#if !defined(UNUSED_TYPE_ALIAS) && COMPILER(GCC_COMPATIBLE)
+#if !defined(UNUSED_TYPE_ALIAS)
 #define UNUSED_TYPE_ALIAS __attribute__((unused))
 #endif
 
@@ -434,7 +434,7 @@
 
 /* UNLIKELY */
 
-#if !defined(UNLIKELY) && COMPILER(GCC_COMPATIBLE)
+#if !defined(UNLIKELY)
 #define UNLIKELY(x) __builtin_expect(!!(x), 0)
 #endif
 
@@ -478,7 +478,7 @@
 
 /* WARN_UNUSED_RETURN */
 
-#if !defined(WARN_UNUSED_RETURN) && COMPILER(GCC_COMPATIBLE)
+#if !defined(WARN_UNUSED_RETURN)
 #define WARN_UNUSED_RETURN __attribute__((__warn_unused_result__))
 #endif
 

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -406,14 +406,10 @@ using WTF::tryFastCompactMalloc;
 using WTF::tryFastCompactZeroedMalloc;
 using WTF::fastCompactAlignedMalloc;
 
-#if COMPILER(GCC_COMPATIBLE) && OS(DARWIN)
+#if OS(DARWIN)
 #define WTF_PRIVATE_INLINE __private_extern__ inline __attribute__((always_inline))
-#elif COMPILER(GCC_COMPATIBLE)
-#define WTF_PRIVATE_INLINE inline __attribute__((always_inline))
-#elif COMPILER(MSVC)
-#define WTF_PRIVATE_INLINE __forceinline
 #else
-#define WTF_PRIVATE_INLINE inline
+#define WTF_PRIVATE_INLINE inline __attribute__((always_inline))
 #endif
 
 #define WTF_MAKE_FAST_ALLOCATED_IMPL \

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -612,16 +612,10 @@ inline unsigned clz(T value)
     using UT = typename std::make_unsigned<T>::type;
     UT uValue = value;
 
-#if COMPILER(GCC_COMPATIBLE)
     constexpr unsigned bitSize64 = sizeof(uint64_t) * CHAR_BIT;
     if (uValue)
         return __builtin_clzll(uValue) - (bitSize64 - bitSize);
     return bitSize;
-#else
-    UNUSED_PARAM(bitSize);
-    UNUSED_PARAM(uValue);
-    return clzConstexpr(value);
-#endif
 }
 
 template <typename T>
@@ -651,15 +645,9 @@ inline unsigned ctz(T value)
     using UT = typename std::make_unsigned<T>::type;
     UT uValue = value;
 
-#if COMPILER(GCC_COMPATIBLE)
     if (uValue)
         return __builtin_ctzll(uValue);
     return bitSize;
-#else
-    UNUSED_PARAM(bitSize);
-    UNUSED_PARAM(uValue);
-    return ctzConstexpr(value);
-#endif
 }
 
 template<typename T>
@@ -694,7 +682,7 @@ constexpr unsigned getMSBSetConstexpr(T t)
 
 inline uint32_t reverseBits32(uint32_t value)
 {
-#if COMPILER(GCC_COMPATIBLE) && CPU(ARM64)
+#if CPU(ARM64)
     uint32_t result;
     asm ("rbit %w0, %w1"
         : "=r"(result)

--- a/Source/WTF/wtf/PlatformCPU.h
+++ b/Source/WTF/wtf/PlatformCPU.h
@@ -301,7 +301,6 @@
 #define WTF_CPU_NEEDS_ALIGNED_ACCESS 1
 #endif
 
-#if COMPILER(GCC_COMPATIBLE)
 /* __LP64__ is not defined on 64bit Windows since it uses LLP64. Using __SIZEOF_POINTER__ is simpler. */
 #if __SIZEOF_POINTER__ == 8
 #define WTF_CPU_ADDRESS64 1
@@ -309,22 +308,6 @@
 #define WTF_CPU_ADDRESS32 1
 #else
 #error "Unsupported pointer width"
-#endif
-#elif COMPILER(MSVC)
-#if defined(_WIN64)
-#define WTF_CPU_ADDRESS64 1
-#else
-#define WTF_CPU_ADDRESS32 1
-#endif
-#else
-/* This is the most generic way. But in OS(DARWIN), Platform.h can be included by sandbox definition file (.sb).
- * At that time, we cannot include "stdint.h" header. So in the case of known compilers, we use predefined constants instead. */
-#include <stdint.h>
-#if UINTPTR_MAX > UINT32_MAX
-#define WTF_CPU_ADDRESS64 1
-#else
-#define WTF_CPU_ADDRESS32 1
-#endif
 #endif
 
 /* CPU general purpose register width. */
@@ -338,7 +321,6 @@
 
 /* CPU(BIG_ENDIAN) or CPU(MIDDLE_ENDIAN) or neither, as appropriate. */
 
-#if COMPILER(GCC_COMPATIBLE)
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define WTF_CPU_BIG_ENDIAN 1
 #elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
@@ -347,41 +329,6 @@
 #define WTF_CPU_MIDDLE_ENDIAN 1
 #else
 #error "Unknown endian"
-#endif
-#else
-#if defined(WIN32) || defined(_WIN32)
-/* Windows only have little endian architecture. */
-#define WTF_CPU_LITTLE_ENDIAN 1
-#else
-#include <sys/types.h>
-#if __has_include(<endian.h>)
-#include <endian.h>
-#if __BYTE_ORDER == __BIG_ENDIAN
-#define WTF_CPU_BIG_ENDIAN 1
-#elif __BYTE_ORDER == __LITTLE_ENDIAN
-#define WTF_CPU_LITTLE_ENDIAN 1
-#elif __BYTE_ORDER == __PDP_ENDIAN
-#define WTF_CPU_MIDDLE_ENDIAN 1
-#else
-#error "Unknown endian"
-#endif
-#else
-#if __has_include(<machine/endian.h>)
-#include <machine/endian.h>
-#else
-#include <sys/endian.h>
-#endif
-#if BYTE_ORDER == BIG_ENDIAN
-#define WTF_CPU_BIG_ENDIAN 1
-#elif BYTE_ORDER == LITTLE_ENDIAN
-#define WTF_CPU_LITTLE_ENDIAN 1
-#elif BYTE_ORDER == PDP_ENDIAN
-#define WTF_CPU_MIDDLE_ENDIAN 1
-#else
-#error "Unknown endian"
-#endif
-#endif
-#endif
 #endif
 
 #if !CPU(LITTLE_ENDIAN) && !CPU(BIG_ENDIAN)

--- a/Source/WTF/wtf/PlatformCallingConventions.h
+++ b/Source/WTF/wtf/PlatformCallingConventions.h
@@ -41,7 +41,7 @@
 
 #if CPU(X86) && COMPILER(MSVC)
 #define JSC_HOST_CALL_ATTRIBUTES __fastcall
-#elif CPU(X86) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(X86)
 #define JSC_HOST_CALL_ATTRIBUTES __attribute__ ((fastcall))
 #else
 #define JSC_HOST_CALL_ATTRIBUTES SYSV_ABI

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -257,9 +257,7 @@
 
 #endif
 
-#if COMPILER(GCC_COMPATIBLE)
 #define HAVE_COMPUTED_GOTO 1
-#endif
 
 #if (CPU(ARM64E) && OS(DARWIN)) || (COMPILER(CLANG) && defined(__ARM_FEATURE_JCVT))
 #define HAVE_FJCVTZS_INSTRUCTION 1
@@ -811,7 +809,7 @@
 #endif
 #endif
 
-#if COMPILER(GCC_COMPATIBLE) && defined(__has_attribute)
+#if defined(__has_attribute)
 #if __has_attribute(objc_direct)
 #if !defined(HAVE_NS_DIRECT_SUPPORT)
 #define HAVE_NS_DIRECT_SUPPORT 1

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -145,7 +145,7 @@
 
 /* FIXME: This name should be more specific if it is only for use with CallFrame* */
 /* Use __builtin_frame_address(1) to get CallFrame* */
-#if COMPILER(GCC_COMPATIBLE) && (CPU(ARM64) || CPU(X86_64))
+#if CPU(ARM64) || CPU(X86_64)
 #define USE_BUILTIN_FRAME_ADDRESS 1
 #endif
 

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -146,7 +146,7 @@ void printInternal(PrintStream& out, unsigned char value)
 
 void printInternal(PrintStream& out, char16_t value)
 {
-    out.printf("%lc", value);
+    out.printf("%lc", static_cast<wint_t>(value));
 }
 
 void printInternal(PrintStream& out, char32_t value)

--- a/Source/WTF/wtf/StackPointer.cpp
+++ b/Source/WTF/wtf/StackPointer.cpp
@@ -42,7 +42,7 @@ extern "C" __declspec(naked) void currentStackPointer()
     }
 }
 
-#elif CPU(X86) & COMPILER(GCC_COMPATIBLE)
+#elif CPU(X86)
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -71,7 +71,7 @@ asm (
     ".ascii \"-export:currentStackPointer\"" "\n"
 );
 
-#elif CPU(X86_64) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(X86_64)
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -83,7 +83,7 @@ asm (
     ".previous" "\n"
 );
 
-#elif CPU(ARM64E) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(ARM64E)
 asm (
     ".text" "\n"
     ".balign 16" "\n"
@@ -96,7 +96,7 @@ asm (
     ".previous" "\n"
 );
 
-#elif CPU(ARM64) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(ARM64)
 asm (
     ".text" "\n"
     ".balign 16" "\n"
@@ -108,7 +108,7 @@ asm (
     ".previous" "\n"
 );
 
-#elif CPU(ARM_THUMB2) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(ARM_THUMB2)
 asm (
     ".text" "\n"
     ".align 2" "\n"
@@ -122,7 +122,7 @@ asm (
     ".previous" "\n"
 );
 
-#elif CPU(MIPS) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(MIPS)
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -138,7 +138,7 @@ asm (
     ".previous" "\n"
 );
 
-#elif CPU(RISCV64) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(RISCV64)
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -149,7 +149,7 @@ asm (
      ".previous" "\n"
 );
 
-#elif CPU(LOONGARCH64) && COMPILER(GCC_COMPATIBLE)
+#elif CPU(LOONGARCH64)
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
@@ -170,13 +170,7 @@ constexpr size_t sizeOfFrameHeader = 2 * sizeof(void*);
 SUPPRESS_ASAN NEVER_INLINE
 void* currentStackPointer()
 {
-#if COMPILER(GCC_COMPATIBLE)
     return reinterpret_cast<uint8_t*>(__builtin_frame_address(0)) + sizeOfFrameHeader;
-#else
-    // Make sure that sp is the only local variable declared in this function.
-    void* sp = reinterpret_cast<uint8_t*>(&sp) + sizeOfFrameHeader + sizeof(sp);
-    return sp;
-#endif
 }
 #endif // USE(GENERIC_CURRENT_STACK_POINTER)
 

--- a/Source/WTF/wtf/StackPointer.h
+++ b/Source/WTF/wtf/StackPointer.h
@@ -27,7 +27,7 @@
 
 namespace WTF {
 
-#if defined(NDEBUG) && COMPILER(GCC_COMPATIBLE) \
+#if defined(NDEBUG) \
     && (CPU(X86_64) || CPU(X86) || CPU(ARM64) || CPU(ARM_THUMB2) || CPU(ARM_TRADITIONAL))
 
 // We can only use the inline asm implementation on release builds because it

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -85,7 +85,7 @@
  * - https://bugs.webkit.org/show_bug.cgi?id=38045
  * - http://gcc.gnu.org/bugzilla/show_bug.cgi?id=43976
  */
-#if (CPU(ARM) || CPU(MIPS) || CPU(RISCV64)) && COMPILER(GCC_COMPATIBLE)
+#if CPU(ARM) || CPU(MIPS) || CPU(RISCV64)
 template<typename Type>
 inline bool isPointerTypeAlignmentOkay(Type* ptr)
 {
@@ -386,7 +386,7 @@ bool findBitInWord(T word, size_t& startOrResultIndex, size_t endIndex, bool val
     size_t index = startOrResultIndex;
     word >>= index;
 
-#if COMPILER(GCC_COMPATIBLE) && (CPU(X86_64) || CPU(ARM64))
+#if CPU(X86_64) || CPU(ARM64)
     // We should only use ctz() when we know that ctz() is implementated using
     // a fast hardware instruction. Otherwise, this will actually result in
     // worse performance.

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -103,11 +103,7 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
     if (length == 1)
         return *aLChar == bLChar.front();
 
-#if COMPILER(GCC_COMPATIBLE)
     switch (sizeof(unsigned) * CHAR_BIT - clz(length - 1)) { // Works as really fast log2, since length != 0.
-#else
-    switch (fastLog2(length)) {
-#endif
     case 0:
         RELEASE_ASSERT_NOT_REACHED();
     case 1: // Length is 2.
@@ -158,11 +154,7 @@ ALWAYS_INLINE bool equal(const UChar* aUChar, std::span<const UChar> bUChar)
     if (length == 1)
         return *aUChar == bUChar.front();
 
-#if COMPILER(GCC_COMPATIBLE)
     switch (sizeof(unsigned) * CHAR_BIT - clz(length - 1)) { // Works as really fast log2, since length != 0.
-#else
-    switch (fastLog2(length)) {
-#endif
     case 0:
         RELEASE_ASSERT_NOT_REACHED();
     case 1: // Length is 2 (4 bytes).
@@ -983,7 +975,7 @@ inline void copyElements(uint8_t* __restrict destination, const uint16_t* __rest
 
     for (; i < length; ++i)
         destination[i] = source[i];
-#elif COMPILER(GCC_COMPATIBLE) && CPU(ARM64) && CPU(ADDRESS64) && !ASSERT_ENABLED
+#elif CPU(ARM64) && CPU(ADDRESS64) && !ASSERT_ENABLED
     const uint8_t* const end = destination + length;
     const uintptr_t memoryAccessSize = 16;
 
@@ -1004,7 +996,7 @@ inline void copyElements(uint8_t* __restrict destination, const uint16_t* __rest
 
     while (destination != end)
         *destination++ = static_cast<uint8_t>(*source++);
-#elif COMPILER(GCC_COMPATIBLE) && CPU(ARM_NEON) && !(CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN)) && !ASSERT_ENABLED
+#elif CPU(ARM_NEON) && !(CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN)) && !ASSERT_ENABLED
     const uint8_t* const end = destination + length;
     const uintptr_t memoryAccessSize = 8;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
@@ -104,7 +104,7 @@ TEST(Signals, SignalsAccessFault)
     OSAllocator::protect(ptr, 4096, false, false);
 
     // Try and read, triggering an AccessFault
-    dataLogF("Reading from protected memory", ptr[0]);
+    dataLogLn("Reading from protected memory", static_cast<unsigned>(ptr[0]));
 
     EXPECT_TRUE(handlerRan);
 }


### PR DESCRIPTION
#### 7c2b66cb6a43f86add1fc1d5abd3301d1ae789dd
<pre>
[WTF] Start removing GCC_COMPATIBLE
<a href="https://bugs.webkit.org/show_bug.cgi?id=274364">https://bugs.webkit.org/show_bug.cgi?id=274364</a>
<a href="https://rdar.apple.com/128345506">rdar://128345506</a>

Reviewed by Ross Kirsling.

Now all supported compilers are GCC-compatible.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::forEachSetBit const):
* Source/WTF/wtf/CheckedArithmetic.h:
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/MathExtras.h:
(WTF::clz):
(WTF::ctz):
(WTF::reverseBits32):
* Source/WTF/wtf/PlatformCPU.h:
* Source/WTF/wtf/PlatformCallingConventions.h:
* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/PlatformUse.h:
* Source/WTF/wtf/StackPointer.cpp:
(WTF::currentStackPointer):
* Source/WTF/wtf/StackPointer.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::findBitInWord):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::equal):
(WTF::copyElements):

Canonical link: <a href="https://commits.webkit.org/278988@main">https://commits.webkit.org/278988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa5fe6dee716d46d9a4465d6375d554fadbabc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42436 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2279 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1030 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57018 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51656 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49834 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49068 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29418 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63963 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7633 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28251 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12108 "Passed tests") | 
<!--EWS-Status-Bubble-End-->