### PR TITLE
PublicSuffixStore::platformTopPrivatelyControlledDomain() should take in a StringView

### DIFF
--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -53,7 +53,7 @@ private:
     PublicSuffixStore() = default;
 
     bool platformIsPublicSuffix(StringView domain) const;
-    String platformTopPrivatelyControlledDomain(const String& host) const;
+    String platformTopPrivatelyControlledDomain(StringView host) const;
 
     mutable Lock m_HostTopPrivatelyControlledDomainCacheLock;
     mutable HashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -49,12 +49,12 @@ bool PublicSuffixStore::platformIsPublicSuffix(StringView domain) const
     return isPublicSuffixCF(domainString);
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& host) const
+String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView host) const
 {
     size_t separatorPosition;
     for (unsigned labelStart = 0; (separatorPosition = host.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {
         if (isPublicSuffix(host.substring(separatorPosition + 1)))
-            return host.substring(labelStart);
+            return host.substring(labelStart).toString();
     }
 
     return { };

--- a/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
+++ b/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
@@ -50,7 +50,7 @@ static String topPrivatelyControlledDomainInternal(const psl_ctx_t* psl, const c
     return String();
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& domain) const
+String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain) const
 {
     if (platformIsPublicSuffix(domain))
         return String();

--- a/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
@@ -39,7 +39,7 @@ bool PublicSuffixStore::platformIsPublicSuffix(StringView domain) const
     return soup_tld_domain_is_public_suffix(domain.convertToASCIILowercase().utf8().data());
 }
 
-static String permissiveTopPrivateDomain(const String& domain)
+static String permissiveTopPrivateDomain(StringView domain)
 {
     auto position = domain.length();
     bool foundDot = false;
@@ -50,15 +50,15 @@ static String permissiveTopPrivateDomain(const String& domain)
     while (position-- > 0) {
         if (domain[position] == '.') {
             if (foundDot)
-                return domain.substring(position + 1);
+                return domain.substring(position + 1).toString();
             foundDot = true;
         }
     }
 
-    return foundDot ? domain : String();
+    return foundDot ? domain.toString() : String();
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& domain) const
+String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain) const
 {
     CString domainUTF8 = domain.utf8();
 
@@ -84,7 +84,7 @@ String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& dom
         return String();
 
     if (g_error_matches(error.get(), SOUP_TLD_ERROR, SOUP_TLD_ERROR_IS_IP_ADDRESS))
-        return domain;
+        return domain.toString();
 
     ASSERT_NOT_REACHED();
     return String();


### PR DESCRIPTION
#### 9dce2ade92d582c9e7d6431ea8335a47d1985788
<pre>
PublicSuffixStore::platformTopPrivatelyControlledDomain() should take in a StringView
<a href="https://bugs.webkit.org/show_bug.cgi?id=274433">https://bugs.webkit.org/show_bug.cgi?id=274433</a>

Reviewed by Ryosuke Niwa.

PublicSuffixStore::platformTopPrivatelyControlledDomain() should take in a StringView
instead of a String. It keeps calling substring(), which is a lot more efficient on a
StringView than a String.

* Source/WebCore/platform/PublicSuffixStore.h:
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp:
(WebCore::permissiveTopPrivateDomain):
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):

Canonical link: <a href="https://commits.webkit.org/279035@main">https://commits.webkit.org/279035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d11ff717fb5f1b21d72eae6c085b6fc4737a87cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3047 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2746 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1943 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45158 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1206 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57194 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2616 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45278 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11426 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64139 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28428 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/64139 "Build is in progress. Recent messages:") | 
<!--EWS-Status-Bubble-End-->