### PR TITLE
[Skia] Use a different GL context on every thread

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -262,6 +262,9 @@ GLContext* PlatformDisplay::sharingGLContext()
 
 void PlatformDisplay::clearSharingGLContext()
 {
+#if USE(SKIA)
+    invalidateSkiaGLContexts();
+#endif
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     m_gstGLContext = nullptr;
 #endif

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -61,11 +61,15 @@ typedef struct _GstGLDisplay GstGLDisplay;
 
 #if USE(SKIA)
 #include <skia/gpu/GrDirectContext.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #endif
 
 namespace WebCore {
 
 class GLContext;
+#if USE(SKIA)
+class SkiaGLContext;
+#endif
 
 class PlatformDisplay {
     WTF_MAKE_NONCOPYABLE(PlatformDisplay); WTF_MAKE_FAST_ALLOCATED;
@@ -141,7 +145,7 @@ public:
 
 #if USE(SKIA)
     GLContext* skiaGLContext();
-    GrDirectContext* skiaGrContext() { RELEASE_ASSERT(m_skiaGLContext); return m_skiaGrContext.get(); }
+    GrDirectContext* skiaGrContext();
 #endif
 
 #if USE(LCMS)
@@ -199,6 +203,10 @@ protected:
 private:
     static std::unique_ptr<PlatformDisplay> createPlatformDisplay();
 
+#if USE(SKIA)
+    void invalidateSkiaGLContexts();
+#endif
+
 #if ENABLE(WEBGL) && !PLATFORM(WIN)
     void clearANGLESharingGLContext();
 #endif
@@ -226,8 +234,7 @@ private:
 #endif
 
 #if USE(SKIA)
-    std::unique_ptr<GLContext> m_skiaGLContext;
-    sk_sp<GrDirectContext> m_skiaGrContext;
+    ThreadSafeWeakHashSet<SkiaGLContext> m_skiaGLContexts;
 #endif
 
 #if PLATFORM(WPE)

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -29,16 +29,18 @@
 #if USE(SKIA)
 #include "GLContext.h"
 #include <skia/gpu/GrBackendSurface.h>
-
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
-#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
-IGNORE_CLANG_WARNINGS_END
-
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
 #include <skia/gpu/gl/GrGLInterface.h>
 #include <skia/gpu/gl/GrGLTypes.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/RunLoop.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+IGNORE_CLANG_WARNINGS_END
 
 #if USE(LIBEPOXY)
 #include <skia/gpu/gl/epoxy/GrGLMakeEpoxyEGLInterface.h>
@@ -61,29 +63,101 @@ static sk_sp<const GrGLInterface> skiaGLInterface()
 
     return interface.get();
 }
+
+static thread_local RefPtr<SkiaGLContext> s_skiaGLContext;
+
+class SkiaGLContext : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SkiaGLContext> {
+public:
+    static Ref<SkiaGLContext> create(PlatformDisplay& display)
+    {
+        return adoptRef(*new SkiaGLContext(display));
+    }
+
+    ~SkiaGLContext() = default;
+
+    void invalidate()
+    {
+        if (&RunLoop::current() == m_runLoop) {
+            invalidateOnCurrentThread();
+            return;
+        }
+
+        BinarySemaphore semaphore;
+        m_runLoop->dispatch([&semaphore, this] {
+            invalidateOnCurrentThread();
+            semaphore.signal();
+        });
+        semaphore.wait();
+    }
+
+    GLContext* skiaGLContext() const
+    {
+        Locker locker { m_lock };
+        return m_skiaGLContext.get();
+    }
+
+    GrDirectContext* skiaGrContext() const
+    {
+        Locker locker { m_lock };
+        return m_skiaGrContext.get();
+    }
+
+private:
+    explicit SkiaGLContext(PlatformDisplay& display)
+        : m_runLoop(&RunLoop::current())
+    {
+        auto glContext = GLContext::createOffscreen(display);
+        if (!glContext || !glContext->makeContextCurrent())
+            return;
+
+        // FIXME: add GrContextOptions, shader cache, etc.
+        if (auto grContext = GrDirectContexts::MakeGL(skiaGLInterface())) {
+            m_skiaGLContext = WTFMove(glContext);
+            m_skiaGrContext = WTFMove(grContext);
+        }
+    }
+
+    void invalidateOnCurrentThread()
+    {
+        Locker locker { m_lock };
+        m_skiaGrContext = nullptr;
+        m_skiaGLContext = nullptr;
+    }
+
+    RunLoop* m_runLoop { nullptr };
+    std::unique_ptr<GLContext> m_skiaGLContext WTF_GUARDED_BY_LOCK(m_lock);
+    sk_sp<GrDirectContext> m_skiaGrContext WTF_GUARDED_BY_LOCK(m_lock);
+    mutable Lock m_lock;
+};
 #endif
 
 GLContext* PlatformDisplay::skiaGLContext()
 {
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [this] {
-        // The PlayStation OpenGL implementation does not dispatch to the context bound to
-        //  the current thread so Skia cannot use OpenGL with coordinated graphics
 #if !(PLATFORM(PLAYSTATION) && USE(COORDINATED_GRAPHICS))
-        auto skiaGLContext = GLContext::createOffscreen(*this);
-        if (!skiaGLContext || !skiaGLContext->makeContextCurrent())
-            return;
-
-        // FIXME: add GrContextOptions, shader cache, etc.
-        if (auto skiaGrContext = GrDirectContexts::MakeGL(skiaGLInterface())) {
-            m_skiaGLContext = WTFMove(skiaGLContext);
-            m_skiaGrContext = WTFMove(skiaGrContext);
-        }
+    if (!s_skiaGLContext) {
+        s_skiaGLContext = SkiaGLContext::create(*this);
+        m_skiaGLContexts.add(*s_skiaGLContext);
+    }
+    return s_skiaGLContext->skiaGLContext();
 #else
-        UNUSED_PARAM(this);
+    // The PlayStation OpenGL implementation does not dispatch to the context bound to
+    // the current thread so Skia cannot use OpenGL with coordinated graphics.
+    return nullptr;
 #endif
+}
+
+GrDirectContext* PlatformDisplay::skiaGrContext()
+{
+    RELEASE_ASSERT(s_skiaGLContext);
+    return s_skiaGLContext->skiaGrContext();
+}
+
+void PlatformDisplay::invalidateSkiaGLContexts()
+{
+    auto contexts = WTFMove(m_skiaGLContexts);
+    contexts.forEach([](auto& context) {
+        context.invalidate();
     });
-    return m_skiaGLContext.get();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 685354bc969a297feb8030122b0ab696294debd7
<pre>
[Skia] Use a different GL context on every thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=274454">https://bugs.webkit.org/show_bug.cgi?id=274454</a>

Reviewed by Miguel Gomez.

This will allow to have accelerated ImageBitmap and offscreen canvas.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::clearSharingGLContext):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
(WebCore::PlatformDisplay::skiaGrContext): Deleted.
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::skiaGLInterface):
(WebCore::SkiaGLContext::create):
(WebCore::SkiaGLContext::invalidate):
(WebCore::SkiaGLContext::skiaGLContext const):
(WebCore::SkiaGLContext::skiaGrContext const):
(WebCore::SkiaGLContext::SkiaGLContext):
(WebCore::PlatformDisplay::skiaGLContext):
(WebCore::PlatformDisplay::skiaGrContext):
(WebCore::PlatformDisplay::invalidateSkiaGLContexts):

Canonical link: <a href="https://commits.webkit.org/279119@main">https://commits.webkit.org/279119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d396bef1abc0510c29e9b4402cd9a9f8793e0ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52564 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2988 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29567 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23798 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2644 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1446 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50101 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45480 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7703 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->