### PR TITLE
[GStreamer] GstVideoFrame leaks

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
@@ -29,6 +29,7 @@
 #include "SharedBuffer.h"
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -37,7 +38,7 @@ class ImageDecoderGStreamerSample;
 
 void teardownGStreamerImageDecoders();
 
-class ImageDecoderGStreamer final : public ImageDecoder {
+class ImageDecoderGStreamer final : public ImageDecoder, public CanMakeWeakPtr<ImageDecoderGStreamer> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ImageDecoderGStreamer);
 public:

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
@@ -21,23 +21,20 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
-#include "BitmapImage.h"
 #include "FloatRect.h"
 #include "GStreamerCommon.h"
+#include "PlatformImage.h"
 
-#include <gst/gst.h>
 #include <gst/video/video-frame.h>
 
-#include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
+#include <wtf/Forward.h>
 
 namespace WebCore {
 class IntSize;
 
 class ImageGStreamer : public RefCounted<ImageGStreamer> {
 public:
-    static Ref<ImageGStreamer> createImage(GRefPtr<GstSample>&& sample)
+    static Ref<ImageGStreamer> create(GRefPtr<GstSample>&& sample)
     {
         return adoptRef(*new ImageGStreamer(WTFMove(sample)));
     }
@@ -45,11 +42,7 @@ public:
 
     operator bool() const { return !!m_image; }
 
-    BitmapImage& image()
-    {
-        ASSERT(m_image);
-        return *m_image.get();
-    }
+    PlatformImagePtr image() const { return m_image; }
 
     void setCropRect(FloatRect rect) { m_cropRect = rect; }
     FloatRect rect()
@@ -57,7 +50,7 @@ public:
         ASSERT(m_image);
         if (!m_cropRect.isEmpty())
             return FloatRect(m_cropRect);
-        return FloatRect(0, 0, m_image->size().width(), m_image->size().height());
+        return FloatRect(0, 0, m_size.width(), m_size.height());
     }
 
     bool hasAlpha() const { return m_hasAlpha; }
@@ -65,12 +58,13 @@ public:
 private:
     ImageGStreamer(GRefPtr<GstSample>&&);
     GRefPtr<GstSample> m_sample;
-    RefPtr<BitmapImage> m_image;
+    PlatformImagePtr m_image;
     FloatRect m_cropRect;
 #if USE(CAIRO)
     GstVideoFrame m_videoFrame;
     bool m_frameMapped { false };
 #endif
+    FloatSize m_size;
     bool m_hasAlpha { false };
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
@@ -74,6 +74,8 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     int height = GST_VIDEO_FRAME_HEIGHT(&m_videoFrame);
     RefPtr<cairo_surface_t> surface;
 
+    m_size = { static_cast<float>(width), static_cast<float>(height) };
+
     if (m_hasAlpha || componentSwapRequired) {
         uint8_t* surfaceData = static_cast<uint8_t*>(fastMalloc(height * stride));
         uint8_t* surfacePixel = surfaceData;
@@ -156,7 +158,7 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
         surface = adoptRef(cairo_image_surface_create_for_data(bufferData, CAIRO_FORMAT_ARGB32, width, height, stride));
 
     ASSERT(cairo_surface_status(surface.get()) == CAIRO_STATUS_SUCCESS);
-    m_image = BitmapImage::create(WTFMove(surface));
+    m_image = WTFMove(surface);
 
     if (GstVideoCropMeta* cropMeta = gst_buffer_get_video_crop_meta(buffer))
         setCropRect(FloatRect(cropMeta->x, cropMeta->y, cropMeta->width, cropMeta->height));

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -28,17 +28,23 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER) && USE(SKIA)
 
-#include "GStreamerCommon.h"
 #include "NotImplemented.h"
-#include <gst/gst.h>
-#include <gst/video/gstvideometa.h>
+#include <skia/ColorSpaceSkia.h>
 #include <skia/core/SkImage.h>
 
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 #include <skia/core/SkPixmap.h>
 IGNORE_CLANG_WARNINGS_END
 
+#include <wtf/StdLibExtras.h>
+#include <wtf/glib/WTFGType.h>
+
 namespace WebCore {
+
+struct BufferData {
+    std::span<const uint8_t> planeData;
+};
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(BufferData);
 
 ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     : m_sample(WTFMove(sample))
@@ -47,16 +53,14 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     if (UNLIKELY(!GST_IS_BUFFER(buffer)))
         return;
 
-    GstVideoInfo videoInfo;
-    if (!gst_video_info_from_caps(&videoInfo, gst_sample_get_caps(m_sample.get())))
-        return;
-
-    auto videoFrame = makeUnique<GstMappedFrame>(buffer, &videoInfo, GST_MAP_READ);
+    auto videoFrame = makeUnique<GstMappedFrame>(m_sample, GST_MAP_READ);
     if (!*videoFrame)
         return;
 
+    auto videoInfo = videoFrame->info();
+
     // The frame has to be RGB so we can paint it.
-    ASSERT(GST_VIDEO_INFO_IS_RGB(&videoInfo));
+    ASSERT(GST_VIDEO_INFO_IS_RGB(videoInfo));
 
     // The video buffer may have these formats in these cases:
     // { BGRx, BGRA } on little endian
@@ -91,17 +95,24 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
         break;
     }
 
+    m_size = { static_cast<float>(videoFrame->width()), static_cast<float>(videoFrame->height()) };
+
     auto toSkiaColorSpace = [](const PlatformVideoColorSpace&) {
         notImplemented();
         return SkColorSpace::MakeSRGB();
     };
-    auto imageInfo = SkImageInfo::Make(videoFrame->width(), videoFrame->height(), colorType, alphaType, toSkiaColorSpace(videoColorSpaceFromInfo(videoInfo)));
-    SkPixmap pixmap(imageInfo, videoFrame->planeData(0), videoFrame->planeStride(0));
-    auto image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
-        std::unique_ptr<GstMappedFrame> videoFrame(static_cast<GstMappedFrame*>(context));
-    }, videoFrame.release());
+    auto imageInfo = SkImageInfo::Make(videoFrame->width(), videoFrame->height(), colorType, alphaType, toSkiaColorSpace(videoColorSpaceFromInfo(*videoInfo)));
 
-    m_image = BitmapImage::create(WTFMove(image));
+    // Copy the buffer data. Keeping the whole mapped GstVideoFrame alive would increase memory
+    // pressure and the file descriptor(s) associated with the buffer pool open. We only need the
+    // data here.
+    auto bufferData = createBufferData();
+    bufferData->planeData = { reinterpret_cast<const uint8_t*>(videoFrame->planeData(0)), static_cast<unsigned>(videoFrame->planeStride(0)) };
+
+    SkPixmap pixmap(imageInfo, bufferData->planeData.data(), bufferData->planeData.size_bytes());
+    m_image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
+        destroyBufferData(reinterpret_cast<BufferData*>(context));
+    }, bufferData);
 
     if (auto* cropMeta = gst_buffer_get_video_crop_meta(buffer))
         m_cropRect = FloatRect(cropMeta->x, cropMeta->y, cropMeta->width, cropMeta->height);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -54,6 +54,8 @@ public:
     PlatformSample::Type platformSampleType() const override { return PlatformSample::GStreamerSampleType; }
     void dump(PrintStream&) const override;
 
+    const GRefPtr<GstSample>& sample() const { return m_sample; }
+
 protected:
     MediaSampleGStreamer(GRefPtr<GstSample>&&, const FloatSize& presentationSize, TrackID);
     virtual ~MediaSampleGStreamer() = default;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -24,6 +24,7 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
+#include "BitmapImage.h"
 #include "GLContext.h"
 #include "GStreamerCommon.h"
 #include "GraphicsContext.h"
@@ -82,7 +83,7 @@ static RefPtr<ImageGStreamer> convertSampleToImage(const GRefPtr<GstSample>& sam
     if (!convertedSample)
         return nullptr;
 
-    return ImageGStreamer::createImage(WTFMove(convertedSample));
+    return ImageGStreamer::create(WTFMove(convertedSample));
 }
 
 RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
@@ -540,7 +541,7 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
     callback({ });
 }
 
-void VideoFrame::paintInContext(GraphicsContext & context, const FloatRect& destination, const ImageOrientation& destinationImageOrientation, bool shouldDiscardAlpha)
+void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& destination, const ImageOrientation& destinationImageOrientation, bool shouldDiscardAlpha)
 {
     auto image = convertSampleToImage(downcast<VideoFrameGStreamer>(*this).sample());
     if (!image)
@@ -549,7 +550,11 @@ void VideoFrame::paintInContext(GraphicsContext & context, const FloatRect& dest
     auto imageRect = image->rect();
     auto source = destinationImageOrientation.usesWidthAsHeight() ? FloatRect(imageRect.location(), imageRect.size().transposedSize()) : imageRect;
     auto compositeOperator = !shouldDiscardAlpha && image->hasAlpha() ? CompositeOperator::SourceOver : CompositeOperator::Copy;
-    context.drawImage(image->image(), destination, source, { compositeOperator, destinationImageOrientation });
+    auto platformImage = image->image();
+    auto bitmapImage = BitmapImage::create(WTFMove(platformImage));
+    if (!bitmapImage)
+        return;
+    context.drawImage(*bitmapImage.get(), destination, source, { compositeOperator, destinationImageOrientation });
 }
 
 uint32_t VideoFrameGStreamer::pixelFormat() const


### PR DESCRIPTION
#### f5bc5e55ae85bcd192d63e135c7007999c2f7f2a
<pre>
[GStreamer] GstVideoFrame leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=274257">https://bugs.webkit.org/show_bug.cgi?id=274257</a>

Reviewed by Xabier Rodriguez-Calvar.

The ImageGStreamer no longer holds a BitmapImage, but a PlatformImagePtr. A BitmapImage is now
created by VideoFrameGStreamer when painting is required. The ImageGStreamerSkia implementation no
longer holds the mapped GstVideoFrame because that keeps un-necessary references and file
descriptors open, the needed plane data is copied instead. The static ImageDecoderGStreamer vector
now stores WeakPtrs instead of RefPtr, which semantically more correct but in practice makes no difference.

* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ensureDebugCategoryIsInitialized):
(WebCore::teardownGStreamerImageDecoders):
(WebCore::ImageDecoderGStreamer::create):
(WebCore::ImageDecoderGStreamer::ImageDecoderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h:
(WebCore::ImageGStreamer::create):
(WebCore::ImageGStreamer::image const):
(WebCore::ImageGStreamer::rect):
(WebCore::ImageGStreamer::createImage): Deleted.
(WebCore::ImageGStreamer::image): Deleted.
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h:
(WebCore::MediaSampleGStreamer::sample const):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::convertSampleToImage):
(WebCore::VideoFrame::paintInContext):

Canonical link: <a href="https://commits.webkit.org/279052@main">https://commits.webkit.org/279052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a29e1fbf5b295eb04a10700d2e3e0cb40ccf58d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42462 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1857 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26412 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2307 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57048 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49856 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49090 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11434 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->