### PR TITLE
[GTK][WPE]: Regression (278519@main): build error with gcc 12.3.0

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h
@@ -47,7 +47,7 @@ struct MetaResolver : Base {
 
     static ResultType resolve(const typename MetaConsumeResult<Ts...>::type& consumeResult, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
     {
-        return WTF::switchOn(consumeResult, [&](auto value) -> ResultType {
+        return WTF::switchOn(consumeResult, [&](auto& value) -> ResultType {
             return Base::resolve(value, symbolTable, options);
         });
     }


### PR DESCRIPTION
#### d77aeedaad489af1a0b49016acc044ec08caafca
<pre>
[GTK][WPE]: Regression (278519@main): build error with gcc 12.3.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=274072">https://bugs.webkit.org/show_bug.cgi?id=274072</a>

Reviewed by Sam Weinig.

To parse a CSS time value in `CSSPropertyParserHelpers::consumeTime()`,
we call `CSSPrimitiveValueResolver&lt;TimeRaw&gt;::consumeAndResolve()` static
method.

This method consumes a range of tokens, creates a `MetaConsumeResult`,
which is essentially a `std::variant&lt;TimeRow, UnevaluatedCalc&lt;TimeRaw&gt;`,
and passes it to `CSSPrimitiveValueResolver&lt;TimeRaw&gt;::resolve()`.

Then `WTF::switchOn()` is used to get the `consumeResult` value.
Beacuse `UnevaluatedCalc` is a struct that includes
a `Ref&lt;CSSCalcValue&gt;` `calc`, and it is passed by value to
`WTF::switchOn()` lambda, GCC believes that it&apos;s there is a possibility
of the `calc` value being destroyed but still reachable.

Passing `consumeResult` value by reference fixes the warning and reduces
reference-counting churn.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h:
(WebCore::CSSPropertyParserHelpers::MetaResolver::resolve):

Canonical link: <a href="https://commits.webkit.org/279040@main">https://commits.webkit.org/279040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba44c3df0c0cc0840014c0e9d6ed1df3f5c2c727

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42475 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49867 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49104 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->