### PR TITLE
[iOS] Enable automatic live resize on iPadOS at runtime

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -702,10 +702,10 @@ AutomaticLiveResizeEnabled:
   humanReadableDescription: "Automatically synchronize web view resize with painting"
   webcoreBinding: none
   exposed: [ WebKit ]
+  condition: PLATFORM(IOS_FAMILY)
   defaultValue:
     WebKit:
-      "PLATFORM(VISION)": true
-      default: false
+      default: WebKit::defaultAutomaticLiveResizeEnabled()
 
 BackgroundFetchAPIEnabled:
   type: bool

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1006,10 +1006,6 @@ typedef NS_OPTIONS(NSInteger, UIWKDocumentRequestFlags) {
 
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
 
-@interface UIWindowScene ()
-@property (nonatomic, readonly, getter=_isInLiveResize) BOOL _inLiveResize;
-@end
-
 extern NSNotificationName const _UIWindowSceneDidBeginLiveResizeNotification;
 extern NSNotificationName const _UIWindowSceneDidEndLiveResizeNotification;
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -110,6 +110,10 @@ bool defaultRemoveBackgroundEnabled();
 bool defaultGamepadVibrationActuatorEnabled();
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+bool defaultAutomaticLiveResizeEnabled();
+#endif
+
 bool defaultRunningBoardThrottlingEnabled();
 bool defaultShouldDropNearSuspendedAssertionAfterDelay();
 bool defaultShouldTakeNearSuspendedAssertion();

--- a/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
+++ b/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
@@ -109,6 +109,18 @@ bool defaultWriteRichTextDataWhenCopyingOrDragging()
     return !isAsyncTextInputFeatureFlagEnabled();
 }
 
+bool defaultAutomaticLiveResizeEnabled()
+{
+#if PLATFORM(VISION)
+    return true;
+#elif USE(BROWSERENGINEKIT)
+    static bool enabled = PAL::deviceHasIPadCapability() && os_feature_enabled(UIKit, async_text_input_ipad);
+    return enabled;
+#else
+    return false;
+#endif
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -310,7 +310,8 @@ struct PerWebProcessState {
     RetainPtr<UIView> _resizeAnimationView;
     CGFloat _lastAdjustmentForScroller;
 
-    RetainPtr<id> _endLiveResizeNotificationObserver;
+    CGSize _lastKnownWindowSize;
+    RetainPtr<NSTimer> _endLiveResizeTimer;
 
     WebCore::FloatBoxExtent _obscuredInsetsWhenSaved;
 


### PR DESCRIPTION
#### ea884a9b50d637b50ca72d62c0813d555f94bc19
<pre>
[iOS] Enable automatic live resize on iPadOS at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=274410">https://bugs.webkit.org/show_bug.cgi?id=274410</a>

Reviewed by Abrar Rahman Protyasha.

Enable automatic live resize on iPad, with runtime enablement guarded by a system feature flag.
Additionally, remove usage of two SPIs that currently support automatic live resize behaviors:

• `_UIWindowSceneDidEndLiveResizeNotification`
• `-[UIWindowScene _isInLiveResize]`

...by instead changing how automatic live resize works:

(a) Don&apos;t wait for the live resize gesture to end before allowing geometry updates to commence;
    instead, use an arbitrary hysteresis of 500 ms to determine when the viewport dimensions have
    stabilized, before ending live resize.

(b) Use automatic live resize whenever the window itself is changing size; to detect this, keep
    track of the last known size of the window containing the web view, and only trigger live resize
    when this size is changing.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm:
(WebKit::defaultAutomaticLiveResizeEnabled):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView didMoveToWindow]):
(-[WKWebView _beginAutomaticLiveResizeIfNeeded]):

Refactor this so that we debounce the new &quot;end live resize&quot; timer instead of just early returning
when the size changes.

(-[WKWebView _rescheduleEndLiveResizeTimer]):
(-[WKWebView _acquireResizeAssertionForReason:]):

Remove unnecessary runtime staging, since support for this SPI has long shipped.

(-[WKWebView _endLiveResize]):
(-[WKWebView _destroyEndLiveResizeObserver]): Deleted.

Replace this notification observer with an `NSTimer` instead, which is debounced whenever the web
view size changes, and otherwise fires after a fixed delay of half a second.

Canonical link: <a href="https://commits.webkit.org/279030@main">https://commits.webkit.org/279030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e0a36748d6b0e23738ef8ff0bb3982a5e3bce4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2969 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42515 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1128 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45595 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57116 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51754 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49907 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45212 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49149 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11423 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29517 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64061 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28350 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12126 "Passed tests") | 
<!--EWS-Status-Bubble-End-->