### PR TITLE
[GTK] Undeprecate and document webkit_print_operation_print() behavior

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -871,7 +871,10 @@ static GRefPtr<GtkPrinter> printerFromSettingsOrDefault(GtkPrintSettings* settin
  * operation finishes. If an error occurs while printing the signal
  * #WebKitPrintOperation::failed is emitted before #WebKitPrintOperation::finished.
  *
- * Deprecated: 2.46. This function does nothing if the app is sandboxed.
+ * If the app is running in a sandbox, this function only works if printing to
+ * a file that is in a location accessible to the sandbox, usually acquired
+ * through the File Chooser portal. This function will not work for physical
+ * printers when running in a sandbox.
  */
 void webkit_print_operation_print(WebKitPrintOperation* printOperation)
 {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in
@@ -83,7 +83,7 @@ WEBKIT_API WebKitPrintOperationResponse
 webkit_print_operation_run_dialog         (WebKitPrintOperation *print_operation,
                                            GtkWindow            *parent);
 
-WEBKIT_DEPRECATED void
+WEBKIT_API void
 webkit_print_operation_print              (WebKitPrintOperation *print_operation);
 
 G_END_DECLS


### PR DESCRIPTION
#### 041231a01472dbc17a0717c044bf364274adadb5
<pre>
[GTK] Undeprecate and document webkit_print_operation_print() behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=274456">https://bugs.webkit.org/show_bug.cgi?id=274456</a>

Reviewed by Carlos Garcia Campos.

Turns out, there might be legitimate use cases for webkit_print_operation_print()
for sandboxed apps. However, they&apos;re very specific, and this function only works
in very specific situations.

Document that, and undeprecate the function.

* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in:

Canonical link: <a href="https://commits.webkit.org/279054@main">https://commits.webkit.org/279054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bf3477324599e35947532e829d1e1fe21c3c83f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2795 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23665 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52217 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1255 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27499 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2657 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45320 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11436 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->