### PR TITLE
GlyphDisplayListCache should follow to traditional cache protocol

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2938,6 +2938,8 @@ webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/letter-spacing/
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-loose-hyphens-001.html [ ImageOnlyFailure ]
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-shaping-001.html [ ImageOnlyFailure ]
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-017.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-013.html [ ImageOnlyFailure Pass ]
+imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-014.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-022.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-023.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-atomic-003.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -159,6 +159,7 @@ struct Box {
     void setIsFirstForLayoutBox(bool isFirstBox) { m_isFirstForLayoutBox = isFirstBox; }
     void setIsLastForLayoutBox(bool isLastBox) { m_isLastForLayoutBox = isLastBox; }
 
+    bool isInGlyphDisplayListCache() const { return m_isInGlyphDisplayListCache; }
     void setIsInGlyphDisplayListCache() { m_isInGlyphDisplayListCache = true; }
     void removeFromGlyphDisplayListCache();
 

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -107,11 +107,11 @@ public:
 
     static GlyphDisplayListCache& singleton();
 
-    DisplayList::DisplayList* get(const LegacyInlineTextBox& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun);
-    DisplayList::DisplayList* get(const InlineDisplay::Box& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun);
+    DisplayList::DisplayList* get(const LegacyInlineTextBox&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
+    DisplayList::DisplayList* get(const InlineDisplay::Box&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
 
-    DisplayList::DisplayList* getIfExists(const LegacyInlineTextBox& run) { return getIfExists(&run); }
-    DisplayList::DisplayList* getIfExists(const InlineDisplay::Box& run) { return getIfExists(&run); }
+    DisplayList::DisplayList* getIfExists(const LegacyInlineTextBox&);
+    DisplayList::DisplayList* getIfExists(const InlineDisplay::Box&);
 
     void remove(const LegacyInlineTextBox& run) { remove(&run); }
     void remove(const InlineDisplay::Box& run) { remove(&run); }
@@ -119,15 +119,22 @@ public:
     void clear();
     unsigned size() const;
 
+    void setForceUseGlyphDisplayListForTesting(bool flag)
+    {
+        m_forceUseGlyphDisplayListForTesting = flag;
+    }
+
 private:
     static bool canShareDisplayList(const DisplayList::DisplayList&);
 
-    template <typename LayoutRun> DisplayList::DisplayList* getDisplayList(const LayoutRun*, const FontCascade&, GraphicsContext&, const TextRun&);
-    DisplayList::DisplayList* getIfExists(const void* run);
+    template<typename LayoutRun> DisplayList::DisplayList* getDisplayList(const LayoutRun&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
+    template<typename LayoutRun> DisplayList::DisplayList* getIfExistsImpl(const LayoutRun&);
     void remove(const void* run);
 
     HashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForLayoutRun;
+    HashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForFrequentlyPaintedLayoutRun;
     HashSet<SingleThreadWeakRef<GlyphDisplayListCacheEntry>> m_entries;
+    bool m_forceUseGlyphDisplayListForTesting { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -242,6 +242,10 @@ public:
     bool knownToHaveNoOverflow() const { return m_bitfields.knownToHaveNoOverflow(); }
     void clearKnownToHaveNoOverflow();
 
+    // For LegacyInlineTextBox
+    bool isInGlyphDisplayListCache() const { return m_bitfields.isInGlyphDisplayListCache(); }
+    void setIsInGlyphDisplayListCache(bool inCache = true) { m_bitfields.setIsInGlyphDisplayListCache(inCache); }
+
 private:
     LegacyInlineBox* m_nextOnLine { nullptr }; // The next element on the same line as us.
     LegacyInlineBox* m_previousOnLine { nullptr }; // The previous element on the same line as us.
@@ -339,10 +343,6 @@ protected:
     bool endsWithBreak() const { return m_bitfields.endsWithBreak(); }
     void setEndsWithBreak(bool endsWithBreak) { m_bitfields.setEndsWithBreak(endsWithBreak); }
 
-    // For LegacyInlineTextBox
-    bool isInGlyphDisplayListCache() const { return m_bitfields.isInGlyphDisplayListCache(); }
-    void setIsInGlyphDisplayListCache(bool inCache = true) { m_bitfields.setIsInGlyphDisplayListCache(inCache); }
-    
     // For LegacyInlineFlowBox and LegacyInlineTextBox
     bool extracted() const { return m_bitfields.extracted(); }
 

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -214,20 +214,14 @@ void TextPainter::paintRange(const TextRun& textRun, const FloatRect& boxRect, c
     paintTextAndEmphasisMarksIfNeeded(textRun, boxRect, textOrigin, start, end, m_style, m_shadow, m_shadowColorFilter);
 }
 
-static bool forceUseGlyphDisplayListForTesting = false;
-
 bool TextPainter::shouldUseGlyphDisplayList(const PaintInfo& paintInfo)
 {
-#if USE(GLYPH_DISPLAY_LIST_CACHE)
-    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer() && (paintInfo.enclosingSelfPaintingLayer()->paintingFrequently() || forceUseGlyphDisplayListForTesting);
-#else
-    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer() && forceUseGlyphDisplayListForTesting;
-#endif
+    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer();
 }
 
 void TextPainter::setForceUseGlyphDisplayListForTesting(bool enabled)
 {
-    forceUseGlyphDisplayListForTesting = enabled;
+    GlyphDisplayListCache::singleton().setForceUseGlyphDisplayListForTesting(enabled);
 }
 
 void TextPainter::clearGlyphDisplayListCacheForTesting()

--- a/Source/WebCore/rendering/TextPainter.h
+++ b/Source/WebCore/rendering/TextPainter.h
@@ -66,7 +66,7 @@ public:
         if (!TextPainter::shouldUseGlyphDisplayList(paintInfo))
             const_cast<LayoutRun&>(run).removeFromGlyphDisplayListCache();
         else
-            m_glyphDisplayList = GlyphDisplayListCache::singleton().get(run, m_font, m_context, textRun);
+            m_glyphDisplayList = GlyphDisplayListCache::singleton().get(run, m_font, m_context, textRun, paintInfo);
     }
 
     static bool shouldUseGlyphDisplayList(const PaintInfo&);


### PR DESCRIPTION
#### adec93572da688683977e3f27c99757792ec3d5c
<pre>
GlyphDisplayListCache should follow to traditional cache protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=274380">https://bugs.webkit.org/show_bug.cgi?id=274380</a>
<a href="https://rdar.apple.com/128376419">rdar://128376419</a>

Reviewed by Alan Baradlay.

We found that GlyphDisplayListCache is not effective much. So much time is used by Glyph DisplayList creation.
In this patch, we change the cache to 2-tier-based.

1. If layer is frequently painted, then do caching anyway. It is aligned to the current behavior.
2. Still we have a front cache, which has limited size. And stop doing a cache when it reaches to the threshold.
   Since cache entries are wiped when LayoutRun gets destroyed, size of Cache is not monotonically increasing.
   Rather it stays within small size.

* LayoutTests/TestExpectations: We found that these tests are already broken before this patch (if you change the window size to flush, then it disappears). So listing them.
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCache::clear):
(WebCore::GlyphDisplayListCache::getDisplayList):
(WebCore::GlyphDisplayListCache::get):
(WebCore::GlyphDisplayListCache::getIfExists):
(WebCore::GlyphDisplayListCache::remove):
* Source/WebCore/rendering/GlyphDisplayListCache.h:
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::shouldUseGlyphDisplayList):
* Source/WebCore/rendering/TextPainter.h:
(WebCore::TextPainter::setGlyphDisplayListIfNeeded):

Canonical link: <a href="https://commits.webkit.org/279037@main">https://commits.webkit.org/279037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ffb44e8dd7aee37d8fc556bd28aad1ee937ae53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45160 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1211 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2619 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45280 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7665 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->