### PR TITLE
[JSC][offlineasm] Remove $emitWinAsm

### DIFF
--- a/Source/JavaScriptCore/offlineasm/ast.rb
+++ b/Source/JavaScriptCore/offlineasm/ast.rb
@@ -1257,9 +1257,6 @@ class LocalLabel < NoChildren
     
     def self.unique(comment)
         newName = "_#{comment}"
-        if $emitWinAsm and newName.length > 90
-            newName = newName[0...45] + "___" + newName[-45..-1]
-        end
         if $labelMapping[newName]
             while $labelMapping[newName = "_#{@@uniqueNameCounter}_#{comment}"]
                 @@uniqueNameCounter += 1

--- a/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/Source/JavaScriptCore/offlineasm/parser.rb
@@ -68,7 +68,7 @@ class CodeOrigin
     end
 
     def debugDirective
-        $emitWinAsm ? nil : "\".loc #{@sourceFile.fileNumber} #{lineNumber}\\n\""
+        "\".loc #{@sourceFile.fileNumber} #{lineNumber}\\n\""
     end
 
     def to_s

--- a/Source/JavaScriptCore/offlineasm/settings.rb
+++ b/Source/JavaScriptCore/offlineasm/settings.rb
@@ -191,17 +191,8 @@ end
 
 def emitCodeInConfiguration(concreteSettings, ast, backend)
     Label.resetReferenced
+    $output.puts cppSettingsTest(concreteSettings)
 
-    if !$emitWinAsm
-        $output.puts cppSettingsTest(concreteSettings)
-    else
-        if backend == "X86_WIN"
-            $output.puts ".MODEL FLAT, C"
-        end
-        $output.puts "INCLUDE #{File.basename($output.path)}.sym"
-        $output.puts "_TEXT SEGMENT"
-    end
-    
     if isASTErroneous(ast)
         $output.puts "#error \"Invalid configuration. Error at: #{ast.filter(Error)[0].codeOrigin}\""
     elsif not WORKING_BACKENDS.include? backend
@@ -209,22 +200,8 @@ def emitCodeInConfiguration(concreteSettings, ast, backend)
     else
         yield concreteSettings, ast, backend
     end
-    
-    if !$emitWinAsm
-        $output.puts "#endif"
-    else
-        $output.puts "_TEXT ENDS"
-        $output.puts "END"
 
-        # Write symbols needed by MASM
-        File.open("#{File.basename($output.path)}.sym", "w") {
-            | outp |
-            Label.forReferencedExtern {
-                | name |
-                outp.puts "EXTERN #{name[1..-1]} : near"
-            }
-        }
-    end
+    $output.puts "#endif"
 end
 
 #


### PR DESCRIPTION
#### c3c24e01624650960b23ea2b7546157331da934f
<pre>
[JSC][offlineasm] Remove $emitWinAsm
<a href="https://bugs.webkit.org/show_bug.cgi?id=274378">https://bugs.webkit.org/show_bug.cgi?id=274378</a>

Reviewed by Yusuke Suzuki.

As of 278767@main, $emitWinAsm is constant false, so let&apos;s do away with it.

* Source/JavaScriptCore/offlineasm/asm.rb:
* Source/JavaScriptCore/offlineasm/ast.rb:
* Source/JavaScriptCore/offlineasm/parser.rb:
* Source/JavaScriptCore/offlineasm/settings.rb:

Canonical link: <a href="https://commits.webkit.org/278980@main">https://commits.webkit.org/278980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1d5c4f4361bd28806ad158af0c99959fa9db90d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55433 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42448 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23519 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1042 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45509 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57030 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51668 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2491 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49078 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11408 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29431 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/63975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28263 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/63975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->