### PR TITLE
Re-add access to WKBrowsingContextController on iOS with linked-on-or-after check

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -36,6 +36,7 @@ enum class SDKAlignedBehavior {
     ApplicationStateTrackerDoesNotObserveWindow,
     AuthorizationHeaderOnSameOriginRedirects,
     BlanksViewOnJSPrompt,
+    BrowsingContextControllerSPIAccessRemoved,
     ContextMenuTriggersLinkActivationNavigationType,
     ConvertsInvalidURLsToBlank,
     DataURLFragmentRemoval,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -142,11 +142,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)loadRequest:(NSURLRequest *)request userData:(id)userData
 {
-    RefPtr<WebKit::ObjCObjectGraph> wkUserData;
-    if (userData)
-        wkUserData = WebKit::ObjCObjectGraph::create(userData);
-
-    _page->loadRequest(request, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, wkUserData.get());
+    ASSERT(!userData);
+    _page->loadRequest(request, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow, { });
 }
 
 - (void)loadFileURL:(NSURL *)URL restrictToFilesWithin:(NSURL *)allowedDirectory
@@ -156,14 +153,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)loadFileURL:(NSURL *)URL restrictToFilesWithin:(NSURL *)allowedDirectory userData:(id)userData
 {
+    ASSERT(!userData);
     if (![URL isFileURL] || (allowedDirectory && ![allowedDirectory isFileURL]))
         [NSException raise:NSInvalidArgumentException format:@"Attempted to load a non-file URL"];
 
-    RefPtr<WebKit::ObjCObjectGraph> wkUserData;
-    if (userData)
-        wkUserData = WebKit::ObjCObjectGraph::create(userData);
-
-    _page->loadFile(bytesAsString(bridge_cast(URL)), bytesAsString(bridge_cast(allowedDirectory)), wkUserData.get());
+    _page->loadFile(bytesAsString(bridge_cast(URL)), bytesAsString(bridge_cast(allowedDirectory)), { });
 }
 
 - (void)loadHTMLString:(NSString *)HTMLString baseURL:(NSURL *)baseURL
@@ -173,12 +167,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)loadHTMLString:(NSString *)HTMLString baseURL:(NSURL *)baseURL userData:(id)userData
 {
-    RefPtr<WebKit::ObjCObjectGraph> wkUserData;
-    if (userData)
-        wkUserData = WebKit::ObjCObjectGraph::create(userData);
-
+    ASSERT(!userData);
     NSData *data = [HTMLString dataUsingEncoding:NSUTF8StringEncoding];
-    _page->loadData(span(data), "text/html"_s, "UTF-8"_s, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
+    _page->loadData(span(data), "text/html"_s, "UTF-8"_s, bytesAsString(bridge_cast(baseURL)), { });
 }
 
 - (void)loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
@@ -194,11 +185,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)loadData:(NSData *)data MIMEType:(NSString *)MIMEType textEncodingName:(NSString *)encodingName baseURL:(NSURL *)baseURL userData:(id)userData
 {
-    RefPtr<WebKit::ObjCObjectGraph> wkUserData;
-    if (userData)
-        wkUserData = WebKit::ObjCObjectGraph::create(userData);
-
-    _page->loadData(span(data), MIMEType, encodingName, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
+    ASSERT(!userData);
+    _page->loadData(span(data), MIMEType, encodingName, bytesAsString(bridge_cast(baseURL)), { });
 }
 
 - (void)stopLoading

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -336,6 +336,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return [_contentView isBackground];
 }
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+- (WKBrowsingContextController *)browsingContextController
+{
+    if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::BrowsingContextControllerSPIAccessRemoved))
+        return nil;
+    return [_contentView browsingContextController];
+}
+ALLOW_DEPRECATED_DECLARATIONS_END
+
 - (BOOL)becomeFirstResponder
 {
 #if PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -59,6 +59,10 @@ enum class ViewStabilityFlag : uint8_t;
     WeakObjCPtr<WKWebView> _webView;
 }
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+@property (nonatomic, readonly) WKBrowsingContextController *browsingContextController;
+ALLOW_DEPRECATED_DECLARATIONS_END
+
 @property (nonatomic, readonly) WebKit::WebPageProxy* page;
 @property (nonatomic, readonly) BOOL isFocusingElement;
 @property (nonatomic, getter=isShowingInspectorIndication) BOOL showingInspectorIndication;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -165,6 +165,9 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
 @implementation WKContentView {
     std::unique_ptr<WebKit::PageClientImpl> _pageClient;
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    RetainPtr<WKBrowsingContextController> _browsingContextController;
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     RetainPtr<UIView> _rootContentView;
     RetainPtr<UIView> _fixedClippingView;
@@ -541,6 +544,16 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     else
         [self cleanUpInteractionPreviewContainers];
 }
+
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+- (WKBrowsingContextController *)browsingContextController
+{
+    if (!_browsingContextController)
+        _browsingContextController = adoptNS([[WKBrowsingContextController alloc] _initWithPageRef:toAPI(_page.get())]);
+
+    return _browsingContextController.get();
+}
+ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKPageRef)_pageRef
 {


### PR DESCRIPTION
#### 4112a1e17fe67a4f8091c6f2a5a13d9619ac83f7
<pre>
Re-add access to WKBrowsingContextController on iOS with linked-on-or-after check
<a href="https://bugs.webkit.org/show_bug.cgi?id=274417">https://bugs.webkit.org/show_bug.cgi?id=274417</a>
<a href="https://rdar.apple.com/128283322">rdar://128283322</a>

Reviewed by Brady Eidson.

WKBrowsingContextController is SPI that does not exist in public headers, but at
least one app is doing some tricky ObjC runtime things to access and use it.  This
PR puts it back but with a linked-on-or-after check removing access so when the app
updates it will no longer be able to access the SPI.

The original motivation for disconnecting WKBrowsingContextController was to remove
use of ObjCObjectGraph, which was used to communicate with the injected bundle in
some early prototypes of multi-process WebKit.  I verified ObjCObjectGraph was not
used, which makes sense because there is no injected bundle to communicate with.
To make this re-adding of WKBrowsingContextController access not hold up the removal
of ObjCObjectGraph, I also removed the use of ObjCObjectGraph in WKBrowsingContextController.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController loadRequest:userData:]):
(-[WKBrowsingContextController loadFileURL:restrictToFilesWithin:userData:]):
(-[WKBrowsingContextController loadHTMLString:baseURL:userData:]):
(-[WKBrowsingContextController loadData:MIMEType:textEncodingName:baseURL:userData:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView browsingContextController]):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView browsingContextController]):

Canonical link: <a href="https://commits.webkit.org/279022@main">https://commits.webkit.org/279022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe7b2d01456259d79ad59287b974413517b33f99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2681 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1910 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23594 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1142 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45609 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57130 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51768 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2575 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45224 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64075 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7656 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28364 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12127 "Passed tests") | 
<!--EWS-Status-Bubble-End-->