### PR TITLE
[view-transitions] https://pokedex-dev.vercel.app/pokemons has super low framerate.

### DIFF
--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -275,10 +275,12 @@ bool MutableStyleProperties::addParsedProperty(const CSSProperty& property)
     return setProperty(property);
 }
 
-void MutableStyleProperties::mergeAndOverrideOnConflict(const StyleProperties& other)
+bool MutableStyleProperties::mergeAndOverrideOnConflict(const StyleProperties& other)
 {
+    bool changed = false;
     for (auto property : other)
-        addParsedProperty(property.toCSSProperty());
+        changed |= addParsedProperty(property.toCSSProperty());
+    return changed;
 }
 
 void MutableStyleProperties::clear()

--- a/Source/WebCore/css/MutableStyleProperties.h
+++ b/Source/WebCore/css/MutableStyleProperties.h
@@ -74,7 +74,7 @@ public:
     bool removeProperty(CSSPropertyID, String* returnText = nullptr);
     bool removeProperties(std::span<const CSSPropertyID>);
 
-    void mergeAndOverrideOnConflict(const StyleProperties&);
+    bool mergeAndOverrideOnConflict(const StyleProperties&);
 
     void clear();
     bool parseDeclaration(const String& styleDeclaration, CSSParserContext);

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -48,10 +48,13 @@ void RenderViewTransitionCapture::setImage(RefPtr<ImageBuffer> oldImage)
     m_oldImage = oldImage;
 }
 
-void RenderViewTransitionCapture::setSize(const LayoutSize& size, const LayoutRect& overflowRect)
+bool RenderViewTransitionCapture::setSize(const LayoutSize& size, const LayoutRect& overflowRect)
 {
+    if (m_overflowRect == overflowRect && intrinsicSize() == size)
+        return false;
     setIntrinsicSize(size);
     m_overflowRect = overflowRect;
+    return true;
 }
 
 void RenderViewTransitionCapture::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -37,7 +37,7 @@ public:
     virtual ~RenderViewTransitionCapture();
 
     void setImage(RefPtr<ImageBuffer>);
-    void setSize(const LayoutSize&, const LayoutRect& overflowRect);
+    bool setSize(const LayoutSize&, const LayoutRect& overflowRect);
 
     void paintReplaced(PaintInfo&, const LayoutPoint& paintOffset) override;
 


### PR DESCRIPTION
#### a3c50349375a13f4f925ec6b5dba329ab1d5ac17
<pre>
[view-transitions] <a href="https://pokedex-dev.vercel.app/pokemons">https://pokedex-dev.vercel.app/pokemons</a> has super low framerate.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274439">https://bugs.webkit.org/show_bug.cgi?id=274439</a>
&lt;<a href="https://rdar.apple.com/128030956">rdar://128030956</a>&gt;

Reviewed by Tim Nguyen.

We invalidate the stylesheet every frame, resulting in way too much painting.

Instead, only invalidate the stylesheet if we actually inserted new styles.
Also invalidate layout, and the layer configuration for the pseudo if we
change those.

* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::mergeAndOverrideOnConflict):
* Source/WebCore/css/MutableStyleProperties.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePseudoElementStyles):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::setSize):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/279049@main">https://commits.webkit.org/279049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b34b431953738b501c25a0dc898e7a789786130f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42552 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1947 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2434 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57197 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49946 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49188 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11433 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->