### PR TITLE
Adopt more smart pointers in rendering/mathml

### DIFF
--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -75,8 +75,8 @@ bool RenderMathMLBlock::isChildAllowed(const RenderObject& child, const RenderSt
 static LayoutUnit axisHeight(const RenderStyle& style)
 {
     // If we have a MATH table we just return the AxisHeight constant.
-    const auto& primaryFont = style.fontCascade().primaryFont();
-    if (auto* mathData = primaryFont.mathData())
+    const Ref primaryFont = style.fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData())
         return LayoutUnit(mathData->getMathConstant(primaryFont, OpenTypeMathData::AxisHeight));
 
     // Otherwise, the idea is to try and use the middle of operators as the math axis which we thus approximate by "half of the x-height".

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
@@ -60,17 +60,17 @@ RenderMathMLFenced::~RenderMathMLFenced() = default;
 
 void RenderMathMLFenced::updateFromElement()
 {
-    const auto& fenced = element();
+    const Ref fenced = element();
 
     // The open operator defaults to a left parenthesis.
-    auto& open = fenced.attributeWithoutSynchronization(MathMLNames::openAttr);
+    auto& open = fenced->attributeWithoutSynchronization(MathMLNames::openAttr);
     m_open = open.isNull() ? gOpeningBraceChar : open;
 
     // The close operator defaults to a right parenthesis.
-    auto& close = fenced.attributeWithoutSynchronization(MathMLNames::closeAttr);
+    auto& close = fenced->attributeWithoutSynchronization(MathMLNames::closeAttr);
     m_close = close.isNull() ? gClosingBraceChar : close;
 
-    auto& separators = fenced.attributeWithoutSynchronization(MathMLNames::separatorsAttr);
+    auto& separators = fenced->attributeWithoutSynchronization(MathMLNames::separatorsAttr);
     if (!separators.isNull()) {
         StringBuilder characters;
         for (unsigned i = 0; i < separators.length(); i++) {

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -74,8 +74,8 @@ RenderBox& RenderMathMLFraction::denominator() const
 
 LayoutUnit RenderMathMLFraction::defaultLineThickness() const
 {
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    if (const auto* mathData = primaryFont.mathData())
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData())
         return LayoutUnit(mathData->getMathConstant(primaryFont, OpenTypeMathData::FractionRuleThickness));
     return ruleThicknessFallback();
 }
@@ -101,10 +101,9 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::fractionParameter
     LayoutUnit numeratorGapMin, denominatorGapMin, numeratorMinShiftUp, denominatorMinShiftDown;
 
     // We try and read constants to draw the fraction from the OpenType MATH and use fallback values otherwise.
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    const auto* mathData = style().fontCascade().primaryFont().mathData();
     bool display = style().mathStyle() == MathStyle::Normal;
-    if (mathData) {
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData()) {
         numeratorGapMin = mathData->getMathConstant(primaryFont, display ? OpenTypeMathData::FractionNumDisplayStyleGapMin : OpenTypeMathData::FractionNumeratorGapMin);
         denominatorGapMin = mathData->getMathConstant(primaryFont, display ? OpenTypeMathData::FractionDenomDisplayStyleGapMin : OpenTypeMathData::FractionDenominatorGapMin);
         numeratorMinShiftUp = mathData->getMathConstant(primaryFont, display ? OpenTypeMathData::FractionNumeratorDisplayStyleShiftUp : OpenTypeMathData::FractionNumeratorShiftUp);
@@ -140,10 +139,9 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::stackParameters()
     LayoutUnit gapMin;
     
     // We try and read constants to draw the stack from the OpenType MATH and use fallback values otherwise.
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    const auto* mathData = style().fontCascade().primaryFont().mathData();
     bool display = style().mathStyle() == MathStyle::Normal;
-    if (mathData) {
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData()) {
         gapMin = mathData->getMathConstant(primaryFont, display ? OpenTypeMathData::StackDisplayStyleGapMin : OpenTypeMathData::StackGapMin);
         parameters.numeratorShiftUp = mathData->getMathConstant(primaryFont, display ? OpenTypeMathData::StackTopDisplayStyleShiftUp : OpenTypeMathData::StackTopShiftUp);
         parameters.denominatorShiftDown = mathData->getMathConstant(primaryFont, display ? OpenTypeMathData::StackBottomDisplayStyleShiftDown : OpenTypeMathData::StackBottomShiftDown);

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -111,8 +111,8 @@ RenderMathMLRoot::HorizontalParameters RenderMathMLRoot::horizontalParameters()
         return parameters;
 
     // We try and read constants to draw the radical from the OpenType MATH and use fallback values otherwise.
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    if (auto* mathData = style().fontCascade().primaryFont().mathData()) {
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData()) {
         parameters.kernBeforeDegree = mathData->getMathConstant(primaryFont, OpenTypeMathData::RadicalKernBeforeDegree);
         parameters.kernAfterDegree = mathData->getMathConstant(primaryFont, OpenTypeMathData::RadicalKernAfterDegree);
     } else {
@@ -128,8 +128,8 @@ RenderMathMLRoot::VerticalParameters RenderMathMLRoot::verticalParameters()
 {
     VerticalParameters parameters;
     // We try and read constants to draw the radical from the OpenType MATH and use fallback values otherwise.
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    if (auto* mathData = style().fontCascade().primaryFont().mathData()) {
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData()) {
         parameters.ruleThickness = mathData->getMathConstant(primaryFont, OpenTypeMathData::RadicalRuleThickness);
         parameters.verticalGap = mathData->getMathConstant(primaryFont, style().mathStyle() == MathStyle::Normal ? OpenTypeMathData::RadicalDisplayStyleVerticalGap : OpenTypeMathData::RadicalVerticalGap);
         parameters.extraAscender = mathData->getMathConstant(primaryFont, OpenTypeMathData::RadicalExtraAscender);

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -157,8 +157,8 @@ std::optional<RenderMathMLScripts::ReferenceChildren> RenderMathMLScripts::valid
 
 LayoutUnit RenderMathMLScripts::spaceAfterScript()
 {
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    if (auto* mathData = primaryFont.mathData())
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData())
         return LayoutUnit(mathData->getMathConstant(primaryFont, OpenTypeMathData::SpaceAfterScript));
     return LayoutUnit(style().fontCascade().size() / 5);
 }
@@ -231,8 +231,8 @@ void RenderMathMLScripts::computePreferredLogicalWidths()
 auto RenderMathMLScripts::verticalParameters() const -> VerticalParameters
 {
     VerticalParameters parameters;
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    if (auto* mathData = primaryFont.mathData()) {
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    if (RefPtr mathData = primaryFont->mathData()) {
         parameters.subscriptShiftDown = mathData->getMathConstant(primaryFont, OpenTypeMathData::SubscriptShiftDown);
         parameters.superscriptShiftUp = mathData->getMathConstant(primaryFont, OpenTypeMathData::SuperscriptShiftUp);
         parameters.subscriptBaselineDropMin = mathData->getMathConstant(primaryFont, OpenTypeMathData::SubscriptBaselineDropMin);

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -56,16 +56,16 @@ void RenderMathMLSpace::computePreferredLogicalWidths()
 
 LayoutUnit RenderMathMLSpace::spaceWidth() const
 {
-    auto& spaceElement = element();
+    Ref spaceElement = element();
     // FIXME: Negative width values are not supported yet.
-    return std::max<LayoutUnit>(0, toUserUnits(spaceElement.width(), style(), 0));
+    return std::max<LayoutUnit>(0, toUserUnits(spaceElement->width(), style(), 0));
 }
 
 void RenderMathMLSpace::getSpaceHeightAndDepth(LayoutUnit& height, LayoutUnit& depth) const
 {
-    auto& spaceElement = element();
-    height = toUserUnits(spaceElement.height(), style(), 0);
-    depth = toUserUnits(spaceElement.depth(), style(), 0);
+    Ref spaceElement = element();
+    height = toUserUnits(spaceElement->height(), style(), 0);
+    depth = toUserUnits(spaceElement->depth(), style(), 0);
 
     // If the total height is negative, set vertical dimensions to 0.
     if (height + depth < 0) {

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -534,11 +534,11 @@ void RenderMathMLToken::updateMathVariantGlyph()
             return;
     }
 
-    const auto& tokenElement = element();
+    const Ref tokenElement = element();
     if (auto codePoint = MathMLTokenElement::convertToSingleCodePoint(element().textContent())) {
         MathMLElement::MathVariant mathvariant = mathMLStyle().mathVariant();
         if (mathvariant == MathMLElement::MathVariant::None)
-            mathvariant = tokenElement.hasTagName(MathMLNames::miTag) ? MathMLElement::MathVariant::Italic : MathMLElement::MathVariant::Normal;
+            mathvariant = tokenElement->hasTagName(MathMLNames::miTag) ? MathMLElement::MathVariant::Italic : MathMLElement::MathVariant::Normal;
         char32_t transformedCodePoint = mathVariant(codePoint.value(), mathvariant);
         if (transformedCodePoint != codePoint.value()) {
             m_mathVariantCodePoint = mathVariant(codePoint.value(), mathvariant);

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -244,8 +244,8 @@ RenderMathMLUnderOver::VerticalParameters RenderMathMLUnderOver::verticalParamet
     parameters.overExtraAscender = 0;
     parameters.accentBaseHeight = 0;
 
-    const auto& primaryFont = style().fontCascade().primaryFont();
-    auto* mathData = primaryFont.mathData();
+    const Ref primaryFont = style().fontCascade().primaryFont();
+    RefPtr mathData = primaryFont->mathData();
     if (!mathData) {
         // The MATH table specification does not really provide any suggestions, except for some underbar/overbar values and AccentBaseHeight.
         LayoutUnit defaultLineThickness = ruleThicknessFallback();


### PR DESCRIPTION
#### 63e956ceca0793f620202fd952c2286f15379827
<pre>
Adopt more smart pointers in rendering/mathml
<a href="https://bugs.webkit.org/show_bug.cgi?id=274384">https://bugs.webkit.org/show_bug.cgi?id=274384</a>

Reviewed by Sihui Liu.

Adopt more smart pointers in endering/mathml based on the
[alpha.webkit.UncountedLocalVarsChecker] warning.

* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::axisHeight):
* Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp:
(WebCore::RenderMathMLFenced::updateFromElement):
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::defaultLineThickness const):
(WebCore::RenderMathMLFraction::fractionParameters const):
(WebCore::RenderMathMLFraction::stackParameters const):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::horizontalParameters):
(WebCore::RenderMathMLRoot::verticalParameters):
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::spaceAfterScript):
(WebCore::RenderMathMLScripts::verticalParameters const):
* Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
(WebCore::RenderMathMLSpace::spaceWidth const):
(WebCore::RenderMathMLSpace::getSpaceHeightAndDepth const):
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::RenderMathMLToken::updateMathVariantGlyph):
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
(WebCore::RenderMathMLUnderOver::verticalParameters const):

Canonical link: <a href="https://commits.webkit.org/279042@main">https://commits.webkit.org/279042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a922302ccff0efb0d22dcdbaa2bda6e2b8dd226f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55452 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42463 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1858 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57049 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49858 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45150 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49095 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11429 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->