### PR TITLE
[Win] Don't use raw pointers for ScrollBar in WebPopupMenuProxyWin

### DIFF
--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -522,16 +522,16 @@ LRESULT WebPopupMenuProxyWin::onMouseActivate(HWND hWnd, UINT message, WPARAM, L
 LRESULT WebPopupMenuProxyWin::onSize(HWND hWnd, UINT message, WPARAM, LPARAM lParam, bool& handled)
 {
     handled = true;
-    if (!scrollbar())
+    if (!m_scrollbar)
         return 0;
 
     IntSize size(LOWORD(lParam), HIWORD(lParam));
     scrollbar()->setFrameRect(IntRect(size.width() - scrollbar()->width(), 0, scrollbar()->width(), size.height()));
 
     int visibleItems = this->visibleItems();
-    scrollbar()->setEnabled(visibleItems < m_items.size());
-    scrollbar()->setSteps(1, std::max(1, visibleItems - 1));
-    scrollbar()->setProportion(visibleItems, m_items.size());
+    m_scrollbar->setEnabled(visibleItems < m_items.size());
+    m_scrollbar->setSteps(1, std::max(1, visibleItems - 1));
+    m_scrollbar->setProportion(visibleItems, m_items.size());
     return 0;
 }
 
@@ -631,13 +631,13 @@ LRESULT WebPopupMenuProxyWin::onMouseMove(HWND hWnd, UINT message, WPARAM wParam
     handled = true;
 
     IntPoint mousePoint(MAKEPOINTS(lParam));
-    if (scrollbar()) {
-        IntRect scrollBarRect = scrollbar()->frameRect();
+    if (m_scrollbar) {
+        IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollbarCapturingMouse() || scrollBarRect.contains(mousePoint)) {
             // Put the point into coordinates relative to the scroll bar
             mousePoint.move(-scrollBarRect.x(), -scrollBarRect.y());
             PlatformMouseEvent event(hWnd, message, wParam, makeScaledPoint(mousePoint, m_scaleFactor));
-            scrollbar()->mouseMoved(event);
+            m_scrollbar->mouseMoved(event);
             return 0;
         }
     }
@@ -672,13 +672,13 @@ LRESULT WebPopupMenuProxyWin::onLButtonDown(HWND hWnd, UINT message, WPARAM wPar
     handled = true;
 
     IntPoint mousePoint(MAKEPOINTS(lParam));
-    if (scrollbar()) {
-        IntRect scrollBarRect = scrollbar()->frameRect();
+    if (m_scrollbar) {
+        IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollBarRect.contains(mousePoint)) {
             // Put the point into coordinates relative to the scroll bar
             mousePoint.move(-scrollBarRect.x(), -scrollBarRect.y());
             PlatformMouseEvent event(hWnd, message, wParam, makeScaledPoint(mousePoint, m_scaleFactor));
-            scrollbar()->mouseDown(event);
+            m_scrollbar->mouseDown(event);
             setScrollbarCapturingMouse(true);
             return 0;
         }
@@ -703,14 +703,14 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
     handled = true;
 
     IntPoint mousePoint(MAKEPOINTS(lParam));
-    if (scrollbar()) {
-        IntRect scrollBarRect = scrollbar()->frameRect();
+    if (m_scrollbar) {
+        IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollbarCapturingMouse() || scrollBarRect.contains(mousePoint)) {
             setScrollbarCapturingMouse(false);
             // Put the point into coordinates relative to the scroll bar
             mousePoint.move(-scrollBarRect.x(), -scrollBarRect.y());
             PlatformMouseEvent event(hWnd, message, wParam, makeScaledPoint(mousePoint, m_scaleFactor));
-            scrollbar()->mouseUp(event);
+            m_scrollbar->mouseUp(event);
             // FIXME: This is a hack to work around Scrollbar not invalidating correctly when it doesn't have a parent widget
             RECT r = scrollBarRect;
             ::InvalidateRect(m_popup, &r, TRUE);
@@ -739,7 +739,7 @@ LRESULT WebPopupMenuProxyWin::onMouseWheel(HWND hWnd, UINT message, WPARAM wPara
 {
     handled = true;
 
-    if (!scrollbar())
+    if (!m_scrollbar)
         return 0;
 
     int i = 0;

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -65,8 +65,6 @@ public:
 private:
     WebPopupMenuProxyWin(WebView*, WebPopupMenuProxy::Client&);
 
-    WebCore::Scrollbar* scrollbar() const { return m_scrollbar.get(); }
-
     // ScrollableArea
     WebCore::ScrollPosition scrollPosition() const override;
     void setScrollOffset(const WebCore::IntPoint&) override;


### PR DESCRIPTION
#### f988a6b3674bbc5b8f081c2404fa87ceb3401a19
<pre>
[Win] Don&apos;t use raw pointers for ScrollBar in WebPopupMenuProxyWin
<a href="https://bugs.webkit.org/show_bug.cgi?id=274376">https://bugs.webkit.org/show_bug.cgi?id=274376</a>

Reviewed by Fujii Hironori.

Remove existing unnecessary usage of raw pointers for ScrollBar on
WebPopupMenuProxyWin.

* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h:

Canonical link: <a href="https://commits.webkit.org/278979@main">https://commits.webkit.org/278979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b6d82d34c0a0887905917cc4823d4134fd48f0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55431 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2579 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54254 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1040 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27283 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28517 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29429 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7626 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->