### PR TITLE
Update WTF::equal() to take in 2 spans

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -241,7 +241,7 @@ template<typename CharacterType1, typename CharacterType2>
 inline std::optional<UCollationResult> compareASCIIWithUCADUCET(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
 {
     if (characters1.size() == characters2.size()) {
-        if (equal(characters1.data(), characters2))
+        if (equalWithLength(characters1, characters2, characters2.size()))
             return UCOL_EQUAL;
     }
 

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -661,7 +661,7 @@ std::optional<String> mapHostName(const String& hostName, URLDecodeFunction deco
         return std::nullopt;
 
     auto span = std::span { destinationBuffer }.first(numCharactersConverted);
-    if (numCharactersConverted == length && equal(sourceBuffer.data(), span))
+    if (numCharactersConverted == length && equalWithLength(sourceBuffer, span, span.size()))
         return String();
 
     if (!decodeFunction && !allCharactersInAllowedIDNScriptList(span) && !allCharactersAllowedByTLDRules(span))

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -135,8 +135,8 @@ struct HashedUTF8CharactersTranslator {
 
         auto charactersLatin1 = spanReinterpretCast<const LChar>(characters.characters);
         if (string->is8Bit())
-            return WTF::equal(string->span8().data(), charactersLatin1);
-        return WTF::equal(string->span16().data(), charactersLatin1);
+            return WTF::equalWithLength(string->span8(), charactersLatin1, charactersLatin1.size());
+        return WTF::equalWithLength(string->span16(), charactersLatin1, charactersLatin1.size());
     }
 
     static void translate(AtomStringTable::StringEntry& location, const HashedUTF8Characters& characters, unsigned hash)

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -119,9 +119,7 @@ bool operator==(const CString& a, const CString& b)
 {
     if (a.isNull() != b.isNull())
         return false;
-    if (a.length() != b.length())
-        return false;
-    return equal(a.span().data(), b.span());
+    return equal(a.span(), b.span());
 }
 
 bool operator==(const CString& a, const char* b)

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -91,17 +91,19 @@ bool equalIgnoringASCIICase(const char*, const char*);
 
 // Do comparisons 8 or 4 bytes-at-a-time on architectures where it's safe.
 #if (CPU(X86_64) || CPU(ARM64)) && !ASAN_ENABLED
-ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
+ALWAYS_INLINE bool equalWithLength(std::span<const LChar> aLChar, std::span<const LChar> bLChar, size_t lengthToCompare)
 {
-    ASSERT(bLChar.size() <= std::numeric_limits<unsigned>::max());
-    unsigned length = bLChar.size();
+    ASSERT(aLChar.size() >= lengthToCompare);
+    ASSERT(bLChar.size() >= lengthToCompare);
+    ASSERT(lengthToCompare <= std::numeric_limits<unsigned>::max());
+    unsigned length = static_cast<unsigned>(lengthToCompare);
 
     // These branches could be combined into one, but it's measurably faster
     // for length 0 or 1 strings to separate them out like this.
     if (!length)
         return true;
     if (length == 1)
-        return *aLChar == bLChar.front();
+        return aLChar.front() == bLChar.front();
 
 #if COMPILER(GCC_COMPATIBLE)
     switch (sizeof(unsigned) * CHAR_BIT - clz(length - 1)) { // Works as really fast log2, since length != 0.
@@ -111,36 +113,36 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
     case 0:
         RELEASE_ASSERT_NOT_REACHED();
     case 1: // Length is 2.
-        return unalignedLoad<uint16_t>(aLChar) == unalignedLoad<uint16_t>(bLChar.data());
+        return unalignedLoad<uint16_t>(aLChar.data()) == unalignedLoad<uint16_t>(bLChar.data());
     case 2: // Length is 3 or 4.
-        return unalignedLoad<uint16_t>(aLChar) == unalignedLoad<uint16_t>(bLChar.data())
-            && unalignedLoad<uint16_t>(aLChar + length - 2) == unalignedLoad<uint16_t>(bLChar.data() + length - 2);
+        return unalignedLoad<uint16_t>(aLChar.data()) == unalignedLoad<uint16_t>(bLChar.data())
+            && unalignedLoad<uint16_t>(aLChar.data() + length - 2) == unalignedLoad<uint16_t>(bLChar.data() + length - 2);
     case 3: // Length is between 5 and 8 inclusive.
-        return unalignedLoad<uint32_t>(aLChar) == unalignedLoad<uint32_t>(bLChar.data())
-            && unalignedLoad<uint32_t>(aLChar + length - 4) == unalignedLoad<uint32_t>(bLChar.data() + length - 4);
+        return unalignedLoad<uint32_t>(aLChar.data()) == unalignedLoad<uint32_t>(bLChar.data())
+            && unalignedLoad<uint32_t>(aLChar.data() + length - 4) == unalignedLoad<uint32_t>(bLChar.data() + length - 4);
     case 4: // Length is between 9 and 16 inclusive.
-        return unalignedLoad<uint64_t>(aLChar) == unalignedLoad<uint64_t>(bLChar.data())
-            && unalignedLoad<uint64_t>(aLChar + length - 8) == unalignedLoad<uint64_t>(bLChar.data() + length - 8);
+        return unalignedLoad<uint64_t>(aLChar.data()) == unalignedLoad<uint64_t>(bLChar.data())
+            && unalignedLoad<uint64_t>(aLChar.data() + length - 8) == unalignedLoad<uint64_t>(bLChar.data() + length - 8);
 #if CPU(ARM64)
     case 5: // Length is between 17 and 32 inclusive.
         return vminvq_u8(vandq_u8(
-            vceqq_u8(unalignedLoad<uint8x16_t>(aLChar), unalignedLoad<uint8x16_t>(bLChar.data())),
-            vceqq_u8(unalignedLoad<uint8x16_t>(aLChar + length - 16), unalignedLoad<uint8x16_t>(bLChar.data() + length - 16))
+            vceqq_u8(unalignedLoad<uint8x16_t>(aLChar.data()), unalignedLoad<uint8x16_t>(bLChar.data())),
+            vceqq_u8(unalignedLoad<uint8x16_t>(aLChar.data() + length - 16), unalignedLoad<uint8x16_t>(bLChar.data() + length - 16))
         ));
     default: // Length is longer than 32 bytes.
-        if (!vminvq_u8(vceqq_u8(unalignedLoad<uint8x16_t>(aLChar), unalignedLoad<uint8x16_t>(bLChar.data()))))
+        if (!vminvq_u8(vceqq_u8(unalignedLoad<uint8x16_t>(aLChar.data()), unalignedLoad<uint8x16_t>(bLChar.data()))))
             return false;
         for (unsigned i = length % 16; i < length; i += 16) {
-            if (!vminvq_u8(vceqq_u8(unalignedLoad<uint8x16_t>(aLChar + i), unalignedLoad<uint8x16_t>(bLChar.data() + i))))
+            if (!vminvq_u8(vceqq_u8(unalignedLoad<uint8x16_t>(aLChar.data() + i), unalignedLoad<uint8x16_t>(bLChar.data() + i))))
                 return false;
         }
         return true;
 #else
     default: // Length is longer than 16 bytes.
-        if (unalignedLoad<uint64_t>(aLChar) != unalignedLoad<uint64_t>(bLChar.data()))
+        if (unalignedLoad<uint64_t>(aLChar.data()) != unalignedLoad<uint64_t>(bLChar.data()))
             return false;
         for (unsigned i = length % 8; i < length; i += 8) {
-            if (unalignedLoad<uint64_t>(aLChar + i) != unalignedLoad<uint64_t>(bLChar.data() + i))
+            if (unalignedLoad<uint64_t>(aLChar.data() + i) != unalignedLoad<uint64_t>(bLChar.data() + i))
                 return false;
         }
         return true;
@@ -148,15 +150,17 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
     }
 }
 
-ALWAYS_INLINE bool equal(const UChar* aUChar, std::span<const UChar> bUChar)
+ALWAYS_INLINE bool equalWithLength(std::span<const UChar> aUChar, std::span<const UChar> bUChar, size_t lengthToCompare)
 {
-    ASSERT(bUChar.size() <= std::numeric_limits<unsigned>::max());
-    unsigned length = bUChar.size();
+    ASSERT(aUChar.size() >= lengthToCompare);
+    ASSERT(bUChar.size() >= lengthToCompare);
+    ASSERT(lengthToCompare <= std::numeric_limits<unsigned>::max());
+    unsigned length = static_cast<unsigned>(lengthToCompare);
 
     if (!length)
         return true;
     if (length == 1)
-        return *aUChar == bUChar.front();
+        return aUChar.front() == bUChar.front();
 
 #if COMPILER(GCC_COMPATIBLE)
     switch (sizeof(unsigned) * CHAR_BIT - clz(length - 1)) { // Works as really fast log2, since length != 0.
@@ -166,33 +170,33 @@ ALWAYS_INLINE bool equal(const UChar* aUChar, std::span<const UChar> bUChar)
     case 0:
         RELEASE_ASSERT_NOT_REACHED();
     case 1: // Length is 2 (4 bytes).
-        return unalignedLoad<uint32_t>(aUChar) == unalignedLoad<uint32_t>(bUChar.data());
+        return unalignedLoad<uint32_t>(aUChar.data()) == unalignedLoad<uint32_t>(bUChar.data());
     case 2: // Length is 3 or 4 (6-8 bytes).
-        return unalignedLoad<uint32_t>(aUChar) == unalignedLoad<uint32_t>(bUChar.data())
-            && unalignedLoad<uint32_t>(aUChar + length - 2) == unalignedLoad<uint32_t>(bUChar.data() + length - 2);
+        return unalignedLoad<uint32_t>(aUChar.data()) == unalignedLoad<uint32_t>(bUChar.data())
+            && unalignedLoad<uint32_t>(aUChar.data() + length - 2) == unalignedLoad<uint32_t>(bUChar.data() + length - 2);
     case 3: // Length is between 5 and 8 inclusive (10-16 bytes).
-        return unalignedLoad<uint64_t>(aUChar) == unalignedLoad<uint64_t>(bUChar.data())
-            && unalignedLoad<uint64_t>(aUChar + length - 4) == unalignedLoad<uint64_t>(bUChar.data() + length - 4);
+        return unalignedLoad<uint64_t>(aUChar.data()) == unalignedLoad<uint64_t>(bUChar.data())
+            && unalignedLoad<uint64_t>(aUChar.data() + length - 4) == unalignedLoad<uint64_t>(bUChar.data() + length - 4);
 #if CPU(ARM64)
     case 4: // Length is between 9 and 16 inclusive (18-32 bytes).
         return vminvq_u16(vandq_u16(
-            vceqq_u16(unalignedLoad<uint16x8_t>(aUChar), unalignedLoad<uint16x8_t>(bUChar.data())),
-            vceqq_u16(unalignedLoad<uint16x8_t>(aUChar + length - 8), unalignedLoad<uint16x8_t>(bUChar.data() + length - 8))
+            vceqq_u16(unalignedLoad<uint16x8_t>(aUChar.data()), unalignedLoad<uint16x8_t>(bUChar.data())),
+            vceqq_u16(unalignedLoad<uint16x8_t>(aUChar.data() + length - 8), unalignedLoad<uint16x8_t>(bUChar.data() + length - 8))
         ));
     default: // Length is longer than 16 (32 bytes).
-        if (!vminvq_u16(vceqq_u16(unalignedLoad<uint16x8_t>(aUChar), unalignedLoad<uint16x8_t>(bUChar.data()))))
+        if (!vminvq_u16(vceqq_u16(unalignedLoad<uint16x8_t>(aUChar.data()), unalignedLoad<uint16x8_t>(bUChar.data()))))
             return false;
         for (unsigned i = length % 8; i < length; i += 8) {
-            if (!vminvq_u16(vceqq_u16(unalignedLoad<uint16x8_t>(aUChar + i), unalignedLoad<uint16x8_t>(bUChar.data() + i))))
+            if (!vminvq_u16(vceqq_u16(unalignedLoad<uint16x8_t>(aUChar.data() + i), unalignedLoad<uint16x8_t>(bUChar.data() + i))))
                 return false;
         }
         return true;
 #else
     default: // Length is longer than 8 (16 bytes).
-        if (unalignedLoad<uint64_t>(aUChar) != unalignedLoad<uint64_t>(bUChar.data()))
+        if (unalignedLoad<uint64_t>(aUChar.data()) != unalignedLoad<uint64_t>(bUChar.data()))
             return false;
         for (unsigned i = length % 4; i < length; i += 4) {
-            if (unalignedLoad<uint64_t>(aUChar + i) != unalignedLoad<uint64_t>(bUChar.data() + i))
+            if (unalignedLoad<uint64_t>(aUChar.data() + i) != unalignedLoad<uint64_t>(bUChar.data() + i))
                 return false;
         }
         return true;
@@ -200,12 +204,14 @@ ALWAYS_INLINE bool equal(const UChar* aUChar, std::span<const UChar> bUChar)
     }
 }
 #elif CPU(X86) && !ASAN_ENABLED
-ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
+ALWAYS_INLINE bool equalWithLength(std::span<const LChar> aLChar, std::span<const LChar> bLChar, size_t lengthToCompare)
 {
+    ASSERT(aUChar.size() >= lengthToCompare);
+    ASSERT(bUChar.size() >= lengthToCompare);
     ASSERT(bLChar.size() <= std::numeric_limits<unsigned>::max());
-    unsigned length = bLChar.size();
+    unsigned length = static_cast<unsigned>(lengthToCompare);
 
-    const char* a = reinterpret_cast<const char*>(aLChar);
+    const char* a = reinterpret_cast<const char*>(aLChar.data());
     const char* b = reinterpret_cast<const char*>(bLChar.data());
 
     unsigned wordLength = length >> 2;
@@ -231,12 +237,14 @@ ALWAYS_INLINE bool equal(const LChar* aLChar, std::span<const LChar> bLChar)
     return true;
 }
 
-ALWAYS_INLINE bool equal(const UChar* aUChar, std::span<const UChar> bUChar)
+ALWAYS_INLINE bool equalWithLength(std::span<const UChar> aUChar, std::span<const UChar> bUChar, size_t lengthToCompare)
 {
-    ASSERT(bUChar.size() <= std::numeric_limits<unsigned>::max());
-    unsigned length = bUChar.size();
+    ASSERT(aUChar.size() >= lengthToCompare);
+    ASSERT(bUChar.size() >= lengthToCompare);
+    ASSERT(lengthToCompare <= std::numeric_limits<unsigned>::max());
+    unsigned length = static_cast<unsigned>(lengthToCompare);
 
-    const char* a = reinterpret_cast<const char*>(aUChar);
+    const char* a = reinterpret_cast<const char*>(aUChar.data());
     const char* b = reinterpret_cast<const char*>(bUChar.data());
 
     unsigned wordLength = length >> 1;
@@ -253,11 +261,14 @@ ALWAYS_INLINE bool equal(const UChar* aUChar, std::span<const UChar> bUChar)
     return true;
 }
 #elif OS(DARWIN) && WTF_ARM_ARCH_AT_LEAST(7) && !ASAN_ENABLED
-ALWAYS_INLINE bool equal(const LChar* a, std::span<const LChar> bSpan)
+ALWAYS_INLINE bool equalWithLength(std::span<const LChar> aSpan, std::span<const LChar> bSpan, size_t lengthToCompare)
 {
-    ASSERT(b.size() <= std::numeric_limits<unsigned>::max());
+    ASSERT(aSpan.size() >= lengthToCompare);
+    ASSERT(bSpan.size() >= lengthToCompare);
+    ASSERT(lengthToCompare <= std::numeric_limits<unsigned>::max());
+    auto* a = aSpan.data();
     auto* b = bSpan.data();
-    unsigned length = bSpan.size();
+    unsigned length = static_cast<unsigned>(lengthToCompare);
 
     bool isEqual = false;
     uint32_t aValue;
@@ -306,11 +317,14 @@ ALWAYS_INLINE bool equal(const LChar* a, std::span<const LChar> bSpan)
     return isEqual;
 }
 
-ALWAYS_INLINE bool equal(const UChar* a, std::span<const UChar> bSpan)
+ALWAYS_INLINE bool equalWithLength(std::span<const UChar> aSpan, std::span<const UChar> bSpan, size_t lengthToCompare)
 {
-    ASSERT(b.size() <= std::numeric_limits<unsigned>::max());
+    ASSERT(aSpan.size() >= lengthToCompare);
+    ASSERT(bSpan.size() >= lengthToCompare);
+    ASSERT(lengthToCompare <= std::numeric_limits<unsigned>::max());
+    auto* a = aSpan.data();
     auto* b = bSpan.data();
-    unsigned length = bSpan.size();
+    unsigned length = static_cast<unsigned>(lengthToCompare);
 
     bool isEqual = false;
     uint32_t aValue;
@@ -349,20 +363,35 @@ ALWAYS_INLINE bool equal(const UChar* a, std::span<const UChar> bSpan)
     return isEqual;
 }
 #elif !ASAN_ENABLED
-ALWAYS_INLINE bool equal(const LChar* a, std::span<const LChar> b) { return !memcmp(a, b.data(), b.size()); }
-ALWAYS_INLINE bool equal(const UChar* a, std::span<const UChar> b) { return !memcmp(a, b.data(), b.size_bytes()); }
-#else
-ALWAYS_INLINE bool equal(const LChar* a, std::span<const LChar> b)
+ALWAYS_INLINE bool equalWithLength(std::span<const LChar> a, std::span<const LChar> b, size_t length)
 {
-    for (size_t i = 0; i < b.size(); ++i) {
+    ASSERT(a.size() >= length);
+    ASSERT(b.size() >= length);
+    return !memcmp(a.data(), b.data(), length);
+}
+
+ALWAYS_INLINE bool equalWithLength(std::span<const UChar> a, std::span<const UChar> b, size_t length)
+{
+    ASSERT(a.size() >= length);
+    ASSERT(b.size() >= length);
+    return !memcmp(a.data(), b.data(), length * sizeof(UChar));
+}
+#else
+ALWAYS_INLINE bool equalWithLength(std::span<const LChar> a, std::span<const LChar> b, size_t length)
+{
+    ASSERT(a.size() >= length);
+    ASSERT(b.size() >= length);
+    for (size_t i = 0; i < length; ++i) {
         if (a[i] != b[i])
             return false;
     }
     return true;
 }
-ALWAYS_INLINE bool equal(const UChar* a, std::span<const UChar> b)
+ALWAYS_INLINE bool equalWithLength(std::span<const UChar> a, std::span<const UChar> b, size_t length)
 {
-    for (size_t i = 0; i < b.size(); ++i) {
+    ASSERT(a.size() >= length);
+    ASSERT(b.size() >= length);
+    for (size_t i = 0; i < length; ++i) {
         if (a[i] != b[i])
             return false;
     }
@@ -370,19 +399,19 @@ ALWAYS_INLINE bool equal(const UChar* a, std::span<const UChar> b)
 }
 #endif
 
-ALWAYS_INLINE bool equal(const LChar* a, std::span<const UChar> b)
+ALWAYS_INLINE bool equalWithLength(std::span<const LChar> a, std::span<const UChar> b, size_t length)
 {
+    ASSERT(a.size() >= length);
+    ASSERT(b.size() >= length);
 #if CPU(ARM64)
-    ASSERT(b.size() <= std::numeric_limits<unsigned>::max());
-    unsigned length = b.size();
-
+    ASSERT(length <= std::numeric_limits<unsigned>::max());
     if (length >= 8) {
-        uint16x8_t aHalves = vmovl_u8(unalignedLoad<uint8x8_t>(a)); // Extends 8 LChars into 8 UChars.
+        uint16x8_t aHalves = vmovl_u8(unalignedLoad<uint8x8_t>(a.data())); // Extends 8 LChars into 8 UChars.
         uint16x8_t bHalves = unalignedLoad<uint16x8_t>(b.data());
         if (!vminvq_u16(vceqq_u16(aHalves, bHalves)))
             return false;
         for (unsigned i = length % 8; i < length; i += 8) {
-            aHalves = vmovl_u8(unalignedLoad<uint8x8_t>(a + i));
+            aHalves = vmovl_u8(unalignedLoad<uint8x8_t>(a.data() + i));
             bHalves = unalignedLoad<uint16x8_t>(b.data() + i);
             if (!vminvq_u16(vceqq_u16(aHalves, bHalves)))
                 return false;
@@ -398,7 +427,7 @@ ALWAYS_INLINE bool equal(const LChar* a, std::span<const UChar> b)
             return static_cast<uint64_t>((v64 | (v64 << 8)) & 0x00ff00ff00ff00ffULL);
         };
 
-        return static_cast<unsigned>(read4(a) == unalignedLoad<uint64_t>(b.data())) & static_cast<unsigned>(read4(a + (length % 4)) == unalignedLoad<uint64_t>(b.data() + (length % 4)));
+        return static_cast<unsigned>(read4(a.data()) == unalignedLoad<uint64_t>(b.data())) & static_cast<unsigned>(read4(a.data() + (length % 4)) == unalignedLoad<uint64_t>(b.data() + (length % 4)));
     }
     if (length >= 2) {
         auto read2 = [](const LChar* p) ALWAYS_INLINE_LAMBDA {
@@ -407,13 +436,13 @@ ALWAYS_INLINE bool equal(const LChar* a, std::span<const UChar> b)
             uint32_t v32 = static_cast<uint32_t>(v16);
             return static_cast<uint32_t>((v32 | (v32 << 8)) & 0x00ff00ffUL);
         };
-        return static_cast<unsigned>(read2(a) == unalignedLoad<uint32_t>(b.data())) & static_cast<unsigned>(read2(a + (length % 2)) == unalignedLoad<uint32_t>(b.data() + (length % 2)));
+        return static_cast<unsigned>(read2(a.data()) == unalignedLoad<uint32_t>(b.data())) & static_cast<unsigned>(read2(a.data() + (length % 2)) == unalignedLoad<uint32_t>(b.data() + (length % 2)));
     }
     if (length == 1)
-        return *a == b.front();
+        return a.front() == b.front();
     return true;
 #else
-    for (size_t i = 0; i < b.size(); ++i) {
+    for (size_t i = 0; i < length; ++i) {
         if (a[i] != b[i])
             return false;
     }
@@ -421,9 +450,30 @@ ALWAYS_INLINE bool equal(const LChar* a, std::span<const UChar> b)
 #endif
 }
 
-ALWAYS_INLINE bool equal(const UChar* a, std::span<const LChar> b)
+ALWAYS_INLINE bool equal(std::span<const LChar> a, std::span<const LChar> b)
 {
-    return equal(b.data(), { a, b.size() });
+    return a.size() == b.size() && equalWithLength(a, b, b.size());
+}
+
+ALWAYS_INLINE bool equal(std::span<const LChar> a, std::span<const UChar> b)
+{
+    return a.size() == b.size() && equalWithLength(a, b, b.size());
+}
+
+ALWAYS_INLINE bool equal(std::span<const UChar> a, std::span<const UChar> b)
+{
+    return a.size() == b.size() && equalWithLength(a, b, b.size());
+}
+
+
+ALWAYS_INLINE bool equalWithLength(std::span<const UChar> a, std::span<const LChar> b, size_t length)
+{
+    return equalWithLength(b, a, length);
+}
+
+ALWAYS_INLINE bool equal(std::span<const UChar> a, std::span<const LChar> b)
+{
+    return equal(b, a);
 }
 
 template<typename StringClassA, typename StringClassB>
@@ -436,19 +486,19 @@ ALWAYS_INLINE bool equalCommon(const StringClassA& a, const StringClassB& b, uns
         auto aSpan = a.span8();
         if (b.is8Bit()) {
             auto bSpan = b.span8();
-            return aSpan.front() == bSpan.front() && equal(aSpan.data() + 1, bSpan.subspan(1));
+            return aSpan.front() == bSpan.front() && equalWithLength(aSpan.subspan(1), bSpan.subspan(1), length - 1);
         }
         auto bSpan = b.span16();
-        return aSpan.front() == bSpan.front() && equal(aSpan.data() + 1, bSpan.subspan(1));
+        return aSpan.front() == bSpan.front() && equalWithLength(aSpan.subspan(1), bSpan.subspan(1), length - 1);
     }
 
     auto aSpan = a.span16();
     if (b.is8Bit()) {
         auto bSpan = b.span8();
-        return aSpan.front() == bSpan.front() && equal(aSpan.data() + 1, bSpan.subspan(1));
+        return aSpan.front() == bSpan.front() && equalWithLength(aSpan.subspan(1), bSpan.subspan(1), length - 1);
     }
     auto bSpan = b.span16();
-    return aSpan.front() == bSpan.front() && equal(aSpan.data() + 1, bSpan.subspan(1));
+    return aSpan.front() == bSpan.front() && equalWithLength(aSpan.subspan(1), bSpan.subspan(1), length - 1);
 }
 
 template<typename StringClassA, typename StringClassB>
@@ -477,9 +527,9 @@ template<typename StringClass, unsigned length> bool equal(const StringClass& a,
         return false;
 
     if (a.is8Bit())
-        return equal(a.span8().data(), { codeUnits, length });
+        return equalWithLength(a.span8(), { codeUnits, length }, length);
 
-    return equal(a.span16().data(), { codeUnits, length });
+    return equalWithLength(a.span16(), { codeUnits, length }, length);
 }
 
 template<typename CharacterTypeA, typename CharacterTypeB> inline bool equalIgnoringASCIICaseWithLength(std::span<const CharacterTypeA> a, std::span<const CharacterTypeB> b, size_t lengthToCheck)
@@ -568,7 +618,7 @@ ALWAYS_INLINE static size_t findInner(std::span<const SearchCharacterType> searc
 
     size_t i = 0;
     // keep looping until we match
-    while (searchHash != matchHash || !equal(searchCharacters.data() + i, matchCharacters)) {
+    while (searchHash != matchHash || !equalWithLength(searchCharacters.subspan(i), matchCharacters, matchCharacters.size())) {
         if (i == delta)
             return notFound;
         searchHash += searchCharacters[i + matchCharacters.size()];
@@ -819,7 +869,7 @@ ALWAYS_INLINE static size_t reverseFindInner(std::span<const SearchCharacterType
     }
 
     // keep looping until we match
-    while (searchHash != matchHash || !equal(searchCharacters.data() + delta, matchCharacters)) {
+    while (searchHash != matchHash || !equalWithLength(searchCharacters.subspan(delta), matchCharacters, matchCharacters.size())) {
         if (!delta)
             return notFound;
         --delta;
@@ -1181,6 +1231,7 @@ using WTF::equalIgnoringASCIICase;
 using WTF::equalIgnoringASCIICaseWithLength;
 using WTF::equalLettersIgnoringASCIICase;
 using WTF::equalLettersIgnoringASCIICaseWithLength;
+using WTF::equalWithLength;
 using WTF::isLatin1;
 using WTF::span;
 using WTF::span8;

--- a/Source/WTF/wtf/text/StringSearch.h
+++ b/Source/WTF/wtf/text/StringSearch.h
@@ -91,9 +91,10 @@ private:
     ALWAYS_INLINE size_t findInner(std::span<const SearchCharacterType> characters, std::span<const MatchCharacterType> matchCharacters) const
     {
         auto* cursor = characters.data();
+        auto* charactersEnd = characters.data() + characters.size();
         auto* last = characters.data() + characters.size() - matchCharacters.size();
         while (cursor <= last) {
-            if (equal(cursor, matchCharacters))
+            if (equalWithLength(std::span { cursor, charactersEnd }, matchCharacters, matchCharacters.size()))
                 return cursor - characters.data();
             cursor += m_table[static_cast<uint8_t>(cursor[matchCharacters.size() - 1])];
         }

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -777,12 +777,9 @@ inline bool equal(StringView a, const LChar* b)
         return !b;
 
     auto bSpan = span8(reinterpret_cast<const char*>(b));
-    if (a.length() != bSpan.size())
-        return false;
-
     if (a.is8Bit())
-        return equal(a.span8().data(), bSpan);
-    return equal(a.span16().data(), bSpan);
+        return equal(a.span8(), bSpan);
+    return equal(a.span16(), bSpan);
 }
 
 ALWAYS_INLINE bool equal(StringView a, ASCIILiteral b)
@@ -1261,17 +1258,18 @@ inline size_t findIgnoringASCIICase(StringView source, StringView stringToFind, 
 
 inline bool startsWith(StringView reference, StringView prefix)
 {
-    if (prefix.length() > reference.length())
+    auto prefixLength = prefix.length();
+    if (prefixLength > reference.length())
         return false;
 
     if (reference.is8Bit()) {
         if (prefix.is8Bit())
-            return equal(reference.span8().data(), prefix.span8());
-        return equal(reference.span8().data(), prefix.span16());
+            return equalWithLength(reference.span8(), prefix.span8(), prefixLength);
+        return equalWithLength(reference.span8(), prefix.span16(), prefixLength);
     }
     if (prefix.is8Bit())
-        return equal(reference.span16().data(), prefix.span8());
-    return equal(reference.span16().data(), prefix.span16());
+        return equalWithLength(reference.span16(), prefix.span8(), prefixLength);
+    return equalWithLength(reference.span16(), prefix.span16(), prefixLength);
 }
 
 inline bool startsWithIgnoringASCIICase(StringView reference, StringView prefix)
@@ -1300,12 +1298,12 @@ inline bool endsWith(StringView reference, StringView suffix)
 
     if (reference.is8Bit()) {
         if (suffix.is8Bit())
-            return equal(reference.span8().data() + startOffset, suffix.span8());
-        return equal(reference.span8().data() + startOffset, suffix.span16());
+            return equalWithLength(reference.span8().subspan(startOffset), suffix.span8(), suffixLength);
+        return equalWithLength(reference.span8().subspan(startOffset), suffix.span16(), suffixLength);
     }
     if (suffix.is8Bit())
-        return equal(reference.span16().data() + startOffset, suffix.span8());
-    return equal(reference.span16().data() + startOffset, suffix.span16());
+        return equalWithLength(reference.span16().subspan(startOffset), suffix.span8(), suffixLength);
+    return equalWithLength(reference.span16().subspan(startOffset), suffix.span16(), suffixLength);
 }
 
 inline bool endsWithIgnoringASCIICase(StringView reference, StringView suffix)

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -111,7 +111,7 @@ public:
     template <typename TokenCharacterType>
     bool processToken(std::span<const TokenCharacterType> characters)
     {
-        if (characters.size() == m_referenceLength && equal(m_referenceCharacters, characters)) {
+        if (equal(std::span { m_referenceCharacters, m_referenceLength }, characters)) {
             m_referenceStringWasFound = true;
             return false;
         }

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1383,16 +1383,16 @@ sub generateFindNameForLength
                 my $letter = substr($string, $currentIndex, 1);
                 print F "${indent}if (buffer[$currentIndex] == '$letter') {\n";
             } else {
-                my $bufferStart = $currentIndex > 0 ? "buffer.data() + $currentIndex" : "buffer.data()";
+                my $bufferStart = $currentIndex > 0 ? "buffer.subspan($currentIndex)" : "buffer";
                 if ($lengthToCompare <= 8) {
-                    print F "${indent}if (compareCharacters($bufferStart";
+                    print F "${indent}if (compareCharacters($bufferStart.data()";
                     for (my $index = $currentIndex; $index < $length; $index = $index + 1) {
                         my $letter = substr($string, $index, 1);
                         print F ", '$letter'";
                     }
                     print F ")) {\n";
                 } else {
-                    print F "${indent}if (WTF::equal($bufferStart, \"". substr($string, $currentIndex, $length - $currentIndex) . "\"_span)) {\n";
+                    print F "${indent}if (WTF::equalWithLength($bufferStart, \"". substr($string, $currentIndex, $length - $currentIndex) . "\"_span, " . ($length - $currentIndex) . ")) {\n";
                 }
             }
             print F "$indent    return ${enumClass}::$enumValue;\n";

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -436,7 +436,7 @@ inline const HTMLToken::Attribute* findAttribute(const HTMLToken::AttributeList&
 {
     for (auto& attribute : attributes) {
         // FIXME: The one caller that uses this probably wants to ignore letter case.
-        if (attribute.name.size() == name.size() && equal(attribute.name.data(), name))
+        if (equal(attribute.name.span(), name))
             return &attribute;
     }
     return nullptr;

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -1403,9 +1403,7 @@ inline void HTMLTokenizer::appendToTemporaryBuffer(UChar character)
 
 inline bool HTMLTokenizer::temporaryBufferIs(ASCIILiteral expectedString)
 {
-    if (m_temporaryBuffer.size() != expectedString.length())
-        return false;
-    return equal(m_temporaryBuffer.data(), expectedString.span8());
+    return equal(m_temporaryBuffer.span(), expectedString.span8());
 }
 
 inline void HTMLTokenizer::appendToPossibleEndTag(UChar character)
@@ -1416,9 +1414,7 @@ inline void HTMLTokenizer::appendToPossibleEndTag(UChar character)
 
 inline bool HTMLTokenizer::isAppropriateEndTag() const
 {
-    if (m_bufferedEndTagName.size() != m_appropriateEndTagName.size())
-        return false;
-    return equal(m_bufferedEndTagName.data(), m_appropriateEndTagName.span());
+    return equal(m_bufferedEndTagName.span(), m_appropriateEndTagName.span());
 }
 
 inline void HTMLTokenizer::parseError()

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -62,9 +62,9 @@ bool VTTScanner::scan(std::span<const LChar> characters)
         return false;
     bool matched;
     if (m_is8Bit)
-        matched = equal(m_data.characters8, characters);
+        matched = equalWithLength({ m_data.characters8, m_end.characters8 }, characters, characters.size());
     else
-        matched = equal(m_data.characters16, characters);
+        matched = equalWithLength({ m_data.characters16, m_end.characters16 }, characters, characters.size());
     if (matched)
         advance(characters.size());
     return matched;


### PR DESCRIPTION
#### 713c2844d4ef06923e46b119cb869fa673be4bb8
<pre>
Update WTF::equal() to take in 2 spans
<a href="https://bugs.webkit.org/show_bug.cgi?id=274379">https://bugs.webkit.org/show_bug.cgi?id=274379</a>

Reviewed by NOBODY (OOPS!).

Update WTF::equal() to take in 2 spans, instead of a raw pointer and a span.

* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::compareASCIIWithUCADUCET):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::mapHostName):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashedUTF8CharactersTranslator::equal):
* Source/WTF/wtf/text/CString.cpp:
(WTF::operator==):
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):
(WTF::equalInner):
(WTF::equalInternal):
(WTF::equalIgnoringNullity):
* Source/WTF/wtf/text/StringSearch.h:
(WTF::BoyerMooreHorspoolTable::findInner const):
* Source/WTF/wtf/text/StringView.h:
(WTF::equal):
(WTF::startsWith):
(WTF::endsWith):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::TokenIsEqualToCharactersTokenProcessor::processToken):
* Source/WebCore/dom/make_names.pl:
(generateFindNameForLength):
* Source/WebCore/html/parser/HTMLToken.h:
(WebCore::findAttribute):
* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::HTMLTokenizer::temporaryBufferIs):
(WebCore::HTMLTokenizer::isAppropriateEndTag const):
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::scan):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/713c2844d4ef06923e46b119cb869fa673be4bb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52161 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2886 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42449 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1845 "Found 1 new test failure: http/tests/security/no-javascript-location-percent-escaped.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1043 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45510 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57031 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51669 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49847 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49080 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29432 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/63976 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28264 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12113 "Passed tests") | 
<!--EWS-Status-Bubble-End-->