### PR TITLE
Revert "[Unified Text Replacement] Refactor `m_textIndicatorCharacterRanges` to be a HashMap"

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -166,7 +166,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveReplaceme
 
         auto resolvedRange = UnifiedTextReplacementController::resolveCharacterRange(*sessionRange, { locationWithOffset, replacementData.originalRange.length });
 
-        replaceContentsOfRangeInSession(session, resolvedRange, replacementData.replacement);
+        replaceContentsOfRangeInSession(session.uuid, resolvedRange, replacementData.replacement);
 
         auto newRangeWithOffset = WebCore::CharacterRange { locationWithOffset, replacementData.replacement.length() };
         auto newResolvedRange = UnifiedTextReplacementController::resolveCharacterRange(*sessionRange, newRangeWithOffset);
@@ -231,7 +231,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
         auto offsetRange = WebCore::OffsetRange { marker.startOffset(), marker.endOffset() };
         document->markers().removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
 
-        replaceContentsOfRangeInSession(session, rangeToReplace, data.originalText);
+        replaceContentsOfRangeInSession(session.uuid, rangeToReplace, data.originalText);
 
         return;
     }
@@ -264,7 +264,7 @@ void UnifiedTextReplacementController::didEndTextReplacementSession<WebUnifiedTe
         markers.removeMarkers(node, offsetRange, { WebCore::DocumentMarker::Type::UnifiedTextReplacement });
 
         if (!accepted && data.state != WebCore::DocumentMarker::UnifiedTextReplacementData::State::Reverted)
-            replaceContentsOfRangeInSession(session, rangeToReplace, data.originalText);
+            replaceContentsOfRangeInSession(session.uuid, rangeToReplace, data.originalText);
 
         return false;
     });
@@ -311,9 +311,9 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WebUni
 
     document->selection().setSelection({ *sessionRange });
 
-    m_textIndicatorCharacterRanges.remove(session.uuid);
-
-    // FIXME: Should this be invoked _before_ the removal of the session from `m_textIndicatorCharacterRanges`?
+    m_textIndicatorCharacterRangesForSessions.removeFirstMatching([&](auto& candidateSession) {
+        return candidateSession.first == session.uuid;
+    });
     removeTransparentMarkersForSession(session.uuid, RemoveAllMarkersForSession::Yes);
 
     m_replacementTypes.remove(session.uuid);
@@ -321,6 +321,51 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WebUni
     m_originalDocumentNodes.remove(session.uuid);
     m_replacedDocumentNodes.remove(session.uuid);
     m_replacementLocationOffsets.remove(session.uuid);
+}
+
+void UnifiedTextReplacementController::removeTransparentMarkersForUUID(const WebCore::SimpleRange& range, const WTF::UUID& uuid)
+{
+
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    document->markers().filterMarkers(range, [&](const WebCore::DocumentMarker& marker) {
+        return std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
+    }, { WebCore::DocumentMarker::Type::TransparentContent });
+}
+
+void UnifiedTextReplacementController::removeTransparentMarkersForSession(const WTF::UUID& uuid, RemoveAllMarkersForSession removeAll)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (auto sessionRange = contextRangeForSessionWithUUID(uuid)) {
+        removeTransparentMarkersForUUID(*sessionRange, uuid);
+        if (removeAll == RemoveAllMarkersForSession::No)
+            return;
+
+        for (auto session : m_textIndicatorCharacterRangesForSessions) {
+            if (session.first == uuid) {
+                for (auto textIndicatorCharacterRange : session.second)
+                    removeTransparentMarkersForUUID(*sessionRange, textIndicatorCharacterRange.first);
+            }
+        }
+    }
+
+    for (auto session : m_textIndicatorCharacterRangesForSessions) {
+        for (auto textIndicatorCharacterRange : session.second) {
+            if (textIndicatorCharacterRange.first == uuid) {
+                if (auto sessionRange = contextRangeForSessionWithUUID(session.first))
+                    removeTransparentMarkersForUUID(*sessionRange, uuid);
+            }
+        }
+    }
 }
 
 void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange(const WebUnifiedTextReplacementSessionData& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebUnifiedTextReplacementContextData& context, bool finished)
@@ -365,9 +410,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
     // the above check ensures that the full range length expression will never underflow.
 
     auto characterCountDelta = sessionRangeCharacterCount - contextTextCharacterCount;
-    auto characterRangeWithDelta = WebCore::CharacterRange { range.location, range.length + characterCountDelta };
-
-    auto resolvedRange = WebCore::resolveCharacterRange(*sessionRange, characterRangeWithDelta);
+    auto resolvedRange = resolveCharacterRange(*sessionRange, { range.location, range.length + characterCountDelta });
 
     if (!m_originalDocumentNodes.contains(session.uuid)) {
         auto contents = m_contextRanges.get(session.uuid)->cloneContents();
@@ -389,35 +432,40 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
     auto subCharacterRange = [](WebCore::CharacterRange superRange, WebCore::CharacterRange previousRange) {
         auto location = previousRange.location + previousRange.length;
         auto length = superRange.length - previousRange.length;
-
-        // FIXME: What guarantees this is true?
         if (superRange.length < previousRange.length) {
             ASSERT_NOT_REACHED();
             return WebCore::CharacterRange { 0, 0 };
         }
-
         return WebCore::CharacterRange { location, length };
     };
 
-    auto replacedRange = [&] {
-        auto characterRanges = m_textIndicatorCharacterRanges.getOptional(session.uuid);
-        if (!characterRanges)
-            return resolvedRange;
+    auto replacedRange = resolvedRange;
+    for (auto [sessionUUID, sessionRangeVector] : m_textIndicatorCharacterRangesForSessions) {
+        if (sessionUUID != session.uuid)
+            continue;
 
         // sessionRangeVector.last() will always be valid because when creating
         // the structure we always create the vector with an element.
-
-        ASSERT(!characterRanges->isEmpty());
-
-        auto replaceCharacterRange = subCharacterRange(range, characterRanges->last().range);
-        return UnifiedTextReplacementController::resolveCharacterRange(*sessionRange, replaceCharacterRange);
-    }();
+        auto replaceCharacterRange = subCharacterRange(range, sessionRangeVector.last().second);
+        replacedRange = UnifiedTextReplacementController::resolveCharacterRange(*sessionRange, replaceCharacterRange);
+        break;
+    }
 
 #if PLATFORM(MAC)
-    auto sourceTextIndicatorUUID = createTextIndicator(replacedRange, TextIndicatorStyle::Source);
+    auto sourceTextIndicatorUUID = WTF::UUID::createVersion4();
+    m_webPage->createTextIndicatorForRange(replacedRange, [sourceTextIndicatorUUID, weakWebPage = WeakPtr { m_webPage }](std::optional<WebCore::TextIndicatorData>&& textIndicatorData) {
+        if (!weakWebPage)
+            return;
+        RefPtr protectedWebPage = weakWebPage.get();
+        if (textIndicatorData)
+            protectedWebPage->addTextIndicatorStyleForID(sourceTextIndicatorUUID, WebKit::TextIndicatorStyle::Source, *textIndicatorData);
+    });
 #endif
 
-    replaceContentsOfRangeInSession(session, resolvedRange, *fragment);
+    replaceContentsOfRangeInSession(session.uuid, resolvedRange, *fragment);
+
+    auto finalTextIndicatorUUID = WTF::UUID::createVersion4();
+    auto characterRangeAfterReplace = WebCore::CharacterRange(range.location, range.length + characterCountDelta);
 
     auto sessionRangeAfterReplace = contextRangeForSessionWithUUID(session.uuid);
     if (!sessionRangeAfterReplace) {
@@ -425,33 +473,38 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
         return;
     }
 
-    auto replacedRangeAfterReplace = UnifiedTextReplacementController::resolveCharacterRange(*sessionRangeAfterReplace, characterRangeWithDelta);
+    auto replacedRangeAfterReplace = UnifiedTextReplacementController::resolveCharacterRange(*sessionRangeAfterReplace, characterRangeAfterReplace);
 
-    auto finalTextIndicatorUUID = createTextIndicator(replacedRangeAfterReplace, TextIndicatorStyle::Final);
+    m_webPage->createTextIndicatorForRange(replacedRangeAfterReplace, [finalTextIndicatorUUID, weakWebPage = WeakPtr { m_webPage }](std::optional<WebCore::TextIndicatorData>&& textIndicatorData) {
+        if (!weakWebPage)
+            return;
+        RefPtr protectedWebPage = weakWebPage.get();
+        if (textIndicatorData)
+            protectedWebPage->addTextIndicatorStyleForID(finalTextIndicatorUUID, TextIndicatorStyle::Final, *textIndicatorData);
+    });
 
-    auto characterRange = [&] {
-        auto characterRanges = m_textIndicatorCharacterRanges.getOptional(session.uuid);
-        // FIXME: Why doesn't this have to be resolved to the session range like above?
-        if (!characterRanges)
-            return characterRangeWithDelta;
-
-        // sessionRangeVector.last() will always be valid because when creating
-        // the structure we always create the vector with an element.
-
-        ASSERT(!characterRanges->isEmpty());
-
-        // FIXME: Why doesn't this have to be resolved to the session range like above?
-        return subCharacterRange(range, characterRanges->last().range);
-    }();
-
-    auto& characterRanges = m_textIndicatorCharacterRanges.ensure(session.uuid, [] {
-        return Vector<UnifiedTextReplacementController::TextIndicatorCharacterRange> { };
-    }).iterator->value;
-
+    bool attachedToExistingSession = false;
+    for (auto& [sessionUUID, sessionRangeVector] : m_textIndicatorCharacterRangesForSessions) {
+        if (sessionUUID == session.uuid) {
+            // sessionRangeVector.last() will always be valid because when creating
+            // the structure we always create the vector with an element.
+            auto characterRange = subCharacterRange(range, sessionRangeVector.last().second);
 #if PLATFORM(MAC)
-    characterRanges.append({ sourceTextIndicatorUUID, characterRange });
+            sessionRangeVector.append({ sourceTextIndicatorUUID, characterRange });
 #endif
-    characterRanges.append({ finalTextIndicatorUUID, characterRange });
+            sessionRangeVector.append({ finalTextIndicatorUUID, characterRange });
+
+            attachedToExistingSession = true;
+            break;
+        }
+    }
+    if (!attachedToExistingSession) {
+#if PLATFORM(MAC)
+        m_textIndicatorCharacterRangesForSessions.append({ session.uuid, { { sourceTextIndicatorUUID, characterRangeAfterReplace }, { finalTextIndicatorUUID , characterRangeAfterReplace } } });
+#else
+        m_textIndicatorCharacterRangesForSessions.append({ session.uuid, { { finalTextIndicatorUUID, characterRangeAfterReplace } } });
+#endif
+    }
 }
 
 void UnifiedTextReplacementController::textReplacementSessionDidReceiveEditAction(const WebUnifiedTextReplacementSessionData& session, WebTextReplacementData::EditAction action)
@@ -510,7 +563,7 @@ void UnifiedTextReplacementController::textReplacementSessionPerformEditActionFo
             }
         }();
 
-        replaceContentsOfRangeInSession(session, rangeToReplace, previousText);
+        replaceContentsOfRangeInSession(session.uuid, rangeToReplace, previousText);
 
         auto newData = WebCore::DocumentMarker::UnifiedTextReplacementData { currentText, oldData.uuid, session.uuid, newState };
         auto newOffsetRange = WebCore::OffsetRange { offsetRange.start, offsetRange.end + previousText.length() - currentText.length() };
@@ -549,7 +602,7 @@ void UnifiedTextReplacementController::textReplacementSessionPerformEditActionFo
         }
 
         m_replacedDocumentNodes.set(session.uuid, contents.returnValue()); // Deep clone.
-        replaceContentsOfRangeInSession(session, *sessionRange, *originalFragment);
+        replaceContentsOfRangeInSession(session.uuid, *sessionRange, *originalFragment);
 
         break;
     }
@@ -562,7 +615,7 @@ void UnifiedTextReplacementController::textReplacementSessionPerformEditActionFo
         }
 
         m_replacedDocumentNodes.set(session.uuid, contents.returnValue()); // Deep clone.
-        replaceContentsOfRangeInSession(session, *sessionRange, *originalFragment);
+        replaceContentsOfRangeInSession(session.uuid, *sessionRange, *originalFragment);
 
         break;
     }
@@ -574,7 +627,7 @@ void UnifiedTextReplacementController::textReplacementSessionPerformEditActionFo
             return;
         }
 
-        replaceContentsOfRangeInSession(session, *sessionRange, *originalFragment);
+        replaceContentsOfRangeInSession(session.uuid, *sessionRange, *originalFragment);
         m_replacedDocumentNodes.remove(session.uuid);
 
         break;
@@ -636,57 +689,6 @@ void UnifiedTextReplacementController::updateStateForSelectedReplacementIfNeeded
     m_webPage->textReplacementSessionUpdateStateForReplacementWithUUID(data.sessionUUID, WebTextReplacementData::State::Active, data.uuid);
 }
 
-void UnifiedTextReplacementController::removeTransparentMarkersForUUID(const WebCore::SimpleRange& range, const WTF::UUID& uuid)
-{
-
-    RefPtr document = this->document();
-    if (!document) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    document->markers().filterMarkers(range, [&](const WebCore::DocumentMarker& marker) {
-        return std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
-    }, { WebCore::DocumentMarker::Type::TransparentContent });
-}
-
-void UnifiedTextReplacementController::removeTransparentMarkersForSession(const WTF::UUID& uuid, RemoveAllMarkersForSession removeAll)
-{
-    RefPtr document = this->document();
-    if (!document) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    // FIXME: `uuid` is either a session's id or a character range's id, so the below logic doesn't make much sense.
-
-    if (auto sessionRange = contextRangeForSessionWithUUID(uuid)) {
-        removeTransparentMarkersForUUID(*sessionRange, uuid);
-
-        if (removeAll == RemoveAllMarkersForSession::No)
-            return;
-
-        auto textIndicatorCharacterRanges = m_textIndicatorCharacterRanges.getOptional(uuid).value_or(Vector<UnifiedTextReplacementController::TextIndicatorCharacterRange> { });
-        for (auto textIndicatorCharacterRange : textIndicatorCharacterRanges)
-            removeTransparentMarkersForUUID(*sessionRange, textIndicatorCharacterRange.uuid);
-    }
-
-    for (const auto& [sessionUUID, characterRanges] : m_textIndicatorCharacterRanges) {
-        auto matches = characterRanges.containsIf([&](const auto& characterRange) {
-            return characterRange.uuid == uuid;
-        });
-
-        if (!matches)
-            continue;
-
-        auto sessionRange = contextRangeForSessionWithUUID(sessionUUID);
-        if (!sessionRange)
-            continue;
-
-        removeTransparentMarkersForUUID(*sessionRange, uuid);
-    }
-}
-
 // MARK: Private instance helper methods.
 
 std::optional<WebCore::SimpleRange> UnifiedTextReplacementController::contextRangeForSessionWithUUID(const WTF::UUID& uuid) const
@@ -694,26 +696,20 @@ std::optional<WebCore::SimpleRange> UnifiedTextReplacementController::contextRan
     return WebCore::makeSimpleRange(m_contextRanges.get(uuid));
 }
 
-// FIXME: This function should either take a session uuid, or a range uuid, not both.
 std::optional<WebCore::SimpleRange> UnifiedTextReplacementController::contextRangeForSessionOrRangeWithUUID(const WTF::UUID& uuid) const
 {
     auto sessionRange = contextRangeForSessionWithUUID(uuid);
     if (sessionRange)
         return sessionRange;
 
-    for (const auto& [sessionUUID, characterRanges] : m_textIndicatorCharacterRanges) {
-        auto index = characterRanges.findIf([&](const auto& characterRange) {
-            return characterRange.uuid == uuid;
-        });
-
-        if (index == WTF::notFound)
-            continue;
-
-        auto sessionRange = contextRangeForSessionWithUUID(sessionUUID);
-        if (!sessionRange)
-            continue;
-
-        return UnifiedTextReplacementController::resolveCharacterRange(*sessionRange, characterRanges[index].range);
+    for (auto [sessionUUID, textIndicatorUUIDtoRanges] : m_textIndicatorCharacterRangesForSessions) {
+        for (auto [textIndicatorUUID, textIndicatorRange] : textIndicatorUUIDtoRanges) {
+            if (textIndicatorUUID == uuid) {
+                auto fullSessionRange = contextRangeForSessionWithUUID(sessionUUID);
+                if (fullSessionRange)
+                    return UnifiedTextReplacementController::resolveCharacterRange(*fullSessionRange, textIndicatorRange);
+            }
+        }
     }
 
     return std::nullopt;
@@ -799,28 +795,7 @@ std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> UnifiedTextR
     return std::nullopt;
 }
 
-WTF::UUID UnifiedTextReplacementController::createTextIndicator(const WebCore::SimpleRange& range, TextIndicatorStyle style)
-{
-    if (!m_webPage) {
-        ASSERT_NOT_REACHED();
-        return WTF::UUID { 0 };
-    }
-
-    auto textIndicatorUUID = WTF::UUID::createVersion4();
-
-    m_webPage->createTextIndicatorForRange(range, [textIndicatorUUID, style, weakWebPage = WeakPtr { m_webPage }](std::optional<WebCore::TextIndicatorData>&& textIndicatorData) {
-        if (!weakWebPage)
-            return;
-        RefPtr protectedWebPage = weakWebPage.get();
-
-        if (textIndicatorData)
-            protectedWebPage->addTextIndicatorStyleForID(textIndicatorUUID, style, *textIndicatorData);
-    });
-
-    return textIndicatorUUID;
-}
-
-void UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal(const WebUnifiedTextReplacementSessionData& session, const WebCore::SimpleRange& range, WTF::Function<void(WebCore::Editor&)>&& replacementOperation)
+void UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal(const WTF::UUID& uuid, const WebCore::SimpleRange& range, WTF::Function<void(WebCore::Editor&)>&& replacementOperation)
 {
     RefPtr document = this->document();
     if (!document) {
@@ -828,7 +803,7 @@ void UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal(c
         return;
     }
 
-    auto sessionRange = contextRangeForSessionWithUUID(session.uuid);
+    auto sessionRange = contextRangeForSessionWithUUID(uuid);
     if (!sessionRange) {
         ASSERT_NOT_REACHED();
         return;
@@ -875,19 +850,19 @@ void UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal(c
     }
 
     auto updatedLiveRange = WebCore::createLiveRange(*newSessionRange);
-    m_contextRanges.set(session.uuid, updatedLiveRange);
+    m_contextRanges.set(uuid, updatedLiveRange);
 }
 
-void UnifiedTextReplacementController::replaceContentsOfRangeInSession(const WebUnifiedTextReplacementSessionData& session, const WebCore::SimpleRange& range, const String& replacementText)
+void UnifiedTextReplacementController::replaceContentsOfRangeInSession(const WTF::UUID& uuid, const WebCore::SimpleRange& range, const String& replacementText)
 {
-    replaceContentsOfRangeInSessionInternal(session, range, [&replacementText](WebCore::Editor& editor) {
+    replaceContentsOfRangeInSessionInternal(uuid, range, [&replacementText](WebCore::Editor& editor) {
         editor.replaceSelectionWithText(replacementText, WebCore::Editor::SelectReplacement::Yes, WebCore::Editor::SmartReplace::No, WebCore::EditAction::InsertReplacement);
     });
 }
 
-void UnifiedTextReplacementController::replaceContentsOfRangeInSession(const WebUnifiedTextReplacementSessionData& session, const WebCore::SimpleRange& range, WebCore::DocumentFragment& fragment)
+void UnifiedTextReplacementController::replaceContentsOfRangeInSession(const WTF::UUID& uuid, const WebCore::SimpleRange& range, WebCore::DocumentFragment& fragment)
 {
-    replaceContentsOfRangeInSessionInternal(session, range, [&fragment](WebCore::Editor& editor) {
+    replaceContentsOfRangeInSessionInternal(uuid, range, [&fragment](WebCore::Editor& editor) {
         editor.replaceSelectionWithFragment(fragment, WebCore::Editor::SelectReplacement::Yes, WebCore::Editor::SmartReplace::No, WebCore::Editor::MatchStyle::No, WebCore::EditAction::InsertReplacement);
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -48,7 +48,6 @@ class Editor;
 namespace WebKit {
 
 enum class WebUnifiedTextReplacementSessionDataReplacementType : uint8_t;
-enum class TextIndicatorStyle : uint8_t;
 
 enum class RemoveAllMarkersForSession : uint8_t { No, Yes };
 
@@ -86,11 +85,6 @@ public:
     void removeTransparentMarkersForSession(const WTF::UUID&, RemoveAllMarkersForSession);
 
 private:
-    struct TextIndicatorCharacterRange {
-        WTF::UUID uuid;
-        WebCore::CharacterRange range;
-    };
-
     static WebCore::CharacterRange characterRange(const WebCore::SimpleRange& scope, const WebCore::SimpleRange&);
     static WebCore::SimpleRange resolveCharacterRange(const WebCore::SimpleRange& scope, WebCore::CharacterRange);
     static uint64_t characterCount(const WebCore::SimpleRange&);
@@ -99,14 +93,12 @@ private:
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(const WebCore::SimpleRange&) const;
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerByUUID(const WebCore::SimpleRange& outerRange, const WTF::UUID& replacementUUID) const;
 
-    void replaceContentsOfRangeInSessionInternal(const WebUnifiedTextReplacementSessionData&, const WebCore::SimpleRange&, WTF::Function<void(WebCore::Editor&)>&&);
-    void replaceContentsOfRangeInSession(const WebUnifiedTextReplacementSessionData&, const WebCore::SimpleRange&, const String&);
-    void replaceContentsOfRangeInSession(const WebUnifiedTextReplacementSessionData&, const WebCore::SimpleRange&, WebCore::DocumentFragment&);
+    void replaceContentsOfRangeInSessionInternal(const WTF::UUID&, const WebCore::SimpleRange&, WTF::Function<void(WebCore::Editor&)>&&);
+    void replaceContentsOfRangeInSession(const WTF::UUID&, const WebCore::SimpleRange&, const String&);
+    void replaceContentsOfRangeInSession(const WTF::UUID&, const WebCore::SimpleRange&, WebCore::DocumentFragment&);
 
     void textReplacementSessionPerformEditActionForPlainText(WebCore::Document&, const WebUnifiedTextReplacementSessionData&, WebTextReplacementData::EditAction);
     void textReplacementSessionPerformEditActionForRichText(WebCore::Document&, const WebUnifiedTextReplacementSessionData&, WebTextReplacementData::EditAction);
-
-    WTF::UUID createTextIndicator(const WebCore::SimpleRange&, TextIndicatorStyle);
 
     template<WebUnifiedTextReplacementSessionData::ReplacementType Type>
     void didEndTextReplacementSession(const WebUnifiedTextReplacementSessionData&, bool accepted);
@@ -115,13 +107,15 @@ private:
 
     WeakPtr<WebPage> m_webPage;
 
+    using TextIndicatorCharacterRange = std::pair<WTF::UUID, WebCore::CharacterRange>;
+    Vector<std::pair<WTF::UUID, Vector<TextIndicatorCharacterRange>>> m_textIndicatorCharacterRangesForSessions;
+
     // FIXME: Unify these states into a single `State` struct.
     HashMap<WTF::UUID, Ref<WebCore::Range>> m_contextRanges;
     HashMap<WTF::UUID, WebUnifiedTextReplacementSessionData::ReplacementType> m_replacementTypes;
     HashMap<WTF::UUID, int> m_replacementLocationOffsets;
     HashMap<WTF::UUID, Ref<WebCore::DocumentFragment>> m_originalDocumentNodes;
     HashMap<WTF::UUID, Ref<WebCore::DocumentFragment>> m_replacedDocumentNodes;
-    HashMap<WTF::UUID, Vector<TextIndicatorCharacterRange>> m_textIndicatorCharacterRanges;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f4583cb4b616555c0b6995f9b682919da80b5c5d
<pre>
Revert &quot;[Unified Text Replacement] Refactor `m_textIndicatorCharacterRanges` to be a HashMap&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=274413">https://bugs.webkit.org/show_bug.cgi?id=274413</a>
<a href="https://rdar.apple.com/128414885">rdar://128414885</a>

Reviewed by Megan Gardner.

This reverts commit d48be59b226a3da86b16e3948e08db42c6637263.

Canonical link: <a href="https://commits.webkit.org/279012@main">https://commits.webkit.org/279012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1765621fa74f63e75ef1bfa8133969582d443e96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/52253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/31585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4673 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/2976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/37987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/55527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/2976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/54349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/37987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/37987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1135 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/37987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57123 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7649 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/28357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->