### PR TITLE
[JSC] Use unified config on Windows and merge C_LOOP_WIN to C_LOOP

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -274,7 +274,7 @@ if (WIN32)
 
     if (NOT ENABLE_JIT)
         if (ENABLE_C_LOOP)
-            set(OFFLINE_ASM_BACKEND "C_LOOP_WIN")
+            set(OFFLINE_ASM_BACKEND "C_LOOP")
         endif ()
     endif ()
 else ()

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -442,7 +442,7 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
         g_jscConfig.startExecutableMemory = reservation.base;
         g_jscConfig.endExecutableMemory = reservationEnd;
 
-#if !USE(SYSTEM_MALLOC) && ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
+#if !USE(SYSTEM_MALLOC)
         static_assert(WebConfig::reservedSlotsForExecutableAllocator >= 2);
         WebConfig::g_config[0] = bitwise_cast<uintptr_t>(reservation.base);
         WebConfig::g_config[1] = bitwise_cast<uintptr_t>(reservationEnd);

--- a/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
+++ b/Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h
@@ -31,13 +31,7 @@
 #include <wtf/Gigacage.h>
 
 #if ENABLE(C_LOOP)
-#if !OS(WINDOWS)
 #define OFFLINE_ASM_C_LOOP 1
-#define OFFLINE_ASM_C_LOOP_WIN 0
-#else
-#define OFFLINE_ASM_C_LOOP 0
-#define OFFLINE_ASM_C_LOOP_WIN 1
-#endif
 #define OFFLINE_ASM_ARMv7 0
 #define OFFLINE_ASM_ARM64 0
 #define OFFLINE_ASM_ARM64E 0
@@ -50,7 +44,6 @@
 #else // ENABLE(C_LOOP)
 
 #define OFFLINE_ASM_C_LOOP 0
-#define OFFLINE_ASM_C_LOOP_WIN 0
 
 #ifdef __ARM_ARCH_7K__
 #define OFFLINE_ASM_ARMv7k 1

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -88,9 +88,7 @@ using namespace JSC::LLInt;
 // Define the opcode dispatch mechanism when using the C loop:
 //
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 using WebConfig::g_config;
-#endif
 
 // These are for building a C Loop interpreter:
 #define OFFLINE_ASM_BEGIN

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -107,7 +107,7 @@ end
 # After calling, calling bytecode is claiming input registers are not used.
 macro dispatchAfterRegularCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadi ArgumentCountIncludingThis + TagOffset[cfr], PC
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         # On non C_LOOP builds, CSR restore takes care of this.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_instructionsRawPointer[PB], PB
@@ -121,7 +121,7 @@ end
 
 macro dispatchAfterTailCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadi ArgumentCountIncludingThis + TagOffset[cfr], PC
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         # On non C_LOOP builds, CSR restore takes care of this.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_instructionsRawPointer[PB], PB
@@ -135,7 +135,7 @@ end
 
 macro dispatchAfterRegularCallIgnoreResult(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadi ArgumentCountIncludingThis + TagOffset[cfr], PC
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         # On non C_LOOP builds, CSR restore takes care of this.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_instructionsRawPointer[PB], PB
@@ -144,7 +144,7 @@ macro dispatchAfterRegularCallIgnoreResult(size, opcodeStruct, valueProfileName,
 end
 
 macro cCall2(function)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPath function, a0, a1
     elsif ARMv7
         call function
@@ -154,7 +154,7 @@ macro cCall2(function)
 end
 
 macro cCall2Void(function)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPathVoid function, a0, a1
     else
         cCall2(function)
@@ -162,7 +162,7 @@ macro cCall2Void(function)
 end
 
 macro cCall3(function)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPath3 function, a0, a1, a2
     elsif ARMv7
         call function
@@ -172,7 +172,7 @@ macro cCall3(function)
 end
 
 macro cCall4(function)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPath4 function, a0, a1, a2, a3
     elsif ARMv7
         call function
@@ -243,7 +243,7 @@ macro doVMEntry(makeCall)
     # Ensure that we have enough additional stack capacity for the incoming args,
     # and the frame for the JS code we're executing. We need to do this check
     # before we start copying the args from the protoCallFrame below.
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         bpaeq t3, VM::m_cloopStackLimit[vm], .stackHeightOK
         move entry, t4
         move vm, t5
@@ -370,7 +370,7 @@ _llint_throw_stack_overflow_error_from_vm_entry:
 macro makeJavaScriptCall(entry, protoCallFrame, temp1, temp2)
     addp CallerFrameAndPCSize, sp
     checkStackPointerAlignment(temp1, 0xbad0dc02)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallJSFunction entry
     else
         call entry
@@ -383,7 +383,7 @@ end
 macro makeHostFunctionCall(entry, protoCallFrame, temp1, temp2)
     move entry, temp1
     storep cfr, [sp]
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         loadp ProtoCallFrame::globalObject[protoCallFrame], a0
         move sp, a1
         storep lr, PtrSize[sp]
@@ -723,7 +723,7 @@ macro functionArityCheck(opcodeName, doneLabel)
     lshiftp 3, t3
     subp cfr, t3, t5
     loadp CodeBlock::m_vm[t1], t0
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         bpbeq VM::m_cloopStackLimit[t0], t5, .stackHeightOK
     else
         bpbeq VM::m_softStackLimit[t0], t5, .stackHeightOK
@@ -2362,13 +2362,8 @@ macro callHelper(opcodeName, opcodeStruct, dispatchAfterCall, valueProfileName, 
         storep 0, address
     end)
     addp %opcodeStruct%::Metadata::m_callLinkInfo, t5, t2 # CallLinkInfo* in t2
-    if X86_64_WIN or C_LOOP_WIN
-        leap JSCConfig + constexpr JSC::offsetOfJSCConfigDefaultCallThunk, t5
-        loadp [t5], t5
-    else
-        leap _g_config, t5
-        loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
-    end
+    leap _g_config, t5
+    loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
     jmp .dispatch
 end
         
@@ -2452,13 +2447,8 @@ macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVi
                 storep 0, address
             end)
             addp %opcodeStruct%::Metadata::m_callLinkInfo, t5, t2 # CallLinkInfo* in t2
-            if X86_64_WIN or C_LOOP_WIN
-                leap JSCConfig + constexpr JSC::offsetOfJSCConfigDefaultCallThunk, t5
-                loadp [t5], t5
-            else
-                leap _g_config, t5
-                loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
-            end
+            leap _g_config, t5
+            loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
             jmp .dispatch
         .dontUpdateSP:
             jmp _llint_throw_from_slow_path_trampoline
@@ -2610,7 +2600,7 @@ macro nativeCallTrampoline(executableOffsetToFunction)
     move cfr, a1
 
     checkStackPointerAlignment(t3, 0xdead0001)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallNative executableOffsetToFunction[a2]
     else
         call executableOffsetToFunction[a2]
@@ -2647,7 +2637,7 @@ macro internalFunctionCallTrampoline(offsetOfFunction)
     move cfr, a1
 
     checkStackPointerAlignment(t3, 0xdead0001)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallNative offsetOfFunction[a2]
     else
         call offsetOfFunction[a2]

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -99,7 +99,7 @@ end
 # After calling, calling bytecode is claiming input registers are not used.
 macro dispatchAfterRegularCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadPC()
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         # On non C_LOOP builds, CSR restore takes care of this.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_instructionsRawPointer[PB], PB
@@ -112,7 +112,7 @@ end
 
 macro dispatchAfterTailCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadPC()
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         # On non C_LOOP builds, CSR restore takes care of this.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_instructionsRawPointer[PB], PB
@@ -125,7 +125,7 @@ end
 
 macro dispatchAfterRegularCallIgnoreResult(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadPC()
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         # On non C_LOOP builds, CSR restore takes care of this.
         loadp CodeBlock[cfr], PB
         loadp CodeBlock::m_instructionsRawPointer[PB], PB
@@ -135,7 +135,7 @@ end
 
 macro cCall2(function)
     checkStackPointerAlignment(t4, 0xbad0c002)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPath function, a0, a1
     elsif X86_64 or X86_64_WIN or ARM64 or ARM64E or RISCV64
         call function
@@ -145,7 +145,7 @@ macro cCall2(function)
 end
 
 macro cCall2Void(function)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPathVoid function, a0, a1
     else
         cCall2(function)
@@ -154,7 +154,7 @@ end
 
 macro cCall3(function)
     checkStackPointerAlignment(t4, 0xbad0c004)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPath3 function, a0, a1, a2
     elsif X86_64 or X86_64_WIN or ARM64 or ARM64E or RISCV64
         call function
@@ -166,7 +166,7 @@ end
 # This barely works. arg3 and arg4 should probably be immediates.
 macro cCall4(function)
     checkStackPointerAlignment(t4, 0xbad0c004)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallSlowPath4 function, a0, a1, a2, a3
     elsif X86_64 or X86_64_WIN or ARM64 or ARM64E or RISCV64
         call function
@@ -207,7 +207,7 @@ macro doVMEntry(makeCall)
     # Ensure that we have enough additional stack capacity for the incoming args,
     # and the frame for the JS code we're executing. We need to do this check
     # before we start copying the args from the protoCallFrame below.
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         bpaeq t3, VM::m_cloopStackLimit[vm], .stackHeightOK
         move entry, t4
         move vm, t5
@@ -339,7 +339,7 @@ _llint_throw_stack_overflow_error_from_vm_entry:
 macro makeJavaScriptCall(entry, protoCallFrame, temp1, temp2)
 _llint_call_javascript:
     addp CallerFrameAndPCSize, sp
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallJSFunction entry
     elsif ARM64E
         move entry, t5
@@ -364,7 +364,7 @@ macro makeHostFunctionCall(entry, protoCallFrame, temp1, temp2)
     storep cfr, [sp]
     loadp ProtoCallFrame::globalObject[protoCallFrame], a0
     move sp, a1
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         storep lr, 8[sp]
         cloopCallNative temp1
     else
@@ -503,7 +503,7 @@ else
 end
 
 macro cage(basePtr, mask, ptr, scratch)
-    if GIGACAGE_ENABLED and not (C_LOOP or C_LOOP_WIN)
+    if GIGACAGE_ENABLED and not C_LOOP
         loadp basePtr, scratch
         btpz scratch, .done
         andp mask, ptr
@@ -513,7 +513,7 @@ macro cage(basePtr, mask, ptr, scratch)
 end
 
 macro cagePrimitive(basePtr, mask, ptr, scratch)
-    if GIGACAGE_ENABLED and not (C_LOOP or C_LOOP_WIN)
+    if GIGACAGE_ENABLED and not C_LOOP
         loadb GigacageConfig + Gigacage::Config::disablingPrimitiveGigacageIsForbidden, scratch
         btbnz scratch, .doCaging
 
@@ -693,13 +693,8 @@ macro structureIDToStructureWithScratch(structureIDThenStructure, scratch)
         lshiftp (constexpr StructureID::encodeShiftAmount), structureIDThenStructure
     elsif ADDRESS64
         andq (constexpr StructureID::structureIDMask), structureIDThenStructure
-        if X86_64_WIN or C_LOOP_WIN
-            leap JSCConfig + constexpr JSC::offsetOfJSCConfigStartOfStructureHeap, scratch
-            loadp [scratch], scratch
-        else
-            leap _g_config, scratch
-            loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigStartOfStructureHeap[scratch], scratch
-        end
+        leap _g_config, scratch
+        loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigStartOfStructureHeap[scratch], scratch
         addp scratch, structureIDThenStructure
     end
 end
@@ -731,7 +726,7 @@ macro functionArityCheck(opcodeName, doneLabel)
     lshiftp 3, t3
     subp cfr, t3, t5
     loadp CodeBlock::m_vm[t1], t0
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         bpbeq VM::m_cloopStackLimit[t0], t5, .stackHeightOK
     else
         bpbeq VM::m_softStackLimit[t0], t5, .stackHeightOK
@@ -2524,13 +2519,8 @@ macro callHelper(opcodeName, opcodeStruct, dispatchAfterCall, valueProfileName, 
         storep 0, address
     end)
     addp %opcodeStruct%::Metadata::m_callLinkInfo, t5, t2 # CallLinkInfo* in t2
-    if X86_64_WIN or C_LOOP_WIN
-        leap JSCConfig + constexpr JSC::offsetOfJSCConfigDefaultCallThunk, t5
-        loadp [t5], t5
-    else
-        leap _g_config, t5
-        loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
-    end
+    leap _g_config, t5
+    loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
     jmp .dispatch
 end
 
@@ -2613,13 +2603,8 @@ macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVi
                 storep 0, address
             end)
             addp %opcodeStruct%::Metadata::m_callLinkInfo, t5, t2 # CallLinkInfo* in t2
-            if X86_64_WIN or C_LOOP_WIN
-                leap JSCConfig + constexpr JSC::offsetOfJSCConfigDefaultCallThunk, t5
-                loadp [t5], t5
-            else
-                leap _g_config, t5
-                loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
-            end
+            leap _g_config, t5
+            loadp JSCConfigOffset + constexpr JSC::offsetOfJSCConfigDefaultCallThunk[t5], t5
             jmp .dispatch
         .dontUpdateSP:
             jmp _llint_throw_from_slow_path_trampoline
@@ -2767,12 +2752,12 @@ macro nativeCallTrampoline(executableOffsetToFunction)
     loadp JSFunction::m_scope[a0], a0
     loadp JSGlobalObject::m_vm[a0], a1
     storep cfr, VM::topCallFrame[a1]
-    if ARM64 or ARM64E or C_LOOP or C_LOOP_WIN
+    if ARM64 or ARM64E or C_LOOP
         storep lr, ReturnPC[cfr]
     end
     move cfr, a1
     checkStackPointerAlignment(t3, 0xdead0001)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallNative executableOffsetToFunction[a2]
     else
         call executableOffsetToFunction[a2], HostFunctionPtrTag
@@ -2799,12 +2784,12 @@ macro internalFunctionCallTrampoline(offsetOfFunction)
     loadp InternalFunction::m_globalObject[a2], a0
     loadp JSGlobalObject::m_vm[a0], a1
     storep cfr, VM::topCallFrame[a1]
-    if ARM64 or ARM64E or C_LOOP or C_LOOP_WIN
+    if ARM64 or ARM64E or C_LOOP
         storep lr, ReturnPC[cfr]
     end
     move cfr, a1
     checkStackPointerAlignment(t3, 0xdead0001)
-    if C_LOOP or C_LOOP_WIN
+    if C_LOOP
         cloopCallNative offsetOfFunction[a2]
     else
         call offsetOfFunction[a2], HostFunctionPtrTag

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -598,7 +598,7 @@ end
 // This is the interpreted analogue to createJSToWasmWrapper
 if JSVALUE64 and (ARM64 or ARM64E or X86_64)
 op(js_to_wasm_wrapper_entry, macro ()
-    if not WEBASSEMBLY or C_LOOP or C_LOOP_WIN
+    if not WEBASSEMBLY or C_LOOP
         error
     end
 
@@ -1177,7 +1177,7 @@ op(wasm_function_prologue_trampoline, macro ()
 end)
 
 op(wasm_function_prologue, macro ()
-    if not WEBASSEMBLY or C_LOOP or C_LOOP_WIN
+    if not WEBASSEMBLY or C_LOOP
         error
     end
 
@@ -1186,7 +1186,7 @@ op(wasm_function_prologue, macro ()
 end)
 
 op(wasm_function_prologue_simd, macro ()
-    if not WEBASSEMBLY or C_LOOP or C_LOOP_WIN
+    if not WEBASSEMBLY or C_LOOP
         error
     end
 

--- a/Source/JavaScriptCore/offlineasm/asm.rb
+++ b/Source/JavaScriptCore/offlineasm/asm.rb
@@ -384,7 +384,7 @@ File.open(outputFlnm, "w") {
             # There could be multiple backends we are generating for, but the C_LOOP is
             # always by itself so this check to turn off $enableDebugAnnotations won't
             # affect the generation for any other backend.
-            if backend == "C_LOOP" || backend == "C_LOOP_WIN"
+            if backend == "C_LOOP"
                 $enableDebugAnnotations = false
                 $preferredCommentStartColumn = 60
                 $emitELFDebugDirectives = false

--- a/Source/JavaScriptCore/offlineasm/backends.rb
+++ b/Source/JavaScriptCore/offlineasm/backends.rb
@@ -43,7 +43,6 @@ BACKENDS =
      "ARM64E",
      "RISCV64",
      "C_LOOP",
-     "C_LOOP_WIN"
     ]
 
 # Keep the set of working backends separate from the set of backends that might be
@@ -60,7 +59,6 @@ WORKING_BACKENDS =
      "ARM64E",
      "RISCV64",
      "C_LOOP",
-     "C_LOOP_WIN"
     ]
 
 BACKEND_PATTERN = Regexp.new('\\A(' + BACKENDS.join(')|(') + ')\\Z')

--- a/Source/JavaScriptCore/offlineasm/cloop.rb
+++ b/Source/JavaScriptCore/offlineasm/cloop.rb
@@ -1212,10 +1212,6 @@ class Instruction
         end
     end
 
-    def lowerC_LOOP_WIN
-        lowerC_LOOP
-    end
-
     def recordMetaDataC_LOOP
         $asm.codeOrigin codeOriginString if $enableCodeOriginComments
         $asm.annotation annotation if $enableInstrAnnotations && (opcode != "cloopDo")

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -145,9 +145,6 @@ void initialize()
         WTF::compilerFence();
         RELEASE_ASSERT(!g_jscConfig.initializeHasBeenCalled);
         g_jscConfig.initializeHasBeenCalled = true;
-#if OS(WINDOWS) && ENABLE(WEBASSEMBLY)
-        g_wtfConfigForLLInt = g_wtfConfig;
-#endif
     });
 }
 

--- a/Source/JavaScriptCore/runtime/JSCConfig.cpp
+++ b/Source/JavaScriptCore/runtime/JSCConfig.cpp
@@ -29,14 +29,6 @@
 
 namespace JSC {
 
-#if !ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-Config g_jscConfig;
-#endif
-
-#if OS(WINDOWS) && ENABLE(WEBASSEMBLY)
-WTF::Config g_wtfConfigForLLInt = g_wtfConfig;
-#endif
-
 Config& Config::singleton()
 {
     return g_jscConfig;

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -115,23 +115,12 @@ struct Config {
 #endif
 };
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 constexpr size_t alignmentOfJSCConfig = std::alignment_of<JSC::Config>::value;
 
 static_assert(WTF::offsetOfWTFConfigExtension + sizeof(JSC::Config) <= WTF::ConfigSizeToProtect);
 static_assert(roundUpToMultipleOf<alignmentOfJSCConfig>(WTF::offsetOfWTFConfigExtension) == WTF::offsetOfWTFConfigExtension);
 
 #define g_jscConfig (*bitwise_cast<JSC::Config*>(&g_wtfConfig.spaceForExtensions))
-
-#else // not ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
-extern "C" JS_EXPORT_PRIVATE Config g_jscConfig;
-#if OS(WINDOWS) && ENABLE(WEBASSEMBLY)
-extern "C" JS_EXPORT_PRIVATE WTF::Config g_wtfConfigForLLInt;
-#endif
-
-#endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
 constexpr size_t offsetOfJSCConfigInitializeHasBeenCalled = offsetof(JSC::Config, initializeHasBeenCalled);
 constexpr size_t offsetOfJSCConfigGateMap = offsetof(JSC::Config, llint.gateMap);
@@ -144,7 +133,3 @@ ALWAYS_INLINE PURE_FUNCTION uintptr_t startOfStructureHeap()
 }
 
 } // namespace JSC
-
-#if !ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-using JSC::g_jscConfig;
-#endif

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -924,10 +924,8 @@ void Options::notifyOptionsChanged()
     Options::useWebAssemblyFastMemory() = false;
 #endif
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
     uint8_t* reservedConfigBytes = reinterpret_cast_ptr<uint8_t*>(WebConfig::g_config + WebConfig::reservedSlotsForExecutableAllocator);
     reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = Options::useAllocationProfiling() ? 1 : 0;
-#endif
 
     // Do range checks where needed and make corrections to the options:
     ASSERT(Options::thresholdForOptimizeAfterLongWarmUp() >= Options::thresholdForOptimizeAfterWarmUp());

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -853,24 +853,6 @@
 #define ENABLE_SIGNAL_BASED_VM_TRAPS 1
 #endif
 
-/* The unified Config record feature is not available for Windows because the
-   Windows port puts WTF in a separate DLL, and the offlineasm code accessing
-   the config record expects the config record to be directly accessible like
-   a global variable (and not have to go thru DLL shenanigans). C++ code would
-   resolve these DLL bindings automatically, but offlineasm does not.
-
-   The permanently freezing feature also currently relies on the Config records
-   being unified, and the Windows port also does not currently have an
-   implementation for the freezing mechanism anyway. For simplicity, we just
-   disable both the use of unified Config record and config freezing for the
-   Windows port.
-*/
-#if OS(WINDOWS)
-#define ENABLE_UNIFIED_AND_FREEZABLE_CONFIG_RECORD 0
-#else
-#define ENABLE_UNIFIED_AND_FREEZABLE_CONFIG_RECORD 1
-#endif
-
 /* CSS Selector JIT Compiler */
 #if !defined(ENABLE_CSS_SELECTOR_JIT) && ((CPU(X86_64) || CPU(ARM64)) && ENABLE(JIT) && (OS(DARWIN) || OS(WINDOWS) || PLATFORM(GTK) || PLATFORM(WPE)))
 #define ENABLE_CSS_SELECTOR_JIT 1

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -48,8 +48,6 @@
 
 #include <mutex>
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 namespace WebConfig {
 
 alignas(WTF::ConfigAlignment) Slot g_config[WTF::ConfigSizeToProtect / sizeof(Slot)];
@@ -60,19 +58,8 @@ alignas(WTF::ConfigAlignment) Slot g_config[WTF::ConfigSizeToProtect / sizeof(Sl
 static_assert(Gigacage::startSlotOfGigacageConfig == WebConfig::reservedSlotsForExecutableAllocator + WebConfig::additionalReservedSlots);
 #endif
 
-#else // not ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 namespace WTF {
 
-Config g_wtfConfig;
-
-} // namespace WTF
-
-#endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
-namespace WTF {
-
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 void setPermissionsOfConfigPage()
 {
 #if PLATFORM(COCOA)
@@ -96,7 +83,6 @@ void setPermissionsOfConfigPage()
     });
 #endif // PLATFORM(COCOA)
 }
-#endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
 void Config::initialize()
 {
@@ -152,7 +138,6 @@ void Config::permanentlyFreeze()
 
     int result = 0;
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 #if PLATFORM(COCOA)
     enum {
         DontUpdateMaximumPermission = false,
@@ -166,12 +151,7 @@ void Config::permanentlyFreeze()
 #elif OS(WINDOWS)
     // FIXME: Implement equivalent, maybe with VirtualProtect.
     // Also need to fix WebKitTestRunner.
-
-    // Note: the Windows port also currently does not support a unified Config
-    // record, which is needed for the current form of the freezing feature to
-    // work. See comments in PlatformEnable.h for UNIFIED_AND_FREEZABLE_CONFIG_RECORD.
 #endif
-#endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
     RELEASE_ASSERT(!result);
     RELEASE_ASSERT(g_wtfConfig.isPermanentlyFrozen);

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -42,7 +42,6 @@ constexpr size_t reservedBytesForGigacageConfig = 0;
 #include <bmalloc/GigacageConfig.h>
 #endif
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 namespace WebConfig {
 
 using Slot = uint64_t;
@@ -59,7 +58,6 @@ enum ReservedConfigByteOffset {
 static_assert(NumberOfReservedConfigBytes <= sizeof(Slot) * additionalReservedSlots);
 
 } // namespace WebConfig
-#endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
 namespace WTF {
 
@@ -102,8 +100,6 @@ struct Config {
     uint64_t spaceForExtensions[1];
 };
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 constexpr size_t startSlotOfWTFConfig = Gigacage::reservedSlotsForGigacageConfig;
 constexpr size_t startOffsetOfWTFConfig = startSlotOfWTFConfig * sizeof(WebConfig::Slot);
 
@@ -117,14 +113,6 @@ static_assert(roundUpToMultipleOf<alignmentOfWTFConfig>(startOffsetOfWTFConfig) 
 WTF_EXPORT_PRIVATE void setPermissionsOfConfigPage();
 
 #define g_wtfConfig (*bitwise_cast<WTF::Config*>(&WebConfig::g_config[WTF::startSlotOfWTFConfig]))
-
-#else // not ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
-inline void setPermissionsOfConfigPage() { }
-
-extern "C" WTF_EXPORT_PRIVATE Config g_wtfConfig;
-
-#endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
 constexpr size_t offsetOfWTFConfigLowestAccessibleAddress = offsetof(WTF::Config, lowestAccessibleAddress);
 
@@ -141,7 +129,3 @@ ALWAYS_INLINE Config::AssertNotFrozenScope::~AssertNotFrozenScope()
 };
 
 } // namespace WTF
-
-#if !ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-using WTF::g_wtfConfig;
-#endif

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -365,24 +365,6 @@
 #define BUSE_PRECOMPUTED_CONSTANTS_VMPAGE16K 1
 #endif
 
-/* The unified Config record feature is not available for Windows because the
-   Windows port puts WTF in a separate DLL, and the offlineasm code accessing
-   the config record expects the config record to be directly accessible like
-   a global variable (and not have to go thru DLL shenanigans). C++ code would
-   resolve these DLL bindings automatically, but offlineasm does not.
-
-   The permanently freezing feature also currently relies on the Config records
-   being unified, and the Windows port also does not currently have an
-   implementation for the freezing mechanism anyway. For simplicity, we just
-   disable both the use of unified Config record and config freezing for the
-   Windows port.
-*/
-#if BOS(WINDOWS)
-#define BENABLE_UNIFIED_AND_FREEZABLE_CONFIG_RECORD 0
-#else
-#define BENABLE_UNIFIED_AND_FREEZABLE_CONFIG_RECORD 1
-#endif
-
 /* We only export the mallocSize and mallocGoodSize APIs if they're supported by the DebugHeap allocator (currently only Darwin) and the current bmalloc allocator (currently only libpas). */
 #if BUSE(LIBPAS) && BOS(DARWIN)
 #define BENABLE_MALLOC_SIZE 1

--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -47,10 +47,6 @@
 
 namespace Gigacage {
 
-#if !BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-Config g_gigacageConfig;
-#endif
-
 struct Callback {
     Callback() { }
     
@@ -96,11 +92,9 @@ void ensureGigacage()
             if (!shouldBeEnabled())
                 return;
 
-#if BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
             // We might only get page size alignment, but that's also the minimum
             // alignment we need for freezing the Config.
             RELEASE_BASSERT(!(reinterpret_cast<size_t>(&WebConfig::g_config) & (vmPageSize() - 1)));
-#endif
 
             Kind shuffledKinds[NumberOfKinds];
             for (unsigned i = 0; i < NumberOfKinds; ++i)

--- a/Source/bmalloc/bmalloc/GigacageConfig.h
+++ b/Source/bmalloc/bmalloc/GigacageConfig.h
@@ -30,16 +30,12 @@
 #include "StdLibExtras.h"
 #include <inttypes.h>
 
-#if BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 namespace WebConfig {
 
 using Slot = uint64_t;
 extern "C" Slot g_config[];
 
 } // namespace WebConfig
-
-#endif // BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
 namespace Gigacage {
 
@@ -102,8 +98,6 @@ struct Config {
     size_t allocSizes[NumberOfKinds];
 };
 
-#if BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 // The first 4 slots are reserved for the use of the ExecutableAllocator.
 constexpr size_t startSlotOfGigacageConfig = 4;
 constexpr size_t startOffsetOfGigacageConfig = startSlotOfGigacageConfig * sizeof(WebConfig::Slot);
@@ -118,14 +112,4 @@ static_assert(bmalloc::roundUpToMultipleOf<alignmentOfGigacageConfig>(startOffse
 
 #define g_gigacageConfig (*bmalloc::bitwise_cast<Gigacage::Config*>(&WebConfig::g_config[Gigacage::startSlotOfGigacageConfig]))
 
-#else // not BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
-extern "C" BEXPORT Config g_gigacageConfig;
-
-#endif // BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 } // namespace Gigacage
-
-#if !BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-using Gigacage::g_gigacageConfig;
-#endif

--- a/Source/bmalloc/bmalloc/mbmalloc.cpp
+++ b/Source/bmalloc/bmalloc/mbmalloc.cpp
@@ -28,8 +28,6 @@
 #include "BExport.h"
 #include "GigacageConfig.h"
 
-#if BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
 namespace WebConfig {
 
 // FIXME: Other than OS(DARWIN) || PLATFORM(PLAYSTATION), CeilingOnPageSize is
@@ -40,16 +38,6 @@ constexpr size_t ConfigSizeToProtect = 16 * bmalloc::Sizes::kB;
 alignas(ConfigAlignment) BEXPORT Slot g_config[ConfigSizeToProtect / sizeof(Slot)];
 
 } // namespace WebConfig
-
-#else // !BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-
-namespace Gigacage {
-
-Config g_gigacageConfig;
-
-} // namespace Gigacage
-
-#endif // BENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
 extern "C" {
 


### PR DESCRIPTION
#### 56c417cfb65eb1e557b6bcba01860684f3adef07
<pre>
[JSC] Use unified config on Windows and merge C_LOOP_WIN to C_LOOP
<a href="https://bugs.webkit.org/show_bug.cgi?id=274459">https://bugs.webkit.org/show_bug.cgi?id=274459</a>
<a href="https://rdar.apple.com/128453165">rdar://128453165</a>

Reviewed by NOBODY (OOPS!).

This patch removes UNIFIED_AND_FREEZABLE_CONFIG_RECORD flag. Windows is no longer building WTF as dll,
so we can just use unified config (while we are not supporting freezing on Windows).
Then, we can merge C_LOOP_WIN backend into C_LOOP backend. We are still keeping X86_64_WIN backend due
to a bit of remaining Windows config in offlineasm. But we can remove it in the future.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/JavaScriptCore/llint/LLIntOfflineAsmConfig.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/offlineasm/asm.rb:
* Source/JavaScriptCore/offlineasm/backends.rb:
* Source/JavaScriptCore/offlineasm/cloop.rb:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCConfig.cpp:
* Source/JavaScriptCore/runtime/JSCConfig.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::setPermissionsOfConfigPage):
(WTF::Config::permanentlyFreeze):
* Source/WTF/wtf/WTFConfig.h:
(WTF::setPermissionsOfConfigPage): Deleted.
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/bmalloc/Gigacage.cpp:
(Gigacage::ensureGigacage):
* Source/bmalloc/bmalloc/GigacageConfig.h:
* Source/bmalloc/bmalloc/mbmalloc.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56c417cfb65eb1e557b6bcba01860684f3adef07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55650 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3099 "Hash 56c417cf for PR 28846 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42592 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/3099 "Hash 56c417cf for PR 28846 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23673 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2479 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1258 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45725 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57246 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51884 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27502 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2659 "Found 1 new test failure: wasm/window-postmessage.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49981 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49231 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29647 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64192 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28480 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12158 "Found 3 new JSC stress test failures: stress/proxy-set-prototype-of.js.no-llint, stress/spread-non-array.js.mini-mode, wasm.yaml/wasm/stress/js-to-wasm-i64-stack.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->