### PR TITLE
Further remove MSVC code

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -71,10 +71,6 @@
 #include "PingPongStackOverflowTest.h"
 #include "TypedArrayCTest.h"
 
-#if COMPILER(MSVC)
-#pragma warning(disable:4204)
-#endif
-
 #if JSC_OBJC_API_ENABLED
 void testObjectiveCAPI(const char*);
 #endif

--- a/Source/JavaScriptCore/API/tests/testapi.cpp
+++ b/Source/JavaScriptCore/API/tests/testapi.cpp
@@ -227,30 +227,6 @@ TestAPI::ScriptResult TestAPI::callFunction(const char* functionSource, Argument
     return Unexpected<JSValueRef>(exception);
 }
 
-#if COMPILER(MSVC)
-template<>
-TestAPI::ScriptResult TestAPI::callFunction(const char* functionSource)
-{
-    JSValueRef function;
-    {
-        ScriptResult functionResult = evaluateScript(functionSource);
-        if (!functionResult)
-            return functionResult;
-        function = functionResult.value();
-    }
-
-    JSValueRef exception = nullptr;
-    if (JSObjectRef functionObject = JSValueToObject(context, function, &exception)) {
-        JSValueRef result = JSObjectCallAsFunction(context, functionObject, functionObject, 0, nullptr, &exception);
-        if (!exception)
-            return ScriptResult(result);
-    }
-
-    RELEASE_ASSERT(exception);
-    return Unexpected<JSValueRef>(exception);
-}
-#endif
-
 template<typename... ArgumentTypes>
 bool TestAPI::functionReturnsTrue(const char* functionSource, ArgumentTypes... arguments)
 {

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp
@@ -1002,7 +1002,7 @@ void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth sav
 #endif
         move(TrustedImmPtr(reinterpret_cast<void*>(ctiMasmProbeTrampoline)), RegisterID::eax);
 
-#if COMPILER(MSVC) || CPU(X86)
+#if CPU(X86)
     push(RegisterID::ecx);
     move(TrustedImmPtr(reinterpret_cast<void*>(Probe::executeJSCJITProbe)), RegisterID::ecx);
 #endif
@@ -1021,15 +1021,11 @@ MacroAssemblerX86Common::CPUID MacroAssemblerX86Common::getCPUID(unsigned level)
 MacroAssemblerX86Common::CPUID MacroAssemblerX86Common::getCPUIDEx(unsigned level, unsigned count)
 {
     CPUID result { };
-#if COMPILER(MSVC)
-    __cpuidex(bitwise_cast<int*>(result.data()), level, count);
-#else
     __asm__ (
         "cpuid\n"
         : "=a"(result[0]), "=b"(result[1]), "=c"(result[2]), "=d"(result[3])
         : "0"(level), "2"(count)
     );
-#endif
     return result;
 }
 

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -43,24 +43,18 @@ inline bool CAN_SIGN_EXTEND_8_32(int32_t value) { return value == (int32_t)(sign
 
 namespace RegisterNames {
 
-#if COMPILER(MSVC)
-#define JSC_X86_ASM_REGISTER_ID_ENUM_BASE_TYPE
-#else
-#define JSC_X86_ASM_REGISTER_ID_ENUM_BASE_TYPE : int8_t
-#endif
-
 #define REGISTER_ID(id, name, res, cs) id,
 
-typedef enum JSC_X86_ASM_REGISTER_ID_ENUM_BASE_TYPE {
+typedef enum : int8_t {
     FOR_EACH_GP_REGISTER(REGISTER_ID)
     InvalidGPRReg = -1,
 } RegisterID;
 
-typedef enum JSC_X86_ASM_REGISTER_ID_ENUM_BASE_TYPE {
+typedef enum : int8_t {
     FOR_EACH_SP_REGISTER(REGISTER_ID)                                                     
 } SPRegisterID;
 
-typedef enum JSC_X86_ASM_REGISTER_ID_ENUM_BASE_TYPE {
+typedef enum : int8_t {
     FOR_EACH_FP_REGISTER(REGISTER_ID)
     InvalidFPRReg = -1,
 } XMMRegisterID;

--- a/Source/JavaScriptCore/builtins/BuiltinNames.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.cpp
@@ -30,11 +30,6 @@
 #include "IdentifierInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable:4307)
-#endif
-
 namespace JSC {
 namespace Symbols {
 
@@ -182,7 +177,3 @@ SymbolImpl* BuiltinNames::lookUpWellKnownSymbol(const String& string) const
 }
 
 } // namespace JSC
-
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif

--- a/Source/JavaScriptCore/config.h
+++ b/Source/JavaScriptCore/config.h
@@ -41,11 +41,3 @@
 #endif
 
 #include <wtf/DisallowCType.h>
-
-/* Disabling warning C4206: nonstandard extension used: translation unit is empty.
-   By design, we rely on #define flags to make some translation units empty.
-   Make sure this warning does not turn into an error.
-*/
-#if COMPILER(MSVC)
-#pragma warning(disable:4206)
-#endif

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
@@ -34,11 +34,6 @@
 #include "WasmOpcodeOrigin.h"
 #include <wtf/TZoneMallocInlines.h>
 
-#if COMPILER(MSVC)
-// See https://msdn.microsoft.com/en-us/library/4wz07268.aspx
-#pragma warning(disable: 4333)
-#endif
-
 namespace JSC {
 
 namespace {

--- a/Source/JavaScriptCore/jit/RegisterAtOffset.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffset.h
@@ -77,9 +77,9 @@ public:
     void dump(PrintStream& out) const;
 
 private:
-    unsigned m_regIndex : 7 = Reg().index();
-    bool m_width : 1 = false;
-    ptrdiff_t m_offsetBits : (sizeof(ptrdiff_t) * CHAR_BIT - 7 - 1) = 0;
+    unsigned m_regIndex : 7 { Reg().index() };
+    unsigned m_width : 1 { false };
+    ptrdiff_t m_offsetBits : (sizeof(ptrdiff_t) * CHAR_BIT - 7 - 1) { 0 };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -140,7 +140,7 @@
 #undef Function
 #endif
 
-#if COMPILER(MSVC)
+#if OS(WINDOWS)
 #include <crtdbg.h>
 #include <mmsystem.h>
 #include <windows.h>
@@ -2813,11 +2813,6 @@ JSC_DEFINE_HOST_FUNCTION(functionQuit, (JSGlobalObject* globalObject, CallFrame*
     vm.codeCache()->write();
 
     jscExit(EXIT_SUCCESS);
-
-#if COMPILER(MSVC) && !COMPILER(CLANG)
-    // Without this, Visual Studio will complain that this method does not return a value.
-    return JSValue::encode(jsUndefined());
-#endif
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionFalse, (JSGlobalObject*, CallFrame*))
@@ -4366,7 +4361,7 @@ int jscmain(int argc, char** argv)
         enableSuperSampler();
 
     bool gigacageDisableRequested = false;
-#if GIGACAGE_ENABLED && !COMPILER(MSVC)
+#if GIGACAGE_ENABLED && !OS(WINDOWS)
     if (char* gigacageEnabled = getenv("GIGACAGE_ENABLED")) {
         if (!strcasecmp(gigacageEnabled, "no") || !strcasecmp(gigacageEnabled, "false") || !strcasecmp(gigacageEnabled, "0"))
             gigacageDisableRequested = true;

--- a/Source/JavaScriptCore/offlineasm/generate_offset_extractor.rb
+++ b/Source/JavaScriptCore/offlineasm/generate_offset_extractor.rb
@@ -116,11 +116,7 @@ File.open(tempFlnm, "w") {
             constsList = constsList(lowLevelAST)
 
             emitCodeInConfiguration(concreteSettings, lowLevelAST, backend) {
-
                 # Windows complains about signed integers being cast to unsigned but we just want the bits.
-                outp.puts "\#if COMPILER(MSVC)"
-                outp.puts "\#pragma warning(disable:4308)"
-                outp.puts "\#endif"
                 constsList.each_with_index {
                     | const, index |
                     outp.puts "constexpr int64_t constValue#{index} = static_cast<int64_t>(#{const.value});"

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -53,11 +53,6 @@ struct SourceProviderCacheItemCreationParameters {
     bool isBodyArrowExpression : 1 { false };
 };
 
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable: 4200) // Disable "zero-sized array in struct/union" warning
-#endif
-
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SourceProviderCacheItem);
 class SourceProviderCacheItem {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SourceProviderCacheItem);
@@ -156,9 +151,5 @@ inline SourceProviderCacheItem::SourceProviderCacheItem(const SourceProviderCach
         m_variables[i] = pointer;
     }
 }
-
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.h
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.h
@@ -117,16 +117,7 @@ using PtrTag = WTF::PtrTag;
         } \
     };
 
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable:4307)
-#endif
-
 FOR_EACH_JSC_PTRTAG(JSC_DECLARE_PTRTAG)
-
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif
 
 #if CPU(ARM64E)
 JS_EXPORT_PRIVATE PtrTagCallerType callerType(PtrTag);
@@ -261,15 +252,6 @@ const char* ptrTagName(PtrTag);
 } // namespace JSC
 namespace WTF {
 
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable:4307)
-#endif
-
 FOR_EACH_JSC_PTRTAG(JSC_DECLARE_PTRTAG_TRAIT)
-
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif
 
 } // namespace WTF

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -243,10 +243,6 @@ private:
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VM);
 
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable: 4200) // Disable "zero-sized array in struct/union" warning
-#endif
 struct ScratchBuffer {
     ScratchBuffer()
     {
@@ -276,9 +272,6 @@ struct ScratchBuffer {
     } u;
     void* m_buffer[0];
 };
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif
 
 class ActiveScratchBufferScope {
 public:

--- a/Source/JavaScriptCore/testRegExp.cpp
+++ b/Source/JavaScriptCore/testRegExp.cpp
@@ -32,7 +32,7 @@
 #include <wtf/WTFProcess.h>
 #include <wtf/text/StringBuilder.h>
 
-#if COMPILER(MSVC)
+#if OS(WINDOWS)
 #include <crtdbg.h>
 #include <mmsystem.h>
 #include <windows.h>

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -46,11 +46,8 @@
 #include <CoreFoundation/CFString.h>
 #endif // USE(CF)
 
-#if COMPILER(MSVC)
-#include <crtdbg.h>
-#endif
-
 #if OS(WINDOWS)
+#include <crtdbg.h>
 #include <windows.h>
 #endif
 
@@ -87,7 +84,7 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 #endif
 
     // Do the format once to get the length.
-#if COMPILER(MSVC)
+#if OS(WINDOWS)
     int result = _vscprintf(format, args);
 #else
     char ch;

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -280,9 +280,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
 #endif // CPU(ARM64)
 
-#if COMPILER(MSVC)
-#define WTFBreakpointTrap()  __debugbreak()
-#elif ASAN_ENABLED
+#if ASAN_ENABLED
 #define WTFBreakpointTrap()  __builtin_trap()
 #elif CPU(X86_64) || CPU(X86)
 #define WTFBreakpointTrap()  asm volatile (WTF_FATAL_CRASH_INST)

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -71,7 +71,7 @@ constexpr double sqrtOfTwoDouble = M_SQRT2;
 constexpr float sqrtOfTwoFloat = static_cast<float>(M_SQRT2);
 #endif
 
-#if COMPILER(MSVC)
+#if OS(WINDOWS)
 
 // Work around a bug in Win, where atan2(+-infinity, +-infinity) yields NaN instead of specific values.
 extern "C" inline double wtf_atan2(double x, double y)
@@ -98,7 +98,7 @@ extern "C" inline double wtf_atan2(double x, double y)
 
 #define atan2(x, y) wtf_atan2(x, y)
 
-#endif // COMPILER(MSVC)
+#endif // OS(WINDOWS)
 
 constexpr double radiansPerDegreeDouble = piDouble / 180.0;
 constexpr double degreesPerRadianDouble = 180.0 / piDouble;

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -138,16 +138,7 @@ constexpr uintptr_t makePtrTagHash(const char (&str)[N])
 static_assert(static_cast<uintptr_t>(NoPtrTag) == static_cast<uintptr_t>(0));
 static_assert(static_cast<uintptr_t>(CFunctionPtrTag) == static_cast<uintptr_t>(1));
 
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable:4307)
-#endif
-
 FOR_EACH_ADDITIONAL_WTF_PTRTAG(WTF_DECLARE_PTRTAG)
-
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif
 
 struct PtrTagLookup {
     using TagForPtrFunc = const char* (*)(const void*);

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -218,14 +218,7 @@ namespace WTF {
 
     private:
         struct Segment {
-#if COMPILER(MSVC)
-#pragma warning(push)
-#pragma warning(disable: 4200)
-#endif
             T entries[0];
-#if COMPILER(MSVC)
-#pragma warning(pop)
-#endif
         };
 
         void deleteAllSegments()

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -53,12 +53,6 @@
 #endif
 #endif
 
-#if !COMPILER(MSVC)
-#include <limits.h>
-#include <sched.h>
-#include <sys/time.h>
-#endif
-
 #if !OS(DARWIN) && OS(UNIX)
 
 #include <semaphore.h>


### PR DESCRIPTION
#### adcd97e5a4ae359e0ea83a4cc9ae2348b95d607f
<pre>
Further remove MSVC code
<a href="https://bugs.webkit.org/show_bug.cgi?id=274450">https://bugs.webkit.org/show_bug.cgi?id=274450</a>
<a href="https://rdar.apple.com/128448731">rdar://128448731</a>

Reviewed by Ross Kirsling.

Further remove MSVC hacks. And we use `OS(WINDOWS)` for code which needs to be used on Windows (even without MSVC).

* Source/JavaScriptCore/API/tests/testapi.c:
* Source/JavaScriptCore/API/tests/testapi.cpp:
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp:
(JSC::MacroAssembler::probe):
(JSC::MacroAssemblerX86Common::getCPUIDEx):
* Source/JavaScriptCore/assembler/X86Assembler.h:
* Source/JavaScriptCore/builtins/BuiltinNames.cpp:
* Source/JavaScriptCore/config.h:
* Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp:
* Source/JavaScriptCore/jit/RegisterAtOffset.cpp:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
(jscmain):
* Source/JavaScriptCore/offlineasm/generate_offset_extractor.rb:
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
* Source/JavaScriptCore/runtime/JSCPtrTag.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/testRegExp.cpp:
* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/MathExtras.h:
* Source/WTF/wtf/PtrTag.h:
* Source/WTF/wtf/SegmentedVector.h:
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:

Canonical link: <a href="https://commits.webkit.org/279108@main">https://commits.webkit.org/279108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8b90f94fbe592b798e3471e962ff55eee8a9ff0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3233 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/38421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42671 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2062 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23760 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26671 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2590 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1392 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45859 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57380 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52020 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27642 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2765 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-subset.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/css-view-transitions/transform-origin-view-transition-group.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50067 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49322 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29782 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64326 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7702 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28619 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12182 "Found 10 new JSC stress test failures: stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.bytecode-cache, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.default, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.dfg-eager, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.dfg-eager-no-cjit-validate, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.eager-jettison-no-cjit, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.lockdown, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.mini-mode, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-cjit-collect-continuously, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-cjit-validate-phases, stress/dfg-ai-direct-get-by-id-attribute-change-transition.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->