### PR TITLE
Adopt more smart pointers in mathml

### DIFF
--- a/Source/WebCore/mathml/MathMLAnnotationElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.cpp
@@ -78,7 +78,7 @@ bool MathMLAnnotationElement::childShouldCreateRenderer(const Node& child) const
 void MathMLAnnotationElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)
 {
     if (name == MathMLNames::srcAttr || name == MathMLNames::encodingAttr) {
-        auto* parent = parentElement();
+        RefPtr parent = parentElement();
         if (is<MathMLElement>(parent) && parent->hasTagName(semanticsTag))
             downcast<MathMLElement>(*parent).updateSelectedChild();
     }

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -246,8 +246,8 @@ void MathMLElement::defaultEventHandler(Event& event)
         if (MouseEvent::canTriggerActivationBehavior(event)) {
             const auto& href = attributeWithoutSynchronization(hrefAttr);
             event.setDefaultHandled();
-            if (auto* frame = document().frame())
-                frame->loader().changeLocation(document().completeURL(href), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
+            if (RefPtr frame = document().frame())
+                frame->checkedLoader()->changeLocation(document().completeURL(href), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
             return;
         }
     }

--- a/Source/WebCore/mathml/MathMLRowElement.cpp
+++ b/Source/WebCore/mathml/MathMLRowElement.cpp
@@ -54,9 +54,9 @@ Ref<MathMLRowElement> MathMLRowElement::create(const QualifiedName& tagName, Doc
 
 void MathMLRowElement::childrenChanged(const ChildChange& change)
 {
-    for (auto child = firstChild(); child; child = child->nextSibling()) {
+    for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
         if (child->hasTagName(moTag))
-            static_cast<MathMLOperatorElement*>(child)->setOperatorFormDirty();
+            static_cast<MathMLOperatorElement*>(child.get())->setOperatorFormDirty();
     }
 
     MathMLPresentationElement::childrenChanged(change);

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -47,7 +47,6 @@ using namespace MathMLNames;
 
 MathMLSelectElement::MathMLSelectElement(const QualifiedName& tagName, Document& document)
     : MathMLRowElement(tagName, document)
-    , m_selectedChild(nullptr)
 {
 }
 
@@ -134,9 +133,9 @@ Element* MathMLSelectElement::getSelectedActionChild()
 {
     ASSERT(hasTagName(mactionTag));
 
-    auto* child = firstElementChild();
+    RefPtr child = firstElementChild();
     if (!child)
-        return child;
+        return nullptr;
 
     // The value of the actiontype attribute is case-sensitive.
     auto& actiontype = attributeWithoutSynchronization(MathMLNames::actiontypeAttr);
@@ -148,17 +147,19 @@ Element* MathMLSelectElement::getSelectedActionChild()
         { }
     } else {
         // For the "toggle" action type or any unknown action type, we rely on the value of the selection attribute to determine the visible child.
-        getSelectedActionChildAndIndex(child);
+        Element* selectedChild;
+        getSelectedActionChildAndIndex(selectedChild);
+        child = selectedChild;
     }
 
-    return child;
+    return child.get();
 }
 
 Element* MathMLSelectElement::getSelectedSemanticsChild()
 {
     ASSERT(hasTagName(semanticsTag));
 
-    auto* child = firstElementChild();
+    RefPtr child = firstElementChild();
     if (!child)
         return nullptr;
 
@@ -167,7 +168,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
         child = child->nextElementSibling();
     } else if (!downcast<MathMLElement>(*child).isSemanticAnnotation()) {
         // The first child is a presentation MathML but not an annotation, so we can just display it.
-        return child;
+        return child.get();
     }
     // Otherwise, the first child is an <annotation> or <annotation-xml> element. This is invalid, but some people use this syntax so we take care of this case too and start the search from this first child.
 
@@ -180,7 +181,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
             if (child->hasAttributeWithoutSynchronization(MathMLNames::srcAttr))
                 continue;
             // Otherwise, we assume it is a text annotation that can always be displayed and we stop here.
-            return child;
+            return child.get();
         }
 
         if (child->hasTagName(MathMLNames::annotation_xmlTag)) {
@@ -190,7 +191,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
             // If the <annotation-xml> element has an encoding attribute describing presentation MathML, SVG or HTML we assume the content can be displayed and we stop here.
             auto& value = child->attributeWithoutSynchronization(MathMLNames::encodingAttr);
             if (isMathMLEncoding(value) || isSVGEncoding(value) || isHTMLEncoding(value))
-                return child;
+                return child.get();
         }
     }
 


### PR DESCRIPTION
#### 71b00c93fe19cd323da86c8b97de37219cb19ed4
<pre>
Adopt more smart pointers in mathml
<a href="https://bugs.webkit.org/show_bug.cgi?id=274388">https://bugs.webkit.org/show_bug.cgi?id=274388</a>

Reviewed by Sihui Liu.

Adopt more smart pointers in mathml based on the
[alpha.webkit.UncountedLocalVarsChecker] warning.

* Source/WebCore/mathml/MathMLAnnotationElement.cpp:
(WebCore::MathMLAnnotationElement::attributeChanged):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::defaultEventHandler):
* Source/WebCore/mathml/MathMLRowElement.cpp:
(WebCore::MathMLRowElement::childrenChanged):
* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::MathMLSelectElement):
(WebCore::MathMLSelectElement::getSelectedActionChild):
(WebCore::MathMLSelectElement::getSelectedSemanticsChild):

Canonical link: <a href="https://commits.webkit.org/279070@main">https://commits.webkit.org/279070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/473142226145a2ed0d1e081c3f6d0b8fd0409ec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2846 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2014 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54520 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23708 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1306 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45368 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11447 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->