### PR TITLE
ASSERTION FAILED: isPublicSuffixCF(publicSuffix) in PublicSuffixStore::addPublicSuffix

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1759,6 +1759,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/ProcessIdentity.h
     platform/ProcessQualified.h
     platform/PromisedAttachmentInfo.h
+    platform/PublicSuffix.h
     platform/PublicSuffixStore.h
     platform/RectEdges.h
     platform/ReferrerPolicy.h

--- a/Source/WebCore/platform/PublicSuffix.h
+++ b/Source/WebCore/platform/PublicSuffix.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CrossThreadCopier.h>
+#include <wtf/HashTraits.h>
+#include <wtf/text/StringHash.h>
+
+namespace WebCore {
+
+class PublicSuffix {
+public:
+    static PublicSuffix fromRawString(String&& string) { return PublicSuffix(WTFMove(string)); }
+    PublicSuffix() = default;
+    bool isValid() const { return !m_string.isEmpty(); }
+    const String& string() const { return m_string; }
+    PublicSuffix isolatedCopy() const { return fromRawString(crossThreadCopy(m_string)); }
+
+    PublicSuffix(WTF::HashTableDeletedValueType)
+        : m_string(WTF::HashTableDeletedValue) { }
+    friend bool operator==(const PublicSuffix&, const PublicSuffix&) = default;
+    bool operator==(ASCIILiteral other) const { return m_string == other; }
+    bool isHashTableDeletedValue() const { return m_string.isHashTableDeletedValue(); }
+    unsigned hash() const { return m_string.hash(); }
+    struct PublicSuffixHash {
+        static unsigned hash(const PublicSuffix& publicSuffix) { return ASCIICaseInsensitiveHash::hash(publicSuffix.m_string.impl()); }
+        static bool equal(const PublicSuffix& a, const PublicSuffix& b) { return equalIgnoringASCIICase(a.string(), b.string()); }
+        static const bool safeToCompareToEmptyOrDeleted = false;
+    };
+
+private:
+    explicit PublicSuffix(String&& string) : m_string(WTFMove(string)) { }
+
+    String m_string;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::PublicSuffix> : WebCore::PublicSuffix::PublicSuffixHash { };
+template<> struct HashTraits<WebCore::PublicSuffix> : SimpleClassHashTraits<WebCore::PublicSuffix> { };
+
+} // namespace WTF

--- a/Source/WebCore/platform/PublicSuffixStore.cpp
+++ b/Source/WebCore/platform/PublicSuffixStore.cpp
@@ -52,7 +52,7 @@ bool PublicSuffixStore::isPublicSuffix(StringView domain) const
     return platformIsPublicSuffix(domain);
 }
 
-String PublicSuffixStore::publicSuffix(const URL& url) const
+PublicSuffix PublicSuffixStore::publicSuffix(const URL& url) const
 {
     if (!url.isValid())
         return { };
@@ -65,7 +65,7 @@ String PublicSuffixStore::publicSuffix(const URL& url) const
     for (unsigned labelStart = 0; (separatorPosition = host.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {
         auto candidate = host.substring(separatorPosition + 1);
         if (isPublicSuffix(candidate))
-            return candidate.toString();
+            return PublicSuffix::fromRawString(candidate.toString());
     }
 
     return { };

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "PublicSuffix.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/StringHash.h>
@@ -38,14 +39,13 @@ public:
 
     // https://url.spec.whatwg.org/#host-public-suffix
     WEBCORE_EXPORT bool isPublicSuffix(StringView domain) const;
-    WEBCORE_EXPORT String publicSuffix(const URL&) const;
+    WEBCORE_EXPORT PublicSuffix publicSuffix(const URL&) const;
     WEBCORE_EXPORT String topPrivatelyControlledDomain(StringView host) const;
     WEBCORE_EXPORT void clearHostTopPrivatelyControlledDomainCache();
 
 #if PLATFORM(COCOA)
-    enum class CanAcceptCustomPublicSuffix : bool { No, Yes };
-    WEBCORE_EXPORT void enablePublicSuffixCache(CanAcceptCustomPublicSuffix = CanAcceptCustomPublicSuffix::No);
-    WEBCORE_EXPORT void addPublicSuffix(const String& publicSuffix);
+    WEBCORE_EXPORT void enablePublicSuffixCache();
+    WEBCORE_EXPORT void addPublicSuffix(const PublicSuffix&);
 #endif
 
 private:
@@ -59,8 +59,7 @@ private:
     mutable HashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);
 #if PLATFORM(COCOA)
     mutable Lock m_publicSuffixCacheLock;
-    std::optional<HashSet<String, ASCIICaseInsensitiveHash>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
-    bool m_canAcceptCustomPublicSuffix { false }; // Only used on the main thread.
+    std::optional<HashSet<PublicSuffix>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
 #endif
 };
 

--- a/Source/WebKit/Shared/GoToBackForwardItemParameters.h
+++ b/Source/WebKit/Shared/GoToBackForwardItemParameters.h
@@ -30,6 +30,7 @@
 #include "WebsitePoliciesData.h"
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/PublicSuffix.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
 #include <wtf/text/WTFString.h>
 
@@ -43,7 +44,7 @@ struct GoToBackForwardItemParameters {
     std::optional<WebsitePoliciesData> websitePolicies;
     bool lastNavigationWasAppInitiated;
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
-    String publicSuffix;
+    WebCore::PublicSuffix publicSuffix;
     SandboxExtension::Handle sandboxExtensionHandle;
 };
 

--- a/Source/WebKit/Shared/GoToBackForwardItemParameters.serialization.in
+++ b/Source/WebKit/Shared/GoToBackForwardItemParameters.serialization.in
@@ -28,6 +28,6 @@
     std::optional<WebKit::WebsitePoliciesData> websitePolicies;
     bool lastNavigationWasAppInitiated;
     std::optional<WebKit::NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
-    String publicSuffix;
+    WebCore::PublicSuffix publicSuffix;
     WebKit::SandboxExtensionHandle sandboxExtensionHandle;
 };

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -33,6 +33,7 @@
 #include <WebCore/AdvancedPrivacyProtections.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/PublicSuffixStore.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
 #include <WebCore/SubstituteData.h>
@@ -51,7 +52,7 @@ using SandboxFlags = int;
 namespace WebKit {
 
 struct LoadParameters {
-    String publicSuffix;
+    WebCore::PublicSuffix publicSuffix;
 
     uint64_t navigationID { 0 };
     std::optional<WebCore::FrameIdentifier> frameIdentifier;

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -25,7 +25,7 @@ enum class WebCore::LockBackForwardList : bool;
 enum class WebKit::NavigatingToAppBoundDomain : bool;
 
 [RValue] struct WebKit::LoadParameters {
-    String publicSuffix;
+    WebCore::PublicSuffix publicSuffix;
     uint64_t navigationID;
     std::optional<WebCore::FrameIdentifier> frameIdentifier;
     [EncodeRequestBody] WebCore::ResourceRequest request;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8155,3 +8155,7 @@ using WebCore::IDBKeyPath = std::variant<String, Vector<String>>;
 using WebCore::ServiceWorkerOrClientData = std::variant<WebCore::ServiceWorkerData, WebCore::ServiceWorkerClientData>
 using WebCore::MediaPlayer::VideoFullscreenMode = uint32_t
 enum class WebCore::CrossOriginMode : bool
+
+[CreateUsing=fromRawString] class WebCore::PublicSuffix {
+    String string();
+};

--- a/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
@@ -192,17 +192,17 @@ TEST_F(PublicSuffix, PublicSuffixCache)
     WTF::URL abExampleURL { "http://a.b.example.example"_s };
     auto& publicSuffixStore = PublicSuffixStore::singleton();
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix("example.example"_s));
-    EXPECT_EQ(String("example"_s), publicSuffixStore.publicSuffix(abExampleURL));
+    EXPECT_EQ(String("example"_s), publicSuffixStore.publicSuffix(abExampleURL).string());
     // Non-cocoa platforms currently do not use public suffix cache for topPrivatelyControlledDomain().
     EXPECT_EQ(String("example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
 
-    publicSuffixStore.enablePublicSuffixCache(PublicSuffixStore::CanAcceptCustomPublicSuffix::Yes);
+    publicSuffixStore.enablePublicSuffixCache();
     publicSuffixStore.clearHostTopPrivatelyControlledDomainCache();
-    publicSuffixStore.addPublicSuffix("example.example"_s);
-    publicSuffixStore.addPublicSuffix(""_s);
+    publicSuffixStore.addPublicSuffix(WebCore::PublicSuffix::fromRawString("example.example"_s));
+    publicSuffixStore.addPublicSuffix(WebCore::PublicSuffix { });
     EXPECT_TRUE(publicSuffixStore.isPublicSuffix("example.example"_s));
-    EXPECT_EQ(String("example.example"_s), publicSuffixStore.publicSuffix(abExampleURL));
+    EXPECT_EQ(String("example.example"_s), publicSuffixStore.publicSuffix(abExampleURL).string());
     EXPECT_EQ(String("b.example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
 }


### PR DESCRIPTION
#### 4031410eeeb157432f0a6e0ca143e54d02665096
<pre>
ASSERTION FAILED: isPublicSuffixCF(publicSuffix) in PublicSuffixStore::addPublicSuffix
<a href="https://bugs.webkit.org/show_bug.cgi?id=274418">https://bugs.webkit.org/show_bug.cgi?id=274418</a>
<a href="https://rdar.apple.com/128255984">rdar://128255984</a>

Reviewed by Chris Dumez.

The assertion was introduced in 276834@main to help debug <a href="https://rdar.apple.com/125417343">rdar://125417343</a>, where we suspected the cause is unexpected
entry being added to public suffix cache, like 276635@main. However, because UI process and web process have different
sandbox access, isPublicSuffixCF (_CFHostIsDomainTopLevel) might return different values on the same string. That means,
in web process, the assertion would be hit even though the string is a valid public suffix according to UI process&apos;s
check.

As the original goal is to ensure UI process only sends valid public suffix (or empty string) to web process, the patch
does the hardening by introducing a new class PublicSuffix. UI process needs to explicity contruct it from URL with
PublicSuffixStore and send PublicSuffix object to web process, which is less error-prone than allowing UI process sends
public suffix in string. With this change, we no longer need the assertion.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/PublicSuffix.h: Added.
(WebCore::PublicSuffix::fromRawString):
(WebCore::PublicSuffix::isValid const):
(WebCore::PublicSuffix::string const):
(WebCore::PublicSuffix::isolatedCopy const):
(WebCore::PublicSuffix::PublicSuffix):
(WebCore::PublicSuffix::operator== const):
(WebCore::PublicSuffix::isHashTableDeletedValue const):
(WebCore::PublicSuffix::hash const):
(WebCore::PublicSuffix::PublicSuffixHash::hash):
(WebCore::PublicSuffix::PublicSuffixHash::equal):
* Source/WebCore/platform/PublicSuffixStore.cpp:
(WebCore::PublicSuffixStore::publicSuffix const):
* Source/WebCore/platform/PublicSuffixStore.h:
(): Deleted.
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::platformIsPublicSuffix const):
(WebCore::PublicSuffixStore::enablePublicSuffixCache):
(WebCore::PublicSuffixStore::addPublicSuffix):
* Source/WebKit/Shared/GoToBackForwardItemParameters.h:
* Source/WebKit/Shared/GoToBackForwardItemParameters.serialization.in:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/279128@main">https://commits.webkit.org/279128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ba11f571fd1c3b0640a985b070bcb23a982accc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52524 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42686 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2067 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57394 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27656 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2778 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content.html, imported/w3c/web-platform-tests/css/css-view-transitions/exit-transition-with-anonymous-layout-object.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-and-box-decorations.html, imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-hidden.html, imported/w3c/web-platform-tests/css/css-view-transitions/transform-origin-view-transition-group.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50083 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45444 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49348 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11487 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->