### PR TITLE
[JSC] Use Data Call IC in Handler IC

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -26,7 +26,7 @@ types [
 
     :BasicBlockLocation,
     :BoundLabel,
-    :BaselineCallLinkInfo,
+    :DataOnlyCallLinkInfo,
     :DebugHookType,
     :ECMAMode,
     :ErrorTypeWithExtension,
@@ -95,7 +95,7 @@ op :tail_call_varargs,
         firstVarArg: int,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
     },
     tmps: {
         argCountIncludingThis: unsigned
@@ -116,7 +116,7 @@ op :call_varargs,
         valueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
     },
     tmps: {
         argCountIncludingThis: unsigned,
@@ -140,7 +140,7 @@ op :iterator_next,
         valueValueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
         doneModeMetadata: GetByIdModeMetadata,
         valueModeMetadata: GetByIdModeMetadata,
         iterableProfile: ArrayProfile,
@@ -166,7 +166,7 @@ op :construct_varargs,
         valueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
     },
     tmps: {
         argCountIncludingThis: unsigned
@@ -192,7 +192,7 @@ op :iterator_open,
         nextValueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
         modeMetadata: GetByIdModeMetadata,
         arrayProfile: ArrayProfile,
         iterationMetadata: IterationModeMetadata,
@@ -247,7 +247,7 @@ op :construct,
         valueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
     }
 
 op :tail_call,
@@ -258,7 +258,7 @@ op :tail_call,
         argv: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
         arrayProfile: ArrayProfile,
     }
 
@@ -274,7 +274,7 @@ op :call_direct_eval,
         valueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
     }
 
 op :tail_call_forward_arguments,
@@ -287,7 +287,7 @@ op :tail_call_forward_arguments,
         firstVarArg: int,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
     }
 
 op_group :CreateInternalFieldObjectOp,
@@ -405,7 +405,7 @@ op :call,
         valueProfile: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
         arrayProfile: ArrayProfile,
     }
 
@@ -416,7 +416,7 @@ op :call_ignore_result,
         argv: unsigned,
     },
     metadata: {
-        callLinkInfo: BaselineCallLinkInfo,
+        callLinkInfo: DataOnlyCallLinkInfo,
         arrayProfile: ArrayProfile,
     }
 

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -134,7 +134,7 @@ void CallLinkInfo::unlinkOrUpgradeImpl(VM& vm, CodeBlock* oldCodeBlock, CodeBloc
 CodeLocationLabel<JSInternalPtrTag> CallLinkInfo::doneLocationIfExists()
 {
     switch (type()) {
-    case Type::Baseline:
+    case Type::DataOnly:
         return { };
     case Type::Optimizing:
 #if ENABLE(JIT)
@@ -280,14 +280,14 @@ void CallLinkInfo::revertCallToStub()
     }
 }
 
-void BaselineCallLinkInfo::initialize(VM& vm, CodeBlock* owner, CallType callType, BytecodeIndex bytecodeIndex)
+void DataOnlyCallLinkInfo::initialize(VM& vm, CodeBlock* owner, CallType callType, CodeOrigin codeOrigin)
 {
     m_owner = owner;
-    m_type = static_cast<unsigned>(Type::Baseline);
-    ASSERT(Type::Baseline == type());
+    m_type = static_cast<unsigned>(Type::DataOnly);
+    ASSERT(Type::DataOnly == type());
     m_useDataIC = static_cast<unsigned>(UseDataIC::Yes);
     ASSERT(UseDataIC::Yes == useDataIC());
-    m_bytecodeIndex = bytecodeIndex;
+    m_codeOrigin = codeOrigin;
     m_callType = callType;
     m_mode = static_cast<unsigned>(Mode::Init);
     // If JIT is disabled, we should not support dynamically generated call IC.
@@ -326,7 +326,7 @@ void CallLinkInfo::reset(VM&)
 
 void CallLinkInfo::revertCall(VM& vm)
 {
-    if (UNLIKELY(!Options::useLLIntICs() && type() == CallLinkInfo::Type::Baseline))
+    if (UNLIKELY(!Options::useLLIntICs() && type() == CallLinkInfo::Type::DataOnly))
         setVirtualCall(vm);
     else
         reset(vm);

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -55,7 +55,6 @@ struct CallFrameShuffleData;
 struct UnlinkedCallLinkInfo;
 struct BaselineUnlinkedCallLinkInfo;
 
-
 using CompileTimeCallLinkInfo = std::variant<OptimizingCallLinkInfo*, BaselineUnlinkedCallLinkInfo*, DFG::UnlinkedCallLinkInfo*>;
 
 class CallLinkInfo : public CallLinkInfoBase {
@@ -65,7 +64,7 @@ public:
     static constexpr uint8_t maxProfiledArgumentCountIncludingThisForVarargs = UINT8_MAX;
 
     enum class Type : uint8_t {
-        Baseline,
+        DataOnly,
         Optimizing,
     };
 
@@ -130,13 +129,13 @@ public:
 #if ENABLE(JIT)
 protected:
     static std::tuple<MacroAssembler::JumpList, MacroAssembler::Label> emitFastPathImpl(CallLinkInfo*, CCallHelpers&, UseDataIC, bool isTailCall, ScopedLambda<void()>&& prepareForTailCall) WARN_UNUSED_RETURN;
-    static std::tuple<MacroAssembler::JumpList, MacroAssembler::Label> emitDataICFastPath(CCallHelpers&) WARN_UNUSED_RETURN;
     static std::tuple<MacroAssembler::JumpList, MacroAssembler::Label> emitTailCallDataICFastPath(CCallHelpers&, ScopedLambda<void()>&& prepareForTailCall) WARN_UNUSED_RETURN;
 
     static void emitSlowPathImpl(VM&, CCallHelpers&, UseDataIC, bool isTailCall, MacroAssembler::Label);
     static void emitDataICSlowPath(VM&, CCallHelpers&, bool isTailCall, MacroAssembler::Label);
 
 public:
+    static std::tuple<MacroAssembler::JumpList, MacroAssembler::Label> emitDataICFastPath(CCallHelpers&) WARN_UNUSED_RETURN;
     static std::tuple<MacroAssembler::JumpList, MacroAssembler::Label> emitFastPath(CCallHelpers&, CompileTimeCallLinkInfo) WARN_UNUSED_RETURN;
     static std::tuple<MacroAssembler::JumpList, MacroAssembler::Label> emitTailCallFastPath(CCallHelpers&, CompileTimeCallLinkInfo, ScopedLambda<void()>&& prepareForTailCall) WARN_UNUSED_RETURN;
     static void emitSlowPath(VM&, CCallHelpers&, CompileTimeCallLinkInfo);
@@ -318,11 +317,12 @@ public:
     std::tuple<CodeBlock*, BytecodeIndex> retrieveCaller(JSCell* owner);
 
 protected:
-    CallLinkInfo(Type type, UseDataIC useDataIC, JSCell* owner)
+    CallLinkInfo(Type type, UseDataIC useDataIC, JSCell* owner, CodeOrigin codeOrigin)
         : CallLinkInfoBase(CallSiteType::CallLinkInfo)
         , m_useDataIC(static_cast<unsigned>(useDataIC))
         , m_type(static_cast<unsigned>(type))
         , m_owner(owner)
+        , m_codeOrigin(codeOrigin)
     {
         ASSERT(type == this->type());
         ASSERT(useDataIC == this->useDataIC());
@@ -364,21 +364,17 @@ protected:
     RefPtr<PolymorphicCallStubRoutine> m_stub;
 #endif
     JSCell* m_owner { nullptr };
+    CodeOrigin m_codeOrigin { };
 };
 
-class BaselineCallLinkInfo final : public CallLinkInfo {
+class DataOnlyCallLinkInfo final : public CallLinkInfo {
 public:
-    BaselineCallLinkInfo()
-        : CallLinkInfo(Type::Baseline, UseDataIC::Yes, nullptr)
+    DataOnlyCallLinkInfo()
+        : CallLinkInfo(Type::DataOnly, UseDataIC::Yes, nullptr, CodeOrigin { })
     {
     }
 
-    void initialize(VM&, CodeBlock*, CallType, BytecodeIndex);
-
-    CodeOrigin codeOrigin() const { return CodeOrigin { m_bytecodeIndex }; }
-
-private:
-    BytecodeIndex m_bytecodeIndex { };
+    void initialize(VM&, CodeBlock*, CallType, CodeOrigin);
 };
 
 struct UnlinkedCallLinkInfo {
@@ -499,13 +495,12 @@ public:
     friend class CallLinkInfo;
 
     OptimizingCallLinkInfo()
-        : CallLinkInfo(Type::Optimizing, UseDataIC::Yes, nullptr)
+        : CallLinkInfo(Type::Optimizing, UseDataIC::Yes, nullptr, CodeOrigin { })
     {
     }
 
     OptimizingCallLinkInfo(CodeOrigin codeOrigin, UseDataIC useDataIC, JSCell* owner)
-        : CallLinkInfo(Type::Optimizing, useDataIC, owner)
-        , m_codeOrigin(codeOrigin)
+        : CallLinkInfo(Type::Optimizing, useDataIC, owner, codeOrigin)
     {
     }
 
@@ -523,8 +518,6 @@ public:
 
     void setSlowPathCallDestination(CodePtr<JSEntryPtrTag>);
 
-    CodeOrigin codeOrigin() const { return m_codeOrigin; }
-
     void initializeFromDFGUnlinkedCallLinkInfo(VM&, const DFG::UnlinkedCallLinkInfo&, CodeBlock*);
 
     static ptrdiff_t offsetOfSlowPathCallDestination()
@@ -538,7 +531,6 @@ private:
     void emitSlowPath(VM&, CCallHelpers&);
     void emitTailCallSlowPath(VM&, CCallHelpers&, MacroAssembler::Label);
 
-    CodeOrigin m_codeOrigin;
     CodePtr<JSEntryPtrTag> m_slowPathCallDestination;
     CodeLocationNearCall<JSInternalPtrTag> m_callLocation NO_UNIQUE_ADDRESS;
     CodeLocationLabel<JSInternalPtrTag> m_doneLocation;
@@ -548,17 +540,7 @@ private:
 
 inline CodeOrigin CallLinkInfo::codeOrigin() const
 {
-    switch (type()) {
-    case Type::Baseline:
-        return static_cast<const BaselineCallLinkInfo*>(this)->codeOrigin();
-    case Type::Optimizing:
-#if ENABLE(JIT)
-        return static_cast<const OptimizingCallLinkInfo*>(this)->codeOrigin();
-#else
-        return { };
-#endif
-    }
-    return { };
+    return m_codeOrigin;
 }
 
 inline JSCell* CallLinkInfo::ownerForSlowPath(CallFrame* calleeFrame)

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -71,7 +71,7 @@ CallLinkStatus CallLinkStatus::computeFor(
     if (!callLinkInfo)
         return CallLinkStatus();
     // m_jitData is nullptr when it is tied to LLInt (not Baseline).
-    if (callLinkInfo->type() == CallLinkInfo::Type::Baseline && !profiledBlock->m_jitData) {
+    if (callLinkInfo->type() == CallLinkInfo::Type::DataOnly && !profiledBlock->m_jitData) {
         if (exitSiteData.takesSlowPath)
             return takesSlowPath();
 #if ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -441,7 +441,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
     };
 
     auto link_callLinkInfo = [&](const auto& instruction, auto bytecode, auto& metadata) {
-        metadata.m_callLinkInfo.initialize(vm, this, CallLinkInfo::callTypeFor(decltype(bytecode)::opcodeID), instruction.index());
+        metadata.m_callLinkInfo.initialize(vm, this, CallLinkInfo::callTypeFor(decltype(bytecode)::opcodeID), CodeOrigin { instruction.index() });
     };
 
 #define LINK_FIELD(__field) \
@@ -1622,7 +1622,7 @@ void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
     if (JITCode::couldBeInterpreted(jitType())) {
         finalizeLLIntInlineCaches();
         // If the CodeBlock is DFG or FTL, CallLinkInfo in metadata is not related.
-        forEachLLIntOrBaselineCallLinkInfo([&](BaselineCallLinkInfo& callLinkInfo) {
+        forEachLLIntOrBaselineCallLinkInfo([&](DataOnlyCallLinkInfo& callLinkInfo) {
             callLinkInfo.visitWeak(vm);
         });
     }
@@ -1691,7 +1691,7 @@ void CodeBlock::destroy(JSCell* cell)
 void CodeBlock::getICStatusMap(const ConcurrentJSLocker&, ICStatusMap& result)
 {
     if (JITCode::couldBeInterpreted(jitType())) {
-        forEachLLIntOrBaselineCallLinkInfo([&](BaselineCallLinkInfo& callLinkInfo) {
+        forEachLLIntOrBaselineCallLinkInfo([&](DataOnlyCallLinkInfo& callLinkInfo) {
             result.add(callLinkInfo.codeOrigin(), ICStatus()).iterator->value.callLinkInfo = &callLinkInfo;
         });
     }

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -443,12 +443,12 @@ public:
     static constexpr GPRReg argumentGPR4 = X86Registers::r8; // regT4
     static constexpr GPRReg argumentGPR5 = X86Registers::r9; // regT7
 
-    static constexpr GPRReg nonArgGPR0 = X86Registers::r10; // regT5 (regT4 on Windows)
+    static constexpr GPRReg nonArgGPR0 = X86Registers::r10; // regT5
     static constexpr GPRReg nonArgGPR1 = X86Registers::eax; // regT0
     static constexpr GPRReg returnValueGPR = X86Registers::eax; // regT0
     static constexpr GPRReg returnValueGPR2 = X86Registers::edx; // regT1 or regT2
-    static constexpr GPRReg nonPreservedNonReturnGPR = X86Registers::r10; // regT5 (regT4 on Windows)
-    static constexpr GPRReg nonPreservedNonArgumentGPR0 = X86Registers::r10; // regT5 (regT4 on Windows)
+    static constexpr GPRReg nonPreservedNonReturnGPR = X86Registers::r10; // regT5
+    static constexpr GPRReg nonPreservedNonArgumentGPR0 = X86Registers::r10; // regT5
     static constexpr GPRReg nonPreservedNonArgumentGPR1 = X86Registers::eax;
 
     static constexpr GPRReg handlerGPR = GPRInfo::nonPreservedNonArgumentGPR1;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -1342,8 +1342,8 @@ public:
         {
             DollarVMAssertScope assertScope;
             Ref<DOMJIT::CallDOMGetterSnippet> snippet = DOMJIT::CallDOMGetterSnippet::create();
-            static_assert(GPRInfo::numberOfRegisters >= 4, "Number of registers should be larger or equal to 4.");
-            unsigned numGPScratchRegisters = GPRInfo::numberOfRegisters - 4;
+            static_assert(GPRInfo::numberOfRegisters >= 5, "Number of registers should be larger or equal to 4.");
+            unsigned numGPScratchRegisters = GPRInfo::numberOfRegisters - 5;
             snippet->numGPScratchRegisters = numGPScratchRegisters;
             snippet->numFPScratchRegisters = 3;
             snippet->requireGlobalObject = true;


### PR DESCRIPTION
#### b0efdb19a6d7a062df7f27a6e43109d9c1e4f9a6
<pre>
[JSC] Use Data Call IC in Handler IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=274398">https://bugs.webkit.org/show_bug.cgi?id=274398</a>
<a href="https://rdar.apple.com/128405738">rdar://128405738</a>

Reviewed by Keith Miller.

This patch integrates Data Call IC into Handler IC. Previously, CallLinkInfo used for Getter / Setter etc.
is managed by the code and the pointer to that was embedded. After this patch, InlineCacheHandler manages
DataOnlyCallLinkInfo vector, and the code will load it from GPRInfo::handlerGPR. This removes dependency
between CallLinkInfo and the code and now allowing Getter / Setter etc. to be cached and shared by Handler IC&apos;s
mechanism. As a result, now Handler IC can cache all the types of AccessCase.

After this change, we will leverage handlerGPR further and make more and more Handler IC code handlerGPR dependent
so that we can remove more code compilations.

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::doneLocationIfExists):
(JSC::DataOnlyCallLinkInfo::initialize):
(JSC::CallLinkInfo::revertCall):
(JSC::BaselineCallLinkInfo::initialize): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::CallLinkInfo):
(JSC::CallLinkInfo::codeOrigin const):
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::computeFor):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finishCreation):
(JSC::CodeBlock::finalizeUnconditionally):
(JSC::CodeBlock::getICStatusMap):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::makeDefaultScratchAllocator):
(JSC::InlineCacheHandler::InlineCacheHandler):
(JSC::InlineCacheHandler::create):
(JSC::InlineCacheHandler::createNonHandlerSlowPath):
(JSC::InlineCacheHandler::createSlowPath):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::regenerate):
(JSC::PolymorphicAccess::visitWeak):
(JSC::InlineCacheHandler::callLinkInfoAt):
(JSC::InlineCacheHandler::visitWeak):
(JSC::PolymorphicAccess::visitWeak const): Deleted.
(JSC::InlineCacheHandler::visitWeak const): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/jit/GPRInfo.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:

Canonical link: <a href="https://commits.webkit.org/279021@main">https://commits.webkit.org/279021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd58bf876ca4654f3cfea69e22eaf1f1811ddba9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42505 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1889 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45068 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23576 "Found 2 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, /WPE/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1096 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45563 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57084 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51722 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2549 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49141 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29485 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64029 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7655 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28317 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12123 "Passed tests") | 
<!--EWS-Status-Bubble-End-->