### PR TITLE
[WebGPU] Buffer instance can transition from Destroyed -> Unmapped state

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2141,6 +2141,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274171.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274290.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274290.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-128396311.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-128396311.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-128396311-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-128396311-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-128396311.html
+++ b/LayoutTests/fast/webgpu/fuzz-128396311.html
@@ -1,0 +1,10659 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let device0 = await adapter0.requestDevice({
+  label: '\ud152\u2b5a\u2f69\u04c3\uf8bd\u027b\u0290\u2ccd\u092f',
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 61,
+    maxVertexAttributes: 29,
+    maxVertexBufferArrayStride: 41251,
+    maxStorageTexturesPerShaderStage: 25,
+    maxStorageBuffersPerShaderStage: 43,
+    maxDynamicStorageBuffersPerPipelineLayout: 40557,
+    maxDynamicUniformBuffersPerPipelineLayout: 57497,
+    maxBindingsPerBindGroup: 4023,
+    maxTextureArrayLayers: 1657,
+    maxTextureDimension1D: 15919,
+    maxTextureDimension2D: 11376,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 142643200,
+    maxStorageBufferBindingSize: 232564805,
+    maxUniformBuffersPerShaderStage: 43,
+    maxSampledTexturesPerShaderStage: 37,
+    maxInterStageShaderVariables: 48,
+    maxInterStageShaderComponents: 67,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let canvas0 = document.createElement('canvas');
+try {
+canvas0.getContext('2d');
+} catch {}
+let querySet0 = device0.createQuerySet({label: '\u{1f622}\u{1f815}\u36b2\u082b\u9ed6\u5014', type: 'occlusion', count: 1210});
+let sampler0 = device0.createSampler({
+  label: '\uebdd\u6154\ud64d\u03dd\u528e\u082a\u7417\u08a3\u06e6',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.96,
+  lodMaxClamp: 99.91,
+  maxAnisotropy: 20,
+});
+let texture0 = device0.createTexture({
+  label: '\u8b9b\u{1f759}\u{1f6fd}\u{1fe6f}\u0b0f\u{1fb59}\u{1fd1b}',
+  size: {width: 128, height: 5, depthOrArrayLayers: 86},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView0 = texture0.createView({label: '\u058a\u4e17\u06fd\u0012\u0a1b\u{1f8b6}\u08dc\u03f1\uc348\u5bb0'});
+document.body.prepend(canvas0);
+let textureView1 = texture0.createView({
+  label: '\u10f0\uca32\u4704\u0095\u0795\uf860\u{1ff59}\u9dec\ue45b\u3724',
+  aspect: 'all',
+  arrayLayerCount: 1,
+});
+let textureView2 = texture0.createView({label: '\u06ec\u83e6\u6bf4\ub29b\u07a8\u082a\u046b\ufd9c'});
+let sampler1 = device0.createSampler({
+  label: '\uaad8\u{1f798}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 80.84,
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder0 = device0.createCommandEncoder({label: '\ua557\u0ad1\u0ed9\u{1fbcf}'});
+let querySet1 = device0.createQuerySet({label: '\u24cd\uea0e\u16d1\ub453\u775e\u4209\u{1fa8e}', type: 'occlusion', count: 813});
+try {
+  await promise0;
+} catch {}
+gc();
+let imageBitmap0 = await createImageBitmap(canvas0);
+let imageData0 = new ImageData(72, 96);
+let buffer0 = device0.createBuffer({label: '\u0ffa\u0358', size: 147045, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\uc3d8\u0727\u{1fef5}',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u0eca\u0c6b\u7ebc\ud623\ube3e\u23c8'});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u699d\u{1f7b8}\ue9b6\u{1fc44}\u04a7\ub846\u{1fb83}'});
+let textureView3 = texture0.createView({label: '\u0c17\u0792\u0eb9\ua4ad\uc2b4\u6c65\u5852\u07a2\uf4e2', baseMipLevel: 0});
+try {
+buffer0.destroy();
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1f7a0}\ucd11\u03b5\u05a9\u2f9f\uf35f\u5aa2\u{1f8ed}\ubd61\u0181\udaa7',
+  entries: [
+    {
+      binding: 2115,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u49b1\ud3c0\u0561\u0b1c\ub72c'});
+let querySet2 = device0.createQuerySet({label: '\u0552\u{1f859}\u0e1a\u{1f9a6}', type: 'occlusion', count: 3018});
+let texture1 = device0.createTexture({
+  label: '\u{1fa70}\ud490\u0e73\u3a34\u8b7b\u{1ff8e}\ud2e3\ud08d\u6210',
+  size: {width: 53},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView4 = texture1.createView({});
+let renderBundle1 = renderBundleEncoder0.finish({});
+let commandEncoder3 = device0.createCommandEncoder({});
+let sampler2 = device0.createSampler({
+  label: '\udc5d\u006d\u{1fe13}\u0de8\u{1fcfc}\ud8b1\u{1fe01}\u017d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.08,
+});
+document.body.prepend(canvas0);
+let bindGroupLayout1 = device0.createBindGroupLayout({label: '\ua359\u0f15\u{1fa1c}', entries: []});
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout1, entries: []});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u087a\u0d86',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1],
+});
+let buffer1 = device0.createBuffer({
+  label: '\u0fc4\u02a9\ue065\u8bf1\u6e64\u8699\u094f\u2f54\u893a',
+  size: 127836,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture2 = device0.createTexture({
+  label: '\uf02f\u8263\u60aa',
+  size: {width: 48, height: 4, depthOrArrayLayers: 492},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let textureView5 = texture2.createView({label: '\u0155\uccad', baseMipLevel: 2});
+let computePassEncoder0 = commandEncoder3.beginComputePass({label: '\uc073\u07a1\u61bd\u9ea3\u{1ff06}\u0b44\u{1f651}\u{1ffbb}\u0e18\u2dea\ube97'});
+let sampler3 = device0.createSampler({
+  label: '\u8a50\u5487\u65ea\u0734\u{1fc79}\u0fc5\u6505\u0a87\u004f\u7dfe',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 23.80,
+  lodMaxClamp: 54.05,
+  maxAnisotropy: 1,
+});
+let imageData1 = new ImageData(120, 216);
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u{1f903}\u{1fe4e}\u0c81\u0a0f\u{1f7a5}\u78b5\u7cd6\ue97d\u{1fcfe}\ub39a\u6260',
+  entries: [
+    {
+      binding: 3576,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1ff87}\ubc36\ubb83\u{1f84a}\u37f9\u0d13\u06d8\ub5c6'});
+canvas0.width = 352;
+let texture3 = device0.createTexture({
+  label: '\u180d\u{1ff34}\u0ecf\u{1fbe4}\uf0c5\uba8a\u{1fe11}\u5b4e',
+  size: [48],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+canvas0.height = 41;
+let bindGroupLayout3 = device0.createBindGroupLayout({entries: []});
+let pipelineLayout1 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout3, bindGroupLayout0, bindGroupLayout1, bindGroupLayout3, bindGroupLayout2, bindGroupLayout2, bindGroupLayout1, bindGroupLayout1],
+});
+let texture4 = device0.createTexture({
+  size: [192],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+try {
+computePassEncoder0.setBindGroup(8, bindGroup0, new Uint32Array(3781), 3051, 0);
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  label: '\u{1f606}\u2d01\ud40d\uf403\ud8be\u{1fd9a}\u641e\u{1ff08}\u0a01',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u9248\u4c04\u751d\u{1fb6a}\u3920'});
+let commandBuffer0 = commandEncoder1.finish({});
+let textureView6 = texture4.createView({label: '\u3966\u{1f868}\u8ec3\ue4cb\u9189\u0c09\u{1fb34}', format: 'r8unorm'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\ucd64\u{1f7a3}\u508f\u{1f79f}\u{1fb1d}\ucf1f',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle2 = renderBundleEncoder0.finish();
+let sampler4 = device0.createSampler({
+  label: '\u{1fafc}\u{1fc22}\u{1fb43}\u0072\u731c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 93.58,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(48)), /* required buffer size: 568 */
+{offset: 568, bytesPerRow: 313, rowsPerImage: 187}, {width: 47, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame0 = new VideoFrame(canvas0, {timestamp: 0});
+let shaderModule0 = device0.createShaderModule({
+  code: `@group(0) @binding(2115)
+var<storage, read_write> parameter0: array<u32>;
+@group(5) @binding(2115)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: u32,
+  @location(4) f2: vec2<i32>,
+  @location(2) f3: vec4<f32>,
+  @location(3) f4: vec3<f32>,
+  @location(1) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: i32, @location(4) a1: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(30) f0: u32,
+  @location(27) f1: f32,
+  @location(29) f2: vec2<i32>,
+  @location(42) f3: vec3<f16>,
+  @location(4) f4: vec4<f16>,
+  @location(8) f5: i32,
+  @location(33) f6: vec4<f16>,
+  @location(45) f7: vec3<f16>,
+  @location(26) f8: vec4<i32>,
+  @location(3) f9: vec4<f16>,
+  @builtin(position) f10: vec4<f32>,
+  @location(9) f11: vec2<f16>,
+  @location(24) f12: vec4<u32>,
+  @location(12) f13: vec2<f32>,
+  @location(44) f14: f32,
+  @location(35) f15: vec2<f32>,
+  @location(10) f16: vec3<f16>,
+  @location(38) f17: vec3<f16>,
+  @location(18) f18: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: i32, @location(15) a1: u32, @location(25) a2: vec3<i32>, @location(10) a3: u32, @location(13) a4: vec4<f32>, @location(23) a5: i32, @location(11) a6: f32, @location(4) a7: vec2<i32>, @location(3) a8: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u01ef\u020f\u{1fd5a}\u83b2\u60b0'});
+let querySet3 = device0.createQuerySet({label: '\u{1fdca}\uf696', type: 'occlusion', count: 3014});
+let computePassEncoder1 = commandEncoder5.beginComputePass({label: '\u070e\ua6c6\u2538'});
+let renderBundle3 = renderBundleEncoder0.finish({label: '\u0e2a\u{1f788}\u{1fbd8}\u361e\u{1f967}'});
+let bindGroup2 = device0.createBindGroup({label: '\u{1ffff}\u2bbd\ud1f0', layout: bindGroupLayout1, entries: []});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u{1fb1d}\u{1f719}\u{1ff6c}'});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 1302});
+let textureView7 = texture2.createView({label: '\u0f18\u96e4\ufa00\u{1fed5}\u{1fedb}\u2306\ucbb8\u{1fc81}\u0f2b', baseMipLevel: 3});
+let computePassEncoder2 = commandEncoder7.beginComputePass({label: '\u5a2f\u{1f7fa}\u8518\u0c12\u00bc'});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder1.setVertexBuffer(7, buffer1, 0, 88824);
+} catch {}
+canvas0.height = 345;
+let imageData2 = new ImageData(32, 8);
+let textureView8 = texture3.createView({label: '\u{1f7c4}\ufc3e'});
+let renderBundle4 = renderBundleEncoder1.finish({label: '\u0251\u07fe\u2084\u736f\u8332\u1092\u2118\u0139\u3837'});
+let sampler5 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 8.370,
+});
+let pipeline0 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let imageData3 = new ImageData(176, 96);
+let commandBuffer1 = commandEncoder0.finish();
+let texture5 = device0.createTexture({
+  label: '\u{1fbb1}\u3fb0',
+  size: [192, 16, 1],
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+commandEncoder2.insertDebugMarker('\u{1f996}');
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u896b\ua747\u0805\u94f1\u0d6a\u0bb6'});
+let textureView9 = texture1.createView({label: '\u0e91\ue060\ube4c\u0804\u07fb', format: 'rgb10a2uint'});
+let renderBundle5 = renderBundleEncoder2.finish({label: '\u{1ff40}\u0ad5\u55d0\u78e3\u82b9\ued89\u21f9\u07f6'});
+let sampler6 = device0.createSampler({
+  label: '\u{1fe89}\u{1f8cc}\u{1f75b}\u6311\u{1f84c}\u3b97\u4e62\u{1fb5d}\u0f6d\u1305',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 98.00,
+  lodMaxClamp: 98.66,
+});
+try {
+commandEncoder8.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(463), /* required buffer size: 463 */
+{offset: 453}, {width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({label: '\u7f8d\u0db4\u493f\udbb6\u04ed\u0750\ufb18'});
+let commandBuffer2 = commandEncoder2.finish({label: '\u{1feef}\u{1f6c7}\u7437\u{1fae6}\u26dd'});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 22305 */
+  offset: 22305,
+  buffer: buffer0,
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder9.insertDebugMarker('\uea7a');
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u{1fa8e}\u06c9\u03a3\udedc\uadde\ucca3\u0f40',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'r8sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'keep', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'replace'},
+    stencilWriteMask: 3116632639,
+    depthBiasSlopeScale: 178.12471417682593,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6044,
+        attributes: [
+          {format: 'uint8x2', offset: 898, shaderLocation: 10},
+          {format: 'sint8x2', offset: 2080, shaderLocation: 23},
+          {format: 'sint8x2', offset: 1402, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 15760,
+        attributes: [
+          {format: 'uint32x4', offset: 624, shaderLocation: 15},
+          {format: 'float32', offset: 640, shaderLocation: 13},
+          {format: 'sint16x2', offset: 1144, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 3668, shaderLocation: 3},
+          {format: 'sint16x2', offset: 1116, shaderLocation: 25},
+        ],
+      },
+      {arrayStride: 5884, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 296,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x2', offset: 12, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let img0 = await imageWithData(133, 58, '#e7fef367', '#ce6d1f0e');
+let video0 = await videoWithData();
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.20,
+  lodMaxClamp: 44.53,
+});
+let externalTexture1 = device0.importExternalTexture({
+  label: '\u4697\u05f1\u0935\u{1fa19}\u0756\ueb37\u677e\u{1fc5d}\u{1feda}',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 745 */
+{offset: 745}, {width: 51, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView10 = texture0.createView({label: '\u3d62\ua42a', dimension: '3d', aspect: 'all'});
+let sampler8 = device0.createSampler({
+  label: '\u5360\u768e\u{1fc4b}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.87,
+  lodMaxClamp: 86.05,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u10bf');
+} catch {}
+let img1 = await imageWithData(185, 207, '#e5187921', '#23c051af');
+let textureView11 = texture5.createView({});
+try {
+  await buffer0.mapAsync(GPUMapMode.READ, 0, 144756);
+} catch {}
+document.body.prepend(canvas0);
+let computePassEncoder3 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(32)), /* required buffer size: 643 */
+{offset: 643, bytesPerRow: 248}, {width: 123, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  label: '\uaeb7\u9160\u0a71\u3d9e\u0017\u3acf\u0eec\u41a3',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 4197886137,
+    stencilWriteMask: 1527783348,
+    depthBiasSlopeScale: 411.4566491234425,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 640,
+        attributes: [
+          {format: 'sint32x2', offset: 120, shaderLocation: 25},
+          {format: 'uint16x4', offset: 64, shaderLocation: 10},
+          {format: 'uint8x2', offset: 58, shaderLocation: 15},
+          {format: 'sint32', offset: 256, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 62, shaderLocation: 11},
+          {format: 'sint8x2', offset: 164, shaderLocation: 20},
+          {format: 'sint8x4', offset: 4, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 56, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 4056,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 1484, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+let renderBundle6 = renderBundleEncoder2.finish();
+let sampler9 = device0.createSampler({
+  label: '\ubb7d\u6b56\u075f\u{1f863}',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.22,
+  lodMaxClamp: 98.44,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u{1fc26}\u{1f83f}\u28be\u065b\u064a\u9f22\u85c0\u69e6\u6bd1\u{1fe5b}\ud5ff', source: video0});
+try {
+commandEncoder9.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 180 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13096 */
+  offset: 13096,
+  rowsPerImage: 271,
+  buffer: buffer0,
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 2353});
+let commandBuffer3 = commandEncoder8.finish({label: '\u0d2c\u99f4\u0cd7\u023f\ucafd\u0757'});
+let textureView12 = texture4.createView({label: '\uef8e\u3b61\u{1f62b}\ua9f9\ua0a2\u1504\u0628\ucfa7\u042e\u6e6e\u0f81', baseMipLevel: 0});
+try {
+commandEncoder4.clearBuffer(buffer0, 113888, 26620);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup('\uc94c');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 545 */
+{offset: 545}, {width: 80, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let commandEncoder10 = device0.createCommandEncoder();
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 343});
+let texture6 = device0.createTexture({
+  label: '\u2e30\u{1ff19}\u0761',
+  size: [2280, 1, 947],
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView13 = texture2.createView({label: '\u{1ffd2}\u4301\u0e3b\ud94b\u30b2', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+try {
+commandEncoder10.insertDebugMarker('\u88f0');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 1_903 */
+{offset: 507, bytesPerRow: 240}, {width: 49, height: 6, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas2 = document.createElement('canvas');
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u02f9\u{1f956}\ue7fc\u05e8\ua880\u0a55\u0800\uf426\u0019\u878c',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout1, bindGroupLayout3, bindGroupLayout0, bindGroupLayout3],
+});
+let textureView14 = texture4.createView({label: '\u5531\u3eeb\u{1f8d7}\u00d0', format: 'r8unorm', arrayLayerCount: 1});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u{1fce1}\uac70\u011f\u0794\u1739\u899d\u{1fa3f}\udd09\u{1f9a4}\u9164\u{1f6b0}',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4129 */
+  offset: 4129,
+  buffer: buffer1,
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\ua219');
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({
+  label: '\u{1fb18}\u{1fd85}\u{1f852}\ude93\u937d\u6f6c\u44b6\u{1feba}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let video1 = await videoWithData();
+let commandEncoder11 = device0.createCommandEncoder({label: '\u0021\uae83\u0494\ud12e\uf486\u7f71\u8988\ue084\u{1fa9a}\ueb41\uce0d'});
+let texture7 = device0.createTexture({
+  label: '\u3ad8\u69f9\u4e1e\u0d80\u0ad6\u3d52\u03f4\u641c',
+  size: [212, 320, 631],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm'],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\uabfa\u09ad\u59ee\u{1f825}\u3cf4\ueaf9\u85b5\u97d0\u21b0\u649c',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder4.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 584 */
+{offset: 584, bytesPerRow: 369, rowsPerImage: 264}, {width: 42, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  label: '\u8527\u1d13\u2e7d\u04ea',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x57559117},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 16472,
+        attributes: [
+          {format: 'sint16x4', offset: 1068, shaderLocation: 25},
+          {format: 'sint32x2', offset: 344, shaderLocation: 23},
+          {format: 'uint16x4', offset: 1024, shaderLocation: 10},
+          {format: 'float32x4', offset: 980, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 636,
+        attributes: [
+          {format: 'snorm16x4', offset: 44, shaderLocation: 13},
+          {format: 'float16x2', offset: 32, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 9080,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 140, shaderLocation: 15},
+          {format: 'sint16x4', offset: 2988, shaderLocation: 20},
+          {format: 'sint16x2', offset: 2300, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+});
+let shaderModule1 = device0.createShaderModule({
+  label: '\u03ad\u1952\u2cfe\ucb02\u5b2a\u1e38\u{1f826}',
+  code: `@group(2) @binding(2115)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(3576)
+var<storage, read_write> n0: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<i32>,
+  @location(1) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(3) f3: vec2<f32>,
+  @location(2) f4: vec4<f32>,
+  @location(0) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(27) a0: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder4 = commandEncoder9.beginComputePass({label: '\u1f7e\u8d2d\u0980\uace9'});
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17752 */
+  offset: 17752,
+  rowsPerImage: 299,
+  buffer: buffer1,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+try {
+canvas2.getContext('webgl2');
+} catch {}
+let texture8 = device0.createTexture({
+  label: '\u0db4\u0075\u{1f67c}\u0273',
+  size: [1140, 1, 221],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let textureView15 = texture1.createView({label: '\u0dd4\uf916\u01fa\u0c02\u0578\u1e50\uf957\ue4a7\u{1fe47}\uf616', aspect: 'all'});
+let computePassEncoder5 = commandEncoder10.beginComputePass({label: '\u0fb0\u2f31\u0393\udd97\u0029\ub9ac\u4610\uc77a'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\ufdd0\u0b6e\u545d\ucbd5\u8d29\u54f1\u{1faf3}\u01f2\u{1ff4e}\u{1fced}',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+let commandBuffer4 = commandEncoder4.finish({label: '\u0e10\u{1fdc6}\u501e\uc64c\u062c\u0daa\uf505\u0481\u980c'});
+let texture9 = device0.createTexture({
+  size: [26, 40, 304],
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(3, buffer1, 0, 46720);
+} catch {}
+let textureView16 = texture9.createView({mipLevelCount: 1, baseArrayLayer: 195, arrayLayerCount: 60});
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+gc();
+let buffer2 = device0.createBuffer({
+  label: '\u0483\u{1ff4b}\u49de\ud9cd\u03c8\uc154\u0fb4\u4619\u{1fe83}\uf7e2',
+  size: 391719,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder12 = device0.createCommandEncoder();
+let externalTexture3 = device0.importExternalTexture({
+  label: '\u2dae\u256c\u{1f774}\u{1f815}\u{1f9fc}\u{1fda9}\u0d78\u0577\u05a7\u520b',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer1, 120220, 5722);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer2, 160784, buffer1, 4004, 68168);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let texture10 = device0.createTexture({
+  label: '\uda17\u3cc3\u0285\u5f83\u0d4a',
+  size: [53, 80, 1],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let renderBundle7 = renderBundleEncoder0.finish({label: '\u080a\u{1f63b}\ue1af\ue117'});
+try {
+renderBundleEncoder3.setBindGroup(8, bindGroup1);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer2, 237588, buffer1, 36460, 89096);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 212, height: 320, depthOrArrayLayers: 631}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 31, y: 5 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 95, y: 12, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup3 = device0.createBindGroup({label: '\u00a6\u4fdd\u04f2', layout: bindGroupLayout1, entries: []});
+let textureView17 = texture1.createView({label: '\u00cd\u04ec', arrayLayerCount: 1});
+let renderBundle8 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder5.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  label: '\uc6ba\u30e6\u{1f918}\u{1fc15}\ua7d4\u0804\uee09\u5cfc',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture11 = device0.createTexture({
+  label: '\u013e\u08d9\u477a\u96a2\ub0d6\u{1fbe9}\u0213',
+  size: [2280, 1, 1],
+  mipLevelCount: 9,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 7, y: 64, z: 27},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 21, y: 2, z: 30},
+  aspect: 'all',
+},
+{width: 4, height: 19, depthOrArrayLayers: 13});
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u61c5');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 106, height: 160, depthOrArrayLayers: 315}
+*/
+{
+  source: canvas0,
+  origin: { x: 82, y: 117 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 5, y: 4, z: 109},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = device0.createComputePipeline({
+  label: '\u6ac3\u0e13\u2264',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0f12\ufec9\u{1ff42}\u23ae\u45dd\u0d48'});
+let commandBuffer5 = commandEncoder13.finish({});
+let renderBundle9 = renderBundleEncoder3.finish();
+let sampler10 = device0.createSampler({
+  label: '\u4cee\u{1fe75}\u{1f638}\u{1fdf1}\u08de\u{1fc4a}\u1735\u10b6',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 80.91,
+  lodMaxClamp: 96.31,
+  maxAnisotropy: 13,
+});
+try {
+commandEncoder11.copyBufferToBuffer(buffer2, 278668, buffer0, 14060, 64684);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 139, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  label: '\u0b3f\u{1fb82}\u498c\u1a76\u051a\u019e\u83db\u{1f9fa}',
+  layout: 'auto',
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 192, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 4696,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 164, shaderLocation: 27}],
+      },
+    ],
+  },
+});
+let imageData4 = new ImageData(92, 188);
+try {
+externalTexture1.label = '\u6372\ud0a2\uf384\u1800\u69ed\u877d';
+} catch {}
+try {
+bindGroupLayout3.label = '\u06ca\u0887\ue30f\ue0fa\u053a';
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder({label: '\u1327\u0782\u96e0\u444f\u779b\u2c09\u0143\uce5f\u{1fd1b}'});
+let textureView18 = texture4.createView({label: '\u{1f65a}\u3db2\u{1fb45}\u3f77\u9817\u{1f69e}\u0a51\u33c6\u0597\u06f0', dimension: '1d'});
+let sampler11 = device0.createSampler({
+  label: '\u0e6c\u{1fb70}\u0c9f\u0431\u1848',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.27,
+  lodMaxClamp: 83.90,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder2.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer1, 0, 102368);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 213136, buffer0, 17972, 41884);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3507,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 176682376, hasDynamicOffset: true },
+    },
+    {binding: 2550, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 1215, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+  ],
+});
+let querySet7 = device0.createQuerySet({label: '\u02a5\u0e51\uc9db\u{1f68d}\u{1fcd7}', type: 'occlusion', count: 2434});
+let texture12 = device0.createTexture({
+  label: '\u0005\u{1f9c5}\u2066\ue70c\u0dd2\u{1fe0a}\u18a0\u4efd\u1cc3',
+  size: [192, 16, 880],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 34364, buffer1, 86316, 28740);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 14472, new Float32Array(1865), 66);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 106, height: 160, depthOrArrayLayers: 315}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 4 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 1, y: 79, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let video2 = await videoWithData();
+let commandEncoder16 = device0.createCommandEncoder({label: '\u0642\u{1f9fd}\u0f1d\ud296\u0419\ua965'});
+let commandBuffer6 = commandEncoder3.finish({label: '\u32c1\u{1fc3c}'});
+let texture13 = device0.createTexture({
+  label: '\u0dce\u2b95\u0a44\u54a5\u1951\ue1ff\uea3c\u008f',
+  size: [512, 20, 488],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let sampler12 = device0.createSampler({
+  label: '\u{1fd0e}\u{1fbd3}\u098e\u8de8\u{1f939}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 82.65,
+  lodMaxClamp: 83.80,
+});
+try {
+commandEncoder11.copyBufferToBuffer(buffer2, 247812, buffer0, 73624, 14056);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let imageData5 = new ImageData(100, 60);
+let shaderModule2 = device0.createShaderModule({
+  label: '\u2f33\u8c18\u{1fdc4}\u{1fa10}\u{1fe53}',
+  code: `@group(2) @binding(2115)
+var<storage, read_write> function0: array<u32>;
+@group(6) @binding(3576)
+var<storage, read_write> function1: array<u32>;
+@group(0) @binding(3576)
+var<storage, read_write> local0: array<u32>;
+@group(5) @binding(3576)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(6) f0: f16,
+  @location(38) f1: vec2<u32>,
+  @location(23) f2: f32,
+  @location(31) f3: u32,
+  @location(13) f4: vec4<f16>,
+  @location(34) f5: vec2<f16>,
+  @location(21) f6: vec2<f16>,
+  @location(19) f7: vec4<u32>,
+  @builtin(sample_index) f8: u32,
+  @location(45) f9: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: f32,
+  @location(0) f3: vec4<u32>,
+  @location(4) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(a0: S1, @location(3) a1: vec2<i32>, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(5) f0: vec4<f32>,
+  @builtin(instance_index) f1: u32,
+  @builtin(vertex_index) f2: u32
+}
+struct VertexOutput0 {
+  @location(45) f19: vec3<i32>,
+  @location(13) f20: vec4<f16>,
+  @location(38) f21: vec2<u32>,
+  @location(19) f22: vec4<u32>,
+  @location(21) f23: vec2<f16>,
+  @location(23) f24: f32,
+  @location(3) f25: vec2<i32>,
+  @location(34) f26: vec2<f16>,
+  @location(6) f27: f16,
+  @builtin(position) f28: vec4<f32>,
+  @location(31) f29: u32
+}
+
+@vertex
+fn vertex0(@location(20) a0: i32, @location(8) a1: vec4<f16>, @location(28) a2: vec4<f32>, @location(18) a3: vec3<u32>, @location(13) a4: i32, @location(19) a5: vec4<f16>, a6: S0, @location(2) a7: vec2<i32>, @location(25) a8: vec3<f16>, @location(15) a9: u32, @location(12) a10: vec4<i32>, @location(1) a11: vec2<i32>, @location(22) a12: vec4<u32>, @location(0) a13: vec3<i32>, @location(11) a14: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView19 = texture8.createView({
+  label: '\u010a\u1d6a\u{1ff8d}\u1824\ue86a',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 82,
+  arrayLayerCount: 121,
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(6, buffer1, 109292, 14463);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 211676 */
+  offset: 14556,
+  bytesPerRow: 256,
+  rowsPerImage: 154,
+  buffer: buffer2,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 14},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 6});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 10252, new DataView(new ArrayBuffer(6054)), 2947, 416);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 21},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(72)), /* required buffer size: 757_559 */
+{offset: 695, bytesPerRow: 72, rowsPerImage: 219}, {width: 5, height: 0, depthOrArrayLayers: 49});
+} catch {}
+let imageData6 = new ImageData(172, 80);
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12456 */
+  offset: 12456,
+  bytesPerRow: 256,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let texture14 = device0.createTexture({
+  label: '\u97ed\u6285\u044e\u0302\u{1f628}\u164e\u73ee',
+  size: [53],
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8snorm', 'rgba8snorm'],
+});
+let textureView20 = texture10.createView({dimension: '2d-array'});
+let sampler13 = device0.createSampler({
+  label: '\u2ad6\u78aa\u6a6f\u0411',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.55,
+  lodMaxClamp: 47.54,
+  compare: 'greater-equal',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup1, new Uint32Array(2333), 2252, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(9, bindGroup2, new Uint32Array(743), 492, 0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer1, 50996, 45239);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 38856 */
+  offset: 38856,
+  buffer: buffer0,
+}, {width: 128, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  label: '\u1d01\ucccd\uc4cf',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgb10a2uint'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'replace'},
+    stencilReadMask: 3542410158,
+    stencilWriteMask: 938775886,
+    depthBias: -2135790917,
+    depthBiasSlopeScale: 654.0807210553055,
+    depthBiasClamp: 965.6660951094148,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 1460, shaderLocation: 27}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let img2 = await imageWithData(205, 126, '#01e839d6', '#b141cec2');
+let videoFrame1 = new VideoFrame(canvas0, {timestamp: 0});
+try {
+adapter0.label = '\u11c6\uf417';
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  label: '\u5003\u07ae\u{1f9bf}\u81ba\u75a9\u9823\u{1feaf}\u7a70\u9149\u909c\ua43a',
+  layout: bindGroupLayout1,
+  entries: [],
+});
+let querySet8 = device0.createQuerySet({label: '\u0dbc\u0404\uebfd\uaf30\u092f\u{1fa30}\u0d96\uf625\ufe71', type: 'occlusion', count: 962});
+let sampler14 = device0.createSampler({
+  label: '\u0bc8\ub87a\u129d\u0760\uc6e1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 83.04,
+  lodMaxClamp: 100.00,
+});
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13124 */
+  offset: 13124,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 75},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 19, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer0, 82972, 52188);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6, commandBuffer4]);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u8ad7\uaef8\u8262\u17c2',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas0 = new OffscreenCanvas(213, 113);
+let computePassEncoder6 = commandEncoder14.beginComputePass();
+let sampler15 = device0.createSampler({
+  label: '\u0cd1\u{1f9d2}\u9990\u00ff\u0c04\u0af6',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.46,
+  lodMaxClamp: 92.90,
+});
+let shaderModule3 = device0.createShaderModule({
+  label: '\u62b8\u{1f60f}\u97aa\ue7e0\u88bd',
+  code: `@group(4) @binding(2115)
+var<storage, read_write> parameter2: array<u32>;
+@group(1) @binding(2115)
+var<storage, read_write> n1: array<u32>;
+@group(0) @binding(3576)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec4<u32>,
+  @location(2) f2: vec4<f32>,
+  @location(0) f3: vec3<u32>,
+  @location(3) f4: f32,
+  @location(4) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(27) f0: f16,
+  @location(16) f1: vec4<f32>,
+  @location(20) f2: vec2<f32>,
+  @location(25) f3: vec4<f16>,
+  @location(28) f4: vec3<u32>,
+  @location(24) f5: vec2<u32>,
+  @location(17) f6: vec2<f32>,
+  @location(13) f7: f32,
+  @location(4) f8: vec2<u32>,
+  @builtin(vertex_index) f9: u32,
+  @location(19) f10: vec4<f16>,
+  @location(9) f11: vec4<f32>,
+  @location(8) f12: f16,
+  @location(0) f13: vec4<f16>,
+  @location(18) f14: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f32>, @location(22) a1: vec4<i32>, @builtin(instance_index) a2: u32, @location(21) a3: vec3<u32>, a4: S2) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture15 = device0.createTexture({
+  label: '\u0ed1\u3f79\u{1fa5e}\u{1f7ac}\u{1f80f}\ub3b6\u{1ff60}\u0fe1\u4461',
+  size: [2280],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+texture1.destroy();
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer0, 44176, 36128);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder11.insertDebugMarker('\ud23a');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 30716, new Int16Array(5992));
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 212, height: 320, depthOrArrayLayers: 631}
+*/
+{
+  source: imageData1,
+  origin: { x: 34, y: 48 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 61, z: 157},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let promise1 = device0.createRenderPipelineAsync({
+  label: '\u6259\ubea1\ua406\u6d94\u4059\u86d5\u9faa\u6852\u5563\u{1fc8c}',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xfdd8e3f6},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgb10a2uint'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 652,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 36, shaderLocation: 21}],
+      },
+      {
+        arrayStride: 472,
+        attributes: [
+          {format: 'float32x4', offset: 272, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 5},
+          {format: 'uint8x2', offset: 4, shaderLocation: 28},
+          {format: 'float32x4', offset: 80, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 60, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 38, shaderLocation: 18},
+          {format: 'snorm16x4', offset: 44, shaderLocation: 25},
+          {format: 'uint8x2', offset: 30, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 28, shaderLocation: 19},
+          {format: 'unorm16x2', offset: 228, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 11824,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 1040, shaderLocation: 24},
+          {format: 'sint32x3', offset: 36, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 1696,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 604, shaderLocation: 27}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 1908, attributes: [{format: 'snorm8x4', offset: 448, shaderLocation: 20}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let video3 = await videoWithData();
+let shaderModule4 = device0.createShaderModule({
+  label: '\u{1fb47}\u24ca\uca79\u0925\udb40\u0431\u{1f7c2}\u{1f770}\u52a5',
+  code: `@group(1) @binding(2115)
+var<storage, read_write> parameter3: array<u32>;
+@group(4) @binding(2115)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(3576)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(1) f0: vec3<f16>,
+  @location(17) f1: vec4<i32>,
+  @location(8) f2: f16,
+  @location(7) f3: vec2<f16>,
+  @location(9) f4: vec3<f32>,
+  @location(3) f5: f32,
+  @location(11) f6: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec2<u32>, @location(2) a1: vec4<f32>, @location(28) a2: vec4<u32>, @location(5) a3: f32, a4: S3, @location(21) a5: vec4<u32>, @location(20) a6: vec2<f32>, @location(13) a7: f16, @location(18) a8: vec3<f16>, @location(26) a9: u32, @location(27) a10: vec4<u32>, @location(4) a11: vec3<f32>, @location(23) a12: vec4<u32>, @location(24) a13: vec3<f32>, @location(12) a14: vec4<f32>, @location(6) a15: vec4<f16>, @builtin(vertex_index) a16: u32, @location(22) a17: vec2<i32>, @location(15) a18: f32, @location(14) a19: vec2<f16>, @location(10) a20: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout5 = device0.createBindGroupLayout({entries: []});
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\uf0e0\u{1fc4f}\u0944\u0b29\u5efb\u058e\u0c75\u00ca\u91c7\u0599',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout5, bindGroupLayout3, bindGroupLayout1],
+});
+let externalTexture5 = device0.importExternalTexture({
+  label: '\u22f2\ue6c5\u0f20\ub91b\u{1fff9}\ua456\u{1f966}\u2339',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer1, 86712, 21868);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let textureView21 = texture8.createView({
+  label: '\u6cb8\u0700\u54d9\u{1fb7f}\u{1ff53}\ua057\u{1fc07}',
+  baseMipLevel: 2,
+  baseArrayLayer: 36,
+  arrayLayerCount: 127,
+});
+try {
+renderBundleEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 27620, new DataView(new ArrayBuffer(53928)));
+} catch {}
+let commandBuffer7 = commandEncoder15.finish();
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u09bd\u0b66\u0eb0\ua6a3\u416e\u686d\u0562\u{1f92a}\u0597',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 139052);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 78}
+*/
+{
+  source: imageData5,
+  origin: { x: 35, y: 8 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 3, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  label: '\u0c69\u0698\u{1fe6e}\u92f3\u0b92\u0982\u{1fb05}\uef45\uc459',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x7be8a97c},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgb10a2uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint'}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9540,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 9536, shaderLocation: 27}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\ub09c\u7e31\ub4ea\u5184\ue95a\u0193',
+  entries: [
+    {binding: 69, visibility: 0, sampler: { type: 'comparison' }},
+    {
+      binding: 1890,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup6 = device0.createBindGroup({label: '\u3439\u0441\u2204\u5104\u049d\uef6a', layout: bindGroupLayout3, entries: []});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u4f3d\u{1fd4e}\u1ed5\u5fd2\u02b7\u3d55'});
+let texture16 = device0.createTexture({
+  size: {width: 1024, height: 40, depthOrArrayLayers: 1624},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float'],
+});
+let textureView22 = texture12.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 4});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(1, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 9432, new Float32Array(43399), 21280);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 70},
+  aspect: 'all',
+}, new ArrayBuffer(1_251_818), /* required buffer size: 1_251_818 */
+{offset: 518, bytesPerRow: 310, rowsPerImage: 248}, {width: 35, height: 69, depthOrArrayLayers: 17});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 53, height: 80, depthOrArrayLayers: 157}
+*/
+{
+  source: imageData3,
+  origin: { x: 46, y: 10 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 4, y: 32, z: 29},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(943, 261);
+let shaderModule5 = device0.createShaderModule({
+  label: '\u{1fb59}\u{1ff48}\u4a16\ubdb3\u{1fe4b}\uc289\u0569',
+  code: `@group(3) @binding(2115)
+var<storage, read_write> function3: array<u32>;
+@group(6) @binding(2115)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @location(19) f0: f32,
+  @location(18) f1: vec3<i32>,
+  @location(6) f2: vec3<u32>,
+  @builtin(sample_mask) f3: u32,
+  @builtin(sample_index) f4: u32
+}
+struct FragmentOutput0 {
+  @location(4) f0: i32,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec2<u32>,
+  @location(1) f3: vec4<u32>,
+  @location(3) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(43) a0: vec3<i32>, @location(22) a1: vec4<u32>, a2: S4, @builtin(position) a3: vec4<f32>, @builtin(front_facing) a4: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(22) f30: vec4<u32>,
+  @location(6) f31: vec3<u32>,
+  @location(18) f32: vec3<i32>,
+  @location(19) f33: f32,
+  @location(43) f34: vec3<i32>,
+  @builtin(position) f35: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec4<i32>, @builtin(vertex_index) a1: u32, @location(17) a2: vec4<u32>, @location(23) a3: f16, @location(3) a4: vec3<f16>, @builtin(instance_index) a5: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 2770});
+let sampler16 = device0.createSampler({
+  label: '\u{1f8af}\u{1f8ee}\u{1f6ea}\u{1ffee}\ucd54\u{1f942}\u0d33\u{1f6e2}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 86.05,
+  lodMaxClamp: 99.22,
+});
+try {
+renderBundleEncoder5.setVertexBuffer(1, buffer1);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\udb72\u{1fc19}\uad58\ubc5b\ubfef\u4ba1\ud15d\u{1fd96}\u{1fbee}\u{1ff6e}',
+  code: `@group(4) @binding(2115)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(4) f1: vec2<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec4<u32>,
+  @location(3) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(7) f0: vec2<f16>,
+  @location(13) f1: vec4<f32>,
+  @location(10) f2: vec4<f16>,
+  @location(24) f3: vec3<f32>,
+  @location(8) f4: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<f16>, @location(2) a1: vec2<f16>, @location(15) a2: vec3<i32>, a3: S5, @location(3) a4: f32, @builtin(vertex_index) a5: u32, @location(12) a6: vec2<i32>, @location(4) a7: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer3 = device0.createBuffer({
+  label: '\u35f9\u065a\u40b7\u2994\u0702\u0350\u07ab',
+  size: 18180,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\u865e\u{1f80d}\u19e5\u{1f84c}\u87d0\uf40c\u{1f868}'});
+try {
+renderBundleEncoder4.setBindGroup(8, bindGroup0);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 72 */
+  offset: 72,
+  buffer: buffer1,
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 53, height: 80, depthOrArrayLayers: 157}
+*/
+{
+  source: img2,
+  origin: { x: 5, y: 26 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 10, y: 5, z: 43},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\u616a\u2805\u0d98\u00c3\u0d73\u032c\u2280\u{1f998}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let pipeline14 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {mask: 0x881bc57a},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'invert'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 380905944,
+    stencilWriteMask: 1246666841,
+    depthBias: -28410347,
+    depthBiasSlopeScale: 860.8905282151998,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 6760, attributes: []},
+      {arrayStride: 29152, attributes: [{format: 'sint32x2', offset: 4056, shaderLocation: 27}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+document.body.prepend(video1);
+let shaderModule7 = device0.createShaderModule({
+  label: '\u{1fb6f}\u0ce9\u0135\u{1fc33}\u7086\u045e',
+  code: `@group(0) @binding(3576)
+var<storage, read_write> parameter4: array<u32>;
+@group(4) @binding(2115)
+var<storage, read_write> global2: array<u32>;
+@group(1) @binding(2115)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<f32>,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(13) f0: vec4<f32>,
+  @location(18) f1: i32,
+  @location(0) f2: vec3<f32>,
+  @location(23) f3: f32,
+  @location(22) f4: f32,
+  @location(11) f5: vec4<f16>,
+  @location(5) f6: f16,
+  @location(10) f7: f16,
+  @location(28) f8: vec4<f32>,
+  @location(6) f9: vec4<f32>,
+  @location(4) f10: vec2<f16>,
+  @location(14) f11: vec3<i32>,
+  @builtin(vertex_index) f12: u32,
+  @location(21) f13: vec3<u32>,
+  @builtin(instance_index) f14: u32,
+  @location(8) f15: vec2<f32>,
+  @location(1) f16: vec2<i32>,
+  @location(7) f17: u32,
+  @location(9) f18: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(27) a0: vec4<f32>, a1: S6) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u{1fbd9}\u4d9f\udbe9\u0bee\u{1f9e1}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout2, bindGroupLayout2, bindGroupLayout6, bindGroupLayout6],
+});
+let texture17 = device0.createTexture({
+  label: '\u0c01\ud7ce\u7981\u{1f7da}\u9b75',
+  size: {width: 4560},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+try {
+commandEncoder17.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise2 = device0.createRenderPipelineAsync({
+  label: '\ub641\u{1f7e8}\u{1fffa}\u08cd\u86a6',
+  layout: pipelineLayout3,
+  multisample: {},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+  },
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one'},
+  },
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'decrement-clamp'},
+    stencilWriteMask: 4242845344,
+    depthBias: 959067277,
+    depthBiasSlopeScale: 531.824110788445,
+    depthBiasClamp: 242.10483277140037,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 9968, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 8104,
+        attributes: [
+          {format: 'sint8x2', offset: 1282, shaderLocation: 12},
+          {format: 'float16x4', offset: 2448, shaderLocation: 24},
+          {format: 'sint32x3', offset: 548, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 884, shaderLocation: 7},
+          {format: 'float32x4', offset: 200, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 76, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 80, shaderLocation: 3},
+          {format: 'sint16x4', offset: 128, shaderLocation: 4},
+          {format: 'float32x2', offset: 900, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 380, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 4328, attributes: [{format: 'unorm16x2', offset: 1088, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+let shaderModule8 = device0.createShaderModule({
+  label: '\uc8d4\u08ad\u0959\ue6ee\u2f85\u{1fc6e}\u0ccf\u06ee\u0cf9\u{1febe}',
+  code: `@group(5) @binding(2115)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(2115)
+var<storage, read_write> n2: array<u32>;
+@group(6) @binding(2115)
+var<storage, read_write> parameter5: array<u32>;
+@group(2) @binding(2115)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(2) f1: vec4<f32>,
+  @location(3) f2: f32,
+  @location(1) f3: vec4<u32>,
+  @location(4) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(7) f0: vec2<f32>,
+  @location(11) f1: vec2<f16>,
+  @location(26) f2: vec4<u32>,
+  @location(17) f3: f32,
+  @location(16) f4: vec3<i32>,
+  @location(3) f5: vec4<i32>,
+  @location(13) f6: vec3<i32>,
+  @location(5) f7: vec4<f16>,
+  @location(28) f8: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f16>, @location(6) a1: vec3<f32>, @location(15) a2: vec2<f16>, @location(24) a3: vec2<u32>, @location(20) a4: vec4<u32>, @location(27) a5: i32, @builtin(instance_index) a6: u32, @location(23) a7: f16, @location(10) a8: vec3<u32>, @location(25) a9: vec3<f16>, @location(21) a10: vec2<i32>, @location(2) a11: vec4<u32>, @location(0) a12: vec3<u32>, a13: S7, @builtin(vertex_index) a14: u32, @location(22) a15: u32, @location(8) a16: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 2872});
+try {
+renderBundleEncoder4.setVertexBuffer(3374, undefined);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 106, height: 160, depthOrArrayLayers: 315}
+*/
+{
+  source: img1,
+  origin: { x: 12, y: 3 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 6, y: 9, z: 49},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  label: '\u02b9\u{1f96d}\u2dd2\ua7d5\u094b\u85e6\u0fb3\u0995\u0796\u59d1\u{1fad5}',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let querySet11 = device0.createQuerySet({label: '\u0e3a\u00ed\u0ac5\u{1fa9a}\ud2c2\u{1fdaf}\u013f', type: 'occlusion', count: 1690});
+let texture18 = device0.createTexture({
+  size: {width: 385, height: 32, depthOrArrayLayers: 180},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView23 = texture13.createView({label: '\u11c5\u{1f78e}\u4529\u0bb6\uc1ca\ubc6b\u0a0d', baseMipLevel: 8});
+let sampler17 = device0.createSampler({
+  label: '\u{1fb6a}\ub3b8\u7fda\u0292\u01af\u4c16',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.78,
+  lodMaxClamp: 76.66,
+  maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder4.setBindGroup(5, bindGroup6, new Uint32Array(9730), 8250, 0);
+} catch {}
+try {
+texture14.destroy();
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u0f38');
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 956, new Float32Array(25764));
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder();
+let textureView24 = texture9.createView({aspect: 'depth-only', mipLevelCount: 2, baseArrayLayer: 16, arrayLayerCount: 19});
+try {
+computePassEncoder3.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup6, new Uint32Array(3762), 366, 0);
+} catch {}
+let bindGroup8 = device0.createBindGroup({label: '\u{1faf8}\u{1fd15}\u6d02\u3932', layout: bindGroupLayout3, entries: []});
+let buffer4 = device0.createBuffer({label: '\u{1fa66}\ud4e8', size: 75873, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder20 = device0.createCommandEncoder({label: '\u{1fb31}\u673f\u019e\u{1fd51}\ud986\u756e\u9be0\u{1fe40}'});
+let querySet12 = device0.createQuerySet({label: '\u{1fd58}\u41e9\u93b1\u824a\u4cb5\u5b0f', type: 'occlusion', count: 1383});
+let texture19 = device0.createTexture({
+  label: '\u06f9\u09e0\ua54f\u9e07\u88e4\u1082\u{1f6e8}\u6930',
+  size: {width: 512, height: 20, depthOrArrayLayers: 714},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+try {
+renderBundleEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer1, 0, 76938);
+} catch {}
+try {
+commandEncoder19.pushDebugGroup('\u{1fdfd}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 1, y: 22, z: 51},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 3_906_229 */
+{offset: 245, bytesPerRow: 548, rowsPerImage: 237}, {width: 97, height: 18, depthOrArrayLayers: 31});
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let videoFrame2 = new VideoFrame(video3, {timestamp: 0});
+let buffer5 = device0.createBuffer({size: 169468, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder21 = device0.createCommandEncoder({label: '\u026d\u3796\u0246'});
+let textureView25 = texture16.createView({
+  label: '\ued87\ueca9\u4a31\u{1fc86}\u{1f686}\u0f2a\u9b8e\u{1f744}',
+  dimension: '3d',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+try {
+renderBundleEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 140840, 7340);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(727, 151);
+document.body.prepend(canvas2);
+let promise3 = adapter0.requestAdapterInfo();
+try {
+offscreenCanvas2.getContext('webgl');
+} catch {}
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 1341});
+let commandBuffer8 = commandEncoder17.finish({label: '\u056c\u6ad5\uc8b0\u{1fa2b}\u0889\u2a18\u{1f9d7}\u0191\u{1fece}'});
+let textureView26 = texture5.createView({dimension: '2d-array'});
+let sampler18 = device0.createSampler({
+  label: '\uad3d\uec1e\u031e\u3608\u{1f64c}\u{1fa9a}\uc75d\u{1f698}\u{1f733}\u0365\u0480',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 22.34,
+  lodMaxClamp: 46.30,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(7, bindGroup3, new Uint32Array(1106), 884, 0);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer3, 14504, buffer1, 112288, 1204);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let video4 = await videoWithData();
+let promise4 = adapter0.requestAdapterInfo();
+try {
+device0.label = '\u0b66\u0d82\u8645';
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout3, bindGroupLayout1, bindGroupLayout4, bindGroupLayout3, bindGroupLayout0],
+});
+let renderBundle10 = renderBundleEncoder3.finish({label: '\u233e\ud22e\u77de\u9a68\u21fd\u{1ff11}'});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 13833 */
+  offset: 13833,
+  buffer: buffer5,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 69, resource: sampler13}, {binding: 1890, resource: sampler14}],
+});
+let commandEncoder22 = device0.createCommandEncoder({label: '\u{1f834}\u{1f862}\u0705\u76d7\u0d0a\uc5bf\u{1f969}\u6e9d\u0f7a\u7e05\u{1f813}'});
+let commandBuffer9 = commandEncoder11.finish();
+let textureView27 = texture19.createView({label: '\u0091\uc093\u0dff\u017f\u4d16\u1fa7\u956d\u4c9e\u0ca1\u0271', baseMipLevel: 1});
+let pipeline15 = await device0.createComputePipelineAsync({
+  label: '\u7bb1\u06b8\u{1fba6}\uaabb\u7c71\u{1fcfb}',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder23 = device0.createCommandEncoder({label: '\u{1f7b3}\u0d8b\u49fe\u03c9\u86d6\ud10a\u18ac'});
+let computePassEncoder7 = commandEncoder22.beginComputePass({label: '\u{1fbb6}\u{1fbeb}\ub76e'});
+let externalTexture8 = device0.importExternalTexture({label: '\uf2ce\u8415\u201b\u{1ffa1}', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer1, 0, 76083);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer3, 5688, buffer0, 98312, 5224);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({
+  label: '\u8b1a\u0bd1\u2966\ud1d9\ue175\u0db8',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder24 = device0.createCommandEncoder({label: '\ubcce\u9d22\u0497\u0ff7\u4c46\uf4aa\u6512\u2888\u094b\u2670\u2ee5'});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer1, 0, 1754);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 988 */
+  offset: 988,
+  buffer: buffer0,
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 272, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 142, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 2360, new DataView(new ArrayBuffer(5518)), 1589, 200);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 212, height: 320, depthOrArrayLayers: 631}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 14, y: 1 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 11, y: 258, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView28 = texture0.createView({aspect: 'all'});
+let computePassEncoder8 = commandEncoder12.beginComputePass({label: '\u0827\u9e98\u068b\u106e\u{1fd54}\u{1f820}\ub5c4\u0000\u{1f6b5}\u{1f925}\ucfbb'});
+let renderBundle11 = renderBundleEncoder2.finish({label: '\u042d\u0130'});
+try {
+computePassEncoder3.setBindGroup(9, bindGroup1);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+buffer4.destroy();
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(731, 315);
+let commandEncoder25 = device0.createCommandEncoder();
+let querySet14 = device0.createQuerySet({label: '\u0c93\ubec8\u0a8d\u9553\u023a', type: 'occlusion', count: 929});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u32a7\u{1fe93}\u{1fb15}\uc80b\u0a3f\u08b4\u00cd',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder2.finish({label: '\u3719\u0fc9\u0549\u147a\u0f39\u4c8f\u28c1'});
+try {
+computePassEncoder3.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9, commandBuffer8]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 6, z: 2},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(64)), /* required buffer size: 2_883_289 */
+{offset: 380, bytesPerRow: 417, rowsPerImage: 111}, {width: 47, height: 32, depthOrArrayLayers: 63});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder26 = device0.createCommandEncoder({label: '\u0309\u1b86\u062a\u544a'});
+try {
+renderBundleEncoder4.setBindGroup(9, bindGroup0, new Uint32Array(2760), 562, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1768, new DataView(new ArrayBuffer(31861)), 14464, 860);
+} catch {}
+offscreenCanvas0.height = 128;
+let pipelineLayout6 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout6, bindGroupLayout2, bindGroupLayout2, bindGroupLayout6, bindGroupLayout4, bindGroupLayout4, bindGroupLayout3],
+});
+let texture20 = device0.createTexture({
+  label: '\u0751\u{1fb9d}\u{1f8b8}\u071a',
+  size: [256, 10, 1733],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView29 = texture5.createView({label: '\u4f5e\u{1fd0f}\u0404\u{1fa4a}\u{1fe36}', dimension: '2d-array', mipLevelCount: 1});
+try {
+buffer2.unmap();
+} catch {}
+let buffer6 = device0.createBuffer({label: '\uebb6\ue48e\u84ce', size: 41072, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u4b93\u6ea8\uc320\uacce\uab2f\u{1fe20}\u7f98\u08e4\uc45e'});
+let textureView30 = texture9.createView({aspect: 'depth-only', baseMipLevel: 2, baseArrayLayer: 225, arrayLayerCount: 44});
+let computePassEncoder9 = commandEncoder7.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(6, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(8, bindGroup5, new Uint32Array(3829), 2997, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 2_179 */
+{offset: 855, bytesPerRow: 84}, {width: 16, height: 16, depthOrArrayLayers: 1});
+} catch {}
+let pipeline17 = await device0.createRenderPipelineAsync({
+  label: '\ue09f\ua036',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8sint'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'never', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 929162237,
+    stencilWriteMask: 310191506,
+    depthBias: 747686855,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 163.49257418550803,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2204,
+        attributes: [
+          {format: 'float16x2', offset: 368, shaderLocation: 8},
+          {format: 'uint8x2', offset: 30, shaderLocation: 21},
+          {format: 'float32x4', offset: 384, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 76, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 35560,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1952, shaderLocation: 17},
+          {format: 'uint8x2', offset: 840, shaderLocation: 4},
+          {format: 'uint32', offset: 192, shaderLocation: 28},
+          {format: 'float16x2', offset: 32976, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 3068,
+        attributes: [
+          {format: 'float32x4', offset: 224, shaderLocation: 18},
+          {format: 'snorm16x4', offset: 104, shaderLocation: 20},
+          {format: 'float32', offset: 324, shaderLocation: 5},
+          {format: 'uint32x3', offset: 196, shaderLocation: 24},
+          {format: 'float32', offset: 392, shaderLocation: 0},
+          {format: 'float32x2', offset: 692, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 192, shaderLocation: 27},
+        ],
+      },
+      {arrayStride: 16568, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 20220,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 194, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 2376, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'front'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+offscreenCanvas0.width = 591;
+let imageData7 = new ImageData(116, 212);
+let querySet15 = device0.createQuerySet({label: '\u{1fbe7}\u1911\u6e9a\u8c5c\u0c23\u16d3\u{1f69c}\u0166\u807a', type: 'occlusion', count: 2919});
+let commandBuffer10 = commandEncoder18.finish({label: '\u8295\u9e82\ub678\u1c97\u1dfb\ua5dc'});
+try {
+computePassEncoder1.setBindGroup(8, bindGroup4, new Uint32Array(9882), 5692, 0);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 158, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 30836, new DataView(new ArrayBuffer(23669)), 20387, 724);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 103},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(16)), /* required buffer size: 652_774 */
+{offset: 664, bytesPerRow: 249, rowsPerImage: 201}, {width: 57, height: 6, depthOrArrayLayers: 14});
+} catch {}
+let pipeline18 = await promise2;
+let video5 = await videoWithData();
+let commandEncoder28 = device0.createCommandEncoder({label: '\ub2d4\uf85b\ue864\ue3c2\u57d7\u{1f728}\u{1fae3}\u3a14\ua1ce\ud81e\u6a1f'});
+let querySet16 = device0.createQuerySet({
+  label: '\u63f6\u0e37\u1588\uf8d9\u3802\u{1fd34}\u{1f75b}\u{1f859}\u196d\u1bd0',
+  type: 'occlusion',
+  count: 2687,
+});
+let texture21 = device0.createTexture({
+  size: [128, 5, 98],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView31 = texture21.createView({
+  label: '\u0b64\u7ae9\u1bd9\ued9d\u{1f86f}\u{1f9a9}',
+  mipLevelCount: 4,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u067a\u2594\u0541\uafbe\ub460\uae91\u01a9\u2799\uf16b\u36d7\u1b7d',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+});
+let renderBundle13 = renderBundleEncoder6.finish({label: '\ua390\uc7b5\u{1f62b}\ua10b\uf4ab'});
+let sampler19 = device0.createSampler({
+  label: '\u{1ff8f}\u4a1b\u0291\ubea7\u45ee\u0322',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.53,
+  lodMaxClamp: 63.72,
+});
+try {
+computePassEncoder3.setBindGroup(7, bindGroup7, new Uint32Array(2395), 1811, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 9, y: 1, z: 105},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+  label: '\u169f\u08eb\u29b3\u{1f612}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule9 = device0.createShaderModule({
+  label: '\u37d6\u{1f8ca}\ub869\ue14a\u{1fee0}\uf54e\u802d\ue4aa\u90ff\u{1f759}\u35fa',
+  code: `@group(2) @binding(2115)
+var<storage, read_write> local2: array<u32>;
+@group(5) @binding(2115)
+var<storage, read_write> global3: array<u32>;
+@group(3) @binding(2115)
+var<storage, read_write> local3: array<u32>;
+@group(6) @binding(2115)
+var<storage, read_write> parameter6: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(2) f2: vec4<f32>,
+  @location(4) f3: i32,
+  @location(6) f4: vec2<u32>,
+  @location(3) f5: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: u32, @location(21) a1: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup10 = device0.createBindGroup({
+  label: '\u{1fe4d}\ubfcb\u02b5\uda2d\u8c14\u40da\u0e9d\ue3d9\u{1fbf2}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 69, resource: sampler13}, {binding: 1890, resource: sampler19}],
+});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u216a\u4ad3\u3723\u{1fac8}\ud2eb\u0551'});
+let texture22 = device0.createTexture({
+  label: '\u0926\u{1fa86}\u{1fc72}\u0543\u8530\u0424\u53da\ud80b',
+  size: {width: 26, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture9 = device0.importExternalTexture({label: '\u{1f7d7}\u{1fa64}\ufe98', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+commandEncoder26.copyBufferToBuffer(buffer2, 35508, buffer0, 100892, 28012);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 65},
+  aspect: 'all',
+},
+{width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 11, y: 6, z: 43},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(72)), /* required buffer size: 529_809 */
+{offset: 561, bytesPerRow: 260, rowsPerImage: 215}, {width: 37, height: 101, depthOrArrayLayers: 10});
+} catch {}
+gc();
+let commandBuffer11 = commandEncoder28.finish();
+let texture23 = gpuCanvasContext1.getCurrentTexture();
+try {
+querySet11.destroy();
+} catch {}
+let arrayBuffer0 = buffer3.getMappedRange();
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 3, y: 103, z: 142},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 955_552 */
+{offset: 616, bytesPerRow: 521, rowsPerImage: 55}, {width: 116, height: 18, depthOrArrayLayers: 34});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let externalTexture10 = device0.importExternalTexture({label: '\u{1f900}\u0011\u0b7f', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+  label: '\u{1f8f5}\u0103\u{1fe23}',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'rgb10a2uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {failOp: 'invert', passOp: 'zero'},
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4284,
+        attributes: [
+          {format: 'sint32x2', offset: 1540, shaderLocation: 13},
+          {format: 'uint32x4', offset: 68, shaderLocation: 20},
+          {format: 'uint32x2', offset: 28, shaderLocation: 26},
+          {format: 'float16x4', offset: 648, shaderLocation: 15},
+          {format: 'uint8x4', offset: 2000, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 340, shaderLocation: 28},
+          {format: 'uint8x2', offset: 802, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 3320,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 724, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 392, shaderLocation: 25},
+          {format: 'float16x4', offset: 756, shaderLocation: 17},
+          {format: 'sint16x4', offset: 20, shaderLocation: 21},
+          {format: 'uint16x2', offset: 432, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 620,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 168, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 158, shaderLocation: 8},
+          {format: 'sint32x2', offset: 0, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 3224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 1920, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 852, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 16, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 21740,
+        attributes: [
+          {format: 'unorm8x2', offset: 4764, shaderLocation: 6},
+          {format: 'sint8x4', offset: 448, shaderLocation: 27},
+        ],
+      },
+      {
+        arrayStride: 8832,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x4', offset: 164, shaderLocation: 16},
+          {format: 'uint32', offset: 300, shaderLocation: 24},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'none'},
+});
+try {
+offscreenCanvas0.getContext('webgpu');
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u014f\u0a15\u866e\u{1fdbb}\ud8df'});
+let texture24 = device0.createTexture({
+  label: '\u2f9d\u09ff\u030f\u8b4a',
+  size: {width: 192, height: 16, depthOrArrayLayers: 1393},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.32,
+  lodMaxClamp: 78.17,
+});
+try {
+computePassEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup2, new Uint32Array(465), 296, 0);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer3, 328, buffer1, 109504, 8896);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 32117 */
+  offset: 32117,
+  bytesPerRow: 256,
+  buffer: buffer2,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 23800, new Int16Array(18910));
+} catch {}
+let canvas3 = document.createElement('canvas');
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 845});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle14 = renderBundleEncoder7.finish({label: '\ufad6\u010e\u7e6f\u{1f7e7}\ua710\u770f\u485b'});
+try {
+commandEncoder16.copyBufferToBuffer(buffer5, 28008, buffer1, 59016, 26340);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 570 widthInBlocks: 570 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4056 */
+  offset: 3486,
+  buffer: buffer1,
+}, {width: 570, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise5 = device0.createRenderPipelineAsync({
+  label: '\u{1f9aa}\u0881\u2916\uad6e\u828d\u05f9\u{1fec1}\u{1fac3}\uf36f\ua1b2\ucd13',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'rgb10a2uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'src'},
+  },
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'dst'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'keep', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'keep', passOp: 'increment-wrap'},
+    stencilReadMask: 4264474556,
+    stencilWriteMask: 1562832520,
+    depthBias: 1314179980,
+    depthBiasSlopeScale: 581.5159436874449,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3896,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 560, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 28},
+          {format: 'float32x4', offset: 1048, shaderLocation: 17},
+          {format: 'uint8x4', offset: 424, shaderLocation: 0},
+          {format: 'sint32x4', offset: 872, shaderLocation: 27},
+          {format: 'unorm10-10-10-2', offset: 296, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 536, shaderLocation: 7},
+          {format: 'sint8x4', offset: 444, shaderLocation: 21},
+          {format: 'sint32x2', offset: 1252, shaderLocation: 3},
+          {format: 'uint8x2', offset: 148, shaderLocation: 10},
+          {format: 'sint32x2', offset: 1452, shaderLocation: 16},
+          {format: 'uint32x3', offset: 2612, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 160, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 2428,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 40, shaderLocation: 23},
+          {format: 'sint32x4', offset: 448, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 168, shaderLocation: 11},
+          {format: 'float32x2', offset: 268, shaderLocation: 6},
+          {format: 'uint16x4', offset: 504, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 5692,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 1244, shaderLocation: 24}],
+      },
+      {
+        arrayStride: 13104,
+        attributes: [
+          {format: 'uint32', offset: 40, shaderLocation: 22},
+          {format: 'uint16x4', offset: 1772, shaderLocation: 26},
+          {format: 'unorm8x2', offset: 3214, shaderLocation: 25},
+        ],
+      },
+      {arrayStride: 7760, attributes: [{format: 'snorm8x2', offset: 1110, shaderLocation: 8}]},
+    ],
+  },
+});
+offscreenCanvas2.width = 1842;
+let bindGroup11 = device0.createBindGroup({label: '\u03b4\u640c\u5c96\u159a', layout: bindGroupLayout3, entries: []});
+let textureView32 = texture23.createView({label: '\u4652\u1177\u1f45\u{1f70a}\u53b6'});
+let renderBundle15 = renderBundleEncoder7.finish({label: '\ufe19\u{1fb3d}\ua07c\u094c\u9dd0\u{1ff3c}\ub7b7\u11eb\uf85f\u{1fc9b}\u5501'});
+let sampler21 = device0.createSampler({
+  label: '\u{1ffd5}\u0cfe\u6ebb\u061a\u4fcf\u{1f798}\u23b3\u{1fb81}\uf0ee\u{1f966}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.79,
+  lodMaxClamp: 94.40,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline21 = await promise1;
+try {
+window.someLabel = commandEncoder27.label;
+} catch {}
+let texture25 = device0.createTexture({
+  label: '\u1808\u{1f665}\u0237',
+  size: [2280, 1, 1],
+  mipLevelCount: 10,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u93b0\u{1f603}\u371c\u07d0\u60a9\u{1f631}',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+});
+let renderBundle16 = renderBundleEncoder8.finish();
+let sampler22 = device0.createSampler({
+  label: '\u070e\u{1fd1a}\u061a\u7daa\u{1f8b3}\u{1f9d3}\u{1fcce}\uadb2\u17d3\u6683',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.11,
+  lodMaxClamp: 96.26,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder7.setBindGroup(7, bindGroup7, new Uint32Array(652), 388, 0);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({label: '\u0d9e\u{1fbde}\u{1f835}\u09c1\u01ad\ue28d'});
+let querySet18 = device0.createQuerySet({label: '\u081d\u6938\u0b04\u{1f923}\u89d4\u{1f6e9}\ubc24\ua5ff', type: 'occlusion', count: 2889});
+let textureView33 = texture9.createView({
+  label: '\u0e9d\u{1ff11}\uc98d\u72d0\u{1f74a}\ucd51\u0afc',
+  mipLevelCount: 2,
+  baseArrayLayer: 123,
+  arrayLayerCount: 136,
+});
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer0, 74732, 37816);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 382},
+  aspect: 'all',
+}, new ArrayBuffer(5_498_234), /* required buffer size: 5_498_234 */
+{offset: 692, bytesPerRow: 1177, rowsPerImage: 222}, {width: 238, height: 9, depthOrArrayLayers: 22});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\u0448\u085a\ue320\u9498\u0061\ue054\u{1fcf3}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let promise6 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0x6d344008},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 376272116,
+    stencilWriteMask: 2499781316,
+    depthBiasSlopeScale: -98.78769126909152,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10592,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 3700, shaderLocation: 17},
+          {format: 'sint8x4', offset: 52, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 14516, stepMode: 'instance', attributes: []},
+      {arrayStride: 1408, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 832,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 108, shaderLocation: 23},
+          {format: 'unorm16x4', offset: 24, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+video2.width = 127;
+try {
+canvas3.getContext('webgl');
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\ubacf\u627f\u{1fcb9}',
+  code: `@group(4) @binding(1890)
+var<storage, read_write> parameter7: array<u32>;
+@group(6) @binding(2550)
+var<storage, read_write> field2: array<u32>;
+@group(5) @binding(3507)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(1890)
+var<storage, read_write> function5: array<u32>;
+@group(5) @binding(1215)
+var<storage, read_write> parameter8: array<u32>;
+@group(3) @binding(3576)
+var<storage, read_write> type3: array<u32>;
+@group(1) @binding(69)
+var<storage, read_write> n3: array<u32>;
+@group(2) @binding(3576)
+var<storage, read_write> field4: array<u32>;
+@group(4) @binding(69)
+var<storage, read_write> local4: array<u32>;
+@group(6) @binding(1215)
+var<storage, read_write> n4: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @builtin(front_facing) f0: bool,
+  @location(42) f1: vec2<i32>,
+  @location(27) f2: vec2<i32>,
+  @builtin(sample_index) f3: u32,
+  @location(16) f4: u32,
+  @location(47) f5: f16,
+  @location(22) f6: vec2<f32>,
+  @location(2) f7: vec3<u32>,
+  @builtin(position) f8: vec4<f32>,
+  @builtin(sample_mask) f9: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec4<f32>, @location(32) a1: vec4<i32>, a2: S9) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(18) f0: vec2<i32>,
+  @builtin(instance_index) f1: u32,
+  @location(28) f2: vec3<u32>,
+  @builtin(vertex_index) f3: u32,
+  @location(2) f4: vec3<f32>,
+  @location(4) f5: vec3<u32>,
+  @location(22) f6: vec3<u32>,
+  @location(17) f7: vec3<f16>,
+  @location(14) f8: i32,
+  @location(24) f9: vec2<i32>,
+  @location(16) f10: vec2<f32>,
+  @location(6) f11: vec4<f32>,
+  @location(23) f12: vec2<f32>,
+  @location(1) f13: vec3<f32>,
+  @location(3) f14: vec4<i32>,
+  @location(5) f15: vec3<i32>,
+  @location(26) f16: vec2<u32>,
+  @location(11) f17: vec2<f16>,
+  @location(8) f18: f32
+}
+struct VertexOutput0 {
+  @location(47) f36: f16,
+  @location(42) f37: vec2<i32>,
+  @location(27) f38: vec2<i32>,
+  @location(16) f39: u32,
+  @builtin(position) f40: vec4<f32>,
+  @location(7) f41: vec4<f32>,
+  @location(32) f42: vec4<i32>,
+  @location(2) f43: vec3<u32>,
+  @location(22) f44: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S8, @location(0) a1: vec2<u32>, @location(19) a2: vec2<u32>, @location(15) a3: u32, @location(10) a4: u32, @location(7) a5: vec3<f32>, @location(9) a6: u32, @location(12) a7: vec3<i32>, @location(25) a8: vec3<f32>, @location(20) a9: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle17 = renderBundleEncoder9.finish({label: '\uee5f\u{1f60f}\u046c\u057e'});
+let externalTexture11 = device0.importExternalTexture({label: '\u0109\u0d48\u65b3\u8a4e\u208e\u0606\u92f5', source: videoFrame1});
+try {
+commandEncoder31.copyBufferToBuffer(buffer5, 129344, buffer0, 107676, 28684);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 864 widthInBlocks: 864 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 110330 */
+  offset: 2970,
+  bytesPerRow: 1024,
+  rowsPerImage: 4,
+  buffer: buffer5,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 32, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 864, height: 1, depthOrArrayLayers: 27});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 319 widthInBlocks: 319 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10135 */
+  offset: 10135,
+  bytesPerRow: 512,
+  buffer: buffer0,
+}, {width: 319, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 5, depthOrArrayLayers: 866}
+*/
+{
+  source: video1,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 30, y: 0, z: 44},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise4;
+} catch {}
+try {
+offscreenCanvas3.getContext('webgl');
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\ud567\u{1fff6}\u1ec6\u7f7d'});
+let commandBuffer12 = commandEncoder32.finish({});
+let texture26 = device0.createTexture({
+  label: '\u0f3c\u7370',
+  size: [4560, 1, 1],
+  mipLevelCount: 12,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView34 = texture9.createView({
+  label: '\u039e\u0645\u{1f9cb}\u{1f646}\u88a7\u{1fb29}\u541b\uf9b4\u{1f6c3}\ucfea\u0eb0',
+  aspect: 'depth-only',
+  format: 'depth32float',
+  baseMipLevel: 2,
+  baseArrayLayer: 111,
+  arrayLayerCount: 102,
+});
+let sampler23 = device0.createSampler({
+  label: '\u3a25\u0b18',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 46.37,
+  lodMaxClamp: 90.23,
+  compare: 'less-equal',
+});
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer0, 58332, 27588);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder19.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 212, height: 320, depthOrArrayLayers: 631}
+*/
+{
+  source: canvas1,
+  origin: { x: 41, y: 0 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 21, z: 256},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.width = 1373;
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u016e\u{1f910}\u99fa\u{1f788}\u01dd'});
+let texture27 = device0.createTexture({
+  label: '\u{1fce1}\u033e\u{1f894}',
+  size: {width: 570},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer1, 0, 71783);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3420, new DataView(new ArrayBuffer(23020)));
+} catch {}
+let imageBitmap1 = await createImageBitmap(img1);
+let imageData8 = new ImageData(232, 60);
+let bindGroupLayout7 = device0.createBindGroupLayout({entries: []});
+let sampler24 = device0.createSampler({
+  label: '\ua17e\u0e9c\u8eb4\ubc7b\u{1f615}\u27b6\u0874\uc1fc\ub2f9\u5668\u073a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.17,
+  lodMaxClamp: 19.64,
+  maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer1, 41232, 40284);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer2, 19452, buffer0, 123420, 4948);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 760 widthInBlocks: 190 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21064 */
+  offset: 21064,
+  bytesPerRow: 1024,
+  buffer: buffer5,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 82},
+  aspect: 'all',
+}, {width: 190, height: 271, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8864 */
+  offset: 8864,
+  rowsPerImage: 29,
+  buffer: buffer0,
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer0, 76096, 29180);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\uf18a');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1132, new Int16Array(13442));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 493, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 96 */
+{offset: 96}, {width: 845, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline23 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}}});
+let canvas4 = document.createElement('canvas');
+try {
+window.someLabel = querySet17.label;
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\u{1fabd}\u{1fc67}\u01ae',
+  layout: bindGroupLayout6,
+  entries: [{binding: 1890, resource: sampler1}, {binding: 69, resource: sampler23}],
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\uaef3\u0b6e\u001d'});
+let sampler25 = device0.createSampler({
+  label: '\u8bb2\ucc0e',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 24.21,
+  lodMaxClamp: 33.47,
+});
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup6, new Uint32Array(6851), 1313, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(34, 73, 1_415_846_833, 225_692_984);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer1, 60496, 12216);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xf2544781},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'constant'},
+    alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10044,
+        attributes: [
+          {format: 'float32x3', offset: 52, shaderLocation: 8},
+          {format: 'uint16x4', offset: 2904, shaderLocation: 4},
+          {format: 'uint32x2', offset: 2876, shaderLocation: 24},
+          {format: 'snorm16x2', offset: 304, shaderLocation: 25},
+          {format: 'float16x4', offset: 528, shaderLocation: 16},
+          {format: 'float16x4', offset: 1004, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 228, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 4024, shaderLocation: 19},
+          {format: 'float32', offset: 104, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 552, shaderLocation: 20},
+          {format: 'uint8x4', offset: 1976, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 108, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 4008, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 15256,
+        attributes: [
+          {format: 'uint16x4', offset: 540, shaderLocation: 28},
+          {format: 'unorm8x4', offset: 660, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 148, attributes: [{format: 'float32x4', offset: 20, shaderLocation: 27}]},
+      {arrayStride: 38916, stepMode: 'vertex', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 4768, attributes: []},
+      {arrayStride: 3152, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 18676,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x4', offset: 6896, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+externalTexture1.label = '\u0136\u0621\u2ee1';
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\u42ce\u7abf\u0cda\u{1fb6d}\u4e95\ucb4d\u0e21\u{1fabc}\u2123'});
+let textureView35 = texture1.createView({label: '\ub3e3\u{1fdae}\u{1fd9d}\u1128\u7706\u7167'});
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup1, new Uint32Array(9281), 7911, 0);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer5, 30948, buffer0, 73116, 41180);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 423, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 129, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer0, 28832, 8204);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let gpuCanvasContext2 = canvas4.getContext('webgpu');
+let bindGroup13 = device0.createBindGroup({layout: bindGroupLayout5, entries: []});
+let buffer7 = device0.createBuffer({
+  label: '\uf223\u33d9\u5bbd\ua130\u0010\u8321\u{1ff3b}\u{1ffd6}',
+  size: 19689,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder5.setBindGroup(4, bindGroup9, new Uint32Array(5573), 225, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+querySet13.destroy();
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 48},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2_580_674 */
+{offset: 482, bytesPerRow: 1054, rowsPerImage: 272}, {width: 906, height: 0, depthOrArrayLayers: 10});
+} catch {}
+let pipeline25 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let imageBitmap2 = await createImageBitmap(video2);
+let shaderModule11 = device0.createShaderModule({
+  code: `@group(2) @binding(2115)
+var<storage, read_write> local5: array<u32>;
+@group(6) @binding(1890)
+var<storage, read_write> global4: array<u32>;
+@group(4) @binding(3576)
+var<storage, read_write> function6: array<u32>;
+@group(5) @binding(69)
+var<storage, read_write> global5: array<u32>;
+@group(6) @binding(69)
+var<storage, read_write> field5: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec2<i32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(21) f0: vec3<u32>,
+  @location(28) f1: vec3<i32>,
+  @location(0) f2: f16,
+  @location(3) f3: vec2<f32>,
+  @location(25) f4: i32,
+  @location(23) f5: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec4<f16>, a1: S10, @location(11) a2: u32, @location(6) a3: vec4<f32>, @location(12) a4: vec2<i32>, @location(10) a5: vec4<f32>, @location(17) a6: vec4<u32>, @location(8) a7: vec4<f32>, @location(1) a8: vec4<u32>, @builtin(instance_index) a9: u32, @location(27) a10: f16, @location(15) a11: i32, @location(9) a12: vec2<i32>, @location(20) a13: i32, @location(14) a14: vec4<u32>, @location(26) a15: u32, @location(22) a16: vec2<i32>, @location(5) a17: vec4<f32>, @location(18) a18: vec3<i32>, @location(7) a19: vec2<f16>, @location(16) a20: vec4<i32>, @location(19) a21: f32, @builtin(vertex_index) a22: u32, @location(2) a23: f32, @location(4) a24: vec2<i32>, @location(24) a25: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u0452\u{1f836}\u616d\u2fbe\ud0aa\udc66\ueb76'});
+let textureView36 = texture22.createView({baseMipLevel: 2, arrayLayerCount: 1});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\ufc2e\u01af\u0cd9\u{1f696}\u08a3',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let externalTexture12 = device0.importExternalTexture({
+  label: '\u3247\u{1f88e}\ua0d0\u0891\u057f\ud4a3\u3e58\u{1fa55}\uaee0\u0f92\u45a5',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder5.drawIndexed(215, 248, 145_562_157);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 30180);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 5,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5849 */
+  offset: 5849,
+  buffer: buffer0,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 78}
+*/
+{
+  source: img0,
+  origin: { x: 38, y: 0 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 4, y: 4, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let texture28 = device0.createTexture({
+  label: '\u{1fdc8}\u4b83\u36ee\u7a1a\ud48d\u0c62\u030d\u9f7c\u{1fcb5}\uf1c2',
+  size: {width: 106},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView37 = texture20.createView({label: '\uebf4\u0b15\u0b45\u3df1\u021b\u06dd\u7137'});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\u{1fa74}\u7c4d\u901f\u2e51\u{1f61c}\u4d51\u{1f8f5}\u01c8\u{1ff41}',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(2062), 50, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder5.draw(136, 35, 254_442_418, 279_051_954);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(6, buffer1, 0, 35294);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 31964, new Float32Array(32630), 29255);
+} catch {}
+let bindGroupLayout8 = pipeline17.getBindGroupLayout(0);
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView38 = texture11.createView({label: '\uc79c\u64b2\u09b2\uecff\u3dbf\ub20b\u{1f853}', baseMipLevel: 3});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm', 'rgba16sint', 'r32float', undefined], stencilReadOnly: true});
+let sampler26 = device0.createSampler({
+  label: '\u4a82\uede9\u1534\ucbb9\u0f30\u{1faa1}\u{1faf9}\u584a\u5f8f',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 84.82,
+  lodMaxClamp: 88.09,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(492), 218, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(189, 169, 1_754_699_333, 1_125_584_102);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(103, 53, 271_527_679);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 12976);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4092 */
+  offset: 3308,
+  bytesPerRow: 256,
+  rowsPerImage: 167,
+  buffer: buffer0,
+}, {width: 4, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u4d0d\u75d5\ua65c\u{1f8a9}',
+  entries: [
+    {
+      binding: 2742,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 961,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\u0098\u0008'});
+let querySet19 = device0.createQuerySet({label: '\u1e09\ua31b\u0d0a\ubc49\u{1f67b}\u{1fc14}\u{1fc98}', type: 'occlusion', count: 3554});
+let textureView39 = texture14.createView({label: '\u0c24\ufcaa', format: 'rgba8snorm', mipLevelCount: 1});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u22f5\uf18c',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture14 = device0.importExternalTexture({label: '\uaf50\u09e6\u7941\u7a73\u3849', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 8312);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer5, 1612, buffer1, 124368, 1608);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10944 */
+  offset: 10944,
+  buffer: buffer7,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 28704, new DataView(new ArrayBuffer(53269)), 47427, 196);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 35_923 */
+{offset: 559, bytesPerRow: 40, rowsPerImage: 221}, {width: 2, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(canvas0);
+let buffer8 = device0.createBuffer({
+  label: '\u0e78\u{1fcfa}\u0a4e\u1c7e\u0469\u0130\ud3af',
+  size: 192959,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder41 = device0.createCommandEncoder({label: '\u1ab5\u52af'});
+let querySet20 = device0.createQuerySet({label: '\ua60b\u03cd\u6b27\u{1fd1f}\u{1fbdc}\u{1fefb}\u60a5\u3848', type: 'occlusion', count: 685});
+let texture29 = device0.createTexture({
+  label: '\ud8f7\u77b8',
+  size: {width: 385},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder10 = commandEncoder9.beginComputePass({label: '\uc69e\u6473\u08f8\u36dd\uab01\u{1faa4}\u0688\u0e4b\ub9eb\uf4bf'});
+let externalTexture15 = device0.importExternalTexture({
+  label: '\uf7be\u735f\ud28e\u0795\ue59e\u00e9\u{1f610}\u0597\u1dee',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder5.drawIndexed(48, 287, 325_108_891, 200_931_407, 36_074_455);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer2, 381436, buffer1, 45940, 2104);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 20480, new BigUint64Array(29538), 4698, 1000);
+} catch {}
+gc();
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u3b2a\ue012\ub517\u{1fe87}\ubd89\u1b7b\u4daa\u{1fe81}\u3f1e',
+  entries: [
+    {
+      binding: 2478,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture30 = device0.createTexture({
+  label: '\u{1ff54}\uaf50\u{1faec}\u27a5\u{1f758}\uacdb',
+  size: [53, 80, 157],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let externalTexture16 = device0.importExternalTexture({label: '\ua781\ua535\u0b3d\u4441\u1664\u0a3a\ued6e\ubdb9', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder5.drawIndexed(216, 389, 5_907_637, 240_302_203, 425_313_615);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 23936);
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(buffer7, 18332, buffer0, 49848, 104);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer0, 137296, 5324);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder24.pushDebugGroup('\uef37');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 12384, new Float32Array(30782), 3759);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 212, height: 320, depthOrArrayLayers: 631}
+*/
+{
+  source: imageData4,
+  origin: { x: 72, y: 34 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 23},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 42, depthOrArrayLayers: 0});
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+  label: '\u0a10\u0b3d\u62ac',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint'}, {format: 'rgb10a2uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8sint'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 23228,
+        attributes: [
+          {format: 'sint8x4', offset: 268, shaderLocation: 20},
+          {format: 'uint32', offset: 2692, shaderLocation: 15},
+          {format: 'uint32', offset: 7308, shaderLocation: 18},
+          {format: 'sint32x4', offset: 9316, shaderLocation: 11},
+          {format: 'float32x2', offset: 116, shaderLocation: 5},
+          {format: 'sint32x3', offset: 1996, shaderLocation: 13},
+          {format: 'sint32x2', offset: 4640, shaderLocation: 0},
+          {format: 'sint16x4', offset: 5924, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 1132, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 5248, shaderLocation: 19},
+          {format: 'float32x2', offset: 320, shaderLocation: 28},
+          {format: 'sint32x2', offset: 6964, shaderLocation: 2},
+          {format: 'float16x4', offset: 2772, shaderLocation: 25},
+        ],
+      },
+      {arrayStride: 8548, attributes: [{format: 'sint8x4', offset: 392, shaderLocation: 1}]},
+      {arrayStride: 17600, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2992,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 778, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(408, 13);
+let commandEncoder42 = device0.createCommandEncoder({});
+let externalTexture17 = device0.importExternalTexture({label: '\u3296\u5802\u9808', source: videoFrame1});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup1, new Uint32Array(5432), 1984, 0);
+} catch {}
+try {
+texture6.destroy();
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer7, 8524, buffer1, 101660, 4120);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 122 widthInBlocks: 122 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 11840 */
+  offset: 11840,
+  buffer: buffer1,
+}, {width: 122, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder24.popDebugGroup();
+} catch {}
+let promise7 = device0.createComputePipelineAsync({
+  label: '\u{1f8e9}\u026d\u39fd\u072e\u77c7\u0cbb\ucce1\u0234\u0d01\u{1fa4c}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video3);
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 38836);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 5, depthOrArrayLayers: 866}
+*/
+{
+  source: video4,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 24, y: 1, z: 485},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync({
+  label: '\u31cd\u2acb\u0cd9\u93a8\u{1ffaf}\u8ef3\u{1fc33}\ucc88',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+}, undefined],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 212,
+        attributes: [
+          {format: 'float32', offset: 16, shaderLocation: 23},
+          {format: 'float16x2', offset: 40, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 11},
+          {format: 'uint8x4', offset: 204, shaderLocation: 7},
+          {format: 'float16x4', offset: 20, shaderLocation: 22},
+          {format: 'sint8x2', offset: 10, shaderLocation: 18},
+          {format: 'sint32x4', offset: 4, shaderLocation: 14},
+          {format: 'sint32', offset: 48, shaderLocation: 9},
+          {format: 'float16x4', offset: 0, shaderLocation: 28},
+          {format: 'unorm16x2', offset: 80, shaderLocation: 0},
+          {format: 'float16x4', offset: 20, shaderLocation: 8},
+          {format: 'float32', offset: 48, shaderLocation: 27},
+          {format: 'snorm16x4', offset: 68, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 164, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x2', offset: 3144, shaderLocation: 10},
+          {format: 'sint16x4', offset: 3468, shaderLocation: 1},
+          {format: 'uint8x2', offset: 4112, shaderLocation: 21},
+        ],
+      },
+    ],
+  },
+});
+let canvas5 = document.createElement('canvas');
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 2447});
+let textureView40 = texture9.createView({
+  label: '\u1d35\u{1fe93}\u7309\u06b9\u76c8\u{1fe32}\u61bd\u0ecf\uf45f\u{1fa4a}',
+  aspect: 'depth-only',
+  baseMipLevel: 2,
+  baseArrayLayer: 22,
+  arrayLayerCount: 6,
+});
+let renderBundle18 = renderBundleEncoder2.finish({label: '\u71e9\u355f\u1b9b\u9e43\u5ca7\u0d96\ua1fd\u17f9\ud356\u05fb\u0528'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 1012);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 56168);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer1, 2412, 13072);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 1054 widthInBlocks: 1054 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 57697 */
+  offset: 57697,
+  buffer: buffer8,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 454, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1054, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer0), /* required buffer size: 118 */
+{offset: 118}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline28 = device0.createComputePipeline({
+  label: '\udafd\ud433\u9dd6\u49e3\u0318\u002c',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u{1f687}\u081a\ua8f8\ua19a\u02ad\u9e28',
+  entries: [
+    {binding: 637, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 1049,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 51});
+let textureView41 = texture3.createView({});
+let sampler27 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMinClamp: 18.89, maxAnisotropy: 20});
+try {
+renderBundleEncoder5.draw(14, 165, 122_596_206, 330_867_999);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(10, 31);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 88);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(4, buffer1, 0, 25473);
+} catch {}
+let video6 = await videoWithData();
+let textureView42 = texture1.createView({label: '\u69bb\u{1fc4a}\u982b\u0f87\u{1fd65}\uc2cc\u{1f661}\uf143\u{1f93e}\u0e20\u0d0f'});
+let sampler28 = device0.createSampler({
+  label: '\u0692\u51a4\u5792\u{1fb2a}\u0d77',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup9, new Uint32Array(7712), 1549, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(112, 145, 166_104_410, -2_069_172_930, 254_633_989);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 78}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 4, y: 2 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 7, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+adapter0.label = '\ua92e\u6774\u{1fa2e}\u30e9\u{1fa4c}\u08b6\u8017\u{1f8d9}\u{1fe7d}\ub480\u0af9';
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({label: '\u0e53\u8520\u55c3\u{1f68f}\u0161\u4114\ufb9e\u41f2\u8232\u4446'});
+let textureView43 = texture6.createView({label: '\u0db6\u0ba0\udca7\uc90d\u{1fa59}', baseMipLevel: 1, baseArrayLayer: 460, arrayLayerCount: 21});
+let renderBundle19 = renderBundleEncoder4.finish({label: '\ue105\ub83d\u652e\u090b'});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 19944);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 304 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 11656 */
+  offset: 11656,
+  bytesPerRow: 512,
+  buffer: buffer8,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3156, new BigUint64Array(14231));
+} catch {}
+canvas4.width = 215;
+let computePassEncoder11 = commandEncoder27.beginComputePass({label: '\u0b24\u08af\u9080\u3bd2\u8d60'});
+try {
+computePassEncoder8.setBindGroup(8, bindGroup8);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 15168, new Int16Array(27681), 2717);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({label: '\uf14c\u4c88', entries: []});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u0077\u026c\u0f34\ue302\u291c\u0f1a'});
+let texture31 = device0.createTexture({
+  label: '\u06b4\u{1f64d}\u02d0',
+  size: {width: 1140, height: 1, depthOrArrayLayers: 218},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView44 = texture1.createView({label: '\u0c96\u5890\uafa9\u99a2\u{1ffb3}\uacb9\udd20\uc40d\u60ed\u21ec'});
+let computePassEncoder12 = commandEncoder29.beginComputePass({label: '\u03f1\u5980\u{1ff05}\u8f84\ue06c'});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 23412);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer1);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u88db');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 5, depthOrArrayLayers: 866}
+*/
+{
+  source: canvas3,
+  origin: { x: 111, y: 33 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 19, y: 0, z: 179},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas5.getContext('webgl');
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({});
+let textureView45 = texture17.createView({label: '\u0bc2\u0275', baseArrayLayer: 0});
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer8, 97580, buffer0, 13252, 49448);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let bindGroupLayout13 = pipeline24.getBindGroupLayout(2);
+let computePassEncoder13 = commandEncoder16.beginComputePass({label: '\u{1f656}\u0be4\u{1f66c}\u0c49'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1f660}\u3a6d\u{1f64e}\u{1fcd2}\u11eb\u0e3d',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let sampler29 = device0.createSampler({
+  label: '\u{1f62f}\u0fdd\ud927\u4047\u449c',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.24,
+  lodMaxClamp: 49.50,
+  compare: 'always',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder1.setBindGroup(8, bindGroup12);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder();
+let textureView46 = texture12.createView({
+  label: '\u0e83\u02ae\u03f8\uee51\uf3ef\u6a4f\u00cc\u07f0\u0547\u0227\uca36',
+  format: 'rgb10a2uint',
+  baseMipLevel: 3,
+});
+let sampler30 = device0.createSampler({
+  label: '\u{1fc02}\u{1fd21}\u0540\u{1f8ec}\u9881\u{1fae7}\u{1fecb}\ub185\u00ee\u{1fca0}\u05b7',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.49,
+  lodMaxClamp: 63.68,
+  maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 7116);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer3, 1592, buffer0, 84200, 9612);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 905, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 210, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 5060, new DataView(new ArrayBuffer(37857)), 28090, 716);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 53, height: 80, depthOrArrayLayers: 157}
+*/
+{
+  source: canvas3,
+  origin: { x: 31, y: 27 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 12, y: 7, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 46, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `@group(5) @binding(3576)
+var<storage, read_write> field6: array<u32>;
+@group(0) @binding(3576)
+var<storage, read_write> parameter9: array<u32>;
+@group(6) @binding(3576)
+var<storage, read_write> parameter10: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @builtin(sample_index) f0: u32,
+  @location(46) f1: vec3<i32>,
+  @location(37) f2: i32,
+  @location(39) f3: f16,
+  @location(12) f4: f16,
+  @location(23) f5: vec4<i32>,
+  @location(25) f6: vec3<f16>,
+  @location(14) f7: f16,
+  @location(33) f8: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(1) f1: vec4<f32>,
+  @location(6) f2: vec2<u32>,
+  @location(2) f3: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(40) a0: f32, @location(30) a1: vec4<i32>, @location(8) a2: f16, @location(21) a3: vec4<u32>, @location(22) a4: u32, @builtin(position) a5: vec4<f32>, @location(42) a6: vec4<f32>, a7: S11, @location(11) a8: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(44) f45: vec3<f16>,
+  @location(30) f46: vec4<i32>,
+  @location(42) f47: vec4<f32>,
+  @location(39) f48: f16,
+  @location(3) f49: f32,
+  @location(46) f50: vec3<i32>,
+  @location(41) f51: vec3<f16>,
+  @location(14) f52: f16,
+  @location(43) f53: vec4<i32>,
+  @location(33) f54: vec2<f32>,
+  @location(22) f55: u32,
+  @location(10) f56: f32,
+  @location(36) f57: vec2<f16>,
+  @location(23) f58: vec4<i32>,
+  @location(11) f59: vec2<f16>,
+  @location(21) f60: vec4<u32>,
+  @location(13) f61: vec4<f16>,
+  @location(37) f62: i32,
+  @location(12) f63: f16,
+  @location(8) f64: f16,
+  @location(4) f65: u32,
+  @location(29) f66: vec2<f32>,
+  @location(40) f67: f32,
+  @location(25) f68: vec3<f16>,
+  @builtin(position) f69: vec4<f32>,
+  @location(1) f70: vec3<f32>,
+  @location(38) f71: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<i32>, @location(5) a1: vec4<i32>, @location(20) a2: vec4<i32>, @location(22) a3: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder47 = device0.createCommandEncoder({label: '\ufe7d\u{1fd3a}\ud36a'});
+let querySet23 = device0.createQuerySet({label: '\uf545\u0701\ub191\u67ac\u00eb\ud901\u0a36', type: 'occlusion', count: 540});
+let textureView47 = texture12.createView({
+  label: '\u6097\u0d0f\uf65f\u008f\u{1f929}\u{1f7af}\u0a4a',
+  format: 'rgb10a2uint',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let computePassEncoder14 = commandEncoder34.beginComputePass({label: '\u{1fd3c}\ud067\u1d05'});
+let renderBundle20 = renderBundleEncoder11.finish({});
+let externalTexture18 = device0.importExternalTexture({
+  label: '\u1150\u0c73\u{1fbef}\u0eb3\u17ca\u{1f70c}\u8518',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder10.setBindGroup(9, bindGroup4);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12, commandBuffer11, commandBuffer10]);
+} catch {}
+let promise8 = device0.createRenderPipelineAsync({
+  label: '\u04fe\ude4c\u{1f7ce}\u09ab\u740c\u00a0\u13c9\u8e8c\u{1f70c}',
+  layout: pipelineLayout4,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 2342302147,
+    stencilWriteMask: 1795905170,
+    depthBiasClamp: -67.79077205395275,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1620,
+        attributes: [
+          {format: 'unorm16x4', offset: 52, shaderLocation: 17},
+          {format: 'uint32x2', offset: 44, shaderLocation: 28},
+          {format: 'uint8x4', offset: 4, shaderLocation: 24},
+          {format: 'float32', offset: 68, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 50, shaderLocation: 5},
+          {format: 'sint32x4', offset: 192, shaderLocation: 22},
+          {format: 'unorm10-10-10-2', offset: 120, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 3512,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 2792, shaderLocation: 25},
+          {format: 'snorm16x4', offset: 916, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 68, shaderLocation: 19},
+          {format: 'uint32x3', offset: 996, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 116, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 556, shaderLocation: 27},
+          {format: 'snorm16x2', offset: 420, shaderLocation: 16},
+          {format: 'float16x2', offset: 456, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 13},
+          {format: 'uint32', offset: 152, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+video0.height = 251;
+gc();
+let commandEncoder48 = device0.createCommandEncoder({label: '\u306c\u038f\u0ca7\u0e23\u0ca0'});
+let querySet24 = device0.createQuerySet({label: '\u{1f928}\uaaf9\u0bd4', type: 'occlusion', count: 2406});
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer1, 0, 27362);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer5, 120752, buffer0, 96512, 4132);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder35.insertDebugMarker('\u7c7f');
+} catch {}
+let pipeline29 = device0.createComputePipeline({
+  label: '\u{1fd3a}\u33ad\u{1f8f4}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout14 = pipeline14.getBindGroupLayout(5);
+let texture32 = device0.createTexture({
+  label: '\ube42\ud81b\u0457\u0d18\u0b0c\u0bc0',
+  size: {width: 48, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView48 = texture6.createView({
+  label: '\u{1f7fc}\u2338\uff1e\u{1f92d}\u7c20',
+  dimension: '2d',
+  baseArrayLayer: 476,
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(212, 28, 3_974_102, 10_078_649);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10188 */
+  offset: 6544,
+  bytesPerRow: 256,
+  rowsPerImage: 26,
+  buffer: buffer7,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 15, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u015b\u0acf\u{1f7d9}\u7641\u08c2\u53a3\u8e8a\u{1f7e0}\u931d\u1be9',
+  entries: [{binding: 3252, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let texture33 = device0.createTexture({
+  label: '\u00ae\u7bcb\u{1fb28}',
+  size: [48, 4, 206],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let texture34 = gpuCanvasContext0.getCurrentTexture();
+let textureView49 = texture15.createView({aspect: 'all'});
+let renderBundle21 = renderBundleEncoder6.finish({label: '\u013b\ub6c8\u451d\u094a\u822f\ua56f\u0d43\u{1f663}'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderBundleEncoder5.draw(36, 254);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(214, 116, 399_973_582);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 24324);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 11, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer0, 17172, 67660);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let video7 = await videoWithData();
+let querySet25 = device0.createQuerySet({label: '\uc066\u8895\ua241', type: 'occlusion', count: 2411});
+let texture35 = device0.createTexture({
+  label: '\u7ded\u0808\ufae3',
+  size: [26, 40, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView50 = texture21.createView({label: '\ueec2\u58e0\u0d58', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder15 = commandEncoder26.beginComputePass({label: '\ue0dc\u2360\u234e\u05ba\ubfe4\u{1fa93}\u{1fe2f}\ub4a0\u4f09\u38f1'});
+let renderBundle22 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder5.draw(31, 175, 99_992_341, 19_076_129);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline12);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 11544 */
+  offset: 11448,
+  buffer: buffer5,
+}, {
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 559 widthInBlocks: 559 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7360 */
+  offset: 7360,
+  buffer: buffer0,
+}, {width: 559, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 53060, new DataView(new ArrayBuffer(43066)), 22338, 4628);
+} catch {}
+let pipeline30 = device0.createComputePipeline({
+  label: '\u8835\uab78\u005c',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas5 = new OffscreenCanvas(922, 193);
+try {
+adapter0.label = '\uf42b\u75e8\u059a\ud0cf\u0a33\u1712\u2d81\u6e24\u9d95\u9671\ue591';
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup4, new Uint32Array(2528), 853, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder5.draw(141, 268, 673_784_169, 268_719_931);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 41556);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer0, 99804, 31144);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 87, y: 142 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 146},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 93, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer13 = commandEncoder23.finish();
+let texture36 = device0.createTexture({
+  label: '\u0fde\u{1ff89}\u43f7\u3633',
+  size: {width: 106, height: 160, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let texture37 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder13.setVertexBuffer(5, buffer1, 0, 9937);
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+  label: '\ud310\udbfc\u0d37\ubc2c\u{1ff15}\u0c0a\u0089\u0447',
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0xe66ba1eb},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint'}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, undefined],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3432,
+        attributes: [
+          {format: 'sint16x2', offset: 880, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 264, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 924, shaderLocation: 23},
+          {format: 'uint16x2', offset: 332, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 10960, attributes: [{format: 'sint32x2', offset: 1212, shaderLocation: 14}]},
+      {
+        arrayStride: 4784,
+        attributes: [
+          {format: 'sint32x3', offset: 600, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 688, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 4612, shaderLocation: 4},
+          {format: 'float32x2', offset: 176, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 6454, shaderLocation: 28},
+          {format: 'float32x2', offset: 28100, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 4116, shaderLocation: 10},
+          {format: 'float16x2', offset: 4704, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x3', offset: 3568, shaderLocation: 11},
+          {format: 'sint32x2', offset: 4560, shaderLocation: 9},
+          {format: 'float32x4', offset: 11344, shaderLocation: 27},
+          {format: 'uint32', offset: 2732, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder50 = device0.createCommandEncoder();
+let texture38 = device0.createTexture({
+  label: '\u0c4a\u6f2c\u{1f9d9}\u5877',
+  size: {width: 4560},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u{1f8c9}\u03a0\u1a29\u3017\ued64\u{1fc7a}\ub394\u2c21',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+});
+let externalTexture19 = device0.importExternalTexture({label: '\u92fc\u{1ff5e}\ude97\u0473\ufe5f\u{1fb68}\u0045\u{1ff9b}\u4442', source: videoFrame1});
+try {
+computePassEncoder3.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 3508);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 384 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 30464 */
+  offset: 30080,
+  rowsPerImage: 156,
+  buffer: buffer2,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\ud3c8\uf350\u09a0\ue94a',
+  entries: [
+    {binding: 3522, visibility: 0, sampler: { type: 'non-filtering' }},
+    {binding: 1475, visibility: 0, externalTexture: {}},
+  ],
+});
+let bindGroup14 = device0.createBindGroup({layout: bindGroupLayout7, entries: []});
+let renderBundle23 = renderBundleEncoder12.finish();
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 1436);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 5260, new BigUint64Array(6738));
+} catch {}
+let promise9 = device0.createRenderPipelineAsync({
+  label: '\u1cda\u{1f88e}\u0105',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x355d0e1c},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgb10a2uint'}, {format: 'rgb10a2unorm', writeMask: 0}, {
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3316,
+        attributes: [
+          {format: 'uint16x2', offset: 916, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 684, shaderLocation: 3},
+          {format: 'sint16x4', offset: 256, shaderLocation: 23},
+          {format: 'sint16x4', offset: 28, shaderLocation: 4},
+          {format: 'float32x4', offset: 640, shaderLocation: 13},
+          {format: 'uint32x2', offset: 272, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 5240, attributes: [{format: 'unorm10-10-10-2', offset: 480, shaderLocation: 11}]},
+      {arrayStride: 1828, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 3480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 440, shaderLocation: 25},
+          {format: 'sint32', offset: 380, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let gpuCanvasContext3 = offscreenCanvas4.getContext('webgpu');
+let canvas6 = document.createElement('canvas');
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({});
+let computePassEncoder16 = commandEncoder44.beginComputePass();
+let sampler31 = device0.createSampler({
+  label: '\uf17c\ub58c\u0d86\u{1fe67}\u{1ff32}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 65.44,
+  lodMaxClamp: 83.06,
+  compare: 'greater-equal',
+});
+let externalTexture20 = device0.importExternalTexture({
+  label: '\u{1fb8b}\u3650\u8b84\u0580\u68e7\u90ad\u{1fd89}\ubd8c',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder14.setBindGroup(9, bindGroup10, new Uint32Array(4977), 3177, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(157, 259);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer1, 0, 59739);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer0, 72972, 24496);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 53, height: 80, depthOrArrayLayers: 157}
+*/
+{
+  source: canvas4,
+  origin: { x: 14, y: 20 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 8, y: 5, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let canvas7 = document.createElement('canvas');
+let bindGroupLayout17 = pipeline17.getBindGroupLayout(6);
+let commandEncoder52 = device0.createCommandEncoder({label: '\u1326\u{1ff72}\u11b8\u6cf7\ubda7\u{1f6bd}\u4609\u68ce\ubc76\ub861\u{1f6cd}'});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 967});
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 13592);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer1, 0, 14517);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\u0a09');
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+canvas7.getContext('bitmaprenderer');
+} catch {}
+let buffer9 = device0.createBuffer({
+  label: '\u69b3\u64a4\u06e0\u0b1a\ucd44\u01f2',
+  size: 79048,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let texture39 = device0.createTexture({
+  label: '\u0674\u09fb\u0e0d\ufbb2\u{1faa1}\ufa76\uc9ed\uf8a1',
+  size: {width: 26, height: 40, depthOrArrayLayers: 78},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView51 = texture12.createView({label: '\u009f\u079e', dimension: '3d', baseMipLevel: 4, mipLevelCount: 1});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 32700);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 100436);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline21);
+} catch {}
+let bindGroup15 = device0.createBindGroup({layout: bindGroupLayout17, entries: [{binding: 3576, resource: textureView43}]});
+let commandEncoder53 = device0.createCommandEncoder({});
+let textureView52 = texture4.createView({label: '\u3970\u00f8\u8134\u003a\u0d74\u{1ff6a}\uffaf\u5d3d\u{1f794}'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u0410\ue06d\u{1f8f2}\u0b43\u0643\u{1f6a5}',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+});
+let sampler32 = device0.createSampler({
+  label: '\u{1f65b}\u6830\u01ee\u9a52\u4ea5\u0444',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 53.82,
+  maxAnisotropy: 5,
+});
+try {
+commandEncoder51.copyBufferToBuffer(buffer7, 4084, buffer9, 52640, 10052);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 275, y: 123 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({label: '\u25c9\u{1fca0}\u11a0\u0aac'});
+let textureView53 = texture20.createView({
+  label: '\u0059\u{1fac3}\u321d\u4608\uccbc\u6698\u{1fcee}\u14f2\u0a0b\u0ee2\ud464',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 27, y: 1 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 304},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let textureView54 = texture33.createView({
+  label: '\u0e23\ueaf7\u056b\u0145\ufc3f\u0e08\u3c2b\udb9d\u00e7\u0fb5',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder17 = commandEncoder52.beginComputePass({label: '\u{1fe34}\u{1f6fa}\u76e3\u0a16\uae31'});
+try {
+computePassEncoder14.setBindGroup(6, bindGroup7, new Uint32Array(1053), 215, 0);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let videoFrame3 = new VideoFrame(canvas6, {timestamp: 0});
+try {
+adapter0.label = '\u0813\u8323\u2a9c\u1f7f\u09ae\u{1fe03}\u{1fb57}\uec64\u2cd8\u0078\u38a4';
+} catch {}
+let buffer10 = device0.createBuffer({label: '\ufeab\u{1fd8d}', size: 130482, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder55 = device0.createCommandEncoder({label: '\u0a9e\u7b4b\u16bc'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u8ae7\u9a15\u0c23\u4ed3\u01b0',
+  colorFormats: ['rgba8uint', 'r32sint', 'r32sint', 'rgb10a2uint'],
+  stencilReadOnly: true,
+});
+let pipeline32 = await device0.createRenderPipelineAsync({
+  label: '\u2c1b\u{1f882}',
+  layout: pipelineLayout0,
+  multisample: {mask: 0xf3ee16e5},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: 0}, {format: 'rg16float', writeMask: GPUColorWrite.RED}, undefined],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6444,
+        attributes: [
+          {format: 'float32x2', offset: 204, shaderLocation: 12},
+          {format: 'sint32x2', offset: 48, shaderLocation: 17},
+          {format: 'uint16x2', offset: 852, shaderLocation: 28},
+          {format: 'uint32x3', offset: 2208, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 356, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 2604, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 4582, shaderLocation: 9},
+          {format: 'float32x2', offset: 1196, shaderLocation: 13},
+          {format: 'float16x2', offset: 2872, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 484, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 2416, shaderLocation: 4},
+          {format: 'uint32x4', offset: 1556, shaderLocation: 11},
+          {format: 'float32x2', offset: 124, shaderLocation: 6},
+          {format: 'float16x4', offset: 216, shaderLocation: 10},
+          {format: 'uint32', offset: 792, shaderLocation: 26},
+          {format: 'uint32x2', offset: 764, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 152, shaderLocation: 5},
+          {format: 'float32', offset: 420, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 852, shaderLocation: 7},
+          {format: 'uint16x2', offset: 3092, shaderLocation: 27},
+          {format: 'uint16x4', offset: 844, shaderLocation: 0},
+          {format: 'float32x2', offset: 124, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 624, shaderLocation: 20},
+          {format: 'sint8x4', offset: 192, shaderLocation: 22},
+          {format: 'float32', offset: 440, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 1676,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 1140, shaderLocation: 18}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+let buffer11 = device0.createBuffer({
+  label: '\u0e36\u{1f98b}\u1d7b\u{1f7d1}\u9533\ue9b4\uefdd',
+  size: 42694,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let textureView55 = texture2.createView({label: '\ubc46\u4952\u{1fc65}\u06de\u0b3d\uc197\u9842\u0727\u{1f909}', mipLevelCount: 1});
+let computePassEncoder18 = commandEncoder54.beginComputePass();
+let renderBundle24 = renderBundleEncoder15.finish({label: '\u03c4\u0a08\u92b5\u49ff\u{1f66f}\u85d3\u7312'});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: imageData5,
+  origin: { x: 16, y: 16 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 93, y: 0, z: 79},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = await promise7;
+try {
+canvas6.getContext('webgpu');
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u{1f628}\u{1f6b6}',
+  layout: bindGroupLayout15,
+  entries: [{binding: 3252, resource: externalTexture3}],
+});
+let commandEncoder56 = device0.createCommandEncoder({label: '\u0ea9\u71aa\u5714\u5328'});
+let querySet27 = device0.createQuerySet({
+  label: '\u0ebc\u088f\u{1fb79}\u462d\u76dd\u07ca\u0fc9\u3cbf\u4c43\u{1fef5}\u0826',
+  type: 'occlusion',
+  count: 2792,
+});
+let textureView56 = texture14.createView({label: '\u02e1\u016c\u077d\u{1fca8}', aspect: 'all'});
+let externalTexture21 = device0.importExternalTexture({
+  label: '\u0b98\u7acd\u829c\u2011\u0b6a\uc81d\uacfb\u04a0\u{1f7e0}\u904d',
+  source: video6,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder16.setBindGroup(5, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline21);
+} catch {}
+let pipeline34 = await device0.createRenderPipelineAsync({
+  label: '\ubd9a\u{1ff06}\ue304\uf6b5\ue538\uec12\u177c\u0d49\u0fb6\u{1f764}\u90dc',
+  layout: pipelineLayout3,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4520,
+        attributes: [
+          {format: 'snorm16x4', offset: 1872, shaderLocation: 23},
+          {format: 'sint8x2', offset: 536, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 17652,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 2328, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 2268, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', unclippedDepth: false},
+});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1f909}\u{1f716}\u8bcd\u1d4c'});
+let textureView57 = texture34.createView({label: '\u04bb\ua6dc\u6418\u06b8\u{1ff10}\uec03\u49b3', mipLevelCount: 1});
+try {
+renderBundleEncoder5.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer1, 13620, 55055);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer7, 11680, buffer0, 134284, 3940);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: canvas4,
+  origin: { x: 14, y: 83 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 36, y: 2, z: 137},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video8 = await videoWithData();
+let imageData9 = new ImageData(192, 152);
+let textureView58 = texture39.createView({label: '\u9ce8\uadfc\u6e8c\u33dd\ue144\u{1f903}\u0fe1\u2008\ua8fc\u3f68', baseMipLevel: 5});
+let computePassEncoder19 = commandEncoder20.beginComputePass({label: '\u6398\u8c75\u{1fc5b}'});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 59732);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(5, buffer1, 0, 107125);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet10, 134, 1063, buffer10, 81920);
+} catch {}
+try {
+window.someLabel = commandEncoder54.label;
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup16, []);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(204, 372, 615_870_231, 427_200_473);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(4, buffer1);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer2, 21716, buffer0, 1576, 77720);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 7, y: 0 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let video9 = await videoWithData();
+let querySet28 = device0.createQuerySet({label: '\u0967\u4332\ue5da\uc2f8\uf2a1\uda57', type: 'occlusion', count: 2825});
+let textureView59 = texture15.createView({label: '\u{1fce9}\u{1fafd}\u{1f882}\uf53e\u2afa\u{1fbcd}\u3763\u{1ffa7}', baseArrayLayer: 0});
+let externalTexture22 = device0.importExternalTexture({label: '\u0067\u5503\ue178', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(536, 39, 173_132_894, 165_969_128, 69_797_951);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 26676);
+} catch {}
+try {
+commandEncoder40.clearBuffer(buffer0, 33224, 65004);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet10, 2481, 162, buffer10, 24064);
+} catch {}
+let pipeline35 = device0.createComputePipeline({
+  label: '\u0335\uade0',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let canvas8 = document.createElement('canvas');
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.16,
+  compare: 'less',
+});
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 23440);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 3, y: 7, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 84 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12932 */
+  offset: 12932,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 42, height: 25, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 22588, new Int16Array(26862));
+} catch {}
+let promise12 = device0.createComputePipelineAsync({
+  label: '\ub880\u084c\u{1f9bc}\ub6f4\ucb99\u9a1c\u9081\u0ee3',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let videoFrame4 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let texture40 = device0.createTexture({
+  label: '\u30e8\u{1f91d}\u097e\u01bf\u0f75\ufaaf\uaaca\uf203',
+  size: {width: 570, height: 1, depthOrArrayLayers: 1152},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let externalTexture23 = device0.importExternalTexture({label: '\u5391\ue3ac\ue3eb\ue20d\ueacb\ude41\uf286\u60fa', source: video8, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup9, new Uint32Array(7879), 4852, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(48, 214, 688_844_932, 225_710_869, 779_446_574);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 14764);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 8556);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer2, 273244, buffer9, 68704, 7736);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 288904 */
+  offset: 29296,
+  bytesPerRow: 256,
+  rowsPerImage: 78,
+  buffer: buffer2,
+}, {
+  texture: texture40,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 27},
+  aspect: 'all',
+}, {width: 24, height: 1, depthOrArrayLayers: 14});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder();
+let texture41 = device0.createTexture({
+  label: '\ub7b5\u{1fde5}\u00ec\ubd59\u6add\ub516\u08a4',
+  size: [256],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint'],
+});
+let renderBundle25 = renderBundleEncoder0.finish();
+let externalTexture24 = device0.importExternalTexture({
+  label: '\ubda6\u{1f981}\u{1f6a7}\ucabe\u263d\u8866\uda66\u095d\ufb5a',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder14.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup10, new Uint32Array(7994), 232, 0);
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(buffer8, 76116, buffer0, 83236, 6728);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 929 */
+{offset: 929, bytesPerRow: 122}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({label: '\u2e38\uf2c7\u8464\u09ca\u01d9\u6c04\u08fa\u0d8f\u{1fc18}\u0ec4\u04af'});
+try {
+computePassEncoder14.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 10560);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer8, 110372, buffer0, 84000, 16996);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u{1fd3b}\u6909\ubeb1\u6905\uf395',
+  code: `@group(6) @binding(3576)
+var<storage, read_write> local6: array<u32>;
+@group(2) @binding(2115)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(3576)
+var<storage, read_write> parameter11: array<u32>;
+@group(5) @binding(3576)
+var<storage, read_write> local7: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec4<u32>,
+  @location(2) f2: vec3<i32>,
+  @location(1) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec3<i32>, @location(19) a1: vec4<f32>, @location(14) a2: vec2<f32>, @location(29) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(22) f0: vec3<f32>,
+  @location(1) f1: vec3<i32>,
+  @location(2) f2: vec3<f32>,
+  @location(27) f3: u32,
+  @location(20) f4: f16,
+  @location(25) f5: vec3<i32>,
+  @location(21) f6: vec3<i32>,
+  @location(15) f7: i32,
+  @location(17) f8: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(44) f72: vec3<u32>,
+  @location(4) f73: vec3<f32>,
+  @location(40) f74: vec4<f16>,
+  @location(22) f75: vec4<i32>,
+  @location(19) f76: vec4<f32>,
+  @location(29) f77: vec4<f32>,
+  @location(23) f78: vec4<f16>,
+  @builtin(position) f79: vec4<f32>,
+  @location(14) f80: vec2<f32>,
+  @location(9) f81: vec3<i32>,
+  @location(37) f82: vec4<f32>,
+  @location(18) f83: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec3<f32>, @location(6) a1: vec4<f16>, @location(18) a2: vec2<i32>, @location(10) a3: f32, @location(12) a4: i32, @location(24) a5: vec4<f16>, @builtin(instance_index) a6: u32, a7: S12, @location(3) a8: vec2<f16>, @location(5) a9: vec3<i32>, @location(26) a10: vec3<u32>, @location(4) a11: vec3<f16>, @location(28) a12: vec3<u32>, @location(16) a13: f32, @location(8) a14: f32, @location(14) a15: f32, @location(11) a16: vec4<u32>, @location(13) a17: u32, @builtin(vertex_index) a18: u32, @location(19) a19: vec3<f32>, @location(0) a20: vec4<i32>, @location(7) a21: u32, @location(9) a22: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer12 = device0.createBuffer({
+  label: '\u{1ff53}\u087c\u0126\u{1f6a4}',
+  size: 31877,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder60 = device0.createCommandEncoder({label: '\u4dee\u0b70\u8a47'});
+let commandBuffer14 = commandEncoder21.finish({label: '\u0323\u206a\u0cd5'});
+let textureView60 = texture15.createView({label: '\u4a0e\u95f2\u7f86\u0a33\u4a3d\u{1f99e}'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder5.draw(24, 49);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 67488 */
+  offset: 67024,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 26, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 70, y: 5, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 3_270 */
+{offset: 722, bytesPerRow: 535}, {width: 102, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let pipeline36 = device0.createComputePipeline({
+  label: '\u{1f8da}\u{1ffd5}\uf576\u03bc',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let video10 = await videoWithData();
+let querySet29 = device0.createQuerySet({label: '\u3dee\u5ec9\u{1fa90}\u445c\u2e8c\ue8b7\u0f5f', type: 'occlusion', count: 1132});
+let texture42 = device0.createTexture({
+  label: '\u{1f678}\u918c\u0955\u{1f66a}',
+  size: [1140],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder5.draw(86, 16, 989_319_572, 905_324_688);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer8, 53380, buffer9, 28384, 15916);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 20960, new DataView(new ArrayBuffer(12218)), 3294);
+} catch {}
+let gpuCanvasContext4 = canvas8.getContext('webgpu');
+document.body.prepend(canvas7);
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.41,
+  lodMaxClamp: 83.55,
+  compare: 'equal',
+  maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer1, 0);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer10, 72528, 25096);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\u5b8a\udd91\u0342\u6ff0\u7d46\u0067\ud832\u7a2f\u{1ffbf}\u0eb4',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder61 = device0.createCommandEncoder({label: '\u6b6f\u0aa7\u0d0d\u0de9\u073b\ud893'});
+let querySet30 = device0.createQuerySet({label: '\u0e91\u036a\u7332\u{1fca2}\u{1fe7b}\u9535\u0620\ube04\ua44f', type: 'occlusion', count: 3054});
+let externalTexture25 = device0.importExternalTexture({
+  label: '\u52f1\udeda\u7df3\u0b67\u88a4\ud7e3\u0171\u1085\u3870',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder14.setPipeline(pipeline31);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet23, 350, 83, buffer10, 4864);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 78}
+*/
+{
+  source: canvas7,
+  origin: { x: 35, y: 35 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 1, y: 7, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let buffer13 = device0.createBuffer({label: '\u0b94\u{1fc3e}\u0bc6\ufdf0\u{1fe3a}', size: 47040, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder62 = device0.createCommandEncoder({label: '\u5ddd\u2d57\u0d4e\u1c5e\ub38b\u1823\u5d65\u1908\u07ef\ud1b3'});
+let texture43 = device0.createTexture({
+  label: '\u213c\u{1ff5b}\u344c\u042b\u05f8\u{1fac7}\u036c\ufe5c\ued4d',
+  size: {width: 512, height: 20, depthOrArrayLayers: 225},
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+let textureView61 = texture22.createView({
+  label: '\u0157\ub554\ua66c\u02ad\u8d6b\ub2a3\u2032\u0876\u{1fe27}\u27da',
+  format: 'rgb10a2uint',
+  baseMipLevel: 3,
+});
+let externalTexture26 = device0.importExternalTexture({label: '\u3b27\u1a55\u8b5f\ueac3\u4133\u{1febc}', source: videoFrame4, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder5.drawIndexed(20, 204, 544_301_748);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync({
+  label: '\u07ef\u2e5e\u378c\ucf17\u0bab\u{1fcd3}\u381a\u{1ffac}\u06c3',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let textureView62 = texture11.createView({label: '\u02b2\u09f9\u3a72\u{1fe0d}\u{1fe82}\u05a0\ucb24\u5ea7\u249c', baseMipLevel: 6});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup9, new Uint32Array(8459), 5885, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 19692);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 1460, new Float32Array(53789), 11517, 10272);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 90, y: 35 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 4, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let computePassEncoder20 = commandEncoder25.beginComputePass({label: '\u0db6\u784b\u0393\u{1f8b8}\u03b3\u0f80\u9755\u5d4f'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 16424);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 32156);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer1, 0, 28280);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 72, new DataView(new ArrayBuffer(25301)), 18298, 2992);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas5,
+  origin: { x: 20, y: 19 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 6, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline38 = await promise12;
+let commandEncoder63 = device0.createCommandEncoder({label: '\u3a63\u0933'});
+let textureView63 = texture7.createView({label: '\u43b3\u1d39', dimension: '3d'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u0066\u15a5\u3665\u0097\u0520',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder5.draw(62, 140, 654_124_141, 2_046_251_163);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 10064);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 3940);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(8691, undefined, 3106528778, 688678244);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer8, 163964, buffer1, 99720, 10380);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet28, 2378, 204, buffer10, 69120);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 7800, new Int16Array(56300), 43213, 1112);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 106, height: 160, depthOrArrayLayers: 315}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 9, y: 8, z: 34},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture44 = device0.createTexture({
+  label: '\u0bdc\u3037\u21cd\u0344\ub4c3\u099f\uf4c1\u0d09\u1e92\u9f2e\u8cfc',
+  size: {width: 128},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup3, new Uint32Array(4551), 3746, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(15, 147, 601_261_105, 320_176_901);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline5);
+} catch {}
+let video11 = await videoWithData();
+let bindGroup18 = device0.createBindGroup({
+  label: '\ue637\u{1fc82}\u3c84\u{1f99e}\u641e\u0031\u0680\u0bc3',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder64 = device0.createCommandEncoder({label: '\u9a36\u0b02\u0a8b\uc088\ue303\u{1f6a9}\uf482\u{1f902}\u{1f633}'});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u75f1\ub4f3\u{1f892}\u1ae9\u6032\uf03f',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder5.draw(256, 96, 405_105_832, 321_990_789);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(431);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 56, y: 1, z: 119},
+  aspect: 'all',
+},
+{width: 8, height: 23, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({label: '\ua31a\u8475\u{1f6a3}'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u79d4\u014d',
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'r32float', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle26 = renderBundleEncoder17.finish({});
+try {
+renderBundleEncoder14.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 4_645 */
+{offset: 863, bytesPerRow: 390}, {width: 68, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: video10,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 20, y: 35, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = device0.createComputePipeline({
+  label: '\u9055\udc31',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+video8.height = 17;
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u4522\u1d03\u{1faa1}\u{1feef}\u2f05\u{1f73c}\u{1f817}\u{1f9b8}\ua70b\u4b2f',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout12, bindGroupLayout8, bindGroupLayout4, bindGroupLayout5, bindGroupLayout5, bindGroupLayout16, bindGroupLayout14, bindGroupLayout16],
+});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u0bae\u0183\uf98f\u{1ff6d}\u0cda\ue175\u0502\u394b\u099a'});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u0493\ua637\u082d',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture27 = device0.importExternalTexture({source: video5, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 3488);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 7688 widthInBlocks: 1922 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7220 */
+  offset: 7220,
+  buffer: buffer5,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 323, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1922, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet3, 980, 344, buffer10, 109824);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 5, depthOrArrayLayers: 866}
+*/
+{
+  source: video10,
+  origin: { x: 1, y: 4 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 6, y: 1, z: 163},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise13;
+} catch {}
+let img3 = await imageWithData(140, 62, '#7247f59e', '#9dac8acf');
+let commandEncoder67 = device0.createCommandEncoder();
+let texture45 = device0.createTexture({
+  label: '\u33db\uc24e\u5d36\u09e2\u0208\u02d1\u{1fabd}',
+  size: [570],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView64 = texture37.createView({label: '\u101c\u2ded\u8ca3\u0c14\u04d7\u05b6\u04ed\u0e97\udac7\u0bad\u0e0d', dimension: '2d-array'});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u{1fa93}\u0803\u9f14\u{1fa30}\u027e',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture28 = device0.importExternalTexture({label: '\u9cda\u15dc\u1b27\u{1fdae}', source: video9});
+try {
+renderBundleEncoder5.setBindGroup(9, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(19, 180);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 15608);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(7, buffer1, 48316);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await buffer13.mapAsync(GPUMapMode.WRITE, 0, 41424);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer8, 34576, buffer10, 5684, 87520);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u179b\u0b81\u2e3f\ue55a\u071e\u159c\u{1ff12}',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: false,
+});
+let renderBundle27 = renderBundleEncoder21.finish({label: '\u0783\udd42\u0ab7\u0cc3\u{1fe5d}\u{1fb66}\u{1fc07}\u{1ff74}\ubc18\u028b\u7b8d'});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 6824);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 29020 */
+  offset: 29020,
+  buffer: buffer1,
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 8964, new BigUint64Array(7352), 5281, 784);
+} catch {}
+let textureView65 = texture28.createView({
+  label: '\u{1fbe4}\u65e0\u0406\u737b\u{1fe5e}\u7e69\u727b\u0895',
+  format: 'rgba16sint',
+  baseMipLevel: 0,
+});
+let sampler35 = device0.createSampler({
+  label: '\u{1f756}\u0dd1\u0fba\u92da\u0d0b\u{1fe31}\u7158\u449d\u518c\u0d5d\u0488',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.27,
+  lodMaxClamp: 91.77,
+  maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 27068);
+} catch {}
+let arrayBuffer1 = buffer13.getMappedRange(33296, 1016);
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet18, 2039, 758, buffer12, 20736);
+} catch {}
+let pipeline40 = device0.createRenderPipeline({
+  label: '\ua121\uaded',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0xbc434258},
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 1038534163,
+    stencilWriteMask: 1861437830,
+    depthBiasSlopeScale: -68.25900862190771,
+    depthBiasClamp: 411.7977792900593,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2684,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 244, shaderLocation: 14},
+          {format: 'uint32x3', offset: 784, shaderLocation: 28},
+          {format: 'unorm16x2', offset: 896, shaderLocation: 16},
+          {format: 'uint32', offset: 28, shaderLocation: 27},
+          {format: 'uint8x4', offset: 156, shaderLocation: 13},
+          {format: 'float16x4', offset: 1576, shaderLocation: 19},
+          {format: 'sint32x4', offset: 400, shaderLocation: 25},
+          {format: 'uint32x2', offset: 456, shaderLocation: 7},
+          {format: 'float16x4', offset: 92, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 1240, shaderLocation: 10},
+          {format: 'sint16x2', offset: 316, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 1080, shaderLocation: 23},
+          {format: 'unorm16x4', offset: 632, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 440, shaderLocation: 24},
+          {format: 'sint16x4', offset: 72, shaderLocation: 18},
+          {format: 'sint32', offset: 376, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 506, shaderLocation: 6},
+          {format: 'sint32', offset: 164, shaderLocation: 21},
+          {format: 'float32x3', offset: 196, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 352, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 684,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 80, shaderLocation: 12},
+          {format: 'sint16x2', offset: 216, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 228, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 166, shaderLocation: 4},
+          {format: 'uint16x2', offset: 132, shaderLocation: 26},
+          {format: 'sint16x2', offset: 240, shaderLocation: 1},
+          {format: 'sint32', offset: 124, shaderLocation: 15},
+          {format: 'uint32x2', offset: 68, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 18572, attributes: []},
+      {arrayStride: 10908, attributes: [{format: 'snorm16x4', offset: 916, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise11;
+} catch {}
+let buffer14 = device0.createBuffer({
+  label: '\u9da4\u0e2f\uaae3\u48e5\u63f8\u{1fb49}\u33e8\u08e2',
+  size: 175796,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle28 = renderBundleEncoder10.finish({label: '\u{1fe57}\u79e2\uae62\ud0a7\u6b1a\u641f\u0343\u{1fc0c}'});
+try {
+computePassEncoder9.setBindGroup(5, bindGroup8);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2336 */
+  offset: 2280,
+  rowsPerImage: 110,
+  buffer: buffer9,
+}, {width: 7, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer10, 108500, 15836);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let texture46 = device0.createTexture({
+  label: '\u824e\u1ba9',
+  size: {width: 570, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle29 = renderBundleEncoder13.finish();
+try {
+commandEncoder35.copyBufferToBuffer(buffer5, 52944, buffer10, 14348, 13792);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 379 widthInBlocks: 379 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 344714 */
+  offset: 4234,
+  bytesPerRow: 512,
+  rowsPerImage: 7,
+  buffer: buffer2,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 16},
+  aspect: 'all',
+}, {width: 379, height: 0, depthOrArrayLayers: 96});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline41 = device0.createRenderPipeline({
+  label: '\u41bc\u145b\u5823\u0003\ub2d0\u5e38\ue9bb\u4189\u0686\u06b3',
+  layout: pipelineLayout1,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r8sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 1329399225,
+    depthBias: 2031411214,
+    depthBiasClamp: 939.8916646926655,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 624,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 232, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 92, shaderLocation: 17},
+          {format: 'float32', offset: 76, shaderLocation: 1},
+          {format: 'uint8x4', offset: 40, shaderLocation: 10},
+          {format: 'float32x3', offset: 24, shaderLocation: 28},
+          {format: 'uint32x4', offset: 40, shaderLocation: 26},
+          {format: 'sint16x4', offset: 32, shaderLocation: 27},
+          {format: 'uint32x3', offset: 32, shaderLocation: 2},
+          {format: 'sint32', offset: 48, shaderLocation: 13},
+          {format: 'uint16x4', offset: 84, shaderLocation: 20},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 25},
+          {format: 'float16x4', offset: 32, shaderLocation: 15},
+          {format: 'uint32x4', offset: 20, shaderLocation: 22},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 5},
+          {format: 'float32x2', offset: 164, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 11},
+          {format: 'float32x4', offset: 116, shaderLocation: 23},
+          {format: 'unorm16x4', offset: 12, shaderLocation: 8},
+          {format: 'uint8x2', offset: 8, shaderLocation: 24},
+          {format: 'sint8x2', offset: 364, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 208, shaderLocation: 7},
+          {format: 'sint8x4', offset: 16, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 480,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 8, shaderLocation: 16}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let video12 = await videoWithData();
+let textureView66 = texture3.createView({label: '\u7031\u98ac\u0672\u{1fe29}\ud849\uc8ed\u{1fbec}\u0eba\u03c7\u74b0', dimension: '1d'});
+try {
+renderBundleEncoder18.setBindGroup(4, bindGroup15, new Uint32Array(1741), 208, 0);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let arrayBuffer2 = buffer13.getMappedRange(36664, 4172);
+let pipeline42 = device0.createComputePipeline({
+  label: '\u1b52\u{1fad4}\uc38e',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let img4 = await imageWithData(213, 289, '#0d7c7e1a', '#ae3b9e44');
+let bindGroup19 = device0.createBindGroup({
+  label: '\ud85a\uc110\u4644\uee9d',
+  layout: bindGroupLayout15,
+  entries: [{binding: 3252, resource: externalTexture19}],
+});
+let commandEncoder68 = device0.createCommandEncoder({label: '\u4fb1\u017b\u027b\u547a\ueb4c'});
+let texture47 = device0.createTexture({
+  label: '\u{1fc8e}\u874d\u04f7\u0c15\ueacb\u{1f6f9}\u1c47\ua5ba\u{1f957}',
+  size: [212],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView67 = texture45.createView({aspect: 'all'});
+let computePassEncoder21 = commandEncoder57.beginComputePass({});
+let renderBundle30 = renderBundleEncoder22.finish();
+try {
+renderBundleEncoder5.drawIndexed(36, 253, 939_143_236, 393_991_928, 2_325_167_558);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 301704);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline43 = await device0.createRenderPipelineAsync({
+  label: '\uef0b\u93f7\u{1fe99}\u{1fa0c}\u86dd\u{1fcf1}\uaf1b\u{1ff21}\uf0c9\u{1fd0a}\u802b',
+  layout: pipelineLayout6,
+  multisample: {mask: 0xb2eb797a},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2360,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 12, shaderLocation: 25},
+          {format: 'float16x4', offset: 116, shaderLocation: 19},
+          {format: 'uint32x3', offset: 348, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 336, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 48, shaderLocation: 5},
+          {format: 'uint8x2', offset: 10, shaderLocation: 28},
+          {format: 'snorm8x4', offset: 36, shaderLocation: 9},
+          {format: 'sint32x2', offset: 148, shaderLocation: 22},
+          {format: 'float32x4', offset: 564, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 280, shaderLocation: 13},
+          {format: 'uint32x3', offset: 1896, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 4492, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 12564,
+        attributes: [
+          {format: 'uint32x2', offset: 924, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 892, shaderLocation: 18},
+          {format: 'float16x2', offset: 212, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 5972,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1384, shaderLocation: 27},
+          {format: 'float32', offset: 980, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 5428, stepMode: 'instance', attributes: []},
+      {arrayStride: 108, stepMode: 'instance', attributes: []},
+      {arrayStride: 14420, attributes: [{format: 'float32x3', offset: 1412, shaderLocation: 20}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+adapter0.label = '\u589b\u3a7d\u{1f9ef}\u0093\u0aa1\u0fb1\u7cde\u{1f9c7}\u0d39\u9491\u0fef';
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({label: '\u{1f71e}\u0e76\u{1fb55}\u7f58\u{1fc66}\u00d9\u{1fee4}\u552e', entries: []});
+let bindGroup20 = device0.createBindGroup({
+  label: '\u4cd5\u0d74\ue9e4\u{1fe57}\u5eb7\u0764\u861e\u0b12\u{1fc16}\u88d0',
+  layout: bindGroupLayout7,
+  entries: [],
+});
+let querySet31 = device0.createQuerySet({label: '\u0d90\u{1fae5}\u9534', type: 'occlusion', count: 3526});
+let texture48 = device0.createTexture({
+  label: '\uca98\u{1fd1b}\ub898\u74dc\uc2ee\u0567\u6500\u4e07\u00db',
+  size: {width: 570, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup2, new Uint32Array(5975), 997, 0);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 204 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5954 */
+  offset: 5750,
+  buffer: buffer7,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 102, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let promise14 = device0.createRenderPipelineAsync({
+  label: '\u685f\u002c\u663c\u18bc',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3900,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 302, shaderLocation: 10},
+          {format: 'sint32x2', offset: 1040, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 56,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 8, shaderLocation: 24},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 7},
+          {format: 'float32x4', offset: 0, shaderLocation: 3},
+          {format: 'float16x2', offset: 16, shaderLocation: 8},
+          {format: 'sint8x4', offset: 4, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 1224,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 112, shaderLocation: 13}],
+      },
+      {arrayStride: 4512, attributes: []},
+      {
+        arrayStride: 13768,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 1396, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 1320, shaderLocation: 9},
+          {format: 'sint8x2', offset: 17914, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let texture49 = device0.createTexture({
+  label: '\u825a\uab27\u03f9\uc3c7\uff72\udab0',
+  size: {width: 106},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView68 = texture41.createView({label: '\u{1fd97}\u8515'});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(5, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(273, 44, 24_335_370, 182_673_350, 142_811_478);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(buffer8, 25956, buffer1, 20824, 27988);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline44 = device0.createRenderPipeline({
+  label: '\u672f\u453f\u0148\u03a3\u07fa',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x2cc9b938},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 4868, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2264,
+        attributes: [
+          {format: 'snorm8x2', offset: 94, shaderLocation: 21},
+          {format: 'uint8x2', offset: 1180, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u{1f6ac}\u0f24\ua818\u0963\u0b37\u{1f780}\u1f96\ubf8b'});
+let texture50 = device0.createTexture({
+  label: '\u6c29\ubb22\u0c9e',
+  size: [128, 5, 445],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(4837), 3649, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(213, 101, 412_984_928);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 22524);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9448 */
+  offset: 9444,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 255, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 280, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 965 */
+{offset: 965}, {width: 1184, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u0423\u0e90\u0d4d\u{1f6de}\u{1fb26}\u{1f9a4}',
+  size: 17679,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let sampler36 = device0.createSampler({
+  label: '\uf71a\uf000\u{1fb69}\u0870\u{1fbd6}\u0663\ub29b\u0836\u{1fe50}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 90.45,
+});
+try {
+computePassEncoder19.setBindGroup(6, bindGroup20, new Uint32Array(3425), 3390, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(8, bindGroup19, new Uint32Array(2357), 200, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(58);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 4820);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer15, 'uint32', 17072, 395);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+document.body.prepend(video1);
+let bindGroup21 = device0.createBindGroup({label: '\u0854\u5909\u0084\u8086\u{1f8ce}', layout: bindGroupLayout1, entries: []});
+let commandBuffer15 = commandEncoder16.finish({label: '\u0673\u31a8\uda9f\u3d48\u5847\u0024\uc4b2\u059c'});
+let textureView69 = texture19.createView({baseMipLevel: 1});
+try {
+computePassEncoder6.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder5.draw(66);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(306, 37, 1_602_650_291, 378_688_352, 145_023_355);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer1, 92128, 13990);
+} catch {}
+let arrayBuffer3 = buffer2.getMappedRange(78448, 205772);
+try {
+commandEncoder37.copyBufferToBuffer(buffer2, 6100, buffer14, 93564, 39288);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5956 */
+  offset: 5780,
+  bytesPerRow: 512,
+  buffer: buffer9,
+}, {width: 44, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+  label: '\uf4bd\u{1f657}\u2535\u0a0b\u{1fc28}\u3746\u{1ffbd}\ub544\u0e45',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let img5 = await imageWithData(47, 45, '#2f80c3f5', '#2ff8b842');
+let textureView70 = texture50.createView({label: '\u064b\u0c6e\u{1fd73}\u08f9\uffa3', dimension: '3d', baseMipLevel: 3, mipLevelCount: 1});
+let sampler37 = device0.createSampler({
+  label: '\ue0e4\u17f6\u65c4\u98f4\u19ca\u083f\u0f32\u{1fafd}\u076a',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.43,
+  compare: 'less',
+  maxAnisotropy: 19,
+});
+let externalTexture29 = device0.importExternalTexture({label: '\u106e\ua3fa\u807c\u{1fac2}', source: video5, colorSpace: 'srgb'});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup3, new Uint32Array(9666), 7373, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(8, bindGroup18, new Uint32Array(4719), 1902, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 32292);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 3092);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 360 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 149328 */
+  offset: 3560,
+  bytesPerRow: 512,
+  rowsPerImage: 56,
+  buffer: buffer14,
+}, {width: 45, height: 5, depthOrArrayLayers: 6});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1, y: 308, z: 27},
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 115, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 54, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 8808, new Float32Array(36874), 24420, 2544);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: video6,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 196},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\u{1fb53}\u6100\ude66',
+  entries: [
+    {binding: 3521, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 3973,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 1753, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let bindGroup22 = device0.createBindGroup({
+  label: '\u{1faf0}\u{1f6a8}\u0366\uc0ba\uf110\u{1f66d}\u0876\u68bb\ufa3f',
+  layout: bindGroupLayout17,
+  entries: [{binding: 3576, resource: textureView43}],
+});
+let querySet32 = device0.createQuerySet({label: '\u{1f658}\u5a29\u{1ff3a}', type: 'occlusion', count: 389});
+let textureView71 = texture36.createView({dimension: '2d-array', format: 'r16uint', mipLevelCount: 6});
+try {
+renderBundleEncoder5.draw(23, 71, 11_848_797, 697_257_099);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(307);
+} catch {}
+let promise15 = buffer6.mapAsync(GPUMapMode.READ, 0, 10556);
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 836 widthInBlocks: 209 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3860 */
+  offset: 3860,
+  bytesPerRow: 1024,
+  rowsPerImage: 294,
+  buffer: buffer7,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 2031, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 209, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 78}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture51 = device0.createTexture({
+  label: '\u2f81\ua0d2\u0c5f\u9965\u0158\u{1fdae}\u{1f65e}',
+  size: {width: 106, height: 160, depthOrArrayLayers: 1138},
+  mipLevelCount: 5,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView72 = texture46.createView({label: '\u{1f9c4}\u{1f8ec}\ud9ad', dimension: '2d-array'});
+let sampler38 = device0.createSampler({
+  label: '\ueb69\ub46d\u{1fe62}\uc451\u56c2\u3be7\ucc05\u{1faf9}\u0a8b',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.24,
+  lodMaxClamp: 85.21,
+  maxAnisotropy: 13,
+});
+let externalTexture30 = device0.importExternalTexture({
+  label: '\ub1f8\u9e65\u20a9\u{1fc1f}\u{1fc5d}\u0887\u{1fb01}\u0580\u5916',
+  source: video12,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder19.setBindGroup(8, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(12, 63, 726_231_900);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 13888);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 5036);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer0, 13264, 52868);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet17, 494, 216, buffer10, 94976);
+} catch {}
+let pipeline46 = device0.createRenderPipeline({
+  label: '\uce3a\u9f0c\uacc6',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xa2cebb7},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 4139391869,
+    stencilWriteMask: 41017505,
+    depthBiasSlopeScale: 983.9224543183225,
+    depthBiasClamp: 546.7025419065341,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6604,
+        attributes: [
+          {format: 'sint32x2', offset: 396, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 976, shaderLocation: 1},
+          {format: 'uint8x2', offset: 1062, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 1472, shaderLocation: 8},
+          {format: 'uint8x2', offset: 1602, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 1500, shaderLocation: 5},
+          {format: 'sint32x4', offset: 556, shaderLocation: 16},
+          {format: 'sint32x2', offset: 1524, shaderLocation: 27},
+          {format: 'unorm16x2', offset: 200, shaderLocation: 25},
+          {format: 'sint32x3', offset: 296, shaderLocation: 3},
+          {format: 'float32x3', offset: 624, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 2188, shaderLocation: 11},
+          {format: 'uint16x4', offset: 280, shaderLocation: 22},
+          {format: 'uint16x4', offset: 1128, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 1170, shaderLocation: 17},
+          {format: 'uint16x2', offset: 512, shaderLocation: 20},
+          {format: 'uint32x4', offset: 1320, shaderLocation: 24},
+          {format: 'unorm16x2', offset: 1688, shaderLocation: 28},
+          {format: 'uint16x4', offset: 468, shaderLocation: 26},
+          {format: 'sint8x4', offset: 1020, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 5960, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 16704, attributes: [{format: 'unorm16x2', offset: 36, shaderLocation: 23}]},
+      {arrayStride: 3152, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3508,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 1838, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\u7863\u0393\u0d8d\u{1f7ae}\u8970\u{1f743}\u084c\uf5cf\udd79\ud118\u7617',
+  code: `@group(0) @binding(2115)
+var<storage, read_write> function7: array<u32>;
+@group(3) @binding(1215)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(17) f0: vec3<f32>,
+  @location(41) f1: vec2<u32>,
+  @location(6) f2: vec3<u32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: f32,
+  @location(6) f1: vec4<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(1) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(30) a0: vec4<i32>, @location(5) a1: vec4<i32>, @location(20) a2: vec3<u32>, @location(25) a3: vec2<i32>, a4: S13, @location(2) a5: vec3<f32>, @location(3) a6: vec4<f16>, @location(35) a7: u32, @location(45) a8: i32, @location(10) a9: vec3<f16>, @location(11) a10: i32, @location(1) a11: i32, @location(23) a12: f32, @builtin(sample_index) a13: u32, @location(24) a14: vec4<i32>, @location(31) a15: u32, @location(9) a16: vec3<f16>, @location(47) a17: vec4<f32>, @location(39) a18: f32, @location(42) a19: vec4<i32>, @location(15) a20: i32, @location(43) a21: vec2<f32>, @location(37) a22: vec3<f32>, @location(19) a23: vec4<f16>, @location(34) a24: u32, @location(46) a25: vec3<f16>, @builtin(position) a26: vec4<f32>, @builtin(front_facing) a27: bool, @builtin(sample_mask) a28: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(25) f84: vec2<i32>,
+  @location(23) f85: f32,
+  @location(34) f86: u32,
+  @location(17) f87: vec3<f32>,
+  @location(15) f88: i32,
+  @location(46) f89: vec3<f16>,
+  @location(19) f90: vec4<f16>,
+  @location(42) f91: vec4<i32>,
+  @location(2) f92: vec3<f32>,
+  @location(11) f93: i32,
+  @location(47) f94: vec4<f32>,
+  @location(5) f95: vec4<i32>,
+  @location(39) f96: f32,
+  @location(30) f97: vec4<i32>,
+  @location(3) f98: vec4<f16>,
+  @location(10) f99: vec3<f16>,
+  @location(45) f100: i32,
+  @location(43) f101: vec2<f32>,
+  @location(31) f102: u32,
+  @builtin(position) f103: vec4<f32>,
+  @location(35) f104: u32,
+  @location(41) f105: vec2<u32>,
+  @location(6) f106: vec3<u32>,
+  @location(37) f107: vec3<f32>,
+  @location(9) f108: vec3<f16>,
+  @location(1) f109: i32,
+  @location(24) f110: vec4<i32>,
+  @location(20) f111: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec3<u32>, @location(18) a1: u32, @location(10) a2: vec4<f16>, @builtin(instance_index) a3: u32, @location(20) a4: f16, @location(2) a5: vec3<i32>, @location(21) a6: vec3<i32>, @location(1) a7: f32, @location(23) a8: vec4<u32>, @location(19) a9: vec4<f16>, @builtin(vertex_index) a10: u32, @location(28) a11: vec4<f16>, @location(12) a12: vec4<f16>, @location(7) a13: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder70 = device0.createCommandEncoder({});
+let querySet33 = device0.createQuerySet({label: '\u9549\u{1fb26}\u01e2\ud315\u5f5f\u5d6b\u1709\u8161', type: 'occlusion', count: 3093});
+let computePassEncoder22 = commandEncoder34.beginComputePass({label: '\u497a\u86c3\uc708\u01a3\u0e43\u8877'});
+let externalTexture31 = device0.importExternalTexture({label: '\u0b87\u87eb\u05fa\u{1fad3}', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 6752);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 2736);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u{1fc59}\u08d0\u8ee7\u5ea7\u05a8\u{1fc2a}\u0079\u4d09\uaac0\u{1f805}',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout15, bindGroupLayout3, bindGroupLayout10],
+});
+let buffer16 = device0.createBuffer({label: '\ud359\u1ff9\u0a9c', size: 159123, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView73 = texture24.createView({label: '\u23de\u811d\u58ef\u00a4\u0818\u4029\u{1fb23}\uab6f', baseMipLevel: 1});
+let computePassEncoder23 = commandEncoder6.beginComputePass({label: '\u{1f663}\u{1f9f8}\u0269\u{1f95f}\u{1f7e7}\u3f49\u2fee\u{1f9c2}\u0f34\u{1f60d}\ub5bb'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u{1ffc4}\u20e7\u56d4',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 4920);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 716);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer1, 0, 58177);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+gc();
+let bindGroupLayout20 = device0.createBindGroupLayout({label: '\ub0ed\ud4c9\u87c7\u09bb\uea39\u9c3c\u007e', entries: []});
+let computePassEncoder24 = commandEncoder69.beginComputePass({label: '\u5665\uce13\u{1f975}\u4b6d\ud3f0\u1af3\u{1fe70}'});
+try {
+renderBundleEncoder5.draw(254);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(66);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer10, 121476, 7220);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 6656, new Int16Array(15369), 4222, 1008);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 18, y: 4, z: 134},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 230_525 */
+{offset: 975, bytesPerRow: 406, rowsPerImage: 149}, {width: 40, height: 119, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({label: '\u5e90\u5b21\u0a60\u0e7f\u{1fa80}\u0aed\ub804\ue64a'});
+let textureView74 = texture5.createView({label: '\u9e10\u0401\u7634\u3f23\u077e\u{1f804}\ua5eb'});
+let computePassEncoder25 = commandEncoder31.beginComputePass();
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder5.draw(60, 13, 263_602_072, 178_066_209);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(53, 77, 323_910_177, 786_854_923, 1_946_314_871);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 440);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 2980);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 31},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 190, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+canvas3.height = 51;
+let texture52 = device0.createTexture({size: [106], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let textureView75 = texture34.createView({label: '\u7111\u9684\u{1f8ab}'});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 19832);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet3, 1487, 1271, buffer12, 11520);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 33140, new Int16Array(40575), 33797, 748);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u1974\u{1fe4e}\u{1fc6e}\u058a\u2125\u{1ff92}\u0807\ue889\u{1fbcb}\u{1fc9f}',
+  entries: [
+    {binding: 3168, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 3514,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup23 = device0.createBindGroup({
+  label: '\u{1fa0f}\u5a83',
+  layout: bindGroupLayout8,
+  entries: [{binding: 3576, resource: textureView43}],
+});
+let buffer17 = device0.createBuffer({size: 35803, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder72 = device0.createCommandEncoder({label: '\u{1feec}\u{1feed}\u{1fc15}\u78c4\u{1feb3}\u5fbc\u07fe\u01f4\u9c3e\u{1f755}\u5338'});
+let commandBuffer16 = commandEncoder37.finish({label: '\u694c\ub2f5'});
+let texture53 = device0.createTexture({
+  label: '\ubaa9\u99f3\u20ee\u0bc6\udf22\u04dc\u76b4\u032c\u08dd\uafe4',
+  size: {width: 256},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline31);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8836 */
+  offset: 8836,
+  buffer: buffer3,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer0, 42924, 72804);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet6, 161, 104, buffer10, 16384);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 212, height: 320, depthOrArrayLayers: 631}
+*/
+{
+  source: video12,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 24, y: 48, z: 101},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = await device0.createComputePipelineAsync({
+  label: '\u18a5\u07e4\uf306\u{1f60c}',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video13 = await videoWithData();
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\ua0be\u65a6\u5b26\u02c3\u0db5\u07c7\u0197',
+  entries: [
+    {
+      binding: 2194,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u0d11\u{1fd4c}\u3f10\u{1f838}\u4598\uba0e\u{1fa9e}\u{1f9a7}\u{1facc}\u081a',
+  bindGroupLayouts: [bindGroupLayout14],
+});
+let texture54 = device0.createTexture({
+  label: '\u0c73\u1248\u56f7\u096b',
+  size: {width: 48},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView76 = texture37.createView({label: '\u0b7f\uf4df\u{1ff97}\ud7a1\u7890\u40d3\u0614'});
+let computePassEncoder26 = commandEncoder48.beginComputePass({label: '\u6e50\u{1fe35}\u9043\u5a56\ucda3\u{1fe62}\u481a\u30d8\u85fb\u{1fd9b}'});
+let renderBundle31 = renderBundleEncoder9.finish({label: '\u{1f6cc}\ua3f9\u{1f780}\u{1fc1b}\u0099\u{1f7b2}\uf28a\ud8e0\u2a55'});
+try {
+computePassEncoder17.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 5988);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer15, 'uint32', 15756, 1910);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer2, 253048, buffer10, 69932, 55228);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 3220 widthInBlocks: 805 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17116 */
+  offset: 17116,
+  buffer: buffer17,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 204, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 805, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 7268, new DataView(new ArrayBuffer(26425)), 13858, 784);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+let commandBuffer17 = commandEncoder60.finish();
+let textureView77 = texture43.createView({label: '\u{1fd51}\u51b9\u02ae\u0f64\u3917\uee67\u0fbc\udb05\u0dd2', format: 'rg16float'});
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(7, buffer1, 81476, 44179);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let video14 = await videoWithData();
+let shaderModule15 = device0.createShaderModule({
+  label: '\u2c75\u{1fea7}\u4dee\uc09c\u01d6\u{1f6a4}\u922e',
+  code: `@group(3) @binding(2478)
+var<storage, read_write> parameter12: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<f32>,
+  @location(4) f2: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(27) a1: vec3<f16>, @location(39) a2: vec4<i32>, @location(3) a3: i32, @location(12) a4: vec3<u32>, @location(40) a5: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(34) f112: vec3<i32>,
+  @location(24) f113: vec2<u32>,
+  @location(40) f114: vec3<f16>,
+  @location(7) f115: vec2<f32>,
+  @location(31) f116: vec2<u32>,
+  @location(2) f117: vec4<f32>,
+  @location(27) f118: vec3<f16>,
+  @location(5) f119: f16,
+  @location(4) f120: vec2<f32>,
+  @location(39) f121: vec4<i32>,
+  @location(1) f122: u32,
+  @builtin(position) f123: vec4<f32>,
+  @location(18) f124: vec4<f32>,
+  @location(47) f125: u32,
+  @location(15) f126: vec2<i32>,
+  @location(3) f127: i32,
+  @location(22) f128: vec4<u32>,
+  @location(0) f129: i32,
+  @location(10) f130: vec3<i32>,
+  @location(41) f131: f32,
+  @location(12) f132: vec3<u32>,
+  @location(43) f133: vec4<u32>,
+  @location(16) f134: vec4<u32>,
+  @location(38) f135: vec3<i32>,
+  @location(25) f136: vec3<u32>,
+  @location(26) f137: vec2<i32>,
+  @location(20) f138: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec4<u32>, @location(8) a1: vec4<i32>, @builtin(vertex_index) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView78 = texture36.createView({
+  label: '\u6843\u0208\u{1fcb8}\u66f4\uf572\u098c',
+  dimension: '2d-array',
+  baseMipLevel: 6,
+  baseArrayLayer: 0,
+});
+let renderBundle32 = renderBundleEncoder9.finish({label: '\ua389\ub10a\u9a8b\u005e'});
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(128, 159);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 27740);
+} catch {}
+let video15 = await videoWithData();
+let commandEncoder73 = device0.createCommandEncoder({label: '\u40a1\u0cff\u038d\ub894\u0f42\u63d2\u{1fbaa}\u72fd\u0e72\ubb9a\ufaef'});
+let querySet34 = device0.createQuerySet({label: '\u{1f6a9}\ud675\uc8fe', type: 'occlusion', count: 1659});
+let texture55 = gpuCanvasContext2.getCurrentTexture();
+let sampler39 = device0.createSampler({
+  label: '\ubd11\u{1f99a}\u{1f98e}\u0205\u7cac\u269d\u0c18\u1812\ub07d\ue060\u0fd4',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.48,
+  lodMaxClamp: 99.68,
+});
+try {
+renderBundleEncoder5.drawIndexed(224, 217, 1_521_667_669, -2_059_913_980, 474_721_113);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 5404);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer1);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline48 = device0.createComputePipeline({
+  label: '\uecb3\u{1fa44}\uc6e9\u5d71\ue0ba\u86d7\u9d5b',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule14, entryPoint: 'compute0'},
+});
+try {
+  await promise15;
+} catch {}
+let bindGroup24 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 3576, resource: textureView43}]});
+let commandEncoder74 = device0.createCommandEncoder();
+let texture56 = device0.createTexture({
+  label: '\u7f7e\u33db\u9ada',
+  size: {width: 106, height: 160, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView79 = texture38.createView({label: '\u{1f67f}\u0371\u43c9\u0a2f\u78f6\ub525\uce12\u02c1\u0036\u1ad4\u0938', baseArrayLayer: 0});
+let sampler40 = device0.createSampler({
+  label: '\u{1fa13}\u7963\u4274\u09cb\u39fb\u0dd1\u9434\uc8d9\u1065',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 25.67,
+  lodMaxClamp: 27.12,
+  compare: 'less',
+});
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 8604);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2177 */
+  offset: 2147,
+  buffer: buffer0,
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline49 = await promise6;
+let bindGroup25 = device0.createBindGroup({label: '\u0d91\u{1ff78}\u0ec5\u{1f895}\udb4e\u0ac8', layout: bindGroupLayout18, entries: []});
+let textureView80 = texture48.createView({label: '\u{1fbbd}\u05ee\ub4cc\u9a46\ub14f\u4b9e', baseMipLevel: 1, baseArrayLayer: 0});
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1076, new Int16Array(17939), 8185, 716);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1_245_320 */
+{offset: 998, bytesPerRow: 101, rowsPerImage: 224}, {width: 2, height: 1, depthOrArrayLayers: 56});
+} catch {}
+let pipeline50 = await device0.createRenderPipelineAsync({
+  label: '\u{1fe9c}\u055c\u{1fab7}',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0xb68b8ddc},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 364, shaderLocation: 9},
+          {format: 'sint32x3', offset: 2212, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 4700,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 4, shaderLocation: 8},
+          {format: 'sint16x4', offset: 392, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 916, shaderLocation: 2},
+          {format: 'float16x4', offset: 1280, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 5580,
+        attributes: [
+          {format: 'sint16x2', offset: 1440, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 684, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 344,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 24},
+          {format: 'float32x3', offset: 72, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 180, attributes: [{format: 'float16x4', offset: 4, shaderLocation: 3}]},
+    ],
+  },
+});
+let videoFrame5 = new VideoFrame(videoFrame1, {timestamp: 0});
+let texture57 = device0.createTexture({
+  label: '\u56a7\u0e51\ua0e5\ud51d\u0b48\u0847',
+  size: {width: 4560, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView81 = texture44.createView({label: '\u0593\u{1ffb9}\u6e4f\u0b9d\u{1fa04}\u8c58\u{1f90e}\u4c85\u03d7', dimension: '1d'});
+let renderBundle33 = renderBundleEncoder12.finish({label: '\u048d\u660b\u4959\u0e3a\u3b1d\u{1f842}\u{1fb9e}\u0dd8\u91f5\u{1f78b}\u064d'});
+let sampler41 = device0.createSampler({
+  label: '\u4406\u3ecc\u4544\ud803\u{1fa2f}\u3db6\u{1fa03}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.98,
+  lodMaxClamp: 98.06,
+  compare: 'greater-equal',
+  maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 22276);
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer0, 67816, 24884);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 78}
+*/
+{
+  source: canvas2,
+  origin: { x: 11, y: 27 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 13, z: 32},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 15, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let commandBuffer18 = commandEncoder51.finish({label: '\u0e56\u{1ff9d}\u7f05\u{1fdbd}\u{1fe2e}\u01fa\u0b6d\u0433\u05a7\u0b7c'});
+let texture58 = device0.createTexture({
+  size: {width: 128},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let textureView82 = texture11.createView({
+  label: '\u00b4\uc462\uf72a\u{1fa51}\u05d9\u{1fbba}\u0c7c\udd69',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+});
+let computePassEncoder27 = commandEncoder55.beginComputePass({});
+try {
+renderBundleEncoder16.setBindGroup(7, bindGroup24, new Uint32Array(8833), 5815, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(93, 92);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 464);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 48744 */
+  offset: 48472,
+  buffer: buffer5,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 183},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3860, new Float32Array(63932), 58260);
+} catch {}
+let texture59 = gpuCanvasContext0.getCurrentTexture();
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u424a\uee5b\u068f\u78c6\u0221\u{1f769}\u84a1',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler42 = device0.createSampler({
+  label: '\u{1fe70}\ud67e\u{1ff4d}\u697f\u05d7\u6ce0\u05df\u3955\u0889',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.75,
+  compare: 'less',
+});
+try {
+renderBundleEncoder19.setBindGroup(9, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder5.draw(98, 36, 132_994_859);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(251);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 1184);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(8, buffer1, 29128, 72616);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise16 = buffer17.mapAsync(GPUMapMode.WRITE, 0, 12544);
+try {
+commandEncoder66.clearBuffer(buffer0, 21180, 9744);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline51 = await device0.createRenderPipelineAsync({
+  label: '\u{1f834}\u659d\udc29\u06d1\ub63a\u05c1\u{1f9f3}\u3cb2',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0xfbae8c14},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA}, undefined],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3944,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1512, shaderLocation: 28},
+          {format: 'sint8x4', offset: 916, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 7684,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 2016, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 1144, shaderLocation: 5},
+          {format: 'float16x2', offset: 2312, shaderLocation: 27},
+          {format: 'float32', offset: 416, shaderLocation: 10},
+          {format: 'sint32x2', offset: 108, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 680, shaderLocation: 22},
+          {format: 'sint32x4', offset: 1220, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 416, shaderLocation: 13},
+          {format: 'float32', offset: 2648, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 11656,
+        attributes: [
+          {format: 'uint32x2', offset: 2500, shaderLocation: 7},
+          {format: 'sint16x2', offset: 28, shaderLocation: 14},
+          {format: 'uint32x4', offset: 1428, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 176, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 2464,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 656, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 1900,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 158, shaderLocation: 23}],
+      },
+      {arrayStride: 14848, attributes: []},
+      {
+        arrayStride: 10152,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 256, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let commandEncoder75 = device0.createCommandEncoder();
+let commandBuffer19 = commandEncoder66.finish();
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'], sampleCount: 4});
+let renderBundle34 = renderBundleEncoder18.finish({});
+let sampler43 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 69.06,
+  lodMaxClamp: 89.94,
+  compare: 'never',
+});
+try {
+renderBundleEncoder24.setBindGroup(9, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 40600);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer2, 276996, buffer9, 74688, 304);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 0, y: 5, z: 2},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 14728, new DataView(new ArrayBuffer(51623)), 13333, 348);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 383 */
+{offset: 383}, {width: 97, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\u{1fff2}\uacec\u{1f876}',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout21, bindGroupLayout7, bindGroupLayout14, bindGroupLayout16],
+});
+let texture60 = gpuCanvasContext2.getCurrentTexture();
+let externalTexture32 = device0.importExternalTexture({label: '\ucc07\u01c1\u0a63\u0d40\u06e5\uaa63', source: video14, colorSpace: 'srgb'});
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 140 */
+  offset: 140,
+  buffer: buffer3,
+}, {
+  texture: texture40,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 43 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9793 */
+  offset: 9750,
+  buffer: buffer0,
+}, {width: 43, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer10, 17692, 103600);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet23, 436, 62, buffer12, 24064);
+} catch {}
+try {
+commandEncoder53.insertDebugMarker('\u09b3');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 6, y: 7, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 102 */
+{offset: 102, bytesPerRow: 13, rowsPerImage: 213}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let pipeline52 = await promise9;
+try {
+  await promise16;
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder({});
+let querySet35 = device0.createQuerySet({label: '\u0ed5\ub28a\u961f\u{1faf8}\u0e53\u2b00\u9978', type: 'occlusion', count: 2395});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u4b39\u1c28\u9f6a\ub9f0\uc546\u4f88\u0477\u1e70\u900e\u002a\u077a',
+  colorFormats: ['rgba8uint', 'r32sint', 'r32sint', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder10.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder5.draw(154);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 1252);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer1, 20564, 101965);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer7, 8380, buffer14, 134564, 9956);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet35, 2333, 17, buffer10, 19456);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 7036, new DataView(new ArrayBuffer(6135)), 5249, 332);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData10 = new ImageData(256, 160);
+let textureView83 = texture18.createView({label: '\u0ff9\u6c1b\u0bb8\u{1ffc8}\u09a7', baseMipLevel: 3, mipLevelCount: 1});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(83, 97, 930_986_260, 509_046_823, 1_408_593_000);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 5064);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer8, 111712, buffer0, 12796, 76636);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 102, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet33, 959, 1057, buffer10, 16640);
+} catch {}
+let pipeline53 = device0.createComputePipeline({
+  label: '\u011b\u5802\u{1f6a7}\u179c\u96be\u0f63\u0658\u{1fa94}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img2);
+offscreenCanvas0.height = 1183;
+let shaderModule16 = device0.createShaderModule({
+  label: '\u{1fd32}\ud82c\u0d4e\ufabe',
+  code: `@group(6) @binding(1475)
+var<storage, read_write> field7: array<u32>;
+@group(6) @binding(3522)
+var<storage, read_write> field8: array<u32>;
+@group(7) @binding(2115)
+var<storage, read_write> parameter13: array<u32>;
+@group(2) @binding(3576)
+var<storage, read_write> local9: array<u32>;
+@group(3) @binding(1215)
+var<storage, read_write> function8: array<u32>;
+@group(8) @binding(1475)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(2550)
+var<storage, read_write> n5: array<u32>;
+@group(8) @binding(3522)
+var<storage, read_write> global7: array<u32>;
+@group(3) @binding(3507)
+var<storage, read_write> parameter14: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: i32,
+  @builtin(sample_mask) f1: u32,
+  @location(1) f2: vec3<f32>,
+  @location(5) f3: vec2<u32>,
+  @location(7) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, a2: S15) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(17) f0: vec3<u32>,
+  @location(14) f1: vec3<f32>,
+  @location(8) f2: vec2<i32>,
+  @location(20) f3: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<u32>, @location(11) a1: vec4<i32>, @location(13) a2: vec3<f16>, @location(4) a3: vec4<f16>, @location(10) a4: vec2<i32>, @location(9) a5: i32, @location(23) a6: u32, @location(0) a7: u32, @location(22) a8: u32, @location(24) a9: vec4<u32>, @location(18) a10: vec4<f32>, @builtin(instance_index) a11: u32, @builtin(vertex_index) a12: u32, @location(5) a13: f16, @location(16) a14: vec4<f16>, @location(3) a15: vec4<f32>, @location(15) a16: f16, @location(7) a17: u32, @location(12) a18: vec4<u32>, a19: S14, @location(2) a20: f32, @location(26) a21: vec3<u32>, @location(19) a22: vec4<i32>, @location(27) a23: vec2<u32>, @location(25) a24: vec2<i32>, @location(21) a25: vec3<f32>, @location(28) a26: vec4<f16>, @location(6) a27: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder77 = device0.createCommandEncoder({label: '\uedd5\u0e59\u0e8f\u012a\u5f5c\u19ce\u{1f835}\ubaed\u012d\udf45\uc461'});
+let textureView84 = texture28.createView({
+  label: '\u0b68\uf09d\u4686\u{1f6c3}\u0159\u585b\udafa\u9b28\u08cd\u{1ff00}\u{1fbbd}',
+  format: 'rgba16sint',
+});
+let renderBundle35 = renderBundleEncoder0.finish();
+let externalTexture33 = device0.importExternalTexture({label: '\u2455\uad11\u5b71\ub7ae\u{1fa6f}\u{1fc97}\ueb09\uef20', source: videoFrame0});
+try {
+computePassEncoder20.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 1500);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer7, 252, buffer10, 101044, 10852);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13040, new BigUint64Array(31979), 18421, 3712);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 2,
+  origin: {x: 1, y: 4, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 253 */
+{offset: 253, bytesPerRow: 111}, {width: 6, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(986, 431);
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\u1bf5\u0165\uf6ba\u006e\u{1f640}\u{1f93a}\u2bba',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout10, bindGroupLayout8],
+});
+let computePassEncoder28 = commandEncoder46.beginComputePass({label: '\ueff2\u9588\u4028\ufe9b\u0c9c\u{1ff43}\uaa94\u6a00'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup0, new Uint32Array(3018), 1263, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer15, 'uint32', 1380, 10177);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 131, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 23},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video3);
+gc();
+let textureView85 = texture30.createView({label: '\u0734\u{1f732}\uab34\u{1fecd}\u059c\u0a46'});
+let sampler44 = device0.createSampler({
+  label: '\u{1fc1d}\ub796\u{1f60c}\u463b\u{1fdb8}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.07,
+});
+let externalTexture34 = device0.importExternalTexture({label: '\uef50\u0264\ue6e7\u826e\uda3c\u{1f946}', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(5, bindGroup7, new Uint32Array(4951), 3231, 0);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({label: '\u{1f914}\u{1f620}\u{1f92e}\uc38d\u5868\u{1f97f}\u9772\u0e46\ud5ce'});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\uf19d\u{1fe91}\u9632',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle36 = renderBundleEncoder10.finish({label: '\u8dde\u{1f9b0}\u3374\u9269\u669e\u048f\ucd7d'});
+let sampler45 = device0.createSampler({
+  label: '\u8c95\u0b2c\u0dd7\uff75\u0a7e\u12fa\u{1fbae}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.86,
+  lodMaxClamp: 78.04,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder25.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer16, 73008, buffer9, 19420, 33812);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let canvas9 = document.createElement('canvas');
+let shaderModule17 = device0.createShaderModule({
+  label: '\u{1ffc2}\u{1f8eb}\u0793\u21f6\u0dff\u7722\u01f4\u02b0\u76d0\u8caa\u{1f94e}',
+  code: `@group(5) @binding(3507)
+var<storage, read_write> function9: array<u32>;
+@group(1) @binding(69)
+var<storage, read_write> local10: array<u32>;
+@group(4) @binding(69)
+var<storage, read_write> local11: array<u32>;
+@group(6) @binding(2550)
+var<storage, read_write> field9: array<u32>;
+@group(6) @binding(1215)
+var<storage, read_write> type5: array<u32>;
+@group(6) @binding(3507)
+var<storage, read_write> function10: array<u32>;
+@group(1) @binding(1890)
+var<storage, read_write> global8: array<u32>;
+@group(3) @binding(3576)
+var<storage, read_write> n6: array<u32>;
+@group(4) @binding(1890)
+var<storage, read_write> type6: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec4<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(28) a0: i32, @location(8) a1: vec4<i32>, @location(36) a2: vec4<f32>, @builtin(sample_index) a3: u32, @location(45) a4: f16, @location(47) a5: vec4<f16>, @location(16) a6: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(11) f0: u32,
+  @location(15) f1: vec3<i32>,
+  @location(3) f2: vec4<f32>,
+  @location(5) f3: i32,
+  @location(1) f4: f16,
+  @location(4) f5: vec4<f16>,
+  @location(28) f6: vec2<f32>,
+  @location(24) f7: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(46) f139: vec3<f32>,
+  @location(37) f140: vec3<f16>,
+  @location(42) f141: vec4<u32>,
+  @location(10) f142: vec3<i32>,
+  @location(26) f143: f32,
+  @location(45) f144: f16,
+  @location(3) f145: vec4<i32>,
+  @location(47) f146: vec4<f16>,
+  @location(36) f147: vec4<f32>,
+  @location(40) f148: vec2<f32>,
+  @location(35) f149: f32,
+  @location(16) f150: vec3<f16>,
+  @location(28) f151: i32,
+  @location(2) f152: u32,
+  @location(9) f153: vec2<f32>,
+  @location(41) f154: vec2<i32>,
+  @location(8) f155: vec4<i32>,
+  @location(32) f156: vec4<i32>,
+  @builtin(position) f157: vec4<f32>,
+  @location(22) f158: vec3<u32>
+}
+
+@vertex
+fn vertex0(a0: S16, @location(17) a1: f16, @location(14) a2: vec2<f32>, @location(25) a3: f32, @location(6) a4: f32, @location(21) a5: vec4<u32>, @location(23) a6: i32, @location(8) a7: vec2<i32>, @location(20) a8: f16, @location(18) a9: vec3<i32>, @location(2) a10: f16, @location(0) a11: vec2<f32>, @location(12) a12: vec4<f16>, @location(19) a13: vec2<i32>, @location(16) a14: vec2<f16>, @location(13) a15: vec2<f32>, @location(26) a16: f32, @location(9) a17: i32, @location(7) a18: vec3<f16>, @builtin(instance_index) a19: u32, @location(27) a20: f16, @location(22) a21: f16, @location(10) a22: i32, @builtin(vertex_index) a23: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u{1f8d5}\u{1f7dc}\u8e05\uc26c\u03c3\uf668\u6c27\ub089\u{1ffbd}\u{1ff45}\u077a',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout7, bindGroupLayout16, bindGroupLayout12, bindGroupLayout16, bindGroupLayout17, bindGroupLayout1, bindGroupLayout3],
+});
+let commandEncoder79 = device0.createCommandEncoder();
+let textureView86 = texture15.createView({label: '\u0e8a\udba7\ub3f0\u0875\uf70c\u0b24\u62aa\u{1f9c3}', dimension: '1d'});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u{1fae2}\u{1fc30}',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder20.setBindGroup(9, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 436);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 82644);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(2, buffer1, 116344, 3648);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer8, 150748, buffer9, 56668, 14528);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 192 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5331 */
+  offset: 5139,
+  buffer: buffer14,
+}, {width: 192, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer14);
+} catch {}
+let pipeline54 = await device0.createComputePipelineAsync({
+  label: '\u2196\u91ea\u2ad6\u{1ffe8}\u5544',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let video16 = await videoWithData();
+let commandEncoder80 = device0.createCommandEncoder({label: '\u07d6\u{1fec9}\u{1f6b1}\u0283\u{1f695}\u047a\u001d'});
+let computePassEncoder29 = commandEncoder39.beginComputePass({label: '\u{1f8ab}\u{1ffb3}\u0bbe'});
+let sampler46 = device0.createSampler({
+  label: '\u02bb\ub2bc\u0cfa\ua444\u85fc\u{1ffe4}\u0e68\u6e6f',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 18.32,
+  lodMaxClamp: 97.89,
+});
+try {
+renderBundleEncoder20.setBindGroup(5, bindGroup8, new Uint32Array(9620), 9491, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 1348);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24100 */
+  offset: 24100,
+  bytesPerRow: 256,
+  buffer: buffer8,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 38, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder24.insertDebugMarker('\uf775');
+} catch {}
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+try {
+renderBundleEncoder5.draw(17, 176);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer15, 'uint32', 15620, 1569);
+} catch {}
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18224 */
+  offset: 18224,
+  bytesPerRow: 512,
+  rowsPerImage: 252,
+  buffer: buffer8,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 10, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 148, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 136 widthInBlocks: 136 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 18555 */
+  offset: 18555,
+  rowsPerImage: 146,
+  buffer: buffer0,
+}, {width: 136, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder47.insertDebugMarker('\u{1f8a9}');
+} catch {}
+let pipeline55 = await device0.createComputePipelineAsync({
+  label: '\u0e89\ufb73\u0f84\uecab\uc637\u38f3\uc124\u6446\u{1fe8f}\u{1fa73}\uea6d',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let pipeline56 = device0.createRenderPipeline({
+  label: '\u3f6b\u82ac\uad4c\ufac0\u0a4a\u{1f88d}\u{1fdbf}\u0087\ud783\u921f',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, undefined],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 1689797237,
+    stencilWriteMask: 3060098435,
+    depthBias: -1662476328,
+    depthBiasSlopeScale: 359.2264919272191,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1680,
+        attributes: [
+          {format: 'float32x3', offset: 56, shaderLocation: 27},
+          {format: 'snorm16x2', offset: 140, shaderLocation: 23},
+          {format: 'float16x2', offset: 164, shaderLocation: 0},
+          {format: 'sint16x2', offset: 548, shaderLocation: 9},
+          {format: 'float32x4', offset: 192, shaderLocation: 4},
+          {format: 'float16x4', offset: 100, shaderLocation: 10},
+          {format: 'uint16x4', offset: 592, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 84, shaderLocation: 13},
+          {format: 'sint8x2', offset: 188, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 26492, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8176,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 174, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 1772, shaderLocation: 22},
+          {format: 'float32x2', offset: 1260, shaderLocation: 28},
+          {format: 'sint32x3', offset: 1572, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 1980, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 1828, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 5318, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 10744, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1672, stepMode: 'instance', attributes: []},
+      {arrayStride: 1228, attributes: []},
+      {arrayStride: 5636, attributes: [{format: 'uint32', offset: 504, shaderLocation: 7}]},
+      {arrayStride: 1712, attributes: []},
+      {
+        arrayStride: 2212,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 76, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let bindGroup26 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 3576, resource: textureView43}]});
+let commandEncoder81 = device0.createCommandEncoder();
+let textureView87 = texture21.createView({label: '\u0760\u{1f82d}', baseMipLevel: 4});
+let computePassEncoder30 = commandEncoder31.beginComputePass({label: '\u{1fc4b}\u5b0d\ua62e\u00a8\u0633'});
+try {
+computePassEncoder6.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder5.draw(39, 37, 212_389_268);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5720, undefined, 0, 4252938370);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 812 widthInBlocks: 203 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 178920 */
+  offset: 8124,
+  bytesPerRow: 1024,
+  rowsPerImage: 452,
+  buffer: buffer8,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1, y: 109, z: 18},
+  aspect: 'all',
+}, {width: 203, height: 167, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 520, new Float32Array(30783), 10980);
+} catch {}
+let pipeline57 = device0.createRenderPipeline({
+  label: '\u0984\u{1f7ac}',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+  },
+}, {format: 'r8sint'}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 10036, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6380,
+        attributes: [
+          {format: 'unorm16x4', offset: 448, shaderLocation: 3},
+          {format: 'uint8x2', offset: 36, shaderLocation: 17},
+          {format: 'sint32x4', offset: 4584, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 132, shaderLocation: 23},
+        ],
+      },
+    ],
+  },
+  primitive: {},
+});
+let video17 = await videoWithData();
+try {
+canvas9.getContext('webgpu');
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({label: '\u{1fd52}\u5254'});
+let textureView88 = texture20.createView({label: '\ub918\u5085', aspect: 'all', baseMipLevel: 1});
+let sampler47 = device0.createSampler({
+  label: '\u70fb\u0b80\uae25\u5fe8\u0a44\u3d33\u710f\u02ba\u903d\u{1f6d2}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 34.52,
+  lodMaxClamp: 90.33,
+});
+try {
+computePassEncoder11.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder5.draw(71, 160, 360_541_479, 1_410_617_355);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 1968);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline51);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 3784, new Float32Array(57053), 44872, 1848);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 431 */
+{offset: 266}, {width: 165, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: imageData9,
+  origin: { x: 11, y: 76 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 403},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap3 = await createImageBitmap(video11);
+let imageData11 = new ImageData(108, 28);
+let textureView89 = texture6.createView({label: '\u0831\u{1fb14}\u32f7\u{1ff66}\u9a27', baseArrayLayer: 27, arrayLayerCount: 101});
+try {
+computePassEncoder10.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 13888);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(2, buffer1);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 4, y: 1, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 33, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 18820, new BigUint64Array(55147), 1748, 156);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: video2,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let computePassEncoder31 = commandEncoder61.beginComputePass({label: '\u1ab9\u{1fea8}\uce82\u0ade\u{1f661}\u3b29\ufbc8\u{1fb83}\ue80d\uf64f\u{1fa7a}'});
+let renderBundle37 = renderBundleEncoder6.finish({label: '\u3c68\u098b\u9107\uc711\u0a6a'});
+let externalTexture35 = device0.importExternalTexture({
+  label: '\u0c49\u{1f8d6}\u08ac\ua8e4\ud23b\ue5db\u0815\u0b8c\u2da2',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder9.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer1, 110604, 5069);
+} catch {}
+let promise18 = device0.popErrorScope();
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 128, height: 5, depthOrArrayLayers: 866}
+*/
+{
+  source: video9,
+  origin: { x: 5, y: 4 },
+  flipY: false,
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 33, y: 1, z: 129},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline58 = await device0.createComputePipelineAsync({layout: pipelineLayout9, compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+let pipeline59 = await device0.createRenderPipelineAsync({
+  label: '\u047a\uaf01\u0f96\u0cdb',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x387b9c7d},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}, {format: 'rgb10a2uint'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 12652, stepMode: 'instance', attributes: []},
+      {arrayStride: 2264, attributes: []},
+      {arrayStride: 488, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 20496,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 9048, shaderLocation: 27}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let renderBundle38 = renderBundleEncoder14.finish();
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 1096);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer1, 20380);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer1, 97944, 11249);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 3468, new Float32Array(32369), 10796, 8);
+} catch {}
+canvas0.width = 750;
+let imageBitmap4 = await createImageBitmap(video7);
+try {
+adapter0.label = '\u4d67\u655c';
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({label: '\u82cc\u{1fdfb}\u57ac\u0fa9\u0334\u{1fa44}\u009f\ubdf6\u22df\ud970'});
+let texture61 = device0.createTexture({
+  size: [1140],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let texture62 = gpuCanvasContext3.getCurrentTexture();
+let textureView90 = texture40.createView({
+  label: '\u2ce0\u0d40\u085e\u{1fba4}\u4e42\u0d73\u{1ff6f}\u040b\u4f75\u{1fa5e}\u{1f89f}',
+  baseMipLevel: 7,
+  mipLevelCount: 2,
+});
+let computePassEncoder32 = commandEncoder45.beginComputePass({label: '\u8ee4\u{1ff56}\ue3f6\u0da5'});
+try {
+computePassEncoder22.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder5.draw(17, 293, 1_935_402_263, 696_393_868);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer15, 'uint32', 392, 15760);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline31);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 10, depthOrArrayLayers: 1733}
+*/
+{
+  source: img1,
+  origin: { x: 44, y: 19 },
+  flipY: true,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 76, y: 1, z: 77},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 42, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({label: '\u7f6d\u3d71\udcce\u3d5f\ue2f3\u0246\u9a0e'});
+let externalTexture36 = device0.importExternalTexture({
+  label: '\u02ee\u8dd9\u0ec5\u4a01\u56a8\u0572\u{1f918}\u4582',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder16.setPipeline(pipeline39);
+} catch {}
+try {
+renderBundleEncoder5.draw(41, 306);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 3932);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let pipeline60 = await device0.createComputePipelineAsync({
+  label: '\u9333\u{1fd38}\ua392\uc279\u5f9d',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\u606d\u{1fa2c}\u0b27\u8f53\u{1ff97}\ucd87\u2133\u93f6\u0ac8\u99af\uca95',
+  entries: [
+    {binding: 1869, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false }},
+    {
+      binding: 3798,
+      visibility: 0,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let texture63 = device0.createTexture({
+  label: '\u058f\u0996\u{1fcd8}\ua270\u025b\u31cf\ua4e6\u0b1d\ue9d9\u0a12\u8554',
+  size: [48, 4, 1],
+  mipLevelCount: 3,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let renderBundle39 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder15.setBindGroup(7, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(7, bindGroup7, new Uint32Array(8465), 250, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 4412);
+} catch {}
+let arrayBuffer4 = buffer6.getMappedRange(0, 7880);
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6632 */
+  offset: 6600,
+  buffer: buffer1,
+}, {width: 8, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline61 = await device0.createRenderPipelineAsync({
+  label: '\u0897\u{1f865}\u{1f7ee}\u0fa1\u7733\u674a\u4575\u0f8b\u073f\u{1fd9a}\ua797',
+  layout: pipelineLayout2,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 364,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 10, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 44, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 52, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 17},
+          {format: 'float16x2', offset: 56, shaderLocation: 25},
+          {format: 'float32x4', offset: 116, shaderLocation: 27},
+          {format: 'uint32', offset: 124, shaderLocation: 24},
+          {format: 'uint32x4', offset: 36, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 352,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 160, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 17184,
+        attributes: [
+          {format: 'snorm16x4', offset: 312, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 940, shaderLocation: 9},
+          {format: 'float32', offset: 412, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 2550, shaderLocation: 0},
+          {format: 'uint32x3', offset: 2836, shaderLocation: 28},
+          {format: 'snorm16x2', offset: 616, shaderLocation: 20},
+        ],
+      },
+      {arrayStride: 15676, attributes: []},
+      {arrayStride: 6252, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 8136,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 2244, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let shaderModule18 = device0.createShaderModule({
+  label: '\u27fc\u339c\u0afd\ua572\u35fb',
+  code: `@group(2) @binding(2115)
+var<storage, read_write> function11: array<u32>;
+@group(5) @binding(2115)
+var<storage, read_write> n7: array<u32>;
+@group(6) @binding(2115)
+var<storage, read_write> parameter15: array<u32>;
+@group(3) @binding(2115)
+var<storage, read_write> type7: array<u32>;
+@group(0) @binding(2115)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(1) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(27) a0: vec4<f16>, @location(11) a1: vec3<i32>, @location(2) a2: vec3<u32>, @location(24) a3: vec3<f16>, @location(3) a4: vec4<u32>, @builtin(instance_index) a5: u32, @location(25) a6: vec4<f32>, @location(6) a7: u32, @builtin(vertex_index) a8: u32, @location(1) a9: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout13 = device0.createPipelineLayout({
+  label: '\u9ec3\u06af',
+  bindGroupLayouts: [bindGroupLayout23, bindGroupLayout2, bindGroupLayout14, bindGroupLayout2, bindGroupLayout0, bindGroupLayout13, bindGroupLayout0, bindGroupLayout22, bindGroupLayout10, bindGroupLayout22],
+});
+let texture64 = device0.createTexture({
+  label: '\u2480\u2b07\u4665\u{1fc4a}\u7763\u64b6\u6fce\u6fa4\u75df\u{1faed}\u7b2f',
+  size: {width: 26},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let renderBundle40 = renderBundleEncoder16.finish({label: '\u0334\u0b1f\ue106\u611a\u5fc8\uda4a\u0c19\ua483\ua29d'});
+let externalTexture37 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder24.setBindGroup(6, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder5.draw(86, 429, 101_246_386, 1_558_530_682);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(277);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline31);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer0, 102428, 39476);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet30, 2303, 620, buffer10, 124160);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 10696, new DataView(new ArrayBuffer(52619)), 38805, 1884);
+} catch {}
+let pipeline62 = device0.createRenderPipeline({
+  label: '\u0748\uf324\u0ef4\u30ea\u0737\u8173\u{1fc5e}\ua5c0\u06a4',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0x81feb037},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7032,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x4', offset: 1680, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 514, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 796, shaderLocation: 20},
+          {format: 'uint32x3', offset: 1232, shaderLocation: 28},
+          {format: 'uint16x2', offset: 1200, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 676, shaderLocation: 24},
+          {format: 'snorm8x4', offset: 7164, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 904, shaderLocation: 25},
+          {format: 'float32x3', offset: 2440, shaderLocation: 18},
+          {format: 'float32x3', offset: 5980, shaderLocation: 27},
+          {format: 'uint32x2', offset: 10792, shaderLocation: 21},
+          {format: 'float32x3', offset: 268, shaderLocation: 13},
+          {format: 'float32', offset: 4436, shaderLocation: 0},
+          {format: 'float16x2', offset: 7196, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 16220,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1984, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 4096, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 4564, attributes: []},
+      {arrayStride: 4304, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 2448,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 144, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'back'},
+});
+try {
+  await promise19;
+} catch {}
+let img6 = await imageWithData(230, 197, '#5b692308', '#f943487b');
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u9c8c\u1b27\u1e4b\u6445',
+  colorFormats: ['r16uint', 'rgb10a2uint', 'rgb10a2unorm', 'r8unorm', 'r8sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder25.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder5.draw(163, 80, 1_196_468_271, 77_620_976);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer16, 12748, buffer14, 7220, 31668);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 238 widthInBlocks: 238 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 46912 */
+  offset: 46674,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 238, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+canvas3.width = 395;
+let buffer18 = device0.createBuffer({
+  label: '\u{1fe77}\u9ab2\ue25c\u5586\u{1fa6f}\u0446\u3897\u1d13\u3b2d\u0da7\u09dd',
+  size: 130957,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder85 = device0.createCommandEncoder({label: '\u6459\u019f\u1dcd\ud085\uf32f'});
+let commandBuffer20 = commandEncoder36.finish({label: '\u0a59\u03e4\u446e\u{1fcee}\uf4ad\u{1fcc9}\ua2c2'});
+let computePassEncoder33 = commandEncoder80.beginComputePass({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.44,
+  maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder5.drawIndexed(279, 18, 1_929_571_320, 264_871_893, 440_691_480);
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline63 = await promise8;
+try {
+  await promise18;
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({label: '\u0085\u{1fd5f}\u{1fa24}\u469e\u0f30\u0149\u961e\ueab4\u8919'});
+let textureView91 = texture23.createView({label: '\u{1f750}\u018c\u0779\u06a1\ueb46\u529f', dimension: '2d-array'});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture36,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet20, 24, 37, buffer12, 4352);
+} catch {}
+let computePassEncoder34 = commandEncoder68.beginComputePass({label: '\u98d0\u065e\u3961\u0f3d\u4b73\ua503\u4374\ub976\u0e2d'});
+let renderBundle41 = renderBundleEncoder1.finish({label: '\u08cc\udb7d\u094c\u0e9f\uda39\ubcf1\u0480'});
+try {
+renderBundleEncoder5.draw(198, 42, 70_190_423);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(8, buffer1, 0);
+} catch {}
+let arrayBuffer5 = buffer6.getMappedRange(8360, 680);
+try {
+commandEncoder85.copyBufferToBuffer(buffer3, 13960, buffer9, 58764, 3640);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 168 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 26832 */
+  offset: 25896,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 21, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet0, 994, 25, buffer12, 20992);
+} catch {}
+let img7 = await imageWithData(263, 96, '#8aa143d7', '#5a97785d');
+let textureView92 = texture2.createView({baseMipLevel: 3});
+let renderBundle42 = renderBundleEncoder28.finish({label: '\u05d4\u0c86\u91ed\u0df4\u417a\u08a5\u084b\u77ba\u0325'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup22, []);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(7, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexed(357, 34, 350_553_565, 575_123_547, 742_604_461);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 784 widthInBlocks: 98 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2560 */
+  offset: 2560,
+  buffer: buffer8,
+}, {
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 98, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 264 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32216 */
+  offset: 32216,
+  buffer: buffer14,
+}, {width: 66, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet10, 1018, 607, buffer10, 81920);
+} catch {}
+try {
+device0.queue.submit([commandBuffer20]);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap5 = await createImageBitmap(canvas0);
+try {
+adapter0.label = '\u{1fea4}\u4d2b\u{1ff2c}';
+} catch {}
+let imageBitmap6 = await createImageBitmap(img3);
+let offscreenCanvas7 = new OffscreenCanvas(462, 148);
+gc();
+let videoFrame6 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+try {
+offscreenCanvas7.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+let offscreenCanvas8 = new OffscreenCanvas(81, 755);
+let canvas10 = document.createElement('canvas');
+document.body.prepend(canvas5);
+let offscreenCanvas9 = new OffscreenCanvas(983, 540);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+window.someLabel = renderBundle25.label;
+} catch {}
+let gpuCanvasContext5 = canvas10.getContext('webgpu');
+let imageBitmap7 = await createImageBitmap(offscreenCanvas0);
+gc();
+try {
+offscreenCanvas8.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+gc();
+let videoFrame7 = new VideoFrame(img3, {timestamp: 0});
+video10.height = 40;
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas9.getContext('webgl2');
+} catch {}
+video12.height = 13;
+gc();
+let offscreenCanvas10 = new OffscreenCanvas(645, 974);
+try {
+adapter0.label = '\u05da\u8bf1\u10ab\u0189\ue6ee\u0c2a\u01ea\u0318\u6c7d\u0716';
+} catch {}
+video4.width = 295;
+let imageData12 = new ImageData(80, 96);
+try {
+offscreenCanvas10.getContext('webgpu');
+} catch {}
+let img8 = await imageWithData(34, 47, '#e6b7fa63', '#f2a764c1');
+let promise20 = adapter0.requestAdapterInfo();
+let imageData13 = new ImageData(196, 104);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame8 = new VideoFrame(videoFrame1, {timestamp: 0});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let img9 = await imageWithData(299, 113, '#291ff2b0', '#137d8d98');
+let videoFrame9 = new VideoFrame(imageBitmap2, {timestamp: 0});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+canvas6.width = 128;
+let offscreenCanvas11 = new OffscreenCanvas(531, 661);
+let imageBitmap8 = await createImageBitmap(imageData1);
+let commandEncoder87 = device0.createCommandEncoder({label: '\u069b\u5eb2\u0936\u0662'});
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 3716);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer1, 0, 67343);
+} catch {}
+let arrayBuffer6 = buffer6.getMappedRange(8352, 0);
+try {
+commandEncoder56.resolveQuerySet(querySet5, 193, 1648, buffer12, 9984);
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+try {
+  await promise20;
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(242, 627);
+let videoFrame10 = new VideoFrame(video0, {timestamp: 0});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let videoFrame11 = new VideoFrame(img8, {timestamp: 0});
+gc();
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+document.body.prepend(video11);
+let img10 = await imageWithData(68, 253, '#a58c1d0b', '#bb3e223a');
+let imageBitmap9 = await createImageBitmap(canvas2);
+document.body.prepend(canvas7);
+let img11 = await imageWithData(213, 183, '#7135f4b4', '#d12a376a');
+try {
+adapter0.label = '\u0b3d\ua4e7\ub8da\u{1f6af}\u027d\ud8b4\u{1f8f3}\uf41e\u{1ffd7}\u37b2\u4f97';
+} catch {}
+let textureView93 = texture42.createView({label: '\u760b\uc20e\u{1ff9d}\u5a0b\u9fe7\uff4a\u0256\u01fd\u977c', arrayLayerCount: 1});
+try {
+renderBundleEncoder23.setBindGroup(8, bindGroup11, []);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(8, bindGroup25, new Uint32Array(7274), 2694, 0);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer18, 6828);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer18, 'uint32', 106420, 6288);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(4, buffer1, 0, 115727);
+} catch {}
+let video18 = await videoWithData();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap10 = await createImageBitmap(videoFrame1);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+externalTexture36.label = '\u0f90\u0ab2\u076b\u{1f910}';
+} catch {}
+canvas7.height = 656;
+let imageData14 = new ImageData(120, 228);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u6927\u0dc0\ubebb\u8f6d\u04bd\u7d12';
+} catch {}
+document.body.prepend(canvas0);
+offscreenCanvas8.height = 497;
+let videoFrame12 = new VideoFrame(videoFrame6, {timestamp: 0});
+let imageData15 = new ImageData(132, 232);
+let img12 = await imageWithData(78, 279, '#a4744db2', '#110eb823');
+let img13 = await imageWithData(169, 153, '#19a8572a', '#7bec373f');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let sampler49 = device0.createSampler({
+  label: '\u{1f9d2}\ue91e\u880b\u5e32\u0baf',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.66,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder5.draw(379, 191, 1_994_153_926, 464_767_127);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 4436);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 91 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 28398 */
+  offset: 6547,
+  bytesPerRow: 256,
+  rowsPerImage: 382,
+  buffer: buffer16,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 3, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 91, height: 86, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 145},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 259, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap11 = await createImageBitmap(offscreenCanvas2);
+let offscreenCanvas13 = new OffscreenCanvas(252, 510);
+let videoFrame13 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let canvas11 = document.createElement('canvas');
+gc();
+gc();
+let video19 = await videoWithData();
+try {
+externalTexture4.label = '\ua8a3\u09fe\u27ff\u{1f657}\ue0e6\u{1fc03}\u75ef';
+} catch {}
+offscreenCanvas8.height = 462;
+let offscreenCanvas14 = new OffscreenCanvas(804, 95);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+canvas11.getContext('webgl');
+} catch {}
+let promise21 = adapter1.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 63,
+    maxVertexAttributes: 19,
+    maxVertexBufferArrayStride: 16068,
+    maxStorageTexturesPerShaderStage: 21,
+    maxStorageBuffersPerShaderStage: 11,
+    maxDynamicStorageBuffersPerPipelineLayout: 38906,
+    maxDynamicUniformBuffersPerPipelineLayout: 45035,
+    maxBindingsPerBindGroup: 6740,
+    maxTextureArrayLayers: 259,
+    maxTextureDimension1D: 12700,
+    maxTextureDimension2D: 12646,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 23741964,
+    maxStorageBufferBindingSize: 242099717,
+    maxUniformBuffersPerShaderStage: 43,
+    maxSampledTexturesPerShaderStage: 23,
+    maxInterStageShaderVariables: 95,
+    maxInterStageShaderComponents: 120,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let canvas12 = document.createElement('canvas');
+try {
+canvas12.getContext('webgpu');
+} catch {}
+offscreenCanvas2.width = 612;
+let video20 = await videoWithData();
+let offscreenCanvas15 = new OffscreenCanvas(309, 466);
+let img14 = await imageWithData(254, 103, '#d26be5ef', '#048ba92f');
+document.body.prepend(canvas4);
+let gpuCanvasContext6 = offscreenCanvas13.getContext('webgpu');
+let canvas13 = document.createElement('canvas');
+let offscreenCanvas16 = new OffscreenCanvas(941, 537);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas14 = document.createElement('canvas');
+offscreenCanvas10.width = 1284;
+let gpuCanvasContext7 = offscreenCanvas16.getContext('webgpu');
+let img15 = await imageWithData(249, 235, '#a72de189', '#89dea0f5');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas15 = document.createElement('canvas');
+video0.width = 97;
+let imageData16 = new ImageData(140, 200);
+let canvas16 = document.createElement('canvas');
+let gpuCanvasContext8 = canvas13.getContext('webgpu');
+let promise22 = adapter1.requestAdapterInfo();
+try {
+canvas16.getContext('bitmaprenderer');
+} catch {}
+let imageBitmap12 = await createImageBitmap(video13);
+let bindGroup27 = device0.createBindGroup({
+  label: '\u0c24\u0066\ud7fc',
+  layout: bindGroupLayout2,
+  entries: [{binding: 3576, resource: textureView89}],
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer17, 32084, buffer14, 12084, 2488);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 111 widthInBlocks: 111 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17078 */
+  offset: 17078,
+  buffer: buffer10,
+}, {width: 111, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder81.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 11, y: 64, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 37, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer10, 55808, 4892);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 26, height: 40, depthOrArrayLayers: 1138}
+*/
+{
+  source: video11,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture51,
+  mipLevel: 2,
+  origin: {x: 2, y: 21, z: 332},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext9 = canvas14.getContext('webgpu');
+canvas12.width = 1137;
+let videoFrame14 = new VideoFrame(canvas15, {timestamp: 0});
+try {
+offscreenCanvas14.getContext('webgpu');
+} catch {}
+let video21 = await videoWithData();
+let gpuCanvasContext10 = offscreenCanvas15.getContext('webgpu');
+let video22 = await videoWithData();
+let videoFrame15 = new VideoFrame(img11, {timestamp: 0});
+document.body.prepend(img6);
+offscreenCanvas15.width = 869;
+let img16 = await imageWithData(12, 110, '#c27b1bd7', '#d7bcb3ec');
+try {
+adapter1.label = '\u174c\u1f01\uf8a7\u{1fcc3}\u7535\u0bd3\u{1f67f}\u7e83\u7cc4\u{1fa34}\u{1fec3}';
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet36 = device0.createQuerySet({label: '\ufa2f\u4a13\u050c\u6b2b', type: 'occlusion', count: 128});
+let textureView94 = texture15.createView({label: '\u{1ffc5}\u0770\u{1fe6c}\u447f', baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder35 = commandEncoder47.beginComputePass({label: '\u0f33\u8469'});
+let sampler50 = device0.createSampler({
+  label: '\u633b\u52e7\u{1fc79}\ua197\u{1fc9f}\u20e8',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 81.37,
+});
+try {
+computePassEncoder7.setBindGroup(7, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup10, new Uint32Array(8078), 4405, 0);
+} catch {}
+try {
+renderBundleEncoder5.draw(48, 178, 10_400_192);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer1, 6476);
+} catch {}
+try {
+commandEncoder72.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 180 widthInBlocks: 180 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 12387 */
+  offset: 12387,
+  buffer: buffer10,
+}, {width: 180, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet34, 1, 884, buffer12, 15360);
+} catch {}
+document.body.prepend(img14);
+try {
+canvas15.getContext('webgpu');
+} catch {}
+let videoFrame16 = new VideoFrame(offscreenCanvas15, {timestamp: 0});
+canvas13.height = 1424;
+let canvas17 = document.createElement('canvas');
+let gpuCanvasContext11 = canvas17.getContext('webgpu');
+try {
+adapter1.label = '\u00cc\u0e44\u4bbc';
+} catch {}
+let video23 = await videoWithData();
+canvas3.width = 382;
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageBitmap13 = await createImageBitmap(offscreenCanvas14);
+let videoFrame17 = new VideoFrame(video6, {timestamp: 0});
+let imageData17 = new ImageData(112, 44);
+offscreenCanvas7.width = 248;
+let img17 = await imageWithData(245, 153, '#a568fc52', '#c7928541');
+let imageBitmap14 = await createImageBitmap(canvas2);
+let video24 = await videoWithData();
+let imageData18 = new ImageData(256, 32);
+let adapter2 = await navigator.gpu.requestAdapter();
+let videoFrame18 = new VideoFrame(canvas8, {timestamp: 0});
+gc();
+document.body.prepend(img12);
+try {
+  await promise22;
+} catch {}
+let videoFrame19 = new VideoFrame(img1, {timestamp: 0});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let videoFrame20 = new VideoFrame(video12, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend(canvas6);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({label: '\u1490\u0428\u{1fb3e}\u06b8\u5360\u039d\u06d9\u024c\u2321\u5d6f'});
+let textureView95 = texture7.createView({baseMipLevel: 3, mipLevelCount: 1});
+let computePassEncoder36 = commandEncoder52.beginComputePass({label: '\uedec\u4bd7\u36e9\u9430\uf6eb\u{1fa76}\u0a5c'});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\ub912\u0945\uff22\u0557\ub982\u097d\u{1fe66}\u3838',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+});
+let renderBundle43 = renderBundleEncoder27.finish();
+try {
+renderBundleEncoder5.drawIndexed(373);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer1, 0, 79154);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 72 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 8642 */
+  offset: 8642,
+  bytesPerRow: 256,
+  buffer: buffer9,
+}, {width: 72, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+offscreenCanvas8.width = 3438;
+gc();
+let videoFrame21 = new VideoFrame(videoFrame3, {timestamp: 0});
+let promise23 = adapter2.requestAdapterInfo();
+try {
+pipeline15.label = '\ub88a\u0333\u{1f613}\u010e\u0bcd\u818a\u087e\u{1fb15}\u040f';
+} catch {}
+try {
+externalTexture14.label = '\u9c1e\u58bb\u0fa5\uce55\u3737\u0a72';
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageBitmap15 = await createImageBitmap(videoFrame17);
+try {
+  await promise23;
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData19 = new ImageData(188, 88);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let img18 = await imageWithData(184, 114, '#bf618586', '#e24b7ff0');
+let commandEncoder89 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({
+  label: '\u5d11\u{1fca6}\udc1f\uc674',
+  size: {width: 106, height: 160, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let textureView96 = texture10.createView({label: '\u0b23\u1258'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u{1feef}\u0bc3',
+  colorFormats: ['bgra8unorm', 'rgba16sint', 'r32float', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder5.draw(99, 94, 493_596_918);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer18, 'uint32');
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer1);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet3, 2844, 96, buffer10, 78336);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video7);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap16 = await createImageBitmap(video1);
+offscreenCanvas12.width = 645;
+video22.width = 272;
+let offscreenCanvas17 = new OffscreenCanvas(68, 432);
+let img19 = await imageWithData(204, 193, '#860d399d', '#7d07bc89');
+try {
+offscreenCanvas17.getContext('webgl');
+} catch {}
+let imageBitmap17 = await createImageBitmap(video2);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+gc();
+let img20 = await imageWithData(47, 191, '#8e63feb0', '#3860d59e');
+let video25 = await videoWithData();
+gc();
+let offscreenCanvas18 = new OffscreenCanvas(423, 901);
+let canvas18 = document.createElement('canvas');
+let img21 = await imageWithData(221, 78, '#6033c237', '#7a585c32');
+let img22 = await imageWithData(295, 225, '#b3facfb2', '#1719bc55');
+try {
+externalTexture33.label = '\u{1fa85}\ua570\u3794\uca1e\u0828\u00c7\u{1f796}\u86c9\u097c';
+} catch {}
+document.body.prepend(img13);
+try {
+  await promise24;
+} catch {}
+let canvas19 = document.createElement('canvas');
+let gpuCanvasContext12 = offscreenCanvas18.getContext('webgpu');
+try {
+canvas19.getContext('bitmaprenderer');
+} catch {}
+let img23 = await imageWithData(97, 192, '#7262133e', '#478ae2dd');
+try {
+canvas18.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let imageBitmap18 = await createImageBitmap(canvas9);
+let promise25 = adapter0.requestAdapterInfo();
+let imageData20 = new ImageData(180, 104);
+let offscreenCanvas19 = new OffscreenCanvas(425, 981);
+try {
+offscreenCanvas19.getContext('webgl2');
+} catch {}
+let videoFrame22 = new VideoFrame(img1, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video23);
+try {
+externalTexture31.label = '\u4502\uc6eb\u{1fce6}';
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+  await promise25;
+} catch {}
+let gpuCanvasContext13 = canvas20.getContext('webgpu');
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(626, 969);
+let img24 = await imageWithData(183, 113, '#0d9c0519', '#a7133dcf');
+let videoFrame23 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let offscreenCanvas21 = new OffscreenCanvas(902, 1015);
+let video26 = await videoWithData();
+document.body.prepend(canvas1);
+gc();
+try {
+offscreenCanvas20.getContext('webgpu');
+} catch {}
+gc();
+try {
+offscreenCanvas21.getContext('webgl');
+} catch {}
+canvas12.width = 611;
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let texture66 = device0.createTexture({
+  label: '\u0b15\u5321\u{1ff6e}\u1af3\u4f1e\u8331\u0820\u7d6d',
+  size: {width: 4560, height: 1, depthOrArrayLayers: 891},
+  mipLevelCount: 9,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView97 = texture10.createView({label: '\u9698\u02ac'});
+let sampler51 = device0.createSampler({
+  label: '\uc489\u4986\u08e5',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.28,
+  lodMaxClamp: 40.14,
+  maxAnisotropy: 8,
+});
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 2096);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let video27 = await videoWithData();
+gc();
+let offscreenCanvas22 = new OffscreenCanvas(662, 496);
+let offscreenCanvas23 = new OffscreenCanvas(423, 832);
+let video28 = await videoWithData();
+let gpuCanvasContext14 = offscreenCanvas22.getContext('webgpu');
+let imageBitmap19 = await createImageBitmap(video20);
+let videoFrame24 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+offscreenCanvas11.height = 342;
+let imageData21 = new ImageData(76, 84);
+document.body.prepend(canvas20);
+let video29 = await videoWithData();
+let gpuCanvasContext15 = offscreenCanvas23.getContext('webgpu');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let canvas21 = document.createElement('canvas');
+let canvas22 = document.createElement('canvas');
+let videoFrame25 = new VideoFrame(offscreenCanvas10, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageBitmap20 = await createImageBitmap(video14);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(1020, 584);
+let imageData22 = new ImageData(196, 248);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let imageBitmap21 = await createImageBitmap(canvas13);
+gc();
+let videoFrame26 = new VideoFrame(offscreenCanvas11, {timestamp: 0});
+let canvas23 = document.createElement('canvas');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let canvas24 = document.createElement('canvas');
+let imageData23 = new ImageData(224, 252);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+video1.height = 168;
+offscreenCanvas6.width = 130;
+try {
+canvas24.getContext('2d');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let img25 = await imageWithData(133, 205, '#b123f178', '#57d29244');
+let imageData24 = new ImageData(36, 256);
+let videoFrame27 = new VideoFrame(imageBitmap13, {timestamp: 0});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+canvas21.getContext('bitmaprenderer');
+} catch {}
+canvas14.height = 314;
+let offscreenCanvas25 = new OffscreenCanvas(575, 567);
+let gpuCanvasContext16 = offscreenCanvas24.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame28 = new VideoFrame(videoFrame11, {timestamp: 0});
+try {
+adapter0.label = '\ue0d0\udf48\uefc9\ub86b\u0c48\u{1fe35}\u087f\u{1f875}\u0068\u0ae2';
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas25.getContext('webgpu');
+let adapter3 = await navigator.gpu.requestAdapter();
+let offscreenCanvas26 = new OffscreenCanvas(823, 775);
+let gpuCanvasContext18 = offscreenCanvas26.getContext('webgpu');
+let imageData25 = new ImageData(64, 152);
+let gpuCanvasContext19 = canvas22.getContext('webgpu');
+document.body.prepend(video0);
+offscreenCanvas4.height = 1123;
+let video30 = await videoWithData();
+try {
+window.someLabel = pipelineLayout4.label;
+} catch {}
+try {
+renderBundleEncoder29.label = '\uedcb\u73c6\u02ad';
+} catch {}
+let gpuCanvasContext20 = canvas23.getContext('webgpu');
+let bindGroup28 = device0.createBindGroup({
+  label: '\u{1fb91}\u9c23\ub433\u{1fe2b}\u0a32\u{1fcc6}\ue3b9\u0e9d',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let commandEncoder90 = device0.createCommandEncoder();
+let textureView98 = texture5.createView({label: '\u0068\u0882\u01aa\u{1f6e0}\u0731\u0241\ufe04\u7eb9\u{1f624}'});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\u67ec\u{1fb1f}\u{1fdba}\u{1f8bc}\u78ba\u012f\u9fc8\u{1fdaa}\u048a',
+  colorFormats: ['r16sint', 'rg16float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder11.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder5.drawIndexedIndirect(buffer15, 3656);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer1);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline64 = device0.createComputePipeline({
+  label: '\u{1fbc6}\u1e7f\ua9c7\uaeec\uc19d\u80f2\u18de\ud894\u{1f725}\u05da\udf4a',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+let adapter4 = await navigator.gpu.requestAdapter({});
+let imageBitmap22 = await createImageBitmap(offscreenCanvas24);
+let video31 = await videoWithData();
+let imageData26 = new ImageData(100, 128);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(1000, 440);
+let videoFrame29 = new VideoFrame(videoFrame22, {timestamp: 0});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView99 = texture37.createView({label: '\uc4c7\u{1f80b}\u9444', dimension: '2d-array'});
+let sampler52 = device0.createSampler({
+  label: '\u9a16\ue4e1\u0791\u0027',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.98,
+});
+try {
+renderBundleEncoder5.draw(97, 137);
+} catch {}
+try {
+renderBundleEncoder5.drawIndirect(buffer15, 4952);
+} catch {}
+try {
+commandEncoder79.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer10, 125056, 5408);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(443), /* required buffer size: 443 */
+{offset: 443}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline65 = await device0.createComputePipelineAsync({
+  label: '\u{1fc87}\u{1fe61}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas27.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(canvas18);
+let imageData27 = new ImageData(176, 212);
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -101,6 +101,7 @@ private:
     bool validateGetMappedRange(size_t offset, size_t rangeSize) const;
     NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
     bool validateUnmap() const;
+    void setState(State);
 
     id<MTLBuffer> m_buffer { nil };
 


### PR DESCRIPTION
#### 2fc583504218dae11bd3c8ede97f841c3f4c075c
<pre>
[WebGPU] Buffer instance can transition from Destroyed -&gt; Unmapped state
<a href="https://bugs.webkit.org/show_bug.cgi?id=274446">https://bugs.webkit.org/show_bug.cgi?id=274446</a>
&lt;radar://128396385&gt;

Reviewed by Dan Glastonbury.

Once destroyed, a Buffer is not allowed to be used in any
operations and should remain in the destroyed state.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-128396311-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-128396311.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::destroy):
(WebGPU::Buffer::mapAsync):
(WebGPU::Buffer::setState):
(WebGPU::Buffer::unmap):

Canonical link: <a href="https://commits.webkit.org/279083@main">https://commits.webkit.org/279083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c69fa37b6c55dc1852f4b3d223a0d7ed90ee6359

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42612 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1959 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23653 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1231 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57219 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49960 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49205 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11452 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->