### PR TITLE
[JSC] Use `var` instead of `let` in built-in `IteratorHelpers.js`

### DIFF
--- a/Source/JavaScriptCore/builtins/IteratorHelpers.js
+++ b/Source/JavaScriptCore/builtins/IteratorHelpers.js
@@ -56,7 +56,7 @@ function performIteration(iterable)
 @linkTimeConstant
 function wrappedIterator(iterator)
 {
-    let wrapper = @Object.@create(null);
+    var wrapper = @Object.@create(null);
     wrapper.@@iterator = function() { return iterator; }
     return wrapper;
 }
@@ -72,7 +72,7 @@ function builtinSetIterable(set)
     // Using the private @@iterator only guarantees that the symbol itself has not been modified, but does not protect
     // against the iterator itself having been replaced. For Sets, `@values` has a copy of the function originally
     // placed at `Symbol.iterator`.
-    let iteratorFunction = set.@values;
+    var iteratorFunction = set.@values;
     
     return @wrappedIterator(iteratorFunction.@call(set));
 }
@@ -88,7 +88,7 @@ function builtinMapIterable(map)
     // Using the private @@iterator only guarantees that the symbol itself has not been modified, but does not protect
     // against the iterator itself having been replaced. For Maps, `@entries` has a copy of the function originally
     // placed at `Symbol.iterator`.
-    let iteratorFunction = map.@entries;
+    var iteratorFunction = map.@entries;
 
     return @wrappedIterator(iteratorFunction.@call(map));
 }


### PR DESCRIPTION
#### d7bdc4ae05980d538508f43938c1e1ee21b844bd
<pre>
[JSC] Use `var` instead of `let` in built-in `IteratorHelpers.js`
<a href="https://bugs.webkit.org/show_bug.cgi?id=274453">https://bugs.webkit.org/show_bug.cgi?id=274453</a>

Reviewed by Alexey Shvayka.

In the built-in JS files, `var` was adopted instead of `let` / `const` by 219251@main[1]. However,
in the functions in `IteratorHelpers.js` added by 250474@main[2], `let` is used.

This patch changes to use `var` instead of `let`.

[1]: <a href="https://commits.webkit.org/219251@main">https://commits.webkit.org/219251@main</a>
[2]: <a href="https://commits.webkit.org/250474@main">https://commits.webkit.org/250474@main</a>

* Source/JavaScriptCore/builtins/IteratorHelpers.js:
(set linkTimeConstant.builtinMapIterable):

Canonical link: <a href="https://commits.webkit.org/279180@main">https://commits.webkit.org/279180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a7630a605bfb65318e0d59f284f16e2b0bc1302

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42750 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2170 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54714 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23848 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2697 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1498 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45967 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57486 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52126 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50143 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49414 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29891 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64432 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28727 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12217 "Passed tests") | 
<!--EWS-Status-Bubble-End-->