### PR TITLE
Drop SharedBuffer::data() in favor of span()

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -113,7 +113,7 @@ static RefPtr<SharedBuffer> sanitizeKeyids(const SharedBuffer& buffer)
     auto object = JSON::Object::create();
     auto kidsArray = JSON::Array::create();
     for (auto& buffer : keyIDBuffer.value())
-        kidsArray->pushString(base64URLEncodeToString(buffer->data(), buffer->size()));
+        kidsArray->pushString(base64URLEncodeToString(buffer->span()));
     object->setArray("kids"_s, WTFMove(kidsArray));
 
     return SharedBuffer::create(object->toJSONString().utf8().span());
@@ -194,7 +194,7 @@ std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDsCenc(con
 #if USE(GSTREAMER)
 bool isPlayReadySanitizedInitializationData(const SharedBuffer& buffer)
 {
-    const char* protectionData = buffer.dataAsCharPtr();
+    auto* protectionData = reinterpret_cast<const char*>(buffer.span().data());
     size_t protectionDataLength = buffer.size();
 
     // The protection data starts with a 10-byte PlayReady version

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
@@ -34,6 +34,7 @@
 #include "JSMediaKeyStatusMap.h"
 #include "MediaKeySession.h"
 #include "SharedBuffer.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -58,10 +59,9 @@ unsigned long MediaKeyStatusMap::size()
 
 static bool keyIdsMatch(const SharedBuffer& a, const BufferSource& b)
 {
-    auto length = a.size();
-    if (!length || length != b.length())
+    if (a.isEmpty())
         return false;
-    return !std::memcmp(a.data(), b.data(), length);
+    return equalSpans(a.span(), b.span());
 }
 
 bool MediaKeyStatusMap::has(const BufferSource& keyId)
@@ -103,7 +103,7 @@ std::optional<KeyValuePair<BufferSource::VariantType, MediaKeyStatus>> MediaKeyS
         return std::nullopt;
 
     auto& pair = statuses[m_index++];
-    auto buffer = ArrayBuffer::create(pair.first->makeContiguous()->data(), pair.first->size());
+    auto buffer = ArrayBuffer::create(pair.first->makeContiguous()->span());
     return KeyValuePair<BufferSource::VariantType, MediaKeyStatus> { RefPtr<ArrayBuffer>(WTFMove(buffer)), pair.second };
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -302,7 +302,7 @@ void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, cons
 void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchBodySource& source, ScriptExecutionContext* context)
 {
     if (auto sharedBuffer = formData.asSharedBuffer()) {
-        if (source.enqueue(ArrayBuffer::tryCreate(sharedBuffer->makeContiguous()->data(), sharedBuffer->size())))
+        if (source.enqueue(ArrayBuffer::tryCreate(sharedBuffer->makeContiguous()->span())))
             source.close();
         return;
     }

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -62,7 +62,7 @@ public:
         if (!m_buffer->isContiguous())
             m_buffer = m_buffer->makeContiguous();
 
-        return downcast<SharedBuffer>(*m_buffer).data();
+        return downcast<SharedBuffer>(*m_buffer).span().data();
     }
 
     void lockUnderlyingBuffer() final

--- a/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
@@ -58,7 +58,7 @@ public:
             return nullptr;
 
         ASSERT(m_buffer->isContiguous());
-        return downcast<SharedBuffer>(*m_buffer).data();
+        return downcast<SharedBuffer>(*m_buffer).span().data();
     }
 
     void lockUnderlyingBuffer() final

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -230,7 +230,7 @@ void FileReaderLoader::didReceiveData(const SharedBuffer& buffer)
     if (length <= 0)
         return;
 
-    memcpy(static_cast<char*>(m_rawData->data()) + m_bytesLoaded, buffer.data(), length);
+    memcpy(static_cast<char*>(m_rawData->data()) + m_bytesLoaded, buffer.span().data(), length);
     m_bytesLoaded += length;
 
     m_isRawDataConverted = false;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -632,7 +632,7 @@ void InspectorNetworkAgent::didReceiveData(ResourceLoaderIdentifier identifier, 
         // Often the data is text and we would have a decoder, but for non-text we won't have a decoder.
         // Sync XHRs may not have a cached resource, while non-sync XHRs usually transfer data over on completion.
         if (m_loadingXHRSynchronously && resourceData && !resourceData->hasBufferedData() && !resourceData->cachedResource())
-            m_resourcesData->setResourceContent(requestId, base64EncodeToString(data->data(), data->size()), true);
+            m_resourcesData->setResourceContent(requestId, base64EncodeToString(data->span()), true);
     }
 
     m_frontendDispatcher->dataReceived(requestId, timestamp(), expectedDataLength, encodedDataLength);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1375,8 +1375,7 @@ void DocumentLoader::dataReceived(const SharedBuffer& buffer)
         return;
 #endif
 
-    ASSERT(buffer.data());
-    ASSERT(buffer.size());
+    ASSERT(!buffer.span().empty());
     ASSERT(!m_response.isNull());
 
     // There is a bug in CFNetwork where callbacks can be dispatched even when loads are deferred.

--- a/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
@@ -197,7 +197,7 @@ RefPtr<ArchiveResource> MHTMLParser::parseNextPart(const MIMEHeader& mimeHeader,
     auto contiguousContent = content.takeAsContiguous();
     switch (mimeHeader.contentTransferEncoding()) {
     case MIMEHeader::Base64: {
-        auto decodedData = base64Decode(contiguousContent->data(), contiguousContent->size());
+        auto decodedData = base64Decode(contiguousContent->span());
         if (!decodedData) {
             LOG_ERROR("Invalid base64 content for MHTML part.");
             return nullptr;

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -723,9 +723,8 @@ SharedBufferDataView::SharedBufferDataView(const SharedBufferDataView& other, si
 
 Ref<SharedBuffer> SharedBufferDataView::createSharedBuffer() const
 {
-    const Ref<const DataSegment> segment = m_segment;
     return SharedBuffer::create(DataSegment::Provider {
-        [segment, data = data()]() { return data; },
+        [segment = m_segment, data = span().data()]() { return data; },
         [size = size()]() { return size; }
     });
 }

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -77,7 +77,6 @@ class SharedMemoryHandle;
 // To modify or combine the data, allocate a new DataSegment.
 class DataSegment : public ThreadSafeRefCounted<DataSegment> {
 public:
-    WEBCORE_EXPORT const uint8_t* data() const;
     WEBCORE_EXPORT size_t size() const;
     std::span<const uint8_t> span() const { return std::span { data(), size() }; }
 
@@ -115,6 +114,8 @@ private:
 #if USE(FOUNDATION)
     void iterate(CFDataRef, const Function<void(std::span<const uint8_t>)>& apply) const;
 #endif
+
+    WEBCORE_EXPORT const uint8_t* data() const;
 
     explicit DataSegment(Vector<uint8_t>&& data)
         : m_immutableData(WTFMove(data)) { }
@@ -306,9 +307,7 @@ public:
 
     WEBCORE_EXPORT static Ref<SharedBuffer> create(Ref<FragmentedSharedBuffer>&&);
 
-    WEBCORE_EXPORT const uint8_t* data() const;
     WEBCORE_EXPORT const uint8_t& operator[](size_t) const;
-    const char* dataAsCharPtr() const { return reinterpret_cast<const char*>(data()); }
     std::span<const uint8_t> span() const { return std::span(data(), size()); }
     WTF::Persistence::Decoder decoder() const;
 
@@ -339,6 +338,7 @@ private:
     WEBCORE_EXPORT explicit SharedBuffer(Ref<FragmentedSharedBuffer>&&);
 
     WEBCORE_EXPORT static RefPtr<SharedBuffer> createFromReadingFile(const String& filePath);
+    WEBCORE_EXPORT const uint8_t* data() const;
 };
 
 class SharedBufferBuilder {
@@ -410,9 +410,7 @@ public:
     WEBCORE_EXPORT SharedBufferDataView(Ref<const DataSegment>&&, size_t positionWithinSegment, std::optional<size_t> newSize = std::nullopt);
     WEBCORE_EXPORT SharedBufferDataView(const SharedBufferDataView&, size_t newSize);
     size_t size() const { return m_size; }
-    const uint8_t* data() const { return m_segment->data() + m_positionWithinSegment; }
-    const char* dataAsCharPtr() const { return reinterpret_cast<const char*>(data()); }
-    std::span<const uint8_t> span() const { return { data(), size() }; }
+    std::span<const uint8_t> span() const { return { m_segment->span().subspan(m_positionWithinSegment, size()) }; }
 
     WEBCORE_EXPORT Ref<SharedBuffer> createSharedBuffer() const;
 #if USE(FOUNDATION)

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 SharedBufferChunkReader::SharedBufferChunkReader(FragmentedSharedBuffer* buffer, const Vector<char>& separator)
     : m_iteratorCurrent(buffer->begin())
     , m_iteratorEnd(buffer->end())
-    , m_segment(m_iteratorCurrent != m_iteratorEnd ? m_iteratorCurrent->segment->data() : nullptr)
+    , m_segment(m_iteratorCurrent != m_iteratorEnd ? m_iteratorCurrent->segment->span().data() : nullptr)
     , m_separator(separator)
 {
 }
@@ -47,7 +47,7 @@ SharedBufferChunkReader::SharedBufferChunkReader(FragmentedSharedBuffer* buffer,
 SharedBufferChunkReader::SharedBufferChunkReader(FragmentedSharedBuffer* buffer, const char* separator)
     : m_iteratorCurrent(buffer->begin())
     , m_iteratorEnd(buffer->end())
-    , m_segment(m_iteratorCurrent != m_iteratorEnd ? m_iteratorCurrent->segment->data() : nullptr)
+    , m_segment(m_iteratorCurrent != m_iteratorEnd ? m_iteratorCurrent->segment->span().data() : nullptr)
 {
     setSeparator(separator);
 }
@@ -99,7 +99,7 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
                 chunk.append(std::span { reinterpret_cast<const uint8_t*>(m_separator.data()), m_separatorIndex });
             return !chunk.isEmpty();
         }
-        m_segment = m_iteratorCurrent->segment->data();
+        m_segment = m_iteratorCurrent->segment->span().data();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -99,7 +99,7 @@ public:
 #if USE(UNIX_DOMAIN_SOCKETS)
     WEBCORE_EXPORT static RefPtr<SharedMemory> wrapMap(void*, size_t, int fileDescriptor);
 #elif OS(DARWIN)
-    WEBCORE_EXPORT static RefPtr<SharedMemory> wrapMap(void*, size_t, Protection);
+    WEBCORE_EXPORT static RefPtr<SharedMemory> wrapMap(std::span<const uint8_t>, Protection);
 #endif
 
     WEBCORE_EXPORT ~SharedMemory();

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -90,7 +90,7 @@ RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_
     GST_TRACE("Creating raw audio wrapper with caps %" GST_PTR_FORMAT, caps.get());
 
     Ref data = SharedBuffer::create(Vector<uint8_t>(sourceData));
-    gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->data()));
+    gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->span().data()));
     auto bufferLength = data->size();
     auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferLength, 0, bufferLength, reinterpret_cast<gpointer>(&data.leakRef()), [](gpointer data) {
         static_cast<SharedBuffer*>(data)->deref();

--- a/Source/WebCore/platform/cocoa/MediaUtilities.cpp
+++ b/Source/WebCore/platform/cocoa/MediaUtilities.cpp
@@ -33,11 +33,11 @@
 
 namespace WebCore {
 
-RetainPtr<CMFormatDescriptionRef> createAudioFormatDescription(const AudioStreamDescription& description, size_t magicCookieSize, const void* magicCookie)
+RetainPtr<CMFormatDescriptionRef> createAudioFormatDescription(const AudioStreamDescription& description, std::span<const uint8_t> magicCookie)
 {
     auto basicDescription = std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
     CMFormatDescriptionRef format = nullptr;
-    auto error = PAL::CMAudioFormatDescriptionCreate(kCFAllocatorDefault, basicDescription, 0, nullptr, magicCookieSize, magicCookie, nullptr, &format);
+    auto error = PAL::CMAudioFormatDescriptionCreate(kCFAllocatorDefault, basicDescription, 0, nullptr, magicCookie.size(), magicCookie.data(), nullptr, &format);
     if (error) {
         LOG_ERROR("createAudioFormatDescription failed with %d", static_cast<int>(error));
         return nullptr;

--- a/Source/WebCore/platform/cocoa/MediaUtilities.h
+++ b/Source/WebCore/platform/cocoa/MediaUtilities.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class AudioStreamDescription;
 class PlatformAudioData;
 
-RetainPtr<CMFormatDescriptionRef> createAudioFormatDescription(const AudioStreamDescription&, size_t magicCookieSize = 0, const void* magicCookie = nullptr);
+RetainPtr<CMFormatDescriptionRef> createAudioFormatDescription(const AudioStreamDescription&, std::span<const uint8_t> magicCookie = { });
 RetainPtr<CMSampleBufferRef> createAudioSampleBuffer(const PlatformAudioData&, const AudioStreamDescription&, CMTime, size_t sampleCount);
 RetainPtr<CMSampleBufferRef> createVideoSampleBuffer(CVPixelBufferRef, CMTime);
 

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -82,7 +82,7 @@
 
 - (const void *)bytes
 {
-    return _dataSegment->data() + _position;
+    return _dataSegment->span().subspan(_position).data();
 }
 
 @end

--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp
@@ -161,16 +161,16 @@ static MachSendRight makeMemoryEntry(size_t size, vm_offset_t offset, SharedMemo
     return MachSendRight::adopt(port);
 }
 
-RefPtr<SharedMemory> SharedMemory::wrapMap(void* data, size_t size, Protection protection)
+RefPtr<SharedMemory> SharedMemory::wrapMap(std::span<const uint8_t> data, Protection protection)
 {
-    ASSERT(size);
+    ASSERT(!data.empty());
 
-    auto sendRight = makeMemoryEntry(size, toVMAddress(data), protection, MACH_PORT_NULL);
+    auto sendRight = makeMemoryEntry(data.size(), toVMAddress(static_cast<void*>(const_cast<uint8_t*>(data.data()))), protection, MACH_PORT_NULL);
     if (!sendRight)
         return nullptr;
 
     Ref sharedMemory = adoptRef(*new SharedMemory);
-    sharedMemory->m_size = size;
+    sharedMemory->m_size = data.size();
     sharedMemory->m_data = nullptr;
     sharedMemory->m_sendRight = WTFMove(sendRight);
     sharedMemory->m_protection = protection;

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -138,8 +138,8 @@ static std::pair<unsigned, unsigned> extractKeyidsLocationFromCencInitData(const
     if (initData.isEmpty() || initData.size() > std::numeric_limits<unsigned>::max())
         return keyIdsMap;
 
-    auto* data = initData.data();
-    unsigned initDataSize = initData.size();
+    auto data = initData.span();
+    unsigned initDataSize = data.size();
     unsigned index = 0;
     unsigned psshSize = 0;
 
@@ -203,7 +203,7 @@ static Ref<SharedBuffer> extractKeyidsFromCencInitData(const SharedBuffer& initD
     // Check if initData is a valid CENC initData.
     if (!keyIdCount || !index)
         return SharedBuffer::create();
-    auto* data = initData.data();
+    auto data = initData.span();
 
     auto object = JSON::Object::create();
     auto keyIdsArray = JSON::Array::create();
@@ -220,8 +220,7 @@ static Ref<SharedBuffer> extractKeyidsFromCencInitData(const SharedBuffer& initD
     }
 
     object->setArray("kids"_s, WTFMove(keyIdsArray));
-    CString jsonData = object->toJSONString().utf8();
-    return SharedBuffer::create(jsonData.span());
+    return SharedBuffer::create(object->toJSONString().utf8().span());
 }
 
 static Ref<SharedBuffer> extractKeyIdFromWebMInitData(const SharedBuffer& initData)
@@ -239,7 +238,7 @@ static Ref<SharedBuffer> extractKeyIdFromWebMInitData(const SharedBuffer& initDa
     // The format is a JSON object containing the following members:
     // "kids"
     // An array of key IDs. Each element of the array is the base64url encoding of the octet sequence containing the key ID value.
-    keyIdsArray->pushString(base64URLEncodeToString(initData.data(), initData.size()));
+    keyIdsArray->pushString(base64URLEncodeToString(initData.span()));
 
     object->setArray("kids"_s, WTFMove(keyIdsArray));
     return SharedBuffer::create(object->toJSONString().utf8().span());

--- a/Source/WebCore/platform/graphics/ImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/ImageBackingStore.h
@@ -67,7 +67,7 @@ public:
 
         buffer.grow(bufferSize);
         m_pixels = FragmentedSharedBuffer::DataSegment::create(WTFMove(buffer));
-        m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->data()));
+        m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->span().data()));
         m_size = size;
         m_frameRect = IntRect(IntPoint(), m_size);
         clear();
@@ -207,7 +207,7 @@ private:
         ASSERT(!m_size.isEmpty() && !isOverSize(m_size));
         Vector<uint8_t> buffer(other.m_pixels->span());
         m_pixels = FragmentedSharedBuffer::DataSegment::create(WTFMove(buffer));
-        m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->data()));
+        m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->span().data()));
     }
 
     bool inBounds(const IntPoint& point) const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -794,7 +794,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         identifier = adoptNS([[NSString alloc] initWithData:initData->makeContiguous()->createNSData().get() encoding:NSUTF8StringEncoding]);
 #if HAVE(FAIRPLAYSTREAMING_CENC_INITDATA)
     else if (initDataType == InitDataRegistry::cencName()) {
-        auto psshString = base64EncodeToString(initData->makeContiguous()->data(), initData->size());
+        auto psshString = base64EncodeToString(initData->makeContiguous()->span());
         initializationData = [NSJSONSerialization dataWithJSONObject:@{ @"pssh": (NSString*)psshString } options:NSJSONWritingPrettyPrinted error:nil];
     }
 #endif
@@ -1289,8 +1289,8 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequests(Vector<Retai
             auto entry = JSON::Object::create();
             auto& keyID = requestData.first;
             auto& payload = requestData.second;
-            entry->setString("keyID"_s, base64EncodeToString(keyID->makeContiguous()->data(), keyID->size()));
-            entry->setString("payload"_s, base64EncodeToString(payload.get().bytes, payload.get().length));
+            entry->setString("keyID"_s, base64EncodeToString(keyID->makeContiguous()->span()));
+            entry->setString("payload"_s, base64EncodeToString(span(payload.get())));
             requestJSON->pushObject(WTFMove(entry));
         }
         auto requestBuffer = utf8Buffer(requestJSON->toJSONString());

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -618,9 +618,9 @@ String ImageDecoderCG::decodeUTI(CGImageSourceRef imageSource, const SharedBuffe
     static constexpr auto avifBrand = FourCC("avif");
     static constexpr auto avisBrand = FourCC("avis");
 
-    auto boxUnsigned = [&data](unsigned index) -> unsigned {
-        static constexpr bool isLittleEndian = false;
-        const unsigned* boxBytes = reinterpret_cast<const unsigned*>(data.data());
+    auto boxUnsigned = [span = data.span()](unsigned index) -> unsigned {
+        constexpr bool isLittleEndian = false;
+        const unsigned* boxBytes = reinterpret_cast<const unsigned*>(span.data());
         // Numbers in the file are BigEndian.
         return flipBytesIfLittleEndian(boxBytes[index], isLittleEndian);
     };

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -148,8 +148,9 @@ RefPtr<FontCustomPlatformData> FontCustomPlatformData::create(SharedBuffer& buff
         return nullptr;
     }
 
+    auto span = buffer.span();
     FT_Face freeTypeFace;
-    if (FT_New_Memory_Face(library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(), 0, &freeTypeFace))
+    if (FT_New_Memory_Face(library, reinterpret_cast<const FT_Byte*>(span.data()), span.size(), 0, &freeTypeFace))
         return nullptr;
     FontPlatformData::CreationData creationData = { buffer, itemInCollection };
     return adoptRef(new FontCustomPlatformData(freeTypeFace, WTFMove(creationData)));

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4428,7 +4428,7 @@ void MediaPlayerPrivateGStreamer::initializationDataEncountered(InitData&& initD
 
         GST_DEBUG("scheduling initializationDataEncountered %s event of size %zu", initData.payloadContainerType().utf8().data(),
             initData.payload()->size());
-        GST_MEMDUMP("init datas", reinterpret_cast<const uint8_t*>(initData.payload()->makeContiguous()->data()), initData.payload()->size());
+        GST_MEMDUMP("init datas", reinterpret_cast<const uint8_t*>(initData.payload()->makeContiguous()->span().data()), initData.payload()->size());
         if (player)
             player->initializationDataEncountered(initData.payloadContainerType(), initData.payload()->tryCreateArrayBuffer());
     });

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1181,7 +1181,8 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
         gst_structure_new("webkit-network-statistics", "read-position", G_TYPE_UINT64, members->readPosition, "size", G_TYPE_UINT64, members->size, nullptr)));
 
     checkUpdateBlocksize(length);
-    GstBuffer* buffer = gstBufferNewWrappedFast(fastMemDup(data.data(), length), length);
+    auto dataSpan = data.span();
+    GstBuffer* buffer = gstBufferNewWrappedFast(fastMemDup(dataSpan.data(), dataSpan.size()), length);
     gst_adapter_push(members->adapter.get(), buffer);
 
     stopLoaderIfNeeded(src.get(), members);

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "GStreamerEMEUtilities.h"
 
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/Base64.h>
 
 #if ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)
@@ -80,7 +81,8 @@ RefPtr<SharedBuffer> InitData::extractCencIfNeeded(RefPtr<SharedBuffer>&& unpars
     GMarkupParseContextUserData userData;
     GUniquePtr<GMarkupParseContext> markupParseContext(g_markup_parse_context_new(&markupParser, (GMarkupParseFlags) 0, &userData, nullptr));
 
-    if (g_markup_parse_context_parse(markupParseContext.get(), payload->dataAsCharPtr(), payload->size(), nullptr)) {
+    auto payloadData = spanReinterpretCast<const char>(payload->span());
+    if (g_markup_parse_context_parse(markupParseContext.get(), payloadData.data(), payloadData.size(), nullptr)) {
         if (userData.pssh)
             payload = WTFMove(userData.pssh);
         else

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -98,7 +98,7 @@ Ref<MediaPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>
 
     ASSERT(!m_appendPromise);
     m_appendPromise.emplace();
-    gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->data()));
+    gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->span().data()));
     auto bufferLength = data->size();
     GRefPtr<GstBuffer> buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(0), bufferData, bufferLength, 0, bufferLength, &data.leakRef(),
         [](gpointer data)

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
@@ -77,16 +77,17 @@ template <typename T> static const T* validateTable(const RefPtr<SharedBuffer>& 
 {
     if (!buffer || buffer->size() < sizeof(T) * count)
         return 0;
-    return reinterpret_cast<const T*>(buffer->data());
+    return reinterpret_cast<const T*>(buffer->span().data());
 }
 
 struct TableBase {
 protected:
     static bool isValidEnd(const SharedBuffer& buffer, const void* position)
     {
-        if (position < buffer.data())
+        auto bufferSpan = buffer.span();
+        if (position < bufferSpan.data())
             return false;
-        size_t offset = static_cast<const uint8_t*>(position) - buffer.data();
+        size_t offset = static_cast<const uint8_t*>(position) - bufferSpan.data();
         return offset <= buffer.size(); // "<=" because end is included as valid
     }
 

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
@@ -29,6 +29,7 @@
 
 #include "FontMemoryResource.h"
 #include "SharedBuffer.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -197,7 +198,7 @@ void EOTHeader::appendPaddingShort()
 bool renameFont(const SharedBuffer& fontData, const String& fontName, Vector<uint8_t>& rewrittenFontData)
 {
     size_t originalDataSize = fontData.size();
-    const sfntHeader* sfnt = reinterpret_cast<const sfntHeader*>(fontData.data());
+    const sfntHeader* sfnt = reinterpret_cast<const sfntHeader*>(fontData.span().data());
 
     // Abort if the data is too small to be a font header with a "tables" entry.
     if (originalDataSize < offsetof(sfntHeader, tables))
@@ -221,16 +222,16 @@ bool renameFont(const SharedBuffer& fontData, const String& fontName, Vector<uin
     size_t nameTableSize = ((offsetof(nameTable, nameRecords) + nameRecordCount * sizeof(nameRecord) + fontName.length() * sizeof(UChar)) & ~3) + 4;
 
     rewrittenFontData.resize(fontData.size() + nameTableSize);
-    auto* data = rewrittenFontData.data();
-    memcpy(data, fontData.data(), originalDataSize);
+    auto dataSpan = rewrittenFontData.mutableSpan();
+    memcpySpan(dataSpan.first(fontData.size()), fontData.span());
 
     // Make the table directory entry point to the new 'name' table.
-    sfntHeader* rewrittenSfnt = reinterpret_cast<sfntHeader*>(data);
+    sfntHeader* rewrittenSfnt = reinterpret_cast<sfntHeader*>(dataSpan.data());
     rewrittenSfnt->tables[t].length = nameTableSize;
     rewrittenSfnt->tables[t].offset = originalDataSize;
 
     // Write the new 'name' table after the original font data.
-    nameTable* name = reinterpret_cast<nameTable*>(data + originalDataSize);
+    nameTable* name = reinterpret_cast<nameTable*>(dataSpan.subspan(originalDataSize).data());
     name->format = 0;
     name->count = nameRecordCount;
     name->stringOffset = offsetof(nameTable, nameRecords) + nameRecordCount * sizeof(nameRecord);
@@ -249,8 +250,9 @@ bool renameFont(const SharedBuffer& fontData, const String& fontName, Vector<uin
     name->nameRecords[3].nameID = 4;
     name->nameRecords[4].nameID = 6;
 
+    auto fontSpan = spanReinterpretCast<BigEndianUShort>(dataSpan.subspan(originalDataSize + name->stringOffset));
     for (unsigned i = 0; i < fontName.length(); ++i)
-        reinterpret_cast<BigEndianUShort*>(data + originalDataSize + name->stringOffset)[i] = fontName[i];
+        fontSpan[i] = fontName[i];
 
     // Update the table checksum in the directory entry.
     rewrittenSfnt->tables[t].checkSum = 0;

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
@@ -64,11 +64,11 @@ static unsigned copyFromSharedBuffer(char* buffer, unsigned bufferLength, const 
     unsigned bytesExtracted = 0;
     for (const auto& element : sharedBuffer) {
         if (bytesExtracted + element.segment->size() <= bufferLength) {
-            memcpy(buffer + bytesExtracted, element.segment->data(), element.segment->size());
+            memcpy(buffer + bytesExtracted, element.segment->span().data(), element.segment->size());
             bytesExtracted += element.segment->size();
         } else {
             ASSERT(bufferLength - bytesExtracted < element.segment->size());
-            memcpy(buffer + bytesExtracted, element.segment->data(), bufferLength - bytesExtracted);
+            memcpy(buffer + bytesExtracted, element.segment->span().data(), bufferLength - bytesExtracted);
             bytesExtracted = bufferLength;
             break;
         }

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
@@ -48,7 +48,8 @@ AVIFImageReader::~AVIFImageReader() = default;
 
 bool AVIFImageReader::parseHeader(const SharedBuffer& data, bool allDataReceived)
 {
-    if (avifDecoderSetIOMemory(m_avifDecoder.get(), data.data(), data.size()) != AVIF_RESULT_OK)
+    auto dataSpan = data.span();
+    if (avifDecoderSetIOMemory(m_avifDecoder.get(), dataSpan.data(), dataSpan.size()) != AVIF_RESULT_OK)
         return allDataReceived ? m_decoder->setFailed() : false;
 
     if (avifDecoderParse(m_avifDecoder.get()) != AVIF_RESULT_OK
@@ -69,7 +70,8 @@ void AVIFImageReader::decodeFrame(size_t frameIndex, ScalableImageDecoderFrame& 
         return;
 
     if (!m_dataParsed) {
-        if (avifDecoderSetIOMemory(m_avifDecoder.get(), data.data(), data.size()) != AVIF_RESULT_OK) {
+        auto dataSpan = data.span();
+        if (avifDecoderSetIOMemory(m_avifDecoder.get(), dataSpan.data(), dataSpan.size()) != AVIF_RESULT_OK) {
             m_decoder->setFailed();
             return;
         }

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageDecoder.cpp
@@ -116,7 +116,8 @@ bool BMPImageDecoder::processFileHeader(size_t* imgDataOffset)
     ASSERT(!m_decodedOffset);
     if (m_data->size() < sizeOfFileHeader)
         return false;
-    const uint16_t fileType = (m_data->data()[0] << 8) | static_cast<uint8_t>(m_data->data()[1]);
+    auto dataSpan = m_data->span();
+    const uint16_t fileType = (dataSpan[0] << 8) | dataSpan[1];
     *imgDataOffset = readUint32(10);
     m_decodedOffset = sizeOfFileHeader;
 

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -45,7 +45,7 @@ public:
     static inline uint16_t readUint16(const SharedBuffer& data, int offset)
     {
         uint16_t result;
-        memcpy(&result, &data.data()[offset], 2);
+        memcpy(&result, &data.span()[offset], 2);
 #if CPU(BIG_ENDIAN)
         result = ((result & 0xff) << 8) | ((result & 0xff00) >> 8);
 #endif
@@ -55,7 +55,7 @@ public:
     static inline uint32_t readUint32(const SharedBuffer& data, int offset)
     {
         uint32_t result;
-        memcpy(&result, &data.data()[offset], 4);
+        memcpy(&result, &data.span()[offset], 4);
 #if CPU(BIG_ENDIAN)
         result = ((result & 0xff) << 24) | ((result & 0xff00) << 8) | ((result & 0xff0000) >> 8) | ((result & 0xff000000) >> 24);
 #endif
@@ -204,7 +204,7 @@ private:
             // of the return value here in little-endian mode, the caller
             // won't read it.
             uint32_t pixel;
-            memcpy(&pixel, &m_data->data()[m_decodedOffset + offset], 3);
+            memcpy(&pixel, &m_data->span()[m_decodedOffset + offset], 3);
 #if CPU(BIG_ENDIAN)
             pixel = ((pixel & 0xff00) << 8) | ((pixel & 0xff0000) >> 8) | ((pixel & 0xff000000) >> 24);
 #endif

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -35,6 +35,7 @@
 
 #include "BMPImageReader.h"
 #include "PNGImageDecoder.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -144,7 +145,7 @@ void ICOImageDecoder::setDataForPNGDecoderAtIndex(size_t index)
     // Copy out PNG data to a separate vector and send to the PNG decoder.
     // FIXME: Save this copy by making the PNG decoder able to take an
     // optional offset.
-    auto pngData = SharedBuffer::create(std::span { &m_data->data()[dirEntry.m_imageOffset], m_data->size() - dirEntry.m_imageOffset });
+    auto pngData = SharedBuffer::create(m_data->span().subspan(dirEntry.m_imageOffset));
     m_pngDecoders[index]->setData(pngData.get(), isAllDataReceived());
 }
 
@@ -274,10 +275,11 @@ ICOImageDecoder::IconDirectoryEntry ICOImageDecoder::readDirectoryEntry()
     // type of the width and height values.  Storing them in ints (instead of
     // matching uint8_ts) is so we can record dimensions of size 256 (which is
     // what a zero byte really means).
-    int width = static_cast<uint8_t>(m_data->data()[m_decodedOffset]);
+    auto dataSpan = m_data->span();
+    int width = dataSpan[m_decodedOffset];
     if (!width)
         width = 256;
-    int height = static_cast<uint8_t>(m_data->data()[m_decodedOffset + 1]);
+    int height = dataSpan[m_decodedOffset + 1];
     if (!height)
         height = 256;
     IconDirectoryEntry entry;
@@ -296,7 +298,7 @@ ICOImageDecoder::IconDirectoryEntry ICOImageDecoder::readDirectoryEntry()
     // this isn't quite what the bitmap info header says later, as we only use
     // this value to determine which icon entry is best.
     if (!entry.m_bitCount) {
-        int colorCount = static_cast<uint8_t>(m_data->data()[m_decodedOffset + 2]);
+        int colorCount = dataSpan[m_decodedOffset + 2];
         if (!colorCount)
             colorCount = 256;  // Vague in the spec, needed by real-world icons.
         for (--colorCount; colorCount; colorCount >>= 1)
@@ -315,7 +317,7 @@ ICOImageDecoder::ImageType ICOImageDecoder::imageTypeAtIndex(size_t index)
     const uint32_t imageOffset = m_dirEntries[index].m_imageOffset;
     if ((imageOffset > m_data->size()) || ((m_data->size() - imageOffset) < 4))
         return Unknown;
-    return memcmp(&m_data->data()[imageOffset], "\x89PNG", 4) ? BMP : PNG;
+    return equalSpans(m_data->span().subspan(imageOffset, 4), "\x89PNG"_span) ? PNG : BMP;
 }
 
 }

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -325,7 +325,7 @@ public:
         unsigned readOffset = m_bufferLength - m_info.src->bytes_in_buffer;
 
         m_info.src->bytes_in_buffer += newByteCount;
-        m_info.src->next_input_byte = (JOCTET*)(data.data()) + readOffset;
+        m_info.src->next_input_byte = (JOCTET*)data.span().subspan(readOffset).data();
 
         // If we still have bytes to skip, try to skip those now.
         if (m_bytesToSkip)
@@ -721,7 +721,8 @@ void JPEGImageDecoder::setICCProfile(RefPtr<SharedBuffer>&& buffer)
     if (!buffer)
         return;
 
-    auto iccProfile = LCMSProfilePtr(cmsOpenProfileFromMem(buffer->data(), buffer->size()));
+    auto span = buffer->span();
+    auto iccProfile = LCMSProfilePtr(cmsOpenProfileFromMem(span.data(), span.size()));
     if (!iccProfile)
         return;
 

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -248,9 +248,9 @@ void JPEGXLImageDecoder::decode(Query query, size_t frameIndex, bool allDataRece
 
     m_lastQuery = query;
 
-    m_data->data();
+    auto dataSpan = m_data->span().subspan(m_readOffset);
     size_t dataSize = m_data->size();
-    if (JxlDecoderSetInput(m_decoder.get(), m_data->data() + m_readOffset, dataSize - m_readOffset) != JXL_DEC_SUCCESS) {
+    if (JxlDecoderSetInput(m_decoder.get(), dataSpan.data(), dataSpan.size()) != JXL_DEC_SUCCESS) {
         setFailed();
         return;
     }

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -157,7 +157,7 @@ public:
         auto bytesToUse = data.size() - bytesToSkip;
         m_readOffset += bytesToUse;
         m_currentBufferSize = m_readOffset;
-        png_process_data(m_png, m_info, reinterpret_cast<png_bytep>(const_cast<uint8_t*>(data.data() + bytesToSkip)), bytesToUse);
+        png_process_data(m_png, m_info, reinterpret_cast<png_bytep>(const_cast<uint8_t*>(data.span().subspan(bytesToSkip).data())), bytesToUse);
         // We explicitly specify the superclass encodedDataStatus() because we
         // merely want to check if we've managed to set the size, not
         // (recursively) trigger additional decoding if we haven't.

--- a/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
@@ -130,8 +130,9 @@ void WEBPImageDecoder::decode(size_t frameIndex, bool allDataReceived)
     // This can be executed both in the main thread (when not using async decoding) or in the decoding thread.
     // When executed in the decoding thread, a call to setData() from the main thread may change the data
     // the WebPDemuxer is using, leaving it in an inconsistent state, so we need to protect the data.
-    RefPtr<const SharedBuffer> protectedData(m_data);
-    WebPData inputData = { protectedData->data(), protectedData->size() };
+    RefPtr protectedData = m_data;
+    auto dataSpan = protectedData->span();
+    WebPData inputData { dataSpan.data(), dataSpan.size() };
     WebPDemuxState demuxerState;
     WebPDemuxer* demuxer = WebPDemuxPartial(&inputData, &demuxerState);
     if (!demuxer) {
@@ -296,7 +297,8 @@ void WEBPImageDecoder::parseHeader()
     if (m_data->size() < webpHeaderSize)
         return; // Await VP8X header so WebPDemuxPartial succeeds.
 
-    WebPData inputData = { m_data->data(), m_data->size() };
+    auto dataSpan = m_data->span();
+    WebPData inputData { dataSpan.data(), dataSpan.size() };
     WebPDemuxState demuxerState;
     WebPDemuxer* demuxer = WebPDemuxPartial(&inputData, &demuxerState);
     if (!demuxer) {

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -377,7 +377,7 @@ int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t
 
     long long remaining = item.length() - m_currentItemReadSize;
     long long bytesToRead = std::min(std::min<long long>(remaining, buffer.size()), m_totalRemainingSize);
-    memcpy(buffer.data(), item.data()->data() + item.offset() + m_currentItemReadSize, bytesToRead);
+    memcpy(buffer.data(), item.data()->span().subspan(item.offset() + m_currentItemReadSize).data(), bytesToRead);
     m_totalRemainingSize -= bytesToRead;
 
     m_currentItemReadSize += bytesToRead;

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -978,8 +978,11 @@ static HGLOBAL createGlobalImageFileContent(FragmentedSharedBuffer* data)
         return 0;
     }
 
-    if (data->size())
-        CopyMemory(fileContents, data->makeContiguous()->data(), data->size());
+    if (data->size()) {
+        auto contiguousData = data->makeContiguous();
+        auto span = contiguousData->span();
+        CopyMemory(fileContents, span.data(), span.size());
+    }
 
     GlobalUnlock(memObj);
 
@@ -1030,8 +1033,11 @@ static HGLOBAL createGlobalHDropContent(const URL& url, String& fileName, Fragme
         // Write the data to this temp file.
         DWORD written;
         BOOL tempWriteSucceeded = FALSE;
-        if (data->size())
-            tempWriteSucceeded = WriteFile(tempFileHandle, data->makeContiguous()->data(), data->size(), &written, 0);
+        if (data->size()) {
+            auto contiguousData = data->makeContiguous();
+            auto span = contiguousData->span();
+            tempWriteSucceeded = WriteFile(tempFileHandle, span.data(), span.size(), &written, 0);
+        }
         CloseHandle(tempFileHandle);
         if (!tempWriteSucceeded)
             return 0;

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -43,7 +43,7 @@ static std::optional<ShareableResource::Handle> tryConvertToShareableResourceHan
         return std::nullopt;
 
     auto& segment = script.buffer()->begin()->segment;
-    auto sharedMemory = SharedMemory::wrapMap(const_cast<uint8_t*>(segment->data()), segment->size(), SharedMemory::Protection::ReadOnly);
+    auto sharedMemory = SharedMemory::wrapMap(segment->span(), SharedMemory::Protection::ReadOnly);
     if (!sharedMemory)
         return std::nullopt;
 

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -147,7 +147,8 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
 
         // We don't specify an encoding here. Neither Gecko nor WinIE respects
         // the encoding specified in the HTTP headers.
-        return xmlReadMemory(data->dataAsCharPtr(), data->size(), (const char*)uri, nullptr, options);
+        auto dataSpan = data->span();
+        return xmlReadMemory(reinterpret_cast<const char*>(dataSpan.data()), dataSpan.size(), (const char*)uri, nullptr, options);
     }
     case XSLT_LOAD_STYLESHEET:
         return globalProcessor->xslStylesheet()->locateStylesheetSubResource(((xsltStylesheetPtr)ctxt)->doc, uri);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -787,8 +787,7 @@ RefPtr<ArrayBuffer> RemoteMediaPlayerProxy::mediaPlayerCachedKeyForKeyId(const S
 
 void RemoteMediaPlayerProxy::mediaPlayerKeyNeeded(const SharedBuffer& message)
 {
-    std::span messageReference { message.data(), message.size() };
-    m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::MediaPlayerKeyNeeded(messageReference), m_id);
+    m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::MediaPlayerKeyNeeded(message.span()), m_id);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -99,9 +99,7 @@ void RemoteMediaRecorder::videoFrameAvailable(SharedVideoFrame&& sharedVideoFram
 void RemoteMediaRecorder::fetchData(CompletionHandler<void(std::span<const uint8_t>, double)>&& completionHandler)
 {
     m_writer->fetchData([completionHandler = WTFMove(completionHandler)](auto&& data, auto timeCode) mutable {
-        auto buffer = data ? data->makeContiguous() : RefPtr<WebCore::SharedBuffer>();
-        auto* pointer = buffer ? buffer->data() : nullptr;
-        completionHandler(std::span { pointer, data ? data->size() : 0 }, timeCode);
+        completionHandler(data ? data->makeContiguous()->span() : std::span<const uint8_t> { }, timeCode);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -331,7 +331,7 @@ void NetworkDataTaskBlob::readData(const BlobDataItem& item)
     if (bytesToRead > m_totalRemainingSize)
         bytesToRead = m_totalRemainingSize;
 
-    std::span data { item.data()->data() + item.offset() + m_currentItemReadSize, static_cast<size_t>(bytesToRead) };
+    auto data = item.data()->span().subspan(item.offset() + m_currentItemReadSize, static_cast<size_t>(bytesToRead));
     m_currentItemReadSize = 0;
 
     consumeData(data);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -110,7 +110,7 @@ RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const
     if (isNull() || !isMap())
         return nullptr;
 
-    return WebCore::SharedMemory::wrapMap(const_cast<uint8_t*>(data()), m_size, WebCore::SharedMemory::Protection::ReadOnly);
+    return WebCore::SharedMemory::wrapMap(span(), WebCore::SharedMemory::Protection::ReadOnly);
 }
 
 }

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -99,7 +99,7 @@ void BackgroundFetchStoreImpl::initializeFetches(const WebCore::ClientOrigin& or
     initializeFetchesInternal(origin, [origin, weakEngine = WeakPtr { m_server->backgroundFetchEngine() }, protectedThis = Ref { *this }, manager = m_manager](Vector<std::pair<RefPtr<WebCore::SharedBuffer>, String>>&& fetches) {
         if (weakEngine && manager) {
             for (auto& fetch : fetches) {
-                weakEngine->addFetchFromStore({ fetch.first->data(), fetch.first->size() }, [&](auto& key, auto& identifier) {
+                weakEngine->addFetchFromStore(fetch.first->span(), [&](auto& key, auto& identifier) {
                     if (identifier.isEmpty()) {
                         manager->dispatchTaskToBackgroundFetchManager(origin, [identifier = crossThreadCopy(WTFMove(fetch.second))](auto* backgroundFetchManager) {
                             if (backgroundFetchManager)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -325,8 +325,7 @@ std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(
             return std::nullopt;
 
         auto sharedBuffer = WebCore::SharedBuffer::create(WTFMove(blobBuffer));
-        auto bodyData = std::span(sharedBuffer->data(), sharedBuffer->size());
-        if (storedInfo->metaData.bodyHash != computeSHA1(bodyData, m_salt))
+        if (storedInfo->metaData.bodyHash != computeSHA1(sharedBuffer->span(), m_salt))
             return std::nullopt;
 
         responseBody = sharedBuffer;

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -92,7 +92,7 @@ const uint8_t* SharedBufferReference::data() const
 #endif
     if (!m_buffer || !m_buffer->isContiguous())
         return nullptr;
-    return downcast<SharedBuffer>(m_buffer.get())->data();
+    return downcast<SharedBuffer>(m_buffer.get())->span().data();
 }
 
 RefPtr<WebCore::SharedMemory> SharedBufferReference::sharedCopy() const

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -148,7 +148,7 @@ template<> void getData(const WebKit::NetworkCache::Data& data, const Function<b
 }
 template<> void getData(const WebCore::SharedBuffer& data, const Function<bool(std::span<const uint8_t>)>& function)
 {
-    function({ data.data(), data.size() });
+    function(data.span());
 }
 
 static std::optional<ContentRuleListMetaData> decodeContentRuleListMetaData(const WebKit::NetworkCache::Data& fileData)

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -77,8 +77,8 @@ DragSource::DragSource(GtkWidget* webView)
             gtk_selection_data_set_text(data, "", -1);
             break;
         case DragTargetType::Custom: {
-            auto& buffer = drag.m_selectionData->customData();
-            gtk_selection_data_set(data, gdk_atom_intern_static_string(PasteboardCustomData::gtkType()), 8, reinterpret_cast<const guchar*>(buffer->data()), buffer->size());
+            auto buffer = drag.m_selectionData->customData()->span();
+            gtk_selection_data_set(data, gdk_atom_intern_static_string(PasteboardCustomData::gtkType()), 8, reinterpret_cast<const guchar*>(buffer.data()), buffer.size());
             break;
         }
         }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2092,7 +2092,7 @@ void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const
         htmlData = WTFMove(htmlData),
         preventProcessShutdownScope = process->shutdownPreventingScope()
     ] () mutable {
-        loadParameters.data = { htmlData->data(), htmlData->size() };
+        loadParameters.data = htmlData->span();
         process->markProcessAsRecentlyUsed();
         process->assumeReadAccessToBaseURL(*this, baseURL.string());
         process->assumeReadAccessToBaseURL(*this, unreachableURL.string());

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -245,15 +245,17 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
                 break;
             case ClipboardTargetType::Custom:
                 if (data.selectionData.hasCustomData()) {
-                    auto& buffer = data.selectionData.customData();
-                    gtk_selection_data_set(selection, gdk_atom_intern_static_string(WebCore::PasteboardCustomData::gtkType().characters()), 8, reinterpret_cast<const guchar*>(buffer->data()), buffer->size());
+                    auto buffer = data.selectionData.customData()->span();
+                    gtk_selection_data_set(selection, gdk_atom_intern_static_string(WebCore::PasteboardCustomData::gtkType().characters()), 8, reinterpret_cast<const guchar*>(buffer.data()), buffer.size());
                 }
                 break;
             case ClipboardTargetType::Buffer: {
                 auto* atom = gtk_selection_data_get_target(selection);
                 GUniquePtr<char> type(gdk_atom_name(atom));
-                if (auto* buffer = data.selectionData.buffer(String::fromUTF8(type.get())))
-                    gtk_selection_data_set(selection, atom, 8, reinterpret_cast<const guchar*>(buffer->data()), buffer->size());
+                if (auto* buffer = data.selectionData.buffer(String::fromUTF8(type.get()))) {
+                    auto span = buffer->span();
+                    gtk_selection_data_set(selection, atom, 8, reinterpret_cast<const guchar*>(span.data()), span.size());
+                }
                 break;
             }
             }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -369,7 +369,8 @@ void PDFPluginBase::streamDidReceiveData(const SharedBuffer& buffer)
             m_data = adoptCF(CFDataCreateMutable(0, 0));
 
         ensureDataBufferLength(m_streamedBytes + buffer.size());
-        memcpy(CFDataGetMutableBytePtr(m_data.get()) + m_streamedBytes, buffer.data(), buffer.size());
+        auto bufferSpan = buffer.span();
+        memcpy(CFDataGetMutableBytePtr(m_data.get()) + m_streamedBytes, bufferSpan.data(), bufferSpan.size());
         m_streamedBytes += buffer.size();
 
         // Keep our ranges-lookup-table compact by continuously updating its first range

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1156,10 +1156,9 @@ void WebLocalFrameLoaderClient::finishedLoading(DocumentLoader* loader)
             return;
 
         RefPtr<const SharedBuffer> contiguousData;
-        RefPtr<const FragmentedSharedBuffer> mainResourceData = loader->mainResourceData();
-        if (mainResourceData)
+        if (RefPtr mainResourceData = loader->mainResourceData())
             contiguousData = mainResourceData->makeContiguous();
-        std::span dataReference(contiguousData ? contiguousData->data() : nullptr, contiguousData ? contiguousData->size() : 0);
+        auto dataReference = contiguousData ? contiguousData->span() : std::span<const uint8_t> { };
         webPage->send(Messages::WebPageProxy::DidFinishLoadingDataForCustomContentProvider(loader->response().suggestedFilename(), dataReference));
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -72,7 +72,7 @@ TEST_F(FragmentedSharedBufferTest, copyBufferCreatedWithContentsOfExistingFile)
     auto copy = buffer->copy();
     EXPECT_GT(buffer->size(), 0U);
     EXPECT_TRUE(buffer->size() == copy->size());
-    EXPECT_TRUE(!memcmp(buffer->data(), copy->makeContiguous()->data(), buffer->size()));
+    EXPECT_TRUE(!memcmp(buffer->span().data(), copy->makeContiguous()->span().data(), buffer->size()));
 }
 
 TEST_F(FragmentedSharedBufferTest, appendBufferCreatedWithContentsOfExistingFile)
@@ -83,8 +83,8 @@ TEST_F(FragmentedSharedBufferTest, appendBufferCreatedWithContentsOfExistingFile
     builder.append(*buffer);
     builder.append("a"_span);
     EXPECT_TRUE(builder.size() == (strlen(FragmentedSharedBufferTest::testData()) + 1));
-    EXPECT_TRUE(!memcmp(builder.get()->makeContiguous()->data(), FragmentedSharedBufferTest::testData(), strlen(FragmentedSharedBufferTest::testData())));
-    EXPECT_EQ('a', builder.get()->makeContiguous()->data()[strlen(FragmentedSharedBufferTest::testData())]);
+    EXPECT_TRUE(!memcmp(builder.get()->makeContiguous()->span().data(), FragmentedSharedBufferTest::testData(), strlen(FragmentedSharedBufferTest::testData())));
+    EXPECT_EQ('a', builder.get()->makeContiguous()->span().data()[strlen(FragmentedSharedBufferTest::testData())]);
 }
 
 TEST_F(FragmentedSharedBufferTest, tryCreateArrayBuffer)
@@ -152,7 +152,7 @@ TEST_F(FragmentedSharedBufferTest, copy)
     EXPECT_EQ(length * 4, builder1.size());
     RefPtr<FragmentedSharedBuffer> clone = builder1.copy();
     EXPECT_EQ(length * 4, clone->size());
-    EXPECT_EQ(0, memcmp(clone->makeContiguous()->data(), builder1.get()->makeContiguous()->data(), clone->size()));
+    EXPECT_EQ(0, memcmp(clone->makeContiguous()->span().data(), builder1.get()->makeContiguous()->span().data(), clone->size()));
 
     SharedBufferBuilder builder2;
     builder2.append(*clone);
@@ -225,21 +225,21 @@ TEST_F(FragmentedSharedBufferTest, getSomeData)
     auto ijkl = buffer->getSomeData(8);
     auto kl = buffer->getSomeData(10);
     auto contiguousBuffer = buffer->makeContiguous();
-    auto abcdefghijkl = contiguousBuffer->data();
+    auto abcdefghijkl = contiguousBuffer->span().data();
     auto gh2 = buffer->getSomeData(6);
     auto ghijkl = contiguousBuffer->getSomeData(6);
     auto l = buffer->getSomeData(11);
-    checkBuffer(abcd.data(), abcd.size(), "abcd");
-    checkBuffer(gh1.data(), gh1.size(), "gh");
-    checkBuffer(h.data(), h.size(), "h");
-    checkBuffer(ijkl.data(), ijkl.size(), "ijkl");
-    checkBuffer(kl.data(), kl.size(), "kl");
+    checkBuffer(abcd.span().data(), abcd.size(), "abcd");
+    checkBuffer(gh1.span().data(), gh1.size(), "gh");
+    checkBuffer(h.span().data(), h.size(), "h");
+    checkBuffer(ijkl.span().data(), ijkl.size(), "ijkl");
+    checkBuffer(kl.span().data(), kl.size(), "kl");
     checkBuffer(abcdefghijkl, buffer->size(), "abcdefghijkl");
-    checkBuffer(gh2.data(), gh2.size(), "gh");
-    checkBuffer(ghijkl.data(), ghijkl.size(), "ghijkl");
+    checkBuffer(gh2.span().data(), gh2.size(), "gh");
+    checkBuffer(ghijkl.span().data(), ghijkl.size(), "ghijkl");
     EXPECT_EQ(gh1.size(), gh2.size());
-    checkBufferWithLength(gh1.data(), gh1.size(), gh2.dataAsCharPtr(), gh2.size());
-    checkBuffer(l.data(), l.size(), "l");
+    checkBufferWithLength(gh1.span().data(), gh1.size(), reinterpret_cast<const char*>(gh2.span().data()), gh2.size());
+    checkBuffer(l.span().data(), l.size(), "l");
 }
 
 TEST_F(FragmentedSharedBufferTest, getContiguousData)
@@ -262,17 +262,17 @@ TEST_F(FragmentedSharedBufferTest, getContiguousData)
     auto ijk = buffer->getContiguousData(8, 3);
     auto kl = buffer->getContiguousData(10, 2);
     auto l = buffer->getContiguousData(11, 1);
-    checkBuffer(abcd->data(), abcd->size(), "abcd");
-    checkBuffer(bcdefghi->data(), bcdefghi->size(), "bcdefghi");
-    checkBuffer(gh->data(), gh->size(), "gh");
-    checkBuffer(ghij->data(), ghij->size(), "ghij");
-    checkBuffer(h->data(), h->size(), "h");
-    checkBuffer(ijk->data(), ijk->size(), "ijk");
-    checkBuffer(kl->data(), kl->size(), "kl");
-    checkBuffer(l->data(), l->size(), "l");
+    checkBuffer(abcd->span().data(), abcd->size(), "abcd");
+    checkBuffer(bcdefghi->span().data(), bcdefghi->size(), "bcdefghi");
+    checkBuffer(gh->span().data(), gh->size(), "gh");
+    checkBuffer(ghij->span().data(), ghij->size(), "ghij");
+    checkBuffer(h->span().data(), h->size(), "h");
+    checkBuffer(ijk->span().data(), ijk->size(), "ijk");
+    checkBuffer(kl->span().data(), kl->size(), "kl");
+    checkBuffer(l->span().data(), l->size(), "l");
     auto fghijkl = buffer->getContiguousData(5, 20);
     EXPECT_EQ(fghijkl->size(), buffer->size() - 5);
-    checkBuffer(fghijkl->data(), fghijkl->size(), "fghijkl");
+    checkBuffer(fghijkl->span().data(), fghijkl->size(), "fghijkl");
     auto outBound = buffer->getContiguousData(30, 20);
     EXPECT_EQ(outBound->size(), 0u);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstMappedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstMappedBuffer.cpp
@@ -111,7 +111,7 @@ TEST_F(GStreamerTest, mappedOwnedBufferReadSanity)
     ASSERT_TRUE(mappedBuf);
     EXPECT_EQ(mappedBuf->size(), 16);
     EXPECT_EQ(memcmp(memory, mappedBuf->data(), 16), 0);
-    EXPECT_EQ(memcmp(memory, mappedBuf->createSharedBuffer()->data(), 16), 0);
+    EXPECT_EQ(memcmp(memory, mappedBuf->createSharedBuffer()->span().data(), 16), 0);
 }
 
 TEST_F(GStreamerTest, mappedOwnedBufferCachesSharedBuffers)
@@ -122,7 +122,7 @@ TEST_F(GStreamerTest, mappedOwnedBufferCachesSharedBuffers)
     auto sharedBuf = mappedBuf->createSharedBuffer();
     // We expect the same data pointer wrapped by shared buffer, no
     // copies need to be made.
-    EXPECT_EQ(sharedBuf->data(), mappedBuf->createSharedBuffer()->data());
+    EXPECT_EQ(sharedBuf->span().data(), mappedBuf->createSharedBuffer()->span().data());
 }
 
 TEST_F(GStreamerTest, mappedOwnedBufferDoesAddsExtraRefs)


### PR DESCRIPTION
#### 24db6e6cb16bb9e9481d9b87778f0f9add40cee1
<pre>
Drop SharedBuffer::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274401">https://bugs.webkit.org/show_bug.cgi?id=274401</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::sanitizeKeyids):
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp:
(WebCore::keyIdsMatch):
(WebCore::MediaKeyStatusMap::Iterator::next):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::consumeFormDataAsStream):
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::didReceiveData):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didReceiveData):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::dataReceived):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::SharedBufferDataView::createSharedBuffer const):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBufferDataView::span const):
(WebCore::SharedBuffer::dataAsCharPtr const): Deleted.
(WebCore::SharedBufferDataView::data const): Deleted.
(WebCore::SharedBufferDataView::dataAsCharPtr const): Deleted.
* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::wrapMap):
* Source/WebCore/platform/cocoa/MediaUtilities.cpp:
(WebCore::createAudioFormatDescription):
* Source/WebCore/platform/cocoa/MediaUtilities.h:
(WebCore::createAudioFormatDescription):
* Source/WebCore/platform/cocoa/SharedBufferCocoa.mm:
(-[WebCoreSharedBufferData bytes]):
* Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp:
(WebCore::SharedMemory::wrapMap):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::extractKeyidsLocationFromCencInitData):
(WebCore::extractKeyidsFromCencInitData):
(WebCore::extractKeyIdFromWebMInitData):
* Source/WebCore/platform/graphics/ImageBackingStore.h:
(WebCore::ImageBackingStore::setSize):
(WebCore::ImageBackingStore::ImageBackingStore):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::requestLicense):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequests):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::decodeUTI):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::createAudioFormatDescription):
(WebCore::PacketDurationParser::PacketDurationParser):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h:
(WebCore::OpenType::validateTable):
(WebCore::OpenType::TableBase::isValidEnd):
* Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readDataSync):
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::tryConvertToShareableResourceHandle):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerKeyNeeded):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::fetchData):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::readData):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::initializeFetches):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::readRecordFromFileData):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::data const):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::getData):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadAlternateHTML):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::streamDidReceiveData):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::finishedLoading):

Canonical link: <a href="https://commits.webkit.org/279097@main">https://commits.webkit.org/279097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/907979968db2f9a6058fe015b27780f28f4731f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42649 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2559 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57339 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50039 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28829 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49294 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29740 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7696 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->