### PR TITLE
[view-transitions] Mispositioned snapshots on https://codepen.io/bramus/full/mdowgYX

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: computed transform for elements with transform-style:flat ancestors is correct (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+body {
+  perspective: 1000px;
+}
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+}
+.outer {
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+  perspective: 1000px;
+}
+body { background: lightpink; }
+</style>
+<div class=outer>
+  <div class=outer>
+    <div class=box></div>
+  </div>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: computed transform for elements with transform-style:flat ancestors is correct (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+body {
+  perspective: 1000px;
+}
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+}
+.outer {
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+  perspective: 1000px;
+}
+body { background: lightpink; }
+</style>
+<div class=outer>
+  <div class=outer>
+    <div class=box></div>
+  </div>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: computed transform for elements with transform-style:flat ancestors is correct</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-flat-transform-ancestor-ref.html">
+<meta name="fuzzy" content="maxDifference=0-63; totalPixels=0-510" />
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<script src="../../../../../resources/ui-helper.js"></script>
+<style>
+body {
+  perspective: 1000px;
+}
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+  view-transition-name: target;
+}
+.outer {
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+  perspective: 1000px;
+}
+
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class=outer>
+  <div class=outer>
+    <div class=box></div>
+  </div>
+</div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  await waitForAtLeastOneFrame();
+
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: computed transform for elements with transform-style:preserve-3d ancestors is correct (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+body { background: lightpink; }
+</style>
+<div class=box></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: computed transform for elements with transform-style:preserve-3d ancestors is correct (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+body { background: lightpink; }
+</style>
+<div class=box></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: computed transform for elements with transform-style:preserve-3d ancestors is correct</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-preserve-3d-ancestor-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<script src="../../../../../resources/ui-helper.js"></script>
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  transform: rotateY(60deg);
+  view-transition-name: target;
+}
+.outer {
+  width: 100px;
+  height: 100px;
+  transform-style: preserve-3d;
+  transform: rotateY(60deg);
+}
+
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class=outer>
+  <div class=outer>
+    <div class=box></div>
+  </div>
+</div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  await waitForAtLeastOneFrame();
+
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+body { background: lightpink; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+  addEventListener("scroll", () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  }, { once: true, capture: true });
+  document.documentElement.scrollTop = 500;
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+body { background: lightpink; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+  addEventListener("scroll", () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  }, { once: true, capture: true });
+  document.documentElement.scrollTop = 500;
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-transform-position-fixed-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<script src="../../../../../resources/ui-helper.js"></script>
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+  view-transition-name: target;
+}
+
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  await waitForAtLeastOneFrame();
+
+  /* Scroll the doc, target element's element-to-screen transform should not change */
+  await new Promise((resolve) => {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }, { once: true, capture: true });
+
+    document.documentElement.scrollTop = 500;
+  });
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html >
+<html class="reftest-wait">
 <title>View transitions: capture root element with scrollbar (ref)</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
@@ -25,6 +26,13 @@ body {
 
 <script>
   function scrollContainer() {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document.documentElement.classList.remove("reftest-wait");
+        });
+      });
+    }, { once: true, capture: true });
     document.documentElement.scrollTop = 500;
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html
@@ -25,6 +25,13 @@ body {
 
 <script>
   function scrollContainer() {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document.documentElement.classList.remove("reftest-wait");
+        });
+      });
+    }, { once: true, capture: true });
     document.documentElement.scrollTop = 500;
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background.html
@@ -56,7 +56,13 @@ failIfNot(document.startViewTransition, "Missing document.startViewTransition");
 async function runTest() {
   await waitForAtLeastOneFrame();
 
-  document.documentElement.scrollTop = 500;
+  await new Promise((resolve) => {
+    addEventListener("scroll", () => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }, { once: true, capture: true });
+
+    document.documentElement.scrollTop = 500;
+  });
   document.startViewTransition(() => {
     requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
   });

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -643,9 +643,9 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
     };
 
     Ref<MutableStyleProperties> props = styleExtractor.copyProperties(transitionProperties);
+    auto& frameView = renderer.view().frameView();
 
     if (renderer.isDocumentElementRenderer()) {
-        auto& frameView = renderer.view().frameView();
         size.setWidth(frameView.frameRect().width());
         size.setHeight(frameView.frameRect().height());
     } else if (CheckedPtr renderBox = dynamicDowncast<RenderBoxModelObject>(&renderer))
@@ -654,30 +654,21 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
     props->setProperty(CSSPropertyWidth, CSSPrimitiveValue::create(size.width(), CSSUnitType::CSS_PX));
     props->setProperty(CSSPropertyHeight, CSSPrimitiveValue::create(size.height(), CSSUnitType::CSS_PX));
 
-    TransformationMatrix transform;
-    RenderElement* current = &renderer;
-    RenderElement* container = nullptr;
-    while (current && !current->isRenderView()) {
-        container = current->container();
-        if (!container)
-            break;
-        LayoutSize containerOffset = current->offsetFromContainer(*container, LayoutPoint());
-        if (container->isRenderView()) {
-            auto frameView = current->view().protectedFrameView();
-            containerOffset -= toLayoutSize(frameView->scrollPositionRespectingCustomFixedPosition());
-        }
-        TransformationMatrix localTransform;
-        current->getTransformFromContainer(containerOffset, localTransform);
-        transform = localTransform * transform;
-        current = container;
-    }
-    // Apply the inverse of what will be added by the default value of 'transform-origin',
-    // since the computed transform has already included it.
-    transform.translate(size.width() / 2, size.height() / 2);
-    transform.translateRight(-size.width() / 2, -size.height() / 2);
+    if (auto transform = renderer.viewTransitionTransform()) {
+        // FIXME(mattwoodrow): `transform` gives absolute coords, not
+        // document. We should be accounting for page zoom to get the
+        // absolute->document conversion correct.
+        auto offset = frameView.documentToClientOffset();
+        transform->translate(offset.width(), offset.height());
 
-    Ref<CSSValue> transformListValue = CSSTransformListValue::create(ComputedStyleExtractor::matrixTransformValue(transform, renderer.style()));
-    props->setProperty(CSSPropertyTransform, WTFMove(transformListValue));
+        // Apply the inverse of what will be added by the default value of 'transform-origin',
+        // since the computed transform has already included it.
+        transform->translate(size.width() / 2, size.height() / 2);
+        transform->translateRight(-size.width() / 2, -size.height() / 2);
+
+        Ref transformListValue = CSSTransformListValue::create(ComputedStyleExtractor::matrixTransformValue(*transform, renderer.style()));
+        props->setProperty(CSSPropertyTransform, WTFMove(transformListValue));
+    }
     return props;
 }
 

--- a/Source/WebCore/platform/graphics/transforms/TransformState.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.cpp
@@ -78,10 +78,14 @@ void TransformState::translateMappedCoordinates(const LayoutSize& offset)
     if (m_tracking != DoNotTrackTransformMatrix) {
         if (!m_trackedTransform)
             m_trackedTransform = makeUnique<TransformationMatrix>();
+        if (shouldFlattenBefore())
+            m_trackedTransform->flatten();
         if (m_direction == ApplyTransformDirection)
             m_trackedTransform->translateRight(offset.width(), offset.height());
         else
             m_trackedTransform->translate(offset.width(), offset.height());
+        if (shouldFlattenAfter())
+            m_trackedTransform->flatten();
     }
 }
 
@@ -270,10 +274,15 @@ void TransformState::flattenWithTransform(const TransformationMatrix& t, bool* w
         }
     }
 
-    if (m_trackedTransform)
+    if (m_trackedTransform) {
+        if (shouldFlattenBefore())
+            m_trackedTransform->flatten();
         *m_trackedTransform = (m_direction == ApplyTransformDirection) ? (t * *m_trackedTransform) : (*m_trackedTransform * t);
-    else if (m_tracking != DoNotTrackTransformMatrix)
+    } else if (m_tracking != DoNotTrackTransformMatrix)
         m_trackedTransform = makeUnique<TransformationMatrix>(t);
+
+    if (m_trackedTransform && shouldFlattenAfter())
+        m_trackedTransform->flatten();
 
     // We could throw away m_accumulatedTransform if we wanted to here, but that
     // would cause thrash when traversing hierarchies with alternating

--- a/Source/WebCore/platform/graphics/transforms/TransformState.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.h
@@ -123,8 +123,8 @@ private:
     void flattenWithTransform(const TransformationMatrix&, bool* wasClamped);
     void applyAccumulatedOffset();
 
-    bool shouldFlattenBefore(TransformAccumulation accumulate);
-    bool shouldFlattenAfter(TransformAccumulation accumulate);
+    bool shouldFlattenBefore(TransformAccumulation accumulate = FlattenTransform);
+    bool shouldFlattenAfter(TransformAccumulation accumulate = FlattenTransform);
     
     TransformDirection inverseDirection() const;
 

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -1642,6 +1642,20 @@ void TransformationMatrix::makeAffine()
     m_matrix[3][3] = 1;
 }
 
+void TransformationMatrix::flatten()
+{
+    m_matrix[0][2] = 0;
+
+    m_matrix[1][2] = 0;
+
+    m_matrix[2][0] = 0;
+    m_matrix[2][1] = 0;
+    m_matrix[2][2] = 1;
+    m_matrix[2][3] = 0;
+
+    m_matrix[3][2] = 0;
+}
+
 AffineTransform TransformationMatrix::toAffineTransform() const
 {
     return AffineTransform(m_matrix[0][0], m_matrix[0][1], m_matrix[1][0],

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -354,6 +354,11 @@ public:
     // Throw away the non-affine parts of the matrix (lossy!).
     WEBCORE_EXPORT void makeAffine();
 
+    // Sets the 3rd row and column to (0, 0, 1, 0).
+    // Should produce the same results as mapping points into 2d before
+    // applying the next matrix.
+    WEBCORE_EXPORT void flatten();
+
     WEBCORE_EXPORT AffineTransform toAffineTransform() const;
 
     bool operator==(const TransformationMatrix& m2) const

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1481,6 +1481,19 @@ FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet
     return transformState.lastPlanarPoint();
 }
 
+std::unique_ptr<TransformationMatrix> RenderObject::viewTransitionTransform() const
+{
+    // Compute the accumulated local to absolute TransformationMatrix, using the
+    // 'TrackSVGCTMMatrix' option. This computes a single matrix, applying flatten()
+    // to the matrix at 3d rendering context boundaries.
+    TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint { });
+    transformState.setTransformMatrixTracking(TransformState::TrackSVGCTMMatrix);
+    OptionSet<MapCoordinatesMode> mode { UseTransforms, ApplyContainerFlip };
+    mapLocalToContainer(nullptr, transformState, mode, nullptr);
+    transformState.flatten();
+    return transformState.releaseTrackedTransform();
+}
+
 FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, OptionSet<MapCoordinatesMode> mode) const
 {
     TransformState transformState(TransformState::UnapplyInverseTransformDirection, containerPoint);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -821,6 +821,7 @@ public:
 
     // Convert the given local point to absolute coordinates. If OptionSet<MapCoordinatesMode> includes UseTransforms, take transforms into account.
     WEBCORE_EXPORT FloatPoint localToAbsolute(const FloatPoint& localPoint = FloatPoint(), OptionSet<MapCoordinatesMode> = { }, bool* wasFixed = nullptr) const;
+    std::unique_ptr<TransformationMatrix> viewTransitionTransform() const;
     FloatPoint absoluteToLocal(const FloatPoint&, OptionSet<MapCoordinatesMode> = { }) const;
 
     // Convert a local quad to absolute coordinates, taking transforms into account.


### PR DESCRIPTION
#### 159906e6201b73d5b59b2ac3aed6788b66c7a7e7
<pre>
[view-transitions] Mispositioned snapshots on <a href="https://codepen.io/bramus/full/mdowgYX">https://codepen.io/bramus/full/mdowgYX</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272185">https://bugs.webkit.org/show_bug.cgi?id=272185</a>
<a href="https://rdar.apple.com/125931829">rdar://125931829</a>

Reviewed by Simon Fraser.

We were previously unconditionally substracting the scroll position from the transform when positioning the snapshots.
This is incorrect in some cases, like when the element is fixed positioned.

This makes use of the existing TransformState/mapLocalToContainer code to correctly account for position:fixed when accumulating
transforms through ancestors.

It also adds support for flattening the &apos;tracked&apos; transform when crossing 3d rendering context boundaries, by setting the 3rd row
and column of the TransformationMatrix to 0.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-preserve-3d-ancestor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-position-fixed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/root-scrollbar-with-fixed-background.html:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::copyElementBaseProperties):
* Source/WebCore/platform/graphics/transforms/TransformState.cpp:
(WebCore::TransformState::translateMappedCoordinates):
(WebCore::TransformState::flattenWithTransform):
* Source/WebCore/platform/graphics/transforms/TransformState.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::TransformationMatrix::flatten):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::localToAbsoluteTransform const):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/279186@main">https://commits.webkit.org/279186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13f3033b18d43f70ed8dd248d29d241635301218

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3188 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2230 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23923 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2833 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1625 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57613 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2976 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45709 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11520 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Checked out pull request; Reviewed by Simon Fraser; Compiled WebKit (warnings); Running layout-tests; Canonicalized commit; Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->