### PR TITLE
Flatten TransformationMatrix when accumulating across flattening boundaries instead of adjusting planar points.

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-object-fit-change-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-object-fit-change-expected.txt
@@ -1,6 +1,6 @@
 PASS width is 50
 PASS height is 25
-PASS width became 100
+PASS width became within 0.01 of 100
 PASS height is 50
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/images/text-recognition/image-overlay-object-fit-change.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-object-fit-change.html
@@ -51,7 +51,7 @@ addEventListener("load", async () => {
     image.style.objectFit = "cover";
     setInterval(updateImageOverlayTextDimensions, 10);
 
-    await shouldBecomeEqual("width", "100");
+    await shouldBecomeCloseTo("width", 100, 0.01);
     shouldBe("height", "50");
 
     finishJSTest();

--- a/LayoutTests/resources/js-test.js
+++ b/LayoutTests/resources/js-test.js
@@ -360,6 +360,48 @@ function shouldBecomeEqual(_a, _b, completionHandler)
   setTimeout(_waitForCondition, 0, condition, completionHandler);
 }
 
+function shouldBecomeCloseTo(_to_eval, _target, _tolerance, completionHandler)
+{
+  if (typeof _to_eval != "string") {
+    testFailed("shouldBecomeCloseTo() requires string argument _to_eval. was type " + typeof _to_eval);
+    completionHandler();
+    return;
+  }
+  if (typeof _target != "number") {
+    testFailed("shouldBecomeCloseTo() requires numeric argument _target. was type " + typeof _target);
+    completionHandler();
+    return;
+  }
+  if (typeof _tolerance != "number") {
+    testFailed("shouldBecomeCloseTo() requires numeric argument _tolerance. was type " + typeof _tolerance);
+    completionHandler();
+    return;
+  }
+
+  function condition() {
+    var exception;
+    var _result;
+    try {
+      _result = eval(_to_eval);
+    } catch (e) {
+      exception = e;
+    }
+    if (typeof(_result) != typeof(_target)) {
+      testFailed(_to_eval + " should be of type " + typeof _target
+                 + " but was of type " + typeof _result);
+    } else if (Math.abs(_result - _target) <= _tolerance) {
+      testPassed(_to_eval + " became within " + _tolerance + " of " + _target);
+      return true;
+    }
+    return false;
+  }
+
+  if (!completionHandler)
+    return new Promise(resolve => setTimeout(_waitForCondition, 0, condition, resolve));
+
+  setTimeout(_waitForCondition, 0, condition, completionHandler);
+}
+
 function shouldBecomeEqualToString(value, reference, completionHandler)
 {
   if (typeof value !== "string" || typeof reference !== "string")

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1529,8 +1529,7 @@ FloatPoint GraphicsLayerCA::computePositionRelativeToBase(float& pageScale) cons
 
 void GraphicsLayerCA::flushCompositingState(const FloatRect& visibleRect)
 {
-    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
-    state.setSecondaryQuad(FloatQuad { visibleRect });
+    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect), FloatQuad { visibleRect });
 
     CommitState commitState;
     commitState.ancestorHadChanges = visibleRect != m_previousCommittedVisibleRect;
@@ -1745,10 +1744,10 @@ GraphicsLayerCA::VisibleAndCoverageRects GraphicsLayerCA::computeVisibleAndCover
     if (masksToBounds()) {
         ASSERT(accumulation == TransformState::FlattenTransform);
         // Flatten, and replace the quad in the TransformState with one that is clipped to this layer's bounds.
-        state.flatten();
-        state.setQuad(clipRectForSelf);
         if (state.isMappingSecondaryQuad())
-            state.setSecondaryQuad(FloatQuad { clipRectForSelf });
+            state.reset(clipRectForSelf, clipRectForSelf);
+        else
+            state.reset(clipRectForSelf);
     }
 
     auto boundsOrigin = m_boundsOrigin;
@@ -1884,7 +1883,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
     VisibleAndCoverageRects rects = computeVisibleAndCoverageRect(localState, accumulateTransform);
     if (adjustCoverageRect(rects, m_visibleRect)) {
         if (state.isMappingSecondaryQuad())
-            localState.setLastPlanarSecondaryQuad(FloatQuad { rects.coverageRect });
+            localState.setSecondaryQuadInMappedSpace(FloatQuad { rects.coverageRect });
     }
     setVisibleAndCoverageRects(rects);
 

--- a/Source/WebCore/platform/graphics/transforms/TransformState.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.cpp
@@ -34,59 +34,25 @@ TransformState& TransformState::operator=(const TransformState& other)
 {
     m_accumulatedOffset = other.m_accumulatedOffset;
     m_tracking = other.m_tracking;
-    m_mapPoint = other.m_mapPoint;
-    m_mapQuad = other.m_mapQuad;
-    if (m_mapPoint)
-        m_lastPlanarPoint = other.m_lastPlanarPoint;
-    if (m_mapQuad) {
-        m_lastPlanarQuad = other.m_lastPlanarQuad;
-        m_lastPlanarSecondaryQuad = other.m_lastPlanarSecondaryQuad;
-    }
-    m_accumulatingTransform = other.m_accumulatingTransform;
+    m_inputPoint = other.m_inputPoint;
+    m_inputQuad = other.m_inputQuad;
+    m_inputSecondaryQuad = other.m_inputSecondaryQuad;
     m_direction = other.m_direction;
     
     m_accumulatedTransform = nullptr;
 
     if (other.m_accumulatedTransform)
         m_accumulatedTransform = makeUnique<TransformationMatrix>(*other.m_accumulatedTransform);
-        
-    m_trackedTransform = nullptr;
-    if (other.m_trackedTransform)
-        m_trackedTransform = makeUnique<TransformationMatrix>(*other.m_trackedTransform);
 
     return *this;
 }
 
-void TransformState::translateTransform(const LayoutSize& offset)
+void TransformState::translateTransform(const LayoutSize& offset, TransformDirection direction)
 {
-    if (m_direction == ApplyTransformDirection)
+    if (direction == ApplyTransformDirection)
         m_accumulatedTransform->translateRight(offset.width(), offset.height());
     else
         m_accumulatedTransform->translate(offset.width(), offset.height());
-}
-
-void TransformState::translateMappedCoordinates(const LayoutSize& offset)
-{
-    LayoutSize adjustedOffset = (m_direction == ApplyTransformDirection) ? offset : -offset;
-    if (m_mapPoint)
-        m_lastPlanarPoint.move(adjustedOffset);
-    if (m_mapQuad) {
-        m_lastPlanarQuad.move(adjustedOffset);
-        if (m_lastPlanarSecondaryQuad)
-            m_lastPlanarSecondaryQuad->move(adjustedOffset);
-    }
-    if (m_tracking != DoNotTrackTransformMatrix) {
-        if (!m_trackedTransform)
-            m_trackedTransform = makeUnique<TransformationMatrix>();
-        if (shouldFlattenBefore())
-            m_trackedTransform->flatten();
-        if (m_direction == ApplyTransformDirection)
-            m_trackedTransform->translateRight(offset.width(), offset.height());
-        else
-            m_trackedTransform->translate(offset.width(), offset.height());
-        if (shouldFlattenAfter())
-            m_trackedTransform->flatten();
-    }
 }
 
 void TransformState::move(const LayoutSize& offset, TransformAccumulation accumulate)
@@ -94,34 +60,14 @@ void TransformState::move(const LayoutSize& offset, TransformAccumulation accumu
     if (shouldFlattenBefore(accumulate))
         flatten();
 
-    if (accumulate == FlattenTransform && !m_accumulatedTransform && m_tracking == DoNotTrackTransformMatrix)
+    if (m_accumulatedTransform) {
+        // If we're accumulating into an existing transform, apply the translation.
+        translateTransform(offset, m_direction);
+    } else
         m_accumulatedOffset += offset;
-    else {
-        applyAccumulatedOffset();
-        if (m_accumulatingTransform && m_accumulatedTransform) {
-            // If we're accumulating into an existing transform, apply the translation.
-            translateTransform(offset);
 
-            // Then flatten if necessary.
-            if (shouldFlattenAfter(accumulate))
-                flatten();
-        } else
-            // Just move the point and/or quad.
-            translateMappedCoordinates(offset);
-    }
-}
-
-void TransformState::applyAccumulatedOffset()
-{
-    LayoutSize offset = m_accumulatedOffset;
-    m_accumulatedOffset = LayoutSize();
-    if (!offset.isZero()) {
-        if (m_accumulatedTransform) {
-            translateTransform(offset);
-            flatten();
-        } else
-            translateMappedCoordinates(offset);
-    }
+    if (shouldFlattenAfter(accumulate))
+        flatten();
 }
 
 bool TransformState::shouldFlattenBefore(TransformAccumulation accumulate)
@@ -150,49 +96,34 @@ void TransformState::applyTransform(const TransformationMatrix& transformFromCon
         return;
     }
 
-    applyAccumulatedOffset();
-
     if (shouldFlattenBefore(accumulate))
         flatten();
 
-    // If we have an accumulated transform from last time, multiply in this transform
-    if (m_accumulatedTransform) {
-        if (m_direction == ApplyTransformDirection)
-            m_accumulatedTransform = makeUnique<TransformationMatrix>(transformFromContainer * *m_accumulatedTransform);
-        else
-            m_accumulatedTransform->multiply(transformFromContainer);
-    }
-
-    if (shouldFlattenAfter(accumulate)) {
-        const TransformationMatrix* finalTransform = m_accumulatedTransform ? m_accumulatedTransform.get() : &transformFromContainer;
-        flattenWithTransform(*finalTransform, wasClamped);
-    } else if (!m_accumulatedTransform) {
-        m_accumulatedTransform = makeUnique<TransformationMatrix>(transformFromContainer);
-        m_accumulatingTransform = true;
-    }
-}
-
-void TransformState::flatten(bool* wasClamped)
-{
-    if (wasClamped)
-        *wasClamped = false;
-
-    applyAccumulatedOffset();
-
     if (!m_accumulatedTransform) {
-        m_accumulatingTransform = false;
-        return;
+        m_accumulatedTransform = makeUnique<TransformationMatrix>(m_accumulatedOffset.width(), m_accumulatedOffset.height());
+        m_accumulatedOffset = { };
     }
-    
-    flattenWithTransform(*m_accumulatedTransform, wasClamped);
+    ASSERT(m_accumulatedOffset.isZero());
+
+    if (m_direction == ApplyTransformDirection)
+        *m_accumulatedTransform = transformFromContainer * *m_accumulatedTransform;
+    else
+        *m_accumulatedTransform *= transformFromContainer;
+
+
+    if (shouldFlattenAfter(accumulate))
+        flatten();
 }
 
-FloatPoint TransformState::mappedPoint(bool* wasClamped) const
+void TransformState::flatten()
 {
-    if (wasClamped)
-        *wasClamped = false;
+    if (m_accumulatedTransform)
+        m_accumulatedTransform->flatten();
+}
 
-    FloatPoint point = m_lastPlanarPoint;
+FloatPoint TransformState::mappedPoint() const
+{
+    FloatPoint point = m_inputPoint;
     point.move((m_direction == ApplyTransformDirection) ? m_accumulatedOffset : -m_accumulatedOffset);
     if (!m_accumulatedTransform)
         return point;
@@ -200,7 +131,7 @@ FloatPoint TransformState::mappedPoint(bool* wasClamped) const
     if (m_direction == ApplyTransformDirection)
         return m_accumulatedTransform->mapPoint(point);
 
-    return valueOrDefault(m_accumulatedTransform->inverse()).projectPoint(point, wasClamped);
+    return valueOrDefault(m_accumulatedTransform->inverse()).projectPoint(point);
 }
 
 FloatQuad TransformState::mappedQuad(bool* wasClamped) const
@@ -208,7 +139,7 @@ FloatQuad TransformState::mappedQuad(bool* wasClamped) const
     if (wasClamped)
         *wasClamped = false;
 
-    FloatQuad quad = m_lastPlanarQuad;
+    FloatQuad quad = m_inputQuad;
     mapQuad(quad, m_direction, wasClamped);
     return quad;
 }
@@ -218,25 +149,34 @@ std::optional<FloatQuad> TransformState::mappedSecondaryQuad(bool* wasClamped) c
     if (wasClamped)
         *wasClamped = false;
 
-    if (!m_lastPlanarSecondaryQuad)
+    if (!m_inputSecondaryQuad)
         return std::nullopt;
 
-    FloatQuad quad = *m_lastPlanarSecondaryQuad;
+    FloatQuad quad = *m_inputSecondaryQuad;
     mapQuad(quad, m_direction, wasClamped);
     return quad;
 }
 
-void TransformState::setLastPlanarSecondaryQuad(const std::optional<FloatQuad>& quad)
+void TransformState::reset(const FloatQuad& quad, const std::optional<FloatQuad>& secondaryQuad)
+{
+    m_inputQuad = quad;
+    m_inputSecondaryQuad = secondaryQuad;
+    m_accumulatedTransform = nullptr;
+    m_accumulatedOffset = { };
+
+}
+
+void TransformState::setSecondaryQuadInMappedSpace(const std::optional<FloatQuad>& quad)
 {
     if (!quad) {
-        m_lastPlanarSecondaryQuad = std::nullopt;
+        m_inputSecondaryQuad = std::nullopt;
         return;
     }
     
     // Map the quad back through any transform or offset back into the last flattening coordinate space.
     FloatQuad backMappedQuad(*quad);
     mapQuad(backMappedQuad, inverseDirection());
-    m_lastPlanarSecondaryQuad = backMappedQuad;
+    m_inputSecondaryQuad = backMappedQuad;
 }
 
 void TransformState::mapQuad(FloatQuad& quad, TransformDirection direction, bool* wasClamped) const
@@ -253,43 +193,12 @@ void TransformState::mapQuad(FloatQuad& quad, TransformDirection direction, bool
     quad = valueOrDefault(m_accumulatedTransform->inverse()).projectQuad(quad, wasClamped);
 }
 
-void TransformState::flattenWithTransform(const TransformationMatrix& t, bool* wasClamped)
+std::unique_ptr<TransformationMatrix> TransformState::releaseTrackedTransform()
 {
-    if (m_direction == ApplyTransformDirection) {
-        if (m_mapPoint)
-            m_lastPlanarPoint = t.mapPoint(m_lastPlanarPoint);
-        if (m_mapQuad) {
-            m_lastPlanarQuad = t.mapQuad(m_lastPlanarQuad);
-            if (m_lastPlanarSecondaryQuad)
-                m_lastPlanarSecondaryQuad = t.mapQuad(*m_lastPlanarSecondaryQuad);
-        }
-    } else {
-        TransformationMatrix inverseTransform = valueOrDefault(t.inverse());
-        if (m_mapPoint)
-            m_lastPlanarPoint = inverseTransform.projectPoint(m_lastPlanarPoint);
-        if (m_mapQuad) {
-            m_lastPlanarQuad = inverseTransform.projectQuad(m_lastPlanarQuad, wasClamped);
-            if (m_lastPlanarSecondaryQuad)
-                m_lastPlanarSecondaryQuad = inverseTransform.projectQuad(*m_lastPlanarSecondaryQuad, wasClamped);
-        }
-    }
-
-    if (m_trackedTransform) {
-        if (shouldFlattenBefore())
-            m_trackedTransform->flatten();
-        *m_trackedTransform = (m_direction == ApplyTransformDirection) ? (t * *m_trackedTransform) : (*m_trackedTransform * t);
-    } else if (m_tracking != DoNotTrackTransformMatrix)
-        m_trackedTransform = makeUnique<TransformationMatrix>(t);
-
-    if (m_trackedTransform && shouldFlattenAfter())
-        m_trackedTransform->flatten();
-
-    // We could throw away m_accumulatedTransform if we wanted to here, but that
-    // would cause thrash when traversing hierarchies with alternating
-    // preserve-3d and flat elements.
     if (m_accumulatedTransform)
-        m_accumulatedTransform->makeIdentity();
-    m_accumulatingTransform = false;
+        return makeUnique<TransformationMatrix>(*m_accumulatedTransform);
+    else
+        return makeUnique<TransformationMatrix>(m_accumulatedOffset.width(), m_accumulatedOffset.height());
 }
 
 TextStream& operator<<(TextStream& ts, const TransformState& state)
@@ -297,14 +206,16 @@ TextStream& operator<<(TextStream& ts, const TransformState& state)
     TextStream multilineStream;
     multilineStream.setIndent(ts.indent() + 2);
 
-    multilineStream.dumpProperty("last planar point"_s, state.lastPlanarPoint());
-    multilineStream.dumpProperty("last planar quad"_s, state.lastPlanarQuad());
+    multilineStream.dumpProperty("mapped point"_s, state.mappedPoint());
+    multilineStream.dumpProperty("mapped quad"_s, state.mappedQuad());
 
-    if (state.lastPlanarSecondaryQuad())
-        multilineStream.dumpProperty("last planar secondary quad"_s, *state.lastPlanarSecondaryQuad());
+    if (state.mappedSecondaryQuad())
+        multilineStream.dumpProperty("mapped secondary quad"_s, *state.mappedSecondaryQuad());
 
     if (state.accumulatedTransform())
         multilineStream.dumpProperty("accumulated transform"_s, ValueOrNull(state.accumulatedTransform()));
+    else
+        multilineStream.dumpProperty("accumulated offset"_s, state.accumulatedOffset());
 
     {
         TextStream::GroupScope scope(ts);

--- a/Source/WebCore/platform/graphics/transforms/TransformState.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.h
@@ -45,26 +45,21 @@ public:
     enum TransformMatrixTracking { DoNotTrackTransformMatrix, TrackSVGCTMMatrix, TrackSVGScreenCTMMatrix };
 
     TransformState(TransformDirection mappingDirection, const FloatPoint& p, const FloatQuad& quad)
-        : m_lastPlanarPoint(p)
-        , m_lastPlanarQuad(quad)
-        , m_mapPoint(true)
-        , m_mapQuad(true)
+        : m_inputPoint(p)
+        , m_inputQuad(quad)
         , m_direction(mappingDirection)
     {
     }
     
     TransformState(TransformDirection mappingDirection, const FloatPoint& p)
-        : m_lastPlanarPoint(p)
-        , m_mapPoint(true)
-        , m_mapQuad(false)
+        : m_inputPoint(p)
         , m_direction(mappingDirection)
     {
     }
     
-    TransformState(TransformDirection mappingDirection, const FloatQuad& quad)
-        : m_lastPlanarQuad(quad)
-        , m_mapPoint(false)
-        , m_mapQuad(true)
+    TransformState(TransformDirection mappingDirection, const FloatQuad& quad, std::optional<FloatQuad> secondaryQuad = std::nullopt)
+        : m_inputQuad(quad)
+        , m_inputSecondaryQuad(secondaryQuad)
         , m_direction(mappingDirection)
     {
     }
@@ -73,21 +68,9 @@ public:
 
     WEBCORE_EXPORT TransformState& operator=(const TransformState&);
 
-    void setQuad(const FloatQuad& quad)
-    {
-        // We must be in a flattened state (no accumulated offset) when setting this quad.
-        ASSERT(m_accumulatedOffset == LayoutSize());
-        m_lastPlanarQuad = quad;
-    }
+    void reset(const FloatQuad&, const std::optional<FloatQuad>& secondaryQuad = std::nullopt);
 
-    void setSecondaryQuad(const std::optional<FloatQuad>& quad)
-    {
-        // We must be in a flattened state (no accumulated offset) when setting this secondary quad.
-        ASSERT(m_accumulatedOffset == LayoutSize());
-        m_lastPlanarSecondaryQuad = quad;
-    }
-
-    void setLastPlanarSecondaryQuad(const std::optional<FloatQuad>&);
+    void setSecondaryQuadInMappedSpace(const std::optional<FloatQuad>&);
 
     void setTransformMatrixTracking(TransformMatrixTracking tracking) { m_tracking = tracking; }
     TransformMatrixTracking transformMatrixTracking() const { return m_tracking; }
@@ -100,47 +83,40 @@ public:
     void move(const LayoutSize&, TransformAccumulation = FlattenTransform);
     void applyTransform(const AffineTransform& transformFromContainer, TransformAccumulation = FlattenTransform, bool* wasClamped = nullptr);
     WEBCORE_EXPORT void applyTransform(const TransformationMatrix& transformFromContainer, TransformAccumulation = FlattenTransform, bool* wasClamped = nullptr);
-    WEBCORE_EXPORT void flatten(bool* wasClamped = nullptr);
 
-    // Return the coords of the point or quad in the last flattened layer
-    FloatPoint lastPlanarPoint() const { return m_lastPlanarPoint; }
-    FloatQuad lastPlanarQuad() const { return m_lastPlanarQuad; }
-    std::optional<FloatQuad> lastPlanarSecondaryQuad() const { return m_lastPlanarSecondaryQuad; }
-    bool isMappingSecondaryQuad() const { return m_lastPlanarSecondaryQuad.has_value(); }
+    bool isMappingSecondaryQuad() const { return m_inputSecondaryQuad.has_value(); }
 
     // Return the point or quad mapped through the current transform
-    FloatPoint mappedPoint(bool* wasClamped = nullptr) const;
+    FloatPoint mappedPoint() const;
     WEBCORE_EXPORT FloatQuad mappedQuad(bool* wasClamped = nullptr) const;
     WEBCORE_EXPORT std::optional<FloatQuad> mappedSecondaryQuad(bool* wasClamped = nullptr) const;
 
+    LayoutSize accumulatedOffset() const { return m_accumulatedOffset; }
     TransformationMatrix* accumulatedTransform() const { return m_accumulatedTransform.get(); }
-    std::unique_ptr<TransformationMatrix> releaseTrackedTransform() { return WTFMove(m_trackedTransform); }
+    std::unique_ptr<TransformationMatrix> releaseTrackedTransform();
     TransformDirection direction() const { return m_direction; }
 
+    void flatten();
+
 private:
-    void translateTransform(const LayoutSize&);
-    void translateMappedCoordinates(const LayoutSize&);
-    void flattenWithTransform(const TransformationMatrix&, bool* wasClamped);
+    void translateTransform(const LayoutSize&, TransformDirection);
     void applyAccumulatedOffset();
+
 
     bool shouldFlattenBefore(TransformAccumulation accumulate = FlattenTransform);
     bool shouldFlattenAfter(TransformAccumulation accumulate = FlattenTransform);
     
     TransformDirection inverseDirection() const;
 
-    void mapQuad(FloatQuad&, TransformDirection, bool* clamped = nullptr) const;
-    
-    FloatPoint m_lastPlanarPoint;
-    FloatQuad m_lastPlanarQuad;
-    std::optional<FloatQuad> m_lastPlanarSecondaryQuad;
+    void mapQuad(FloatQuad&, TransformDirection, bool* wasClamped = nullptr) const;
+
+    FloatPoint m_inputPoint;
+    FloatQuad m_inputQuad;
+    std::optional<FloatQuad> m_inputSecondaryQuad;
 
     // We only allocate the transform if we need to
     std::unique_ptr<TransformationMatrix> m_accumulatedTransform;
-    std::unique_ptr<TransformationMatrix> m_trackedTransform;
     LayoutSize m_accumulatedOffset;
-    bool m_accumulatingTransform { false };
-    bool m_mapPoint;
-    bool m_mapQuad;
     TransformMatrixTracking m_tracking { DoNotTrackTransformMatrix };
     TransformDirection m_direction;
 };

--- a/Source/WebCore/rendering/HitTestingTransformState.cpp
+++ b/Source/WebCore/rendering/HitTestingTransformState.cpp
@@ -30,39 +30,19 @@
 
 namespace WebCore {
 
-void HitTestingTransformState::translate(int x, int y, TransformAccumulation accumulate)
+void HitTestingTransformState::translate(int x, int y)
 {
-    m_accumulatedTransform.translate(x, y);    
-    if (accumulate == FlattenTransform)
-        flattenWithTransform(m_accumulatedTransform);
-
-    m_accumulatingTransform = accumulate == AccumulateTransform;
+    m_accumulatedTransform.translate(x, y);
 }
 
-void HitTestingTransformState::applyTransform(const TransformationMatrix& transformFromContainer, TransformAccumulation accumulate)
+void HitTestingTransformState::applyTransform(const TransformationMatrix& transformFromContainer)
 {
     m_accumulatedTransform.multiply(transformFromContainer);
-    if (accumulate == FlattenTransform)
-        flattenWithTransform(m_accumulatedTransform);
-
-    m_accumulatingTransform = accumulate == AccumulateTransform;
 }
 
 void HitTestingTransformState::flatten()
 {
-    flattenWithTransform(m_accumulatedTransform);
-}
-
-void HitTestingTransformState::flattenWithTransform(const TransformationMatrix& t)
-{
-    if (std::optional<TransformationMatrix> inverse = t.inverse()) {
-        m_lastPlanarPoint = inverse.value().projectPoint(m_lastPlanarPoint);
-        m_lastPlanarQuad = inverse.value().projectQuad(m_lastPlanarQuad);
-        m_lastPlanarArea = inverse.value().projectQuad(m_lastPlanarArea);
-    }
-
-    m_accumulatedTransform.makeIdentity();
-    m_accumulatingTransform = false;
+    m_accumulatedTransform.flatten();
 }
 
 FloatPoint HitTestingTransformState::mappedPoint() const

--- a/Source/WebCore/rendering/HitTestingTransformState.h
+++ b/Source/WebCore/rendering/HitTestingTransformState.h
@@ -50,9 +50,8 @@ public:
         return adoptRef(*new HitTestingTransformState(other));
     }
 
-    enum TransformAccumulation { FlattenTransform, AccumulateTransform };
-    void translate(int x, int y, TransformAccumulation);
-    void applyTransform(const TransformationMatrix& transformFromContainer, TransformAccumulation);
+    void translate(int x, int y);
+    void applyTransform(const TransformationMatrix& transformFromContainer);
 
     FloatPoint mappedPoint() const;
     FloatQuad mappedQuad() const;
@@ -64,14 +63,12 @@ public:
     FloatQuad m_lastPlanarQuad;
     FloatQuad m_lastPlanarArea;
     TransformationMatrix m_accumulatedTransform;
-    bool m_accumulatingTransform;
 
 private:
     HitTestingTransformState(const FloatPoint& p, const FloatQuad& quad, const FloatQuad& area)
         : m_lastPlanarPoint(p)
         , m_lastPlanarQuad(quad)
         , m_lastPlanarArea(area)
-        , m_accumulatingTransform(false)
     {
     }
     
@@ -81,11 +78,8 @@ private:
         , m_lastPlanarQuad(other.m_lastPlanarQuad)
         , m_lastPlanarArea(other.m_lastPlanarArea)
         , m_accumulatedTransform(other.m_accumulatedTransform)
-        , m_accumulatingTransform(other.m_accumulatingTransform)
     {
     }
-    
-    void flattenWithTransform(const TransformationMatrix&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -48,7 +48,6 @@ void RenderGeometryMap::mapToContainer(TransformState& transformState, const Ren
     // If the mapping includes something like columns, we have to go via renderers.
     if (hasNonUniformStep()) {
         m_mapping.last().m_renderer->mapLocalToContainer(container, transformState, ApplyContainerFlip | m_mapCoordinatesFlags);
-        transformState.flatten();
         return;
     }
     
@@ -94,7 +93,6 @@ void RenderGeometryMap::mapToContainer(TransformState& transformState, const Ren
     }
 
     ASSERT(foundContainer);
-    transformState.flatten();    
 }
 
 FloatPoint RenderGeometryMap::mapToContainer(const FloatPoint& p, const RenderLayerModelObject* container) const
@@ -111,7 +109,7 @@ FloatPoint RenderGeometryMap::mapToContainer(const FloatPoint& p, const RenderLa
     } else {
         TransformState transformState(TransformState::ApplyTransformDirection, p);
         mapToContainer(transformState, container);
-        result = transformState.lastPlanarPoint();
+        result = transformState.mappedPoint();
         ASSERT(m_accumulatedOffsetMightBeSaturated ||  areEssentiallyEqual(rendererMappedResult, result));
     }
 
@@ -128,7 +126,7 @@ FloatQuad RenderGeometryMap::mapToContainer(const FloatRect& rect, const RenderL
     } else {
         TransformState transformState(TransformState::ApplyTransformDirection, rect.center(), rect);
         mapToContainer(transformState, container);
-        result = transformState.lastPlanarQuad();
+        result = transformState.mappedQuad();
     }
 
     return result;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4592,9 +4592,9 @@ Ref<HitTestingTransformState> RenderLayer::createLocalTransformState(RenderLayer
     if (renderer().shouldUseTransformFromContainer(containerLayer ? &containerLayer->renderer() : nullptr)) {
         TransformationMatrix containerTransform;
         renderer().getTransformFromContainer(offset, containerTransform);
-        transformState->applyTransform(containerTransform, HitTestingTransformState::AccumulateTransform);
+        transformState->applyTransform(containerTransform);
     } else {
-        transformState->translate(offset.width(), offset.height(), HitTestingTransformState::AccumulateTransform);
+        transformState->translate(offset.width(), offset.height());
     }
     
     return transformState.releaseNonNull();

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1492,9 +1492,8 @@ FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet
 {
     TransformState transformState(TransformState::ApplyTransformDirection, localPoint);
     mapLocalToContainer(nullptr, transformState, mode | ApplyContainerFlip, wasFixed);
-    transformState.flatten();
     
-    return transformState.lastPlanarPoint();
+    return transformState.mappedPoint();
 }
 
 std::unique_ptr<TransformationMatrix> RenderObject::viewTransitionTransform() const
@@ -1506,7 +1505,6 @@ std::unique_ptr<TransformationMatrix> RenderObject::viewTransitionTransform() co
     transformState.setTransformMatrixTracking(TransformState::TrackSVGCTMMatrix);
     OptionSet<MapCoordinatesMode> mode { UseTransforms, ApplyContainerFlip };
     mapLocalToContainer(nullptr, transformState, mode, nullptr);
-    transformState.flatten();
     return transformState.releaseTrackedTransform();
 }
 
@@ -1514,17 +1512,15 @@ FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, Optio
 {
     TransformState transformState(TransformState::UnapplyInverseTransformDirection, containerPoint);
     mapAbsoluteToLocalPoint(mode, transformState);
-    transformState.flatten();
     
-    return transformState.lastPlanarPoint();
+    return transformState.mappedPoint();
 }
 
 FloatQuad RenderObject::absoluteToLocalQuad(const FloatQuad& quad, OptionSet<MapCoordinatesMode> mode) const
 {
     TransformState transformState(TransformState::UnapplyInverseTransformDirection, quad.boundingBox().center(), quad);
     mapAbsoluteToLocalPoint(mode, transformState);
-    transformState.flatten();
-    return transformState.lastPlanarQuad();
+    return transformState.mappedQuad();
 }
 
 void RenderObject::mapLocalToContainer(const RenderLayerModelObject* ancestorContainer, TransformState& transformState, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const
@@ -1619,18 +1615,16 @@ FloatQuad RenderObject::localToContainerQuad(const FloatQuad& localQuad, const R
     // it will use that point as the reference point to decide which column's transform to apply in multiple-column blocks.
     TransformState transformState(TransformState::ApplyTransformDirection, localQuad.boundingBox().center(), localQuad);
     mapLocalToContainer(container, transformState, mode | ApplyContainerFlip, wasFixed);
-    transformState.flatten();
     
-    return transformState.lastPlanarQuad();
+    return transformState.mappedQuad();
 }
 
 FloatPoint RenderObject::localToContainerPoint(const FloatPoint& localPoint, const RenderLayerModelObject* container, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const
 {
     TransformState transformState(TransformState::ApplyTransformDirection, localPoint);
     mapLocalToContainer(container, transformState, mode | ApplyContainerFlip, wasFixed);
-    transformState.flatten();
 
-    return transformState.lastPlanarPoint();
+    return transformState.mappedPoint();
 }
 
 LayoutSize RenderObject::offsetFromContainer(RenderElement& container, const LayoutPoint&, bool* offsetDependsOnPoint) const

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -87,8 +87,6 @@ public:
             }
         }
 
-        transformState.flatten();
-
         auto transform = transformState.releaseTrackedTransform();
         if (!transform)
             return { };


### PR DESCRIPTION
#### 0a3e68d3944dfb05cd23d5803cb794ce4b8a7d03
<pre>
Flatten TransformationMatrix when accumulating across flattening boundaries instead of adjusting planar points.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274375">https://bugs.webkit.org/show_bug.cgi?id=274375</a>
&lt;<a href="https://rdar.apple.com/128373248">rdar://128373248</a>&gt;

Reviewed by Simon Fraser.

Rather than re-mapping the points onto a new plane at each boundary and only
accumulating a matrix within a 3d rendering context, we should be able to
flatten the transform itself and continue to accumulate a single matrix.

Further simplifications could be made to remove the cached point/quad, and
require the caller to hold these and pass them into the mappedPoint/Quad
function instead. Making the storage just a TransformationMatrix/LayoutSize
union would reduce the stack space required for this.

UnapplyInverseTransformDirection could also likely be removed, with the caller
being required to invert() the result if needed.

Fix image-overlay-object-fit-change.html test to handle floating point rounding
differences between scale+translate happening as a single matrix vs separate
steps.

* LayoutTests/fast/images/text-recognition/image-overlay-object-fit-change-expected.txt:
* LayoutTests/fast/images/text-recognition/image-overlay-object-fit-change.html:
* LayoutTests/resources/js-test.js:
(condition):
(shouldBecomeCloseTo):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::flushCompositingState):
(WebCore::GraphicsLayerCA::computeVisibleAndCoverageRect const):
(WebCore::GraphicsLayerCA::recursiveCommitChanges):
* Source/WebCore/platform/graphics/transforms/TransformState.cpp:
(WebCore::TransformState::operator=):
(WebCore::TransformState::translateTransform):
(WebCore::TransformState::move):
(WebCore::TransformState::applyTransform):
(WebCore::TransformState::flatten):
(WebCore::TransformState::mappedPoint const):
(WebCore::TransformState::mappedQuad const):
(WebCore::TransformState::mappedSecondaryQuad const):
(WebCore::TransformState::reset):
(WebCore::TransformState::setSecondaryQuadInMappedSpace):
(WebCore::TransformState::releaseTrackedTransform):
(WebCore::operator&lt;&lt;):
(WebCore::TransformState::translateMappedCoordinates): Deleted.
(WebCore::TransformState::applyAccumulatedOffset): Deleted.
(WebCore::TransformState::setLastPlanarSecondaryQuad): Deleted.
(WebCore::TransformState::flattenWithTransform): Deleted.
* Source/WebCore/platform/graphics/transforms/TransformState.h:
(WebCore::TransformState::TransformState):
(WebCore::TransformState::isMappingSecondaryQuad const):
(WebCore::TransformState::accumulatedOffset const):
(WebCore::TransformState::setQuad): Deleted.
(WebCore::TransformState::setSecondaryQuad): Deleted.
(WebCore::TransformState::lastPlanarPoint const): Deleted.
(WebCore::TransformState::lastPlanarQuad const): Deleted.
(WebCore::TransformState::lastPlanarSecondaryQuad const): Deleted.
(WebCore::TransformState::releaseTrackedTransform): Deleted.
* Source/WebCore/rendering/HitTestingTransformState.cpp:
(WebCore::HitTestingTransformState::translate):
(WebCore::HitTestingTransformState::applyTransform):
(WebCore::HitTestingTransformState::flatten):
(WebCore::HitTestingTransformState::flattenWithTransform): Deleted.
* Source/WebCore/rendering/HitTestingTransformState.h:
(WebCore::HitTestingTransformState::HitTestingTransformState):
(): Deleted.
* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::RenderGeometryMap::mapToContainer const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::createLocalTransformState const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::localToAbsolute const):
(WebCore::RenderObject::viewTransitionTransform const):
(WebCore::RenderObject::absoluteToLocal const):
(WebCore::RenderObject::absoluteToLocalQuad const):
(WebCore::RenderObject::localToContainerQuad const):
(WebCore::RenderObject::localToContainerPoint const):
* Source/WebCore/rendering/svg/SVGLayerTransformComputation.h:
(WebCore::SVGLayerTransformComputation::computeAccumulatedTransform const):

Canonical link: <a href="https://commits.webkit.org/295560@main">https://commits.webkit.org/295560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8de3d5933f5c9f1bd64f836d8e567879fdeb06ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110580 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56057 "Hash 8de3d593 for PR 28775 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80032 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/56057 "Hash 8de3d593 for PR 28775 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55422 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89406 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89106 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88749 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27990 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37879 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->