### PR TITLE
support device scale factor for GraphicsLayerWC

### DIFF
--- a/Source/WebKit/Shared/NativeWebMouseEvent.h
+++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
@@ -83,7 +83,7 @@ public:
     explicit NativeWebMouseEvent(WPEEvent*);
 #endif
 #elif PLATFORM(WIN)
-    NativeWebMouseEvent(HWND, UINT message, WPARAM, LPARAM, bool);
+    NativeWebMouseEvent(HWND, UINT message, WPARAM, LPARAM, bool, float deviceScaleFactor);
 #endif
 
 #if USE(APPKIT)

--- a/Source/WebKit/Shared/NativeWebWheelEvent.h
+++ b/Source/WebKit/Shared/NativeWebWheelEvent.h
@@ -71,7 +71,7 @@ public:
 #endif
 
 #elif PLATFORM(WIN)
-    NativeWebWheelEvent(HWND, UINT message, WPARAM, LPARAM);
+    NativeWebWheelEvent(HWND, UINT message, WPARAM, LPARAM, float deviceScaleFactor);
 #endif
 
 #if USE(APPKIT)

--- a/Source/WebKit/Shared/PlatformPopupMenuData.h
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.h
@@ -44,7 +44,7 @@ struct PlatformPopupMenuData {
     int m_clientInsetLeft { 0 };
     int m_clientInsetRight { 0 };
     int m_popupWidth { 0 };
-    int m_itemHeight { 0 };
+    float m_itemHeight { 0 };
     RefPtr<WebCore::ShareableBitmap> m_notSelectedBackingStore;
     RefPtr<WebCore::ShareableBitmap> m_selectedBackingStore;
 #endif

--- a/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
@@ -33,7 +33,7 @@ struct WebKit::PlatformPopupMenuData {
     int m_clientInsetLeft;
     int m_clientInsetRight;
     int m_popupWidth;
-    int m_itemHeight;
+    float m_itemHeight;
     RefPtr<WebCore::ShareableBitmap> m_notSelectedBackingStore;
     RefPtr<WebCore::ShareableBitmap> m_selectedBackingStore;
 #endif

--- a/Source/WebKit/Shared/win/NativeWebMouseEventWin.cpp
+++ b/Source/WebKit/Shared/win/NativeWebMouseEventWin.cpp
@@ -31,8 +31,8 @@
 
 namespace WebKit {
 
-NativeWebMouseEvent::NativeWebMouseEvent(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam, bool didActivateWebView)
-    : WebMouseEvent(WebEventFactory::createWebMouseEvent(hwnd, message, wParam, lParam, didActivateWebView))
+NativeWebMouseEvent::NativeWebMouseEvent(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam, bool didActivateWebView, float deviceScaleFactor)
+    : WebMouseEvent(WebEventFactory::createWebMouseEvent(hwnd, message, wParam, lParam, didActivateWebView, deviceScaleFactor))
     , m_nativeEvent(createNativeEvent(hwnd, message, wParam, lParam))
 {
 }

--- a/Source/WebKit/Shared/win/NativeWebWheelEventWin.cpp
+++ b/Source/WebKit/Shared/win/NativeWebWheelEventWin.cpp
@@ -31,8 +31,8 @@
 
 namespace WebKit {
 
-NativeWebWheelEvent::NativeWebWheelEvent(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
-    : WebWheelEvent(WebEventFactory::createWebWheelEvent(hwnd, message, wParam, lParam))
+NativeWebWheelEvent::NativeWebWheelEvent(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam, float deviceScaleFactor)
+    : WebWheelEvent(WebEventFactory::createWebWheelEvent(hwnd, message, wParam, lParam, deviceScaleFactor))
     , m_nativeEvent(createNativeEvent(hwnd, message, wParam, lParam))
 {
 }

--- a/Source/WebKit/Shared/win/WebEventFactory.h
+++ b/Source/WebKit/Shared/win/WebEventFactory.h
@@ -40,8 +40,8 @@ namespace WebKit {
 
 class WebEventFactory {
 public:
-    static WebMouseEvent createWebMouseEvent(HWND, UINT message, WPARAM, LPARAM, bool didActivateWebView);
-    static WebWheelEvent createWebWheelEvent(HWND, UINT message, WPARAM, LPARAM);
+    static WebMouseEvent createWebMouseEvent(HWND, UINT message, WPARAM, LPARAM, bool didActivateWebView, float deviceScaleFactor);
+    static WebWheelEvent createWebWheelEvent(HWND, UINT message, WPARAM, LPARAM, float deviceScaleFactor);
     static WebKeyboardEvent createWebKeyboardEvent(HWND, UINT message, WPARAM, LPARAM);
 #if ENABLE(TOUCH_EVENTS)
     static WebTouchEvent createWebTouchEvent();

--- a/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
+++ b/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
@@ -109,7 +109,7 @@ static void doMouseButtonEvent(WebPageProxy& page, MouseInteraction interaction,
     }
 
     auto hwnd = reinterpret_cast<HWND>(page.viewWidget());
-    page.handleMouseEvent(NativeWebMouseEvent(hwnd, message, wparam, lparam, { }));
+    page.handleMouseEvent(NativeWebMouseEvent(hwnd, message, wparam, lparam, { }, page.deviceScaleFactor()));
 }
 
 void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, MouseInteraction interaction, MouseButton button, const WebCore::IntPoint& locationInView, OptionSet<WebEventModifier> keyModifiers, const String& pointerType)

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -345,6 +345,7 @@ void WebInspectorUIProxy::platformAttach()
     static const unsigned defaultAttachedSize = 300;
     static const unsigned minimumAttachedWidth = 750;
     static const unsigned minimumAttachedHeight = 250;
+    auto deviceScaleFactor = inspectorPage()->deviceScaleFactor();
 
     if (m_inspectorDetachWindow && ::GetParent(m_inspectorViewWindow) == m_inspectorDetachWindow) {
         ::SetParent(m_inspectorViewWindow, m_inspectedViewParentWindow);
@@ -357,11 +358,11 @@ void WebInspectorUIProxy::platformAttach()
     ::GetClientRect(m_inspectedViewWindow, &inspectedWindowRect);
 
     if (m_attachmentSide == AttachmentSide::Bottom) {
-        unsigned inspectedWindowHeight = inspectedWindowRect.bottom - inspectedWindowRect.top;
+        unsigned inspectedWindowHeight = (inspectedWindowRect.bottom - inspectedWindowRect.top) / deviceScaleFactor;
         unsigned maximumAttachedHeight = inspectedWindowHeight * 3 / 4;
         platformSetAttachedWindowHeight(std::max(minimumAttachedHeight, std::min(defaultAttachedSize, maximumAttachedHeight)));
     } else {
-        unsigned inspectedWindowWidth = inspectedWindowRect.right - inspectedWindowRect.left;
+        unsigned inspectedWindowWidth = (inspectedWindowRect.right - inspectedWindowRect.left) / deviceScaleFactor;
         unsigned maximumAttachedWidth = inspectedWindowWidth * 3 / 4;
         platformSetAttachedWindowWidth(std::max(minimumAttachedWidth, std::min(defaultAttachedSize, maximumAttachedWidth)));
     }
@@ -396,6 +397,8 @@ void WebInspectorUIProxy::platformDetach()
 
 void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
 {
+    auto deviceScaleFactor = inspectorPage()->deviceScaleFactor();
+    height *= deviceScaleFactor;
     auto windowInfo = getInspectedWindowInfo(m_inspectedViewWindow, m_inspectedViewParentWindow);
     ::SetWindowPos(m_inspectorViewWindow, 0, windowInfo.left, windowInfo.parentHeight - height, windowInfo.parentWidth - windowInfo.left, height, SWP_NOZORDER);
     ::SetWindowPos(m_inspectedViewWindow, 0, windowInfo.left, windowInfo.top, windowInfo.parentWidth - windowInfo.left, windowInfo.parentHeight - windowInfo.top, SWP_NOZORDER);
@@ -403,6 +406,8 @@ void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
 
 void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
 {
+    auto deviceScaleFactor = inspectorPage()->deviceScaleFactor();
+    width *= deviceScaleFactor;
     auto windowInfo = getInspectedWindowInfo(m_inspectedViewWindow, m_inspectedViewParentWindow);
     ::SetWindowPos(m_inspectorViewWindow, 0, windowInfo.parentWidth - width, windowInfo.top, width, windowInfo.parentHeight - windowInfo.top, SWP_NOZORDER);
     ::SetWindowPos(m_inspectedViewWindow, 0, windowInfo.left, windowInfo.top, windowInfo.parentWidth - windowInfo.left, windowInfo.parentHeight - windowInfo.top, SWP_NOZORDER);

--- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
+++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
@@ -101,8 +101,7 @@ void BackingStore::incorporateUpdate(UpdateInfo&& updateInfo)
         return;
 
 #if ASSERT_ENABLED
-    IntSize updateSize = updateInfo.updateRectBounds.size();
-    updateSize.scale(m_deviceScaleFactor);
+    IntSize updateSize = expandedIntSize(updateInfo.updateRectBounds.size() * m_deviceScaleFactor);
     ASSERT(bitmap->size() == updateSize);
 #endif
 

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -55,11 +55,16 @@ void DrawingAreaProxyWC::paint(PlatformPaintContextPtr context, const WebCore::I
     unpaintedRegion.subtract(WebCore::IntRect({ }, m_backingStore->size()));
 }
 
+void DrawingAreaProxyWC::deviceScaleFactorDidChange()
+{
+    sizeDidChange();
+}
+
 void DrawingAreaProxyWC::sizeDidChange()
 {
     discardBackingStore();
     m_currentBackingStoreStateID++;
-    send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size));
+    send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size, m_webPageProxy->deviceScaleFactor()));
 }
 
 void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, UpdateInfo&& updateInfo)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -44,7 +44,7 @@ public:
 
 private:
     // DrawingAreaProxy
-    void deviceScaleFactorDidChange() override { }
+    void deviceScaleFactorDidChange() override;
     void sizeDidChange() override;
     bool shouldSendWheelEventsToEventDispatcher() const final { return true; }
 

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -79,10 +79,7 @@ WebCore::FloatPoint PageClientImpl::viewScrollPosition()
 
 WebCore::IntSize PageClientImpl::viewSize()
 {
-    RECT clientRect;
-    GetClientRect(m_view.window(), &clientRect);
-
-    return IntRect(clientRect).size();
+    return m_view.viewSize();
 }
 
 bool PageClientImpl::isViewWindowActive()

--- a/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp
@@ -94,7 +94,9 @@ void WebContextMenuProxyWin::showContextMenuWithItems(Vector<Ref<WebContextMenuI
     populate(m_context, m_menu, items);
 
     UINT flags = TPM_RIGHTBUTTON | TPM_TOPALIGN | TPM_VERPOSANIMATION | TPM_HORIZONTAL | TPM_LEFTALIGN | TPM_HORPOSANIMATION;
-    POINT pt { m_context.menuLocation().x(), m_context.menuLocation().y() };
+    auto location = m_context.menuLocation();
+    location.scale(page()->deviceScaleFactor());
+    POINT pt = location;
     HWND wnd = reinterpret_cast<HWND>(page()->viewWidget());
     ::ClientToScreen(wnd, &pt);
     ::TrackPopupMenuEx(m_menu, flags, pt.x, pt.y, wnd, nullptr);

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -350,74 +350,94 @@ void WebPopupMenuProxyWin::hidePopupMenu()
 
 void WebPopupMenuProxyWin::calculatePositionAndSize(const IntRect& rect)
 {
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
     IntRect rectInScreenCoords(rect);
-    rectInScreenCoords.scale(m_scaleFactor);
+    rectInScreenCoords.scale(m_scaleFactor * deviceScaleFactor);
 
-    POINT location(rectInScreenCoords .location());
+    POINT location(rectInScreenCoords.location());
     if (!::ClientToScreen(m_webView->window(), &location))
         return;
     rectInScreenCoords.setLocation(location);
 
     int itemCount = m_items.size();
     m_itemHeight = m_data.m_itemHeight;
+    int itemHeightInDevicePixel = m_itemHeight * deviceScaleFactor;
+    int clientInsetLeftInDevicePixel = m_data.m_clientInsetLeft * deviceScaleFactor;
+    int clientInsetRightInDevicePixel = m_data.m_clientInsetRight * deviceScaleFactor;
 
-    int naturalHeight = m_itemHeight * itemCount;
-    int popupHeight = std::min(maxPopupHeight, naturalHeight);
+    int naturalHeight = itemHeightInDevicePixel * itemCount;
+    int maxPopupHeightInDevicePixel = maxPopupHeight * deviceScaleFactor;
+    int popupHeight = std::min(maxPopupHeightInDevicePixel, naturalHeight);
 
-    // The popup should show an integral number of items (i.e. no partial items should be visible)
-    popupHeight -= popupHeight % m_itemHeight;
+    auto adjustPopupRect = [itemHeightInDevicePixel](IntRect popupRect) -> IntRect {
+        // The popup should show an integral number of items (i.e. no partial items should be visible)
+        int height = popupRect.height();
+        height -= height % itemHeightInDevicePixel;
+        popupRect.setHeight(height);
+
+        // Set window rect with border
+        RECT rect = popupRect;
+        ::AdjustWindowRectEx(&rect, WS_POPUP | WS_BORDER, false, WS_EX_LTRREADING);
+        popupRect = rect;
+        return popupRect;
+    };
 
     // Next determine its width
     int popupWidth = m_data.m_popupWidth;
 
-    if (naturalHeight > maxPopupHeight) {
+    if (naturalHeight > maxPopupHeightInDevicePixel) {
         // We need room for a scrollbar
         popupWidth += ScrollbarTheme::theme().scrollbarThickness(ScrollbarWidth::Thin);
     }
 
-    popupHeight += 2 * popupWindowBorderWidth;
+    popupWidth *= deviceScaleFactor;
+
+    IntRect popupRectWithBorder(0, 0, popupWidth, popupHeight);
+    popupRectWithBorder = adjustPopupRect(popupRectWithBorder);
 
     // The popup should be at least as wide as the control on the page
-    popupWidth = std::max(rectInScreenCoords.width() - m_data.m_clientInsetLeft - m_data.m_clientInsetRight, popupWidth);
+    popupWidth = std::max(rectInScreenCoords.width() - clientInsetLeftInDevicePixel - clientInsetRightInDevicePixel, popupRectWithBorder.width());
+    popupRectWithBorder.setWidth(popupWidth);
 
     // Always left-align items in the popup. This matches popup menus on the mac.
-    int popupX = rectInScreenCoords.x() + m_data.m_clientInsetLeft;
+    int popupX = rectInScreenCoords.x() + clientInsetLeftInDevicePixel;
 
-    IntRect popupRect(popupX, rectInScreenCoords.maxY(), popupWidth, popupHeight);
+    popupRectWithBorder.setLocation(IntPoint(popupX, rectInScreenCoords.maxY()));
 
     // The popup needs to stay within the bounds of the screen and not overlap any toolbars
     HMONITOR monitor = ::MonitorFromWindow(m_webView->window(), MONITOR_DEFAULTTOPRIMARY);
     MONITORINFOEX monitorInfo;
     monitorInfo.cbSize = sizeof(MONITORINFOEX);
     ::GetMonitorInfo(monitor, &monitorInfo);
-    FloatRect screen = static_cast<IntRect>(monitorInfo.rcWork);
+    IntRect screen = static_cast<IntRect>(monitorInfo.rcWork);
 
     // Check that we don't go off the screen vertically
-    if (popupRect.maxY() > screen.height()) {
+    if (popupRectWithBorder.maxY() > screen.height()) {
         // The popup will go off the screen, so try placing it above the client
-        if (rectInScreenCoords.y() - popupRect.height() < 0) {
+        if (rectInScreenCoords.y() - popupRectWithBorder.height() < 0) {
             // The popup won't fit above, either, so place it whereever's bigger and resize it to fit
             if ((rectInScreenCoords.y() + rectInScreenCoords.height() / 2) < (screen.height() / 2)) {
                 // Below is bigger
-                popupRect.setHeight(screen.height() - popupRect.y());
+                int popupRectHeight = screen.height() - popupRectWithBorder.y();
+                popupRectWithBorder.setHeight(popupRectHeight);
+                IntRect adjustedPopupRect = adjustPopupRect(popupRectWithBorder);
+                popupRectWithBorder.setHeight(adjustedPopupRect.height());
+
             } else {
                 // Above is bigger
-                popupRect.setY(0);
-                popupRect.setHeight(rectInScreenCoords.y());
+                int popupRectHeight = rectInScreenCoords.y();
+                popupRectWithBorder.setHeight(popupRectHeight);
+                IntRect adjustedPopupRect = adjustPopupRect(popupRectWithBorder);
+                popupRectWithBorder.setHeight(adjustedPopupRect.height());
+                popupRectWithBorder.setY(rectInScreenCoords.y() - popupRectWithBorder.height());
             }
         } else {
             // The popup fits above, so reposition it
-            popupRect.setY(rectInScreenCoords.y() - popupRect.height());
+            popupRectWithBorder.setY(rectInScreenCoords.y() - popupRectWithBorder.height());
         }
     }
 
-    // Check that we don't go off the screen horizontally
-    if (popupRect.x() < screen.x()) {
-        popupRect.setWidth(popupRect.width() - (screen.x() - popupRect.x()));
-        popupRect.setX(screen.x());
-    }
-
-    m_windowRect = popupRect;
+    m_windowRect = popupRectWithBorder;
 }
 
 IntRect WebPopupMenuProxyWin::clientRect() const
@@ -433,11 +453,11 @@ void WebPopupMenuProxyWin::invalidateItem(int index)
     if (!m_popup)
         return;
 
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
     IntRect damageRect(clientRect());
-    damageRect.setY(m_itemHeight * (index - m_scrollOffset));
-    damageRect.setHeight(m_itemHeight);
-    if (m_scrollbar)
-        damageRect.setWidth(damageRect.width() - m_scrollbar->frameRect().width());
+    float itemHeightInDevicePixel = m_itemHeight * deviceScaleFactor;
+    damageRect.setY(itemHeightInDevicePixel * (index - m_scrollOffset));
+    damageRect.setHeight(ceil(itemHeightInDevicePixel));
 
     RECT r = damageRect;
     ::InvalidateRect(m_popup, &r, TRUE);
@@ -453,6 +473,8 @@ void WebPopupMenuProxyWin::setScrollOffset(const IntPoint& offset)
     scrollTo(offset.y());
 }
 
+// Below two functions use Logical Pixel based size.
+// These functions called by ScrollableArea.cpp
 IntSize WebPopupMenuProxyWin::visibleSize() const
 {
     int scrollbarWidth = m_scrollbar ? m_scrollbar->frameRect().width() : 0;
@@ -461,7 +483,9 @@ IntSize WebPopupMenuProxyWin::visibleSize() const
 
 WebCore::IntSize WebPopupMenuProxyWin::contentsSize() const
 {
-    return IntSize(m_windowRect.width(), m_scrollbar ? m_scrollbar->totalSize() : m_windowRect.height());
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    FloatSize scaledSize(m_windowRect.width() / deviceScaleFactor, m_scrollbar ? m_scrollbar->totalSize() : m_windowRect.height() / deviceScaleFactor);
+    return expandedIntSize(scaledSize);
 }
 
 WebCore::IntRect WebPopupMenuProxyWin::scrollableAreaBoundingBox(bool*) const
@@ -492,12 +516,15 @@ void WebPopupMenuProxyWin::scrollTo(int offset)
 #endif
 
     IntRect listRect = clientRect();
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
     if (m_scrollbar)
-        listRect.setWidth(listRect.width() - m_scrollbar->frameRect().width());
+        listRect.setWidth(m_scrollbar->location().x() * deviceScaleFactor);
     RECT r = listRect;
-    ::ScrollWindowEx(m_popup, 0, scrolledLines * m_itemHeight, &r, 0, 0, 0, flags);
+    ::ScrollWindowEx(m_popup, 0, ceil(scrolledLines * m_itemHeight * deviceScaleFactor), &r, 0, 0, 0, flags);
     if (m_scrollbar) {
-        r = m_scrollbar->frameRect();
+        IntRect scrollRect = m_scrollbar->frameRect();
+        scrollRect.scale(deviceScaleFactor);
+        r = scrollRect;
         ::InvalidateRect(m_popup, &r, TRUE);
     }
     ::UpdateWindow(m_popup);
@@ -507,6 +534,7 @@ void WebPopupMenuProxyWin::invalidateScrollbarRect(Scrollbar& scrollbar, const I
 {
     IntRect scrollRect = rect;
     scrollRect.move(scrollbar.x(), scrollbar.y());
+    scrollRect.scale(m_webView->page()->deviceScaleFactor());
     RECT r = scrollRect;
     ::InvalidateRect(m_popup, &r, false);
 }
@@ -526,7 +554,9 @@ LRESULT WebPopupMenuProxyWin::onSize(HWND hWnd, UINT message, WPARAM, LPARAM lPa
         return 0;
 
     IntSize size(LOWORD(lParam), HIWORD(lParam));
-    m_scrollbar->setFrameRect(IntRect(size.width() - m_scrollbar->width(), 0, m_scrollbar->width(), size.height()));
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    IntSize scaledSize(ceil(size.width() / deviceScaleFactor), ceil(size.height() / deviceScaleFactor));
+    m_scrollbar->setFrameRect(IntRect(scaledSize.width() - m_scrollbar->width(), 0, m_scrollbar->width(), scaledSize.height()));
 
     int visibleItems = this->visibleItems();
     m_scrollbar->setEnabled(visibleItems < m_items.size());
@@ -630,7 +660,9 @@ LRESULT WebPopupMenuProxyWin::onMouseMove(HWND hWnd, UINT message, WPARAM wParam
 {
     handled = true;
 
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
     IntPoint mousePoint(MAKEPOINTS(lParam));
+    mousePoint.scale(1 / deviceScaleFactor);
     if (m_scrollbar) {
         IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollbarCapturingMouse() || scrollBarRect.contains(mousePoint)) {
@@ -648,6 +680,9 @@ LRESULT WebPopupMenuProxyWin::onMouseMove(HWND hWnd, UINT message, WPARAM wParam
 
     RECT bounds;
     ::GetClientRect(m_popup, &bounds);
+    FloatRect scaledBounds(bounds);
+    scaledBounds.scale(1 / deviceScaleFactor);
+    bounds = enclosingIntRect(scaledBounds);
     if (!::PtInRect(&bounds, mousePoint) && !(wParam & MK_LBUTTON)) {
         // When the mouse is not inside the popup menu and the left button isn't down, just
         // repost the message to the web view.
@@ -671,7 +706,9 @@ LRESULT WebPopupMenuProxyWin::onLButtonDown(HWND hWnd, UINT message, WPARAM wPar
 {
     handled = true;
 
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
     IntPoint mousePoint(MAKEPOINTS(lParam));
+    mousePoint.scale((1/ deviceScaleFactor));
     if (m_scrollbar) {
         IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollBarRect.contains(mousePoint)) {
@@ -688,6 +725,9 @@ LRESULT WebPopupMenuProxyWin::onLButtonDown(HWND hWnd, UINT message, WPARAM wPar
     // hide the popup.
     RECT bounds;
     ::GetClientRect(m_popup, &bounds);
+    FloatRect scaledBounds(bounds);
+    scaledBounds.scale(1 / deviceScaleFactor);
+    bounds = enclosingIntRect(scaledBounds);
     if (::PtInRect(&bounds, mousePoint)) {
         setFocusedIndex(listIndexAtPoint(mousePoint), true);
         m_hoveredIndex = listIndexAtPoint(mousePoint);
@@ -702,7 +742,9 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
 {
     handled = true;
 
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
     IntPoint mousePoint(MAKEPOINTS(lParam));
+    mousePoint.scale(1 / deviceScaleFactor);
     if (m_scrollbar) {
         IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollbarCapturingMouse() || scrollBarRect.contains(mousePoint)) {
@@ -712,6 +754,7 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
             PlatformMouseEvent event(hWnd, message, wParam, makeScaledPoint(mousePoint, m_scaleFactor));
             m_scrollbar->mouseUp(event);
             // FIXME: This is a hack to work around Scrollbar not invalidating correctly when it doesn't have a parent widget
+            scrollBarRect.scale(deviceScaleFactor);
             RECT r = scrollBarRect;
             ::InvalidateRect(m_popup, &r, TRUE);
             return 0;
@@ -720,6 +763,9 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
     // Only hide the popup if the mouse is inside the popup window.
     RECT bounds;
     ::GetClientRect(m_popup, &bounds);
+    FloatRect scaledBounds(bounds);
+    scaledBounds.scale(1 / deviceScaleFactor);
+    bounds = enclosingIntRect(scaledBounds);
     if (::PtInRect(&bounds, mousePoint)) {
         hide();
         int index = m_hoveredIndex;
@@ -841,18 +887,29 @@ void WebPopupMenuProxyWin::paint(const IntRect& damageRect, HDC hdc)
 
     GraphicsContextCairo context(m_DC.get());
 
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float itemHeightInDevicePixel = m_itemHeight * deviceScaleFactor;
+
     IntRect translatedDamageRect = damageRect;
-    translatedDamageRect.move(IntSize(0, m_scrollOffset * m_itemHeight));
+    translatedDamageRect.move(IntSize(0, m_scrollOffset * itemHeightInDevicePixel));
     m_data.m_notSelectedBackingStore->paint(context, damageRect.location(), translatedDamageRect);
 
-    IntRect selectedIndexRectInBackingStore(0, focusedIndex() * m_itemHeight, m_data.m_selectedBackingStore->size().width(), m_itemHeight);
+    IntRect selectedIndexRectInBackingStore(0, focusedIndex() * itemHeightInDevicePixel, m_data.m_selectedBackingStore->size().width(), itemHeightInDevicePixel);
     IntPoint selectedIndexDstPoint = selectedIndexRectInBackingStore.location();
-    selectedIndexDstPoint.move(0, -m_scrollOffset * m_itemHeight);
+    selectedIndexDstPoint.move(0, -m_scrollOffset * itemHeightInDevicePixel);
 
     m_data.m_selectedBackingStore->paint(context, selectedIndexDstPoint, selectedIndexRectInBackingStore);
 
-    if (m_scrollbar)
-        m_scrollbar->paint(context, damageRect);
+    if (m_scrollbar) {
+        context.save();
+        context.applyDeviceScaleFactor(deviceScaleFactor);
+
+        IntRect scaledDamageRect = damageRect;
+        scaledDamageRect.scale(1 / deviceScaleFactor);
+        m_scrollbar->paint(context, scaledDamageRect);
+
+        context.restore();
+    }
 
     HWndDC hWndDC;
     HDC localDC = hdc ? hdc : hWndDC.setHWnd(m_popup);
@@ -885,7 +942,7 @@ bool WebPopupMenuProxyWin::setFocusedIndex(int i, bool hotTracking)
 
 int WebPopupMenuProxyWin::visibleItems() const
 {
-    return clientRect().height() / m_itemHeight;
+    return clientRect().height() / (m_itemHeight * m_webView->page()->deviceScaleFactor());
 }
 
 int WebPopupMenuProxyWin::listIndexAtPoint(const IntPoint& point) const

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -141,7 +141,7 @@ private:
     HWND m_popup { nullptr };
     WebCore::IntRect m_windowRect;
 
-    int m_itemHeight { 0 };
+    float m_itemHeight { 0 };
     int m_scrollOffset { 0 };
     int m_wheelDelta { 0 };
     int m_focusedIndex { 0 };

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -43,9 +43,11 @@
 #include "WebProcessPool.h"
 #include <Commctrl.h>
 #include <WebCore/BitmapInfo.h>
+#include <WebCore/CairoUtilities.h>
 #include <WebCore/Cursor.h>
 #include <WebCore/Editor.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/GDIUtilities.h>
 #include <WebCore/HWndDC.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/NotImplemented.h>
@@ -236,10 +238,7 @@ WebView::WebView(RECT rect, const API::PageConfiguration& configuration, HWND pa
     m_page = processPool.createWebPage(*m_pageClient, WTFMove(pageConfiguration));
     m_page->initializeWebPage();
 
-    IntSize windowSize(rect.right - rect.left, rect.bottom - rect.top);
-
-    if (m_page->drawingArea())
-        m_page->drawingArea()->setSize(windowSize);
+    m_page->setIntrinsicDeviceScaleFactor(deviceScaleFactorForWindow(m_window));
 
 #if ENABLE(REMOTE_INSPECTOR)
     m_page->setURLSchemeHandlerForScheme(RemoteInspectorProtocolHandler::create(*m_page), "inspector"_s);
@@ -333,7 +332,7 @@ void WebView::windowAncestryDidChange()
 
 LRESULT WebView::onMouseEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam, bool& handled)
 {
-    NativeWebMouseEvent mouseEvent = NativeWebMouseEvent(hWnd, message, wParam, lParam, m_wasActivatedByMouseEvent);
+    NativeWebMouseEvent mouseEvent = NativeWebMouseEvent(hWnd, message, wParam, lParam, m_wasActivatedByMouseEvent, m_page->deviceScaleFactor());
     setWasActivatedByMouseEvent(false);
 
     switch (message) {
@@ -370,7 +369,7 @@ LRESULT WebView::onMouseEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
 
 LRESULT WebView::onWheelEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam, bool& handled)
 {
-    NativeWebWheelEvent wheelEvent(hWnd, message, wParam, lParam);
+    NativeWebWheelEvent wheelEvent(hWnd, message, wParam, lParam, m_page->deviceScaleFactor());
     if (wheelEvent.controlKey()) {
         // We do not want WebKit to handle Control + Wheel, this should be handled by the client application
         // to zoom the page.
@@ -467,13 +466,16 @@ LRESULT WebView::onKeyEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
     return 0;
 }
 
-static void drawPageBackground(HDC dc, const WebPageProxy* page, const RECT& rect)
+static void drawPageBackground(HDC dc, const WebPageProxy* page, const IntRect& rect)
 {
     auto& backgroundColor = page->backgroundColor();
     if (!backgroundColor || backgroundColor.value().isVisible())
         return;
 
-    ::FillRect(dc, &rect, reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1));
+    auto scaledRect = rect;
+    scaledRect.scale(page->deviceScaleFactor());
+    RECT viewRect = scaledRect;
+    ::FillRect(dc, &viewRect, reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1));
 }
 
 void WebView::paint(HDC hdc, const IntRect& dirtyRect)
@@ -487,8 +489,10 @@ void WebView::paint(HDC hdc, const IntRect& dirtyRect)
             Region unpaintedRegion;
 #if USE(CAIRO)
             cairo_surface_t* surface = cairo_win32_surface_create(hdc);
+            auto deviceScaleFactor = m_page->deviceScaleFactor();
+            cairo_surface_set_device_scale(surface, deviceScaleFactor, deviceScaleFactor);
             cairo_t* context = cairo_create(surface);
-    
+
             drawingArea->paint(context, dirtyRect, unpaintedRegion);
     
             cairo_destroy(context);
@@ -522,7 +526,9 @@ LRESULT WebView::onPaintEvent(HWND hWnd, UINT message, WPARAM, LPARAM, bool& han
 
     PAINTSTRUCT paintStruct;
     HDC hdc = ::BeginPaint(m_window, &paintStruct);
-    paint(hdc, paintStruct.rcPaint);
+    FloatRect dirtyRect(paintStruct.rcPaint);
+    dirtyRect.scale(1 / m_page->deviceScaleFactor());
+    paint(hdc, enclosingIntRect(dirtyRect));
 
     ::EndPaint(m_window, &paintStruct);
 
@@ -544,14 +550,13 @@ LRESULT WebView::onPrintClientEvent(HWND hWnd, UINT, WPARAM wParam, LPARAM, bool
 
 LRESULT WebView::onSizeEvent(HWND hwnd, UINT, WPARAM, LPARAM lParam, bool& handled)
 {
-    int width = LOWORD(lParam);
-    int height = HIWORD(lParam);
-
-    IntSize windowSize(width, height);
+    // If there are no m_page, use intrinsic device scale factor.
+    float deviceScaleFactor = m_page ? m_page->deviceScaleFactor() : deviceScaleFactorForWindow(hwnd);
+    m_viewSize = expandedIntSize(FloatSize(LOWORD(lParam), HIWORD(lParam)) / deviceScaleFactor);
 
     if (m_page && m_page->drawingArea()) {
         // FIXME specify correctly layerPosition.
-        m_page->drawingArea()->setSize(windowSize, m_nextResizeScrollOffset);
+        m_page->drawingArea()->setSize(m_viewSize, m_nextResizeScrollOffset);
         m_nextResizeScrollOffset = IntSize();
     }
 
@@ -854,12 +859,15 @@ void WebView::setScrollOffsetOnNextResize(const IntSize& scrollOffset)
 {
     // The next time we get a WM_SIZE message, scroll by the specified amount in onSizeEvent().
     m_nextResizeScrollOffset = scrollOffset;
+    m_nextResizeScrollOffset.scale(1 / m_page->deviceScaleFactor());
 }
 
 void WebView::setViewNeedsDisplay(const WebCore::Region& region)
 {
-    const RECT r = region.bounds();
-    ::InvalidateRect(m_window, &r, true);
+    auto rect = region.bounds();
+    rect.scale(m_page->deviceScaleFactor());
+    const RECT viewRect(rect);
+    ::InvalidateRect(m_window, &viewRect, true);
 }
 
 void WebView::didCommitLoadForMainFrame(bool useCustomRepresentation)

--- a/Source/WebKit/UIProcess/win/WebView.h
+++ b/Source/WebKit/UIProcess/win/WebView.h
@@ -58,6 +58,7 @@ public:
     HWND window() const { return m_window; }
     void setParentWindow(HWND);
     void windowAncestryDidChange();
+    WebCore::IntSize viewSize() { return m_viewSize; }
     void setIsInWindow(bool);
     void setIsVisible(bool);
     bool isWindowActive();
@@ -154,6 +155,7 @@ private:
 
     std::unique_ptr<WebKit::PageClientImpl> m_pageClient;
     RefPtr<WebPageProxy> m_page;
+    WebCore::IntSize m_viewSize;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -27,6 +27,7 @@
 #include "WebPopupMenu.h"
 
 #include "PlatformPopupMenuData.h"
+#include "WebPage.h"
 #include <WebCore/LengthFunctions.h>
 #include <WebCore/PopupMenuClient.h>
 #include <WebCore/RenderTheme.h>
@@ -36,10 +37,11 @@ using namespace WebCore;
 
 static const int separatorPadding = 4;
 static const int separatorHeight = 1;
-static const int popupWindowBorderWidth = 1;
 
 void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, PlatformPopupMenuData& data)
 {
+    float deviceScaleFactor = page()->deviceScaleFactor();
+
     int itemCount = m_popupClient->listSize();
 
     auto font = m_popupClient->menuStyle().font();
@@ -48,7 +50,7 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
     data.m_clientPaddingRight = m_popupClient->clientPaddingRight();
     data.m_clientInsetLeft = m_popupClient->clientInsetLeft();
     data.m_clientInsetRight = m_popupClient->clientInsetRight();
-    data.m_itemHeight = font.metricsOfPrimaryFont().intHeight() + 1;
+    data.m_itemHeight = ceil((font.metricsOfPrimaryFont().intHeight() + 1) * deviceScaleFactor) / deviceScaleFactor;
 
     int popupWidth = 0;
     for (size_t i = 0; i < itemCount; ++i) {
@@ -69,31 +71,36 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
 
     // FIXME: popupWidth should probably take into account monitor constraints as is done with WebPopupMenuProxyWin::calculatePositionAndSize.
     popupWidth += std::max(0, data.m_clientPaddingRight - data.m_clientInsetRight) + std::max(0, data.m_clientPaddingLeft - data.m_clientInsetLeft);
-    popupWidth += 2 * popupWindowBorderWidth;
     data.m_popupWidth = popupWidth;
+    popupWidth *= deviceScaleFactor;
+
+    int dropdownMenuWidthInDevicePixel = ceil((pageCoordinates.width() - m_popupClient->clientInsetLeft() - m_popupClient->clientInsetRight()) * deviceScaleFactor);
 
     // The backing stores should be drawn at least as wide as the control on the page to match the width of the popup window we'll create.
-    int backingStoreWidth = std::max(pageCoordinates.width() - m_popupClient->clientInsetLeft() - m_popupClient->clientInsetRight(), popupWidth);
+    int backingStoreWidth = std::max(dropdownMenuWidthInDevicePixel, popupWidth);
 
-    IntSize backingStoreSize(backingStoreWidth, (itemCount * data.m_itemHeight));
+    IntSize backingStoreSize(backingStoreWidth, itemCount * data.m_itemHeight * deviceScaleFactor);
     data.m_notSelectedBackingStore = ShareableBitmap::create({ backingStoreSize });
     data.m_selectedBackingStore = ShareableBitmap::create({ backingStoreSize });
 
     std::unique_ptr<GraphicsContext> notSelectedBackingStoreContext = data.m_notSelectedBackingStore->createGraphicsContext();
     std::unique_ptr<GraphicsContext> selectedBackingStoreContext = data.m_selectedBackingStore->createGraphicsContext();
 
+    notSelectedBackingStoreContext->applyDeviceScaleFactor(deviceScaleFactor);
+    selectedBackingStoreContext->applyDeviceScaleFactor(deviceScaleFactor);
+
     Color activeOptionBackgroundColor = RenderTheme::singleton().activeListBoxSelectionBackgroundColor({ });
     Color activeOptionTextColor = RenderTheme::singleton().activeListBoxSelectionForegroundColor({ });
 
-    for (int y = 0; y < backingStoreSize.height(); y += data.m_itemHeight) {
-        int index = y / data.m_itemHeight;
+    for (size_t index = 0; index < itemCount; ++index) {
+        float y = index * data.m_itemHeight;
 
         PopupMenuStyle itemStyle = m_popupClient->itemStyle(index);
 
         Color optionBackgroundColor = itemStyle.backgroundColor();
         Color optionTextColor = itemStyle.foregroundColor();
 
-        IntRect itemRect(0, y, backingStoreWidth, data.m_itemHeight);
+        FloatRect itemRect(0, y, backingStoreWidth, data.m_itemHeight);
 
         // Draw the background for this menu item
         if (itemStyle.isVisible()) {
@@ -102,7 +109,7 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
         }
 
         if (m_popupClient->itemIsSeparator(index)) {
-            IntRect separatorRect(itemRect.x() + separatorPadding, itemRect.y() + (itemRect.height() - separatorHeight) / 2, itemRect.width() - 2 * separatorPadding, separatorHeight);
+            FloatRect separatorRect(itemRect.x() + separatorPadding, itemRect.y() + (itemRect.height() - separatorHeight) / 2, itemRect.width() - 2 * separatorPadding, separatorHeight);
 
             notSelectedBackingStoreContext->fillRect(separatorRect, optionTextColor);
             selectedBackingStoreContext->fillRect(separatorRect, activeOptionTextColor);
@@ -126,21 +133,22 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
 
         // Draw the item text
         if (itemStyle.isVisible()) {
-            int textX = 0;
+            float textX = 0;
             if (m_popupClient->menuStyle().textDirection() == TextDirection::LTR) {
-                textX = std::max<int>(0, m_popupClient->clientPaddingLeft() - m_popupClient->clientInsetLeft());
+                textX = std::max<float>(0, m_popupClient->clientPaddingLeft() - m_popupClient->clientInsetLeft());
                 if (RenderTheme::singleton().popupOptionSupportsTextIndent())
-                    textX += minimumIntValueForLength(itemStyle.textIndent(), itemRect.width());
+                    textX += minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()));
             } else {
                 textX = itemRect.width() - m_popupClient->menuStyle().font().width(textRun);
-                textX = std::min<int>(textX, textX - m_popupClient->clientPaddingRight() + m_popupClient->clientInsetRight());
+                textX = std::min<float>(textX, textX - m_popupClient->clientPaddingRight() + m_popupClient->clientInsetRight());
                 if (RenderTheme::singleton().popupOptionSupportsTextIndent())
-                    textX -= minimumIntValueForLength(itemStyle.textIndent(), itemRect.width());
+                    textX -= minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()));
             }
-            int textY = itemRect.y() + itemFontCascade.metricsOfPrimaryFont().intAscent() + (itemRect.height() - itemFontCascade.metricsOfPrimaryFont().intHeight()) / 2;
+            float textY = itemRect.y() + itemFontCascade.metricsOfPrimaryFont().intAscent() + (itemRect.height() - itemFontCascade.metricsOfPrimaryFont().intHeight()) / 2;
 
-            notSelectedBackingStoreContext->drawBidiText(itemFontCascade, textRun, IntPoint(textX, textY));
-            selectedBackingStoreContext->drawBidiText(itemFontCascade, textRun, IntPoint(textX, textY));
+            FloatPoint textPoint = { textX, textY };
+            notSelectedBackingStoreContext->drawBidiText(itemFontCascade, textRun, textPoint);
+            selectedBackingStoreContext->drawBidiText(itemFontCascade, textRun, textPoint);
         }
     }
 }

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -154,7 +154,7 @@ public:
 #endif
 
 #if USE(GRAPHICS_LAYER_WC)
-    virtual void updateGeometryWC(uint64_t, WebCore::IntSize) { };
+    virtual void updateGeometryWC(uint64_t, WebCore::IntSize, float deviceScaleFactor) { };
 #endif
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -43,7 +43,7 @@ messages -> DrawingArea NotRefCounted {
 #endif
 
 #if USE(GRAPHICS_LAYER_WC)
-    UpdateGeometryWC(uint64_t backingStoreStateID, WebCore::IntSize viewSize)
+    UpdateGeometryWC(uint64_t backingStoreStateID, WebCore::IntSize viewSize, float deviceScaleFactor)
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -99,6 +99,7 @@ void DrawingAreaWC::addRootFrame(WebCore::FrameIdentifier frameID)
     auto layer = GraphicsLayer::create(graphicsLayerFactory(), this->m_rootLayerClient);
     // FIXME: This has an unnecessary string allocation. Adding a StringTypeAdapter for FrameIdentifier or ProcessQualified would remove that.
     layer->setName(makeString("drawing area root "_s, frameID.toString()));
+    layer->setAnchorPoint({ });
     m_rootLayers.append(RootLayerInfo {
         WTFMove(layer),
         nullptr,
@@ -138,9 +139,10 @@ void DrawingAreaWC::setLayerTreeStateIsFrozen(bool isFrozen)
     }
 }
 
-void DrawingAreaWC::updateGeometryWC(uint64_t backingStoreStateID, IntSize viewSize)
+void DrawingAreaWC::updateGeometryWC(uint64_t backingStoreStateID, IntSize viewSize, float deviceScaleFactor)
 {
     m_backingStoreStateID = backingStoreStateID;
+    m_webPage->setDeviceScaleFactor(deviceScaleFactor);
     m_webPage->setSize(viewSize);
 }
 
@@ -268,7 +270,10 @@ void DrawingAreaWC::sendUpdateAC()
             size = m_webPage->size();
         else
             size = frame->size();
-        rootLayer.layer->setSize(size);
+        FloatSize viewport { size };
+        viewport.scale(m_webPage->deviceScaleFactor());
+        m_updateInfo.viewport = WebCore::expandedIntSize(viewport);
+        updateRootLayerDeviceScaleFactor(rootLayer.layer);
         rootLayer.layer->flushCompositingStateForThisLayerOnly();
 
         // Because our view-relative overlay root layer is not attached to the FrameView's GraphicsLayer tree, we need to flush it manually.
@@ -297,6 +302,14 @@ void DrawingAreaWC::sendUpdateAC()
             });
         });
     }
+}
+
+void DrawingAreaWC::updateRootLayerDeviceScaleFactor(WebCore::GraphicsLayer& layer)
+{
+    float deviceScaleFactor = m_webPage->deviceScaleFactor();
+    TransformationMatrix m;
+    m.scale(deviceScaleFactor);
+    layer.setTransform(m);
 }
 
 static bool shouldPaintBoundsRect(const IntRect& bounds, const Vector<IntRect, 1>& rects)
@@ -329,9 +342,7 @@ void DrawingAreaWC::sendUpdateNonAC()
     ASSERT(webPage->bounds().contains(bounds));
     IntSize bitmapSize = bounds.size();
     float deviceScaleFactor = webPage->corePage()->deviceScaleFactor();
-    bitmapSize.scale(deviceScaleFactor);
-
-    auto image = createImageBuffer(bitmapSize);
+    auto image = createImageBuffer(bitmapSize, deviceScaleFactor);
     auto rects = m_dirtyRegion.rects();
     if (shouldPaintBoundsRect(bounds, rects)) {
         rects.clear();
@@ -341,7 +352,7 @@ void DrawingAreaWC::sendUpdateNonAC()
 
     UpdateInfo updateInfo;
     updateInfo.viewSize = webPage->size();
-    updateInfo.deviceScaleFactor = webPage->corePage()->deviceScaleFactor();
+    updateInfo.deviceScaleFactor = deviceScaleFactor;
     updateInfo.updateRectBounds = bounds;
     updateInfo.updateRects = rects;
     updateInfo.scrollRect = m_scrollRect;
@@ -350,10 +361,9 @@ void DrawingAreaWC::sendUpdateNonAC()
     m_scrollOffset = { };
 
     auto& graphicsContext = image->context();
-    graphicsContext.applyDeviceScaleFactor(deviceScaleFactor);
     graphicsContext.translate(-bounds.x(), -bounds.y());
     for (const auto& rect : rects)
-        webPage->drawRect(image->context(), rect);
+        webPage->drawRect(graphicsContext, rect);
     image->flushDrawingContextAsync();
 
     auto fence = m_webPage->ensureRemoteRenderingBackendProxy().flushImageBuffers();
@@ -396,11 +406,11 @@ void DrawingAreaWC::commitLayerUpdateInfo(WCLayerUpdateInfo&& info)
     m_updateInfo.changedLayers.append(WTFMove(info));
 }
 
-RefPtr<ImageBuffer> DrawingAreaWC::createImageBuffer(FloatSize size)
+RefPtr<ImageBuffer> DrawingAreaWC::createImageBuffer(FloatSize size, float deviceScaleFactor)
 {
     if (WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM))
-        return Ref { m_webPage.get() }->ensureRemoteRenderingBackendProxy().createImageBuffer(size, RenderingPurpose::DOM, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, { });
-    return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, RenderingPurpose::DOM, { });
+        return Ref { m_webPage.get() }->ensureRemoteRenderingBackendProxy().createImageBuffer(size, RenderingPurpose::DOM, deviceScaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, { });
+    return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, deviceScaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, RenderingPurpose::DOM, { });
 }
 
 void DrawingAreaWC::displayDidRefresh()

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -68,7 +68,7 @@ private:
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER)    
     void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) override { }
 #endif
-    void updateGeometryWC(uint64_t, WebCore::IntSize) override;
+    void updateGeometryWC(uint64_t, WebCore::IntSize, float deviceScaleFactor) override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void addRootFrame(WebCore::FrameIdentifier) override;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
@@ -79,13 +79,14 @@ private:
     void graphicsLayerAdded(GraphicsLayerWC&) override;
     void graphicsLayerRemoved(GraphicsLayerWC&) override;
     void commitLayerUpdateInfo(WCLayerUpdateInfo&&) override;
-    RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize) override;
+    RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize, float deviceScaleFactor) override;
 
     bool isCompositingMode();
     void updateRendering();
     void sendUpdateAC();
     void sendUpdateNonAC();
     void updateRootLayers();
+    void updateRootLayerDeviceScaleFactor(WebCore::GraphicsLayer&);
 
     struct RootLayerInfo {
         Ref<WebCore::GraphicsLayer> layer;

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -44,7 +44,7 @@ public:
         virtual void graphicsLayerAdded(GraphicsLayerWC&) = 0;
         virtual void graphicsLayerRemoved(GraphicsLayerWC&) = 0;
         virtual void commitLayerUpdateInfo(WCLayerUpdateInfo&&) = 0;
-        virtual RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize) = 0;
+        virtual RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize, float deviceScaleFactor) = 0;
     };
 
     GraphicsLayerWC(Type layerType, WebCore::GraphicsLayerClient&, Observer&);
@@ -104,7 +104,7 @@ public:
 protected:
     friend WCTiledBacking;
 
-    RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize);
+    RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize, float deviceScaleFactor);
     
 private:
     struct VisibleAndCoverageRects {

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
@@ -103,6 +103,7 @@ struct WCLayerUpdateInfo {
     struct BackgroundChanges {
         WebCore::Color color;
         bool hasBackingStore;
+        WebCore::IntSize backingStoreSize;
         Vector<WCTileUpdate> tileUpdates;
     } background;
 
@@ -122,6 +123,7 @@ struct WCLayerUpdateInfo {
 };
 
 struct WCUpdateInfo {
+    WebCore::IntSize viewport;
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier;
     WebCore::PlatformLayerIdentifier rootLayer;
     Vector<WebCore::PlatformLayerIdentifier> addedLayers;

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
@@ -66,6 +66,7 @@ header: "WCUpdateInfo.h"
 [Nested] struct WebKit::WCLayerUpdateInfo::BackgroundChanges {
     WebCore::Color color;
     bool hasBackingStore;
+    WebCore::IntSize backingStoreSize;
     Vector<WebKit::WCTileUpdate> tileUpdates;
 }
 
@@ -109,6 +110,7 @@ header: "WCUpdateInfo.h"
 }
 
 struct WebKit::WCUpdateInfo {
+    WebCore::IntSize viewport;
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier;
     WebCore::PlatformLayerIdentifier rootLayer;
     Vector<WebCore::PlatformLayerIdentifier> addedLayers;

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -199,6 +199,9 @@ WebKitBrowserWindow::WebKitBrowserWindow(BrowserWindowClient& client, WKPageConf
     WKPageSetPageStateClient(page, &stateClient.base);
 
     updateProxySettings();
+
+    // FIXME: The current design of WebKit cannot support fractional device scale factor.
+    WKPageSetCustomBackingScaleFactor(page, 1);
     resetZoom();
 }
 


### PR DESCRIPTION
#### b6d35ab492c201f0cbd3de238a6af2d3c65c156c
<pre>
support device scale factor for GraphicsLayerWC
<a href="https://bugs.webkit.org/show_bug.cgi?id=196339">https://bugs.webkit.org/show_bug.cgi?id=196339</a>

Reviewed by Fujii Hironori.

support device scale factor for GraphicsLayerWC (and WinCairo).
But, NOT using this function now because of following bugs.
so NOW, MiniBrowser sets page zoom to intrinsic device scale factor and
sets &quot;custom device scale factor&quot; to 1.
This simulates the correspondence of device scale factors.

WebInspector always uses intrinsic device scale factor, so if you use
fractional device scale factor, repaint noises may remain.

Remaining bugs
1. Using fractional device scale factor, rendering noises may remain when
   repaint display by JavaScript, scroll with scrollbar dragging or etc.

* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
* Source/WebKit/Shared/NativeWebMouseEvent.h:
* Source/WebKit/Shared/NativeWebWheelEvent.h:
* Source/WebKit/Shared/PlatformPopupMenuData.h:
* Source/WebKit/Shared/PlatformPopupMenuData.serialization.in:
* Source/WebKit/Shared/win/NativeWebMouseEventWin.cpp:
* Source/WebKit/Shared/win/NativeWebWheelEventWin.cpp:
* Source/WebKit/Shared/win/WebEventFactory.cpp:
* Source/WebKit/Shared/win/WebEventFactory.h:
* Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp:
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h:
* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
* Source/WebKit/UIProcess/win/WebContextMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h:
* Source/WebKit/UIProcess/win/WebView.cpp:
* Source/WebKit/UIProcess/win/WebView.h:
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:

Canonical link: <a href="https://commits.webkit.org/279794@main">https://commits.webkit.org/279794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb094f1f254448d4a98eb0cbb2ebcab493538ca9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5329 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5331 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56690 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25342 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/4616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3469 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/4832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59466 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29828 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30978 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47372 "Exiting early after 10 failures. 10 tests run. 4 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31956 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8075 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->