### PR TITLE
[CG] Optimize getting the ImageFrame metadata

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -443,20 +443,9 @@ void BitmapImageSource::cacheMetadataAtIndex(unsigned index, SubsamplingLevel su
     if (index >= m_frames.size())
         return;
 
-    ImageFrame& frame = m_frames[index];
+    auto& frame = m_frames[index];
 
-    if (frame.m_decodingOptions.hasSizeForDrawing()) {
-        ASSERT(frame.hasNativeImage());
-        frame.m_size = frame.nativeImage()->size();
-    } else
-        frame.m_size = m_decoder->frameSizeAtIndex(index, subsamplingLevel);
-
-    frame.m_densityCorrectedSize = m_decoder->densityCorrectedSizeAtIndex(index);
-    frame.m_subsamplingLevel = subsamplingLevel;
-    frame.m_decodingOptions = options;
-    frame.m_hasAlpha = m_decoder->frameHasAlphaAtIndex(index);
-    frame.m_orientation = m_decoder->frameOrientationAtIndex(index);
-    frame.m_decodingStatus = m_decoder->frameIsCompleteAtIndex(index) ? DecodingStatus::Complete : DecodingStatus::Partial;
+    m_decoder->fetchFrameMetaDataAtIndex(index, subsamplingLevel, options, frame);
 
     if (repetitionCount())
         frame.m_duration = m_decoder->frameDurationAtIndex(index);

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class FragmentedSharedBuffer;
+class ImageFrame;
 
 struct ImageDecoderFrameInfo {
     bool hasAlpha;
@@ -48,8 +49,8 @@ class ImageDecoder : public ThreadSafeRefCounted<ImageDecoder> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static RefPtr<ImageDecoder> create(FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
-    virtual ~ImageDecoder() = default;
-    
+    WEBCORE_EXPORT virtual ~ImageDecoder();
+
     using FrameInfo = ImageDecoderFrameInfo;
 
     enum class MediaType {
@@ -96,11 +97,13 @@ public:
     virtual IntSize frameSizeAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const = 0;
     virtual bool frameIsCompleteAtIndex(size_t) const = 0;
     virtual ImageOrientation frameOrientationAtIndex(size_t) const { return ImageOrientation::Orientation::None; }
-    virtual std::optional<IntSize> densityCorrectedSizeAtIndex(size_t) const { return std::nullopt; }
+    virtual std::optional<IntSize> frameDensityCorrectedSizeAtIndex(size_t) const { return std::nullopt; }
 
     virtual Seconds frameDurationAtIndex(size_t) const = 0;
     virtual bool frameHasAlphaAtIndex(size_t) const = 0;
     virtual unsigned frameBytesAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const = 0;
+
+    WEBCORE_EXPORT virtual bool fetchFrameMetaDataAtIndex(size_t, SubsamplingLevel, const DecodingOptions&, ImageFrame&) const;
 
     virtual PlatformImagePtr createFrameImageAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = DecodingOptions(DecodingMode::Synchronous)) = 0;
 
@@ -110,7 +113,7 @@ public:
     virtual void clearFrameBufferCache(size_t) = 0;
 
 protected:
-    ImageDecoder() = default;
+    WEBCORE_EXPORT ImageDecoder();
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -43,6 +43,8 @@ namespace WebCore {
 
 class ImageFrame {
     friend class BitmapImageSource;
+    friend class ImageDecoder;
+    friend class ImageDecoderCG;
 public:
     enum class Caching { Metadata, MetadataAndImage };
 

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -29,6 +29,7 @@
 #if USE(CG)
 
 #include "FourCC.h"
+#include "ImageFrame.h"
 #include "ImageOrientation.h"
 #include "ImageResolution.h"
 #include "IntPoint.h"
@@ -88,7 +89,7 @@ static RetainPtr<CFMutableDictionaryRef> createImageSourceMetadataOptions()
     CFDictionarySetValue(options.get(), kCGImageSourceSkipMetadata, kCFBooleanFalse);
     return options;
 }
-    
+
 static RetainPtr<CFMutableDictionaryRef> createImageSourceThumbnailOptions()
 {
     RetainPtr<CFMutableDictionaryRef> options = createImageSourceOptions();
@@ -113,7 +114,7 @@ static RetainPtr<CFMutableDictionaryRef> appendImageSourceOption(RetainPtr<CFMut
     CFDictionarySetValue(options.get(), kCGImageSourceThumbnailMaxPixelSize, maxDimensionNumber.get());
     return WTFMove(options);
 }
-    
+
 static RetainPtr<CFMutableDictionaryRef> appendImageSourceOptions(RetainPtr<CFMutableDictionaryRef>&& options, SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing)
 {
     if (subsamplingLevel != SubsamplingLevel::Default)
@@ -122,7 +123,7 @@ static RetainPtr<CFMutableDictionaryRef> appendImageSourceOptions(RetainPtr<CFMu
     options = appendImageSourceOption(WTFMove(options), sizeForDrawing);
     return WTFMove(options);
 }
-    
+
 static RetainPtr<CFDictionaryRef> imageSourceOptions(SubsamplingLevel subsamplingLevel = SubsamplingLevel::Default)
 {
     static const auto options = createImageSourceOptions().leakRef();
@@ -139,6 +140,21 @@ static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel s
         options = createImageSourceThumbnailOptions().leakRef();
     });
     return appendImageSourceOptions(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options)), subsamplingLevel, sizeForDrawing);
+}
+
+static IntSize frameSizeFromProperties(CFDictionaryRef properties)
+{
+    if (!properties)
+        return { };
+
+    auto dimension = [&](const void *key) -> int {
+        int value = 0;
+        if (auto num = (CFNumberRef)CFDictionaryGetValue(properties, key))
+            CFNumberGetValue(num, kCFNumberIntType, &value);
+        return value;
+    };
+
+    return { dimension(kCGImagePropertyPixelWidth), dimension(kCGImagePropertyPixelHeight) };
 }
 
 static CFDictionaryRef animationPropertiesFromProperties(CFDictionaryRef properties)
@@ -339,7 +355,7 @@ EncodedDataStatus ImageDecoderCG::encodedDataStatus() const
         break;
     }
 
-    return m_encodedDataStatus; 
+    return m_encodedDataStatus;
 }
 
 size_t ImageDecoderCG::frameCount() const
@@ -407,24 +423,25 @@ std::optional<IntPoint> ImageDecoderCG::hotSpot() const
     return IntPoint(x, y);
 }
 
+bool ImageDecoderCG::hasAlpha() const
+{
+    String uti = this->uti();
+    
+    // Return false if there is no image type or the image type is JPEG, because
+    // JPEG does not support alpha transparency.
+    if (uti.isEmpty() || uti == "public.jpeg"_s)
+        return false;
+    
+    // FIXME: Could return false for other non-transparent image formats.
+    // FIXME: Could maybe return false for a GIF Frame if we have enough info in the GIF properties dictionary
+    // to determine whether or not a transparent color was defined.
+    return true;
+}
+
 IntSize ImageDecoderCG::frameSizeAtIndex(size_t index, SubsamplingLevel subsamplingLevel) const
 {
-    RetainPtr<CFDictionaryRef> properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions(subsamplingLevel).get()));
-    
-    if (!properties)
-        return { };
-    
-    int width = 0;
-    int height = 0;
-    CFNumberRef num = (CFNumberRef)CFDictionaryGetValue(properties.get(), kCGImagePropertyPixelWidth);
-    if (num)
-        CFNumberGetValue(num, kCFNumberIntType, &width);
-    
-    num = (CFNumberRef)CFDictionaryGetValue(properties.get(), kCGImagePropertyPixelHeight);
-    if (num)
-        CFNumberGetValue(num, kCFNumberIntType, &height);
-    
-    return IntSize(width, height);
+    auto properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions(subsamplingLevel).get()));
+    return frameSizeFromProperties(properties.get());
 }
 
 bool ImageDecoderCG::frameIsCompleteAtIndex(size_t index) const
@@ -441,16 +458,16 @@ bool ImageDecoderCG::frameIsCompleteAtIndex(size_t index) const
 
 ImageOrientation ImageDecoderCG::frameOrientationAtIndex(size_t index) const
 {
-    RetainPtr<CFDictionaryRef> properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions().get()));
+    auto properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions().get()));
     if (!properties)
         return ImageOrientation::Orientation::None;
 
     return orientationFromProperties(properties.get());
 }
 
-std::optional<IntSize> ImageDecoderCG::densityCorrectedSizeAtIndex(size_t index) const
+std::optional<IntSize> ImageDecoderCG::frameDensityCorrectedSizeAtIndex(size_t index) const
 {
-    RetainPtr<CFDictionaryRef> properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions().get()));
+    auto properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions().get()));
     if (!properties)
         return std::nullopt;
 
@@ -499,25 +516,41 @@ Seconds ImageDecoderCG::frameDurationAtIndex(size_t index) const
 
 bool ImageDecoderCG::frameHasAlphaAtIndex(size_t index) const
 {
-    if (!frameIsCompleteAtIndex(index))
-        return true;
-    
-    String uti = this->uti();
-    
-    // Return false if there is no image type or the image type is JPEG, because
-    // JPEG does not support alpha transparency.
-    if (uti.isEmpty() || uti == "public.jpeg"_s)
-        return false;
-    
-    // FIXME: Could return false for other non-transparent image formats.
-    // FIXME: Could maybe return false for a GIF Frame if we have enough info in the GIF properties dictionary
-    // to determine whether or not a transparent color was defined.
-    return true;
+    return !frameIsCompleteAtIndex(index) || hasAlpha();
 }
 
 unsigned ImageDecoderCG::frameBytesAtIndex(size_t index, SubsamplingLevel subsamplingLevel) const
 {
     return frameSizeAtIndex(index, subsamplingLevel).area() * 4;
+}
+
+bool ImageDecoderCG::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options, ImageFrame& frame) const
+{
+    auto properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions(subsamplingLevel).get()));
+    if (!properties)
+        return false;
+
+    if (options.hasSizeForDrawing()) {
+        ASSERT(frame.hasNativeImage());
+        frame.m_size = frame.nativeImage()->size();
+    } else
+        frame.m_size = frameSizeFromProperties(properties.get());
+
+    if (!mayHaveDensityCorrectedSize(properties.get()))
+        frame.m_densityCorrectedSize = std::nullopt;
+    else if (auto propertiesWithMetadata = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, createImageSourceMetadataOptions().get())))
+        frame.m_densityCorrectedSize = densityCorrectedSizeFromProperties(propertiesWithMetadata.get());
+    else
+        frame.m_densityCorrectedSize = std::nullopt;
+
+    bool frameIsComplete = frameIsCompleteAtIndex(index);
+
+    frame.m_subsamplingLevel = subsamplingLevel;
+    frame.m_decodingOptions = options;
+    frame.m_hasAlpha = !frameIsComplete || hasAlpha();
+    frame.m_orientation = orientationFromProperties(properties.get());
+    frame.m_decodingStatus = frameIsComplete ? DecodingStatus::Complete : DecodingStatus::Partial;
+    return true;
 }
 
 PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions)
@@ -584,7 +617,7 @@ String ImageDecoderCG::decodeUTI(CGImageSourceRef imageSource, const SharedBuffe
     static constexpr auto ftypSignature = FourCC("ftyp");
     static constexpr auto avifBrand = FourCC("avif");
     static constexpr auto avisBrand = FourCC("avis");
-    
+
     auto boxUnsigned = [&data](unsigned index) -> unsigned {
         static constexpr bool isLittleEndian = false;
         const unsigned* boxBytes = reinterpret_cast<const unsigned*>(data.data());
@@ -667,7 +700,7 @@ bool ImageDecoderCG::canDecodeType(const String& mimeType)
     return MIMETypeRegistry::isSupportedImageMIMEType(mimeType);
 }
 
-}
+} // namespace WebCore
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ImageDecoderCGAdditions.cpp>)
 #include <WebKitAdditions/ImageDecoderCGAdditions.cpp>
@@ -675,10 +708,13 @@ bool ImageDecoderCG::canDecodeType(const String& mimeType)
 namespace WebCore {
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-bool ImageDecoderCG::shouldUseQuickLookForFullscreen() const { return false; }
+bool ImageDecoderCG::shouldUseQuickLookForFullscreen() const
+{
+    return false;
+}
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
-}
+} // namespace WebCore
 #endif
 
 #endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,11 +62,13 @@ public:
     IntSize frameSizeAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const final;
     bool frameIsCompleteAtIndex(size_t) const final;
     ImageOrientation frameOrientationAtIndex(size_t) const final;
-    std::optional<IntSize> densityCorrectedSizeAtIndex(size_t) const final;
+    std::optional<IntSize> frameDensityCorrectedSizeAtIndex(size_t) const final;
 
     Seconds frameDurationAtIndex(size_t) const final;
     bool frameHasAlphaAtIndex(size_t) const final;
     unsigned frameBytesAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const final;
+
+    bool fetchFrameMetaDataAtIndex(size_t, SubsamplingLevel, const DecodingOptions&, ImageFrame&) const final;
 
     PlatformImagePtr createFrameImageAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = DecodingOptions(DecodingMode::Synchronous)) final;
 
@@ -77,12 +79,13 @@ public:
     static String decodeUTI(CGImageSourceRef, const SharedBuffer&);
 
 private:
+    bool hasAlpha() const;
     String decodeUTI(const SharedBuffer&) const;
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool shouldUseQuickLookForFullscreen() const;
 #endif
-    
+
     bool m_isAllDataReceived { false };
     std::atomic<bool> m_isXBitmapImage { false };
     mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
@@ -148,7 +148,7 @@ public:
     bool ignoresGammaAndColorProfile() const { return m_ignoreGammaAndColorProfile; }
 
     ImageOrientation frameOrientationAtIndex(size_t) const final { return m_orientation; }
-    std::optional<IntSize> densityCorrectedSizeAtIndex(size_t) const final { return m_densityCorrectedSize; }
+    std::optional<IntSize> frameDensityCorrectedSizeAtIndex(size_t) const final { return m_densityCorrectedSize; }
 
     enum { ICCColorProfileHeaderLength = 128 };
 


### PR DESCRIPTION
#### 828ba37f8b033c4d0fc61f65f5abc40885b469df
<pre>
[CG] Optimize getting the ImageFrame metadata
<a href="https://bugs.webkit.org/show_bug.cgi?id=274399">https://bugs.webkit.org/show_bug.cgi?id=274399</a>
<a href="https://rdar.apple.com/126232516">rdar://126232516</a>

Reviewed by Simon Fraser.

BitmapImageSource::cacheMetadataAtIndex() currently makes separate calls to
ImageDecoder functions. Some of them calls CGImageSourceCopyPropertiesAtIndex()
and we end up calling CGImageSourceCopyPropertiesAtIndex() multiple times.

This can be optimized by adding ImageDecoder::frameMetadataAtIndex() which fills
in the ImageFrame metadata. This way CGImageSourceCopyPropertiesAtIndex() will
be called once and its CFDictionary will be used to retrieve all the ImageFrame
metadata.

* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::cacheMetadataAtIndex):
* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::ImageDecoder::fetchFrameMetaDataAtIndex const):
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::frameDensityCorrectedSizeAtIndex const):
(WebCore::ImageDecoder::densityCorrectedSizeAtIndex const): Deleted.
* Source/WebCore/platform/graphics/ImageFrame.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::frameSizeFromProperties):
(WebCore::ImageDecoderCG::encodedDataStatus const):
(WebCore::ImageDecoderCG::hasAlpha const):
(WebCore::ImageDecoderCG::frameSizeAtIndex const):
(WebCore::ImageDecoderCG::frameOrientationAtIndex const):
(WebCore::ImageDecoderCG::frameDensityCorrectedSizeAtIndex const):
(WebCore::ImageDecoderCG::frameHasAlphaAtIndex const):
(WebCore::ImageDecoderCG::fetchFrameMetaDataAtIndex const):
(WebCore::ImageDecoderCG::decodeUTI):
(WebCore::ImageDecoderCG::shouldUseQuickLookForFullscreen const):
(WebCore::ImageDecoderCG::densityCorrectedSizeAtIndex const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebCore/platform/image-decoders/ScalableImageDecoder.h:

Canonical link: <a href="https://commits.webkit.org/279069@main">https://commits.webkit.org/279069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb0a0dd054c921ea6f1324b260828c13d61f535

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2847 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2015 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54521 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23711 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1307 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27551 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45369 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11446 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->