### PR TITLE
[view-transitions] https://pokedex-dev.vercel.app/pokemons incorrectly applies clips from ancestors of the captured element.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2-expected.html
@@ -1,0 +1,22 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+html {
+  background: lightpink;
+}
+div {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  left: 150px;
+  top: 150px;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2-ref.html
@@ -1,0 +1,22 @@
+<!doctype HTML>
+<html>
+<head>
+<style>
+html {
+  background: lightpink;
+}
+div {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+  left: 150px;
+  top: 150px;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: clips from ancestor elements are not applied to captures</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="new-content-ancestor-clipped-2-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+.outer {
+  background-color: blue;
+  overflow: hidden;
+  position: relative;
+  left: 100px;
+  top: 100px;
+  width: 200px;
+  height: 200px;
+}
+.inner {
+  background-color: red;
+  position: relative;
+  left: 50px;
+  top: 50px;
+  width: 200px;
+  height: 200px;
+  view-transition-name: inner;
+}
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div class="outer">
+  <div class="inner"></div>
+</div>
+<script>
+
+async function runTest() {
+  let t = document.startViewTransition(() => {
+    requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3216,6 +3216,9 @@ bool RenderLayerCompositor::clippedByAncestor(RenderLayer& layer, const RenderLa
     if (!compositingAncestor)
         return false;
 
+    if (layer.renderer().capturedInViewTransition())
+        return false;
+
     // If the compositingAncestor clips, that will be taken care of by clipsCompositingDescendants(),
     // so we only care about clipping between its first child that is our ancestor (the computeClipRoot),
     // and layer. The exception is when the compositingAncestor isolates composited blending children,


### PR DESCRIPTION
#### 0a968814a2437db3e6cf179e6109a26c6be0e64f
<pre>
[view-transitions] <a href="https://pokedex-dev.vercel.app/pokemons">https://pokedex-dev.vercel.app/pokemons</a> incorrectly applies clips from ancestors of the captured element.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274436">https://bugs.webkit.org/show_bug.cgi?id=274436</a>
&lt;<a href="https://rdar.apple.com/128441443">rdar://128441443</a>&gt;

Reviewed by Tim Nguyen.

Effects from ancestors shouldn&apos;t be applied.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped-2.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::clippedByAncestor const):

Canonical link: <a href="https://commits.webkit.org/279091@main">https://commits.webkit.org/279091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39110b52cd4cc95821769f12bde2f2f4063ee4f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4922 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2921 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/55773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54596 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45304 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1381 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57369 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45421 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11461 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/28608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->