### PR TITLE
[Navigation] Support "initial about:blank document" logic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL currententrychange does not fire when navigating away from the initial about:blank assert_unreached: currententrychange should not fire Reached unreachable code
+PASS currententrychange does not fire when navigating away from the initial about:blank
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange does not fire when navigating away from the initial about:blank (popup window) assert_unreached: currententrychange should not fire Reached unreachable code
+PASS currententrychange does not fire when navigating away from the initial about:blank (popup window)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-initial-about-blank-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-initial-about-blank-unserializablestate-expected.txt
@@ -1,6 +1,4 @@
 
 
-FAIL updateCurrentEntry() with unserializable state on the initial about:blank must throw an "InvalidStateError", not a "DataCloneError" assert_throws_dom: function "() => {
-    iframe.contentWindow.navigation.updateCurrentEntry({ state: document.body });
-  }" threw object "DataCloneError: The object can not be cloned." that is not a DOMException InvalidStateError: property "code" is equal to 25, expected 11
+PASS updateCurrentEntry() with unserializable state on the initial about:blank must throw an "InvalidStateError", not a "DataCloneError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/initial-about-blank-expected.txt
@@ -1,6 +1,4 @@
 
 
-FAIL updateCurrentEntry() must throw if the document is still on the initial about:blank assert_throws_dom: function "() => {
-    iframe.contentWindow.navigation.updateCurrentEntry({ state: 1 });
-  }" did not throw
+PASS updateCurrentEntry() must throw if the document is still on the initial about:blank
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2057,7 +2057,8 @@ bool DocumentLoader::maybeLoadEmpty()
     String mimeType = shouldLoadEmpty ? textHTMLContentTypeAtom() : frameLoader()->client().generatedMIMETypeForURLScheme(m_request.url().protocol());
     m_response = ResourceResponse(m_request.url(), mimeType, 0, "UTF-8"_s);
 
-    if (!frameLoader()->stateMachine().isDisplayingInitialEmptyDocument()) {
+    bool isDisplayingInitialEmptyDocument = frameLoader()->stateMachine().isDisplayingInitialEmptyDocument();
+    if (!isDisplayingInitialEmptyDocument) {
         if (auto coopEnforcementResult = doCrossOriginOpenerHandlingOfResponse(m_response)) {
             m_responseCOOP = coopEnforcementResult->crossOriginOpenerPolicy;
             if (coopEnforcementResult->needsBrowsingContextGroupSwitch)
@@ -2066,6 +2067,7 @@ bool DocumentLoader::maybeLoadEmpty()
     }
 
     SetForScope isInFinishedLoadingOfEmptyDocument { m_isInFinishedLoadingOfEmptyDocument, true };
+    m_isInitialAboutBlank = isDisplayingInitialEmptyDocument;
     finishedLoading();
     return true;
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -508,6 +508,8 @@ public:
     uint64_t navigationID() const { return m_navigationID; }
     WEBCORE_EXPORT void setNavigationID(uint64_t);
 
+    bool isInitialAboutBlank() const { return m_isInitialAboutBlank; }
+
 protected:
     WEBCORE_EXPORT DocumentLoader(const ResourceRequest&, const SubstituteData&);
 
@@ -748,6 +750,7 @@ private:
     bool m_isLoadingMultipartContent { false };
     bool m_isContinuingLoadAfterProvisionalLoadStarted { false };
     bool m_isInFinishedLoadingOfEmptyDocument { false };
+    bool m_isInitialAboutBlank { false };
 
     // FIXME: Document::m_processingLoadEvent and DocumentLoader::m_wasOnloadDispatched are roughly the same
     // and should be merged.

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -29,6 +29,7 @@
 #include "AbortController.h"
 #include "CallbackResult.h"
 #include "DOMFormData.h"
+#include "DocumentLoader.h"
 #include "ErrorEvent.h"
 #include "EventNames.h"
 #include "Exception.h"
@@ -415,6 +416,8 @@ ExceptionOr<void> Navigation::updateCurrentEntry(UpdateCurrentEntryOptions&& opt
 bool Navigation::hasEntriesAndEventsDisabled() const
 {
     if (!window()->document() || !window()->document()->isFullyActive())
+        return true;
+    if (window()->document()->loader() && window()->document()->loader()->isInitialAboutBlank())
         return true;
     if (window()->securityOrigin() && window()->securityOrigin()->isOpaque())
         return true;


### PR DESCRIPTION
#### 5a53929d85a19d356f2d0c0b40a13e84165db281
<pre>
[Navigation] Support &quot;initial about:blank document&quot; logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=274393">https://bugs.webkit.org/show_bug.cgi?id=274393</a>

Reviewed by Darin Adler.

Keep track of the &quot;initial about:blank document&quot; flag and check it in
the &quot;has entries and events disabled&quot; algorithm.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#has-entries-and-events-disabled">https://html.spec.whatwg.org/multipage/nav-history-apis.html#has-entries-and-events-disabled</a> (Step 3)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-initial-about-blank-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/initial-about-blank-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::maybeLoadEmpty):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::isInitialAboutBlank const):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::hasEntriesAndEventsDisabled const):

Canonical link: <a href="https://commits.webkit.org/280378@main">https://commits.webkit.org/280378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a94e87cd7b1ff2a1785f540cdd699936f047795b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45730 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4822 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6045 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5896 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52885 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/324 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->