### PR TITLE
[WGSL] Type checker does not handle shadowing of overloaded built-ins correctly

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
@@ -30,3 +30,32 @@ fn f4() {
     // CHECK-L: cannot initialize variable with expression of type 'void'
     let x = f3();
 }
+
+@group(0) @binding(0) var<storage, read_write> x: array<f32>;
+fn f5()
+{
+    let arrayLength = 1;
+    // CHECK-L: cannot call value of type 'i32'
+    _ = arrayLength(&x);
+}
+
+fn f6()
+{
+    let array = 1f;
+    // CHECK-L: cannot call value of type 'f32'
+    _ = array<i32, 1>(1);
+}
+
+fn f7()
+{
+    let vec2 = 1u;
+    // CHECK-L: cannot call value of type 'u32'
+    _ = vec2<i32>(1);
+}
+
+fn f8()
+{
+    let bitcast = 1h;
+    // CHECK-L: cannot call value of type 'f16'
+    _ = bitcast<i32>(1);
+}


### PR DESCRIPTION
#### 7db8345cbe6b5da4ca87617e866b1f6bac6f4a65
<pre>
[WGSL] Type checker does not handle shadowing of overloaded built-ins correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=274391">https://bugs.webkit.org/show_bug.cgi?id=274391</a>
<a href="https://rdar.apple.com/128202008">rdar://128202008</a>

Reviewed by Mike Wyrzykowski.

The type checker incorrectly looked up the built-in definition even there was another
definition shadowing it.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/function-call.wgsl:

Canonical link: <a href="https://commits.webkit.org/279053@main">https://commits.webkit.org/279053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/151c2cdcd2b9a2a854400d690bd743788d466817

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2918 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42480 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45048 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23550 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26427 "Found unexpected failure with change (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1077 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57065 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49872 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11435 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->