### PR TITLE
Nullptr crash due to `display:block ruby` and continuations

### DIFF
--- a/LayoutTests/fast/ruby/ruby-block-continuation-crash-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-block-continuation-crash-expected.txt
@@ -1,0 +1,3 @@
+base with
+forced
+line break annotation This test passes if it doesn't crash.

--- a/LayoutTests/fast/ruby/ruby-block-continuation-crash.html
+++ b/LayoutTests/fast/ruby/ruby-block-continuation-crash.html
@@ -1,0 +1,9 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<ruby style="position: absolute">
+  <rb><span>base with <div>forced</div> line break</span></rb>
+  <rt>annotation</rt>
+</ruby>
+This test passes if it doesn't crash.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -65,10 +65,17 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
     if (!child.isRenderText() && child.style().display() == DisplayType::Ruby && parent.style().display() == DisplayType::RubyBlock)
         return parent;
 
-    if (parent.style().display() == DisplayType::RubyBlock && parent.firstChild()) {
+    if (parent.style().display() == DisplayType::RubyBlock) {
         // See if we have an anonymous ruby box already.
-        ASSERT(parent.firstChild()->style().display() == DisplayType::Ruby);
-        return downcast<RenderElement>(*parent.firstChild());
+        // FIXME: It should be the immediate child but continuations can break this assumption.
+        for (CheckedPtr first = parent.firstChild(); first; first = first->firstChildSlow()) {
+            if (!first->isAnonymous()) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+            if (first->style().display() == DisplayType::Ruby)
+                return downcast<RenderElement>(*first);
+        }
     }
 
     if (parent.style().display() != DisplayType::Ruby) {


### PR DESCRIPTION
#### c2f9092d3a8e7bf63dd1c55c9917cd391fff2665
<pre>
Nullptr crash due to `display:block ruby` and continuations
<a href="https://bugs.webkit.org/show_bug.cgi?id=268770">https://bugs.webkit.org/show_bug.cgi?id=268770</a>
<a href="https://rdar.apple.com/121960530">rdar://121960530</a>

Reviewed by Alan Baradlay.

Continuations may end up splitting anonymous &apos;display:ruby&apos; box inside block ruby.

* LayoutTests/fast/ruby/ruby-block-continuation-crash-expected.txt: Added.
* LayoutTests/fast/ruby/ruby-block-continuation-crash.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):

Find the correct anonymous box from nested continuation structure.

Canonical link: <a href="https://commits.webkit.org/279005@main">https://commits.webkit.org/279005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/315a60c01d7f8bd81b3a2dea8c6dc5ed20597ed7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54505 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/37961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2622 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1877 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23557 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26433 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2328 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57071 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2529 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45170 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11414 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->