### PR TITLE
Web Inspector: BackendDispatcher::CallbackBase should have a virtual destructor

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
@@ -56,6 +56,7 @@ public:
     class JS_EXPORT_PRIVATE CallbackBase : public RefCounted<CallbackBase> {
     public:
         CallbackBase(Ref<BackendDispatcher>&&, long requestId);
+        virtual ~CallbackBase() { }
 
         bool isActive() const;
         void disable() { m_alreadySent = true; }


### PR DESCRIPTION
#### 74af740dd35fd0ca455c36e7672201aa44e820b3
<pre>
Web Inspector: BackendDispatcher::CallbackBase should have a virtual destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=274440">https://bugs.webkit.org/show_bug.cgi?id=274440</a>

Reviewed by Chris Dumez.

Added the virtual destructor to BackendDispatcher::CallbackBase since it has a bunch of subclasses.

* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/279071@main">https://commits.webkit.org/279071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03dcea1f353d0d607fe3f56536c639c6fe764694

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3055 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42555 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1949 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1214 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45681 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57202 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51840 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49951 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49193 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29603 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64147 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7682 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28436 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12140 "Found 15 new JSC stress test failures: stress/spread-non-array.js.no-llint, wasm.yaml/wasm/function-tests/float-sub.js.wasm-eager, wasm.yaml/wasm/function-tests/grow-memory-3.js.wasm-eager, wasm.yaml/wasm/function-tests/i32-load8-s.js.wasm-eager, wasm.yaml/wasm/function-tests/memory-grow-invalid.js.wasm-eager, wasm.yaml/wasm/function-tests/struct.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-load-shared.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-load.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-store-shared.js.wasm-eager, wasm.yaml/wasm/js-api/extension-MemoryMode.js.wasm-eager-jettison ... (failure)") | 
<!--EWS-Status-Bubble-End-->