### PR TITLE
REGRESSION (r145541): Incorrect local to device transformation when the SVG is rendered into a separate composited layer

### DIFF
--- a/LayoutTests/svg/custom/filter-css-transform-resolution-expected.html
+++ b/LayoutTests/svg/custom/filter-css-transform-resolution-expected.html
@@ -1,0 +1,10 @@
+<style>
+    .circle {
+        height: 200px;
+        width: 200px;
+        background-color: green;
+        border-radius: 50%;
+    }
+</style>
+
+<div class="circle"></div>

--- a/LayoutTests/svg/custom/filter-css-transform-resolution.html
+++ b/LayoutTests/svg/custom/filter-css-transform-resolution.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        function runAfterLayoutAndPaint(callback, autoNotifyDone) {
+            if (!window.testRunner) {
+                // For manual test. Delay 500ms to allow us to see the visual change
+                // caused by the callback.
+                setTimeout(callback, 500);
+                return;
+            }
+
+            if (autoNotifyDone)
+                testRunner.waitUntilDone();
+
+            // We do requestAnimationFrame and setTimeout to ensure a frame has started
+            // and layout and paint have run. The requestAnimationFrame fires after the
+            // frame has started but before layout and paint. The setTimeout fires
+            // at the beginning of the next frame, meaning that the previous frame has
+            // completed layout and paint.
+            // See http://crrev.com/c/1395193/10/third_party/blink/web_tests/http/tests/resources/run-after-layout-and-paint.js
+            // for more discussions.
+            requestAnimationFrame(function() {
+                setTimeout(function() {
+                    callback();
+                    if (autoNotifyDone)
+                        testRunner.notifyDone();
+                }, 1);
+            });
+        }
+    </script>
+  <script>
+    function repaintTest() {
+      document.getElementById('div').style.transform = '';
+    }
+  </script>
+</head>
+<body onload="runAfterLayoutAndPaint(repaintTest, true);">
+  <!-- Test for http://crbug.com/345441 - the circle edge should not be blurry -->
+  <div id="div" style="transform: rotate3d(1, 0, 0, 85deg); -webkit-transform-origin: 100px 100px 0px;">
+    <svg width="300" height="300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <defs>
+        <filter x="0" y="0" width="100%" height="100%" id="filter">
+          <feOffset/>
+        </filter>
+      </defs>
+      <circle cx="100" cy="100" r="100" fill="green" filter="url(#filter)"/>
+    </svg>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -201,7 +201,6 @@ AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinat
 {
     AffineTransform absoluteTransform = currentContentTransformation();
 
-    float deviceScaleFactor = renderer.document().deviceScaleFactor();
     // Walk up the render tree, accumulating SVG transforms.
     const RenderObject* ancestor = &renderer;
     while (ancestor) {
@@ -214,17 +213,17 @@ AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinat
     // Continue walking up the layer tree, accumulating CSS transforms.
     RenderLayer* layer = ancestor ? ancestor->enclosingLayer() : nullptr;
     while (layer) {
-        if (TransformationMatrix* layerTransform = layer->transform())
-            absoluteTransform = layerTransform->toAffineTransform() * absoluteTransform;
-
         // We can stop at compositing layers, to match the backing resolution.
         if (layer->isComposited())
             break;
 
+        if (TransformationMatrix* layerTransform = layer->transform())
+            absoluteTransform = layerTransform->toAffineTransform() * absoluteTransform;
+
         layer = layer->parent();
     }
 
-    absoluteTransform.scale(deviceScaleFactor);
+    absoluteTransform.scale(renderer.document().deviceScaleFactor());
     return absoluteTransform;
 }
 


### PR DESCRIPTION
<pre>
REGRESSION (r145541): Incorrect local to device transformation when the SVG is rendered into a separate composited layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=115072">https://bugs.webkit.org/show_bug.cgi?id=115072</a>
rdar://problem/13717823

Reviewed by NOBODY (OOPS!).

Patch Authored by Said Abou-Hallawa

Inspired by - <a href="https://github.com/chromium/chromium/commit/56aadb8e9811da743049e788e35dc0503d18f734">https://github.com/chromium/chromium/commit/56aadb8e9811da743049e788e35dc0503d18f734</a>

calculateTransformationToOutermostCoordinateSystem() should stop at the
first composited layer to match its backing resolution. Currently, we
are incorrectly taking the layer transform into account (the stop
condition is off by one). This bug is affecting the SVG clipper, masker
and filter.

* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem):
* LayoutTests/svg/custom/filter-css-transform-resolution.html: Add Test Case
* LayoutTests/svg/custom/filter-css-transform-resolution-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b66c09ee0735bf42d619373963b35c4f5520a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42541 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1934 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1186 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57174 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49934 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49176 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->