### PR TITLE
[Skia][Nicosia] Add support for accelerated offscreen canvas

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -299,12 +299,6 @@ bool CanvasBase::shouldAccelerate(uint64_t area) const
     if (!scriptExecutionContext()->settingsValues().acceleratedCompositingEnabled)
         return false;
 #endif
-#if USE(SKIA)
-    // FIXME: Skia based ports don't implement accelerated offscreen canvas yet.
-    auto* context = renderingContext();
-    if (context && context->isOffscreen2d())
-        return false;
-#endif
     return true;
 #else
     UNUSED_PARAM(area);

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h
@@ -65,8 +65,8 @@ public:
 private:
     RefPtr<ContentLayer> m_nicosiaLayer;
 
-    mutable Lock m_imageBufferLock;
-    RefPtr<WebCore::ImageBuffer> m_imageBuffer;
+    RefPtr<WebCore::NativeImage> m_image WTF_GUARDED_BY_LOCK(m_imageLock);
+    mutable Lock m_imageLock;
 };
 
 class NicosiaImageBufferPipe final : public WebCore::ImageBufferPipe {


### PR DESCRIPTION
#### 2c9a11ae2283ca6a64bea080f8a7187af59c8dfd
<pre>
[Skia][Nicosia] Add support for accelerated offscreen canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=274461">https://bugs.webkit.org/show_bug.cgi?id=274461</a>

Reviewed by Miguel Gomez.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::shouldAccelerate const):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::handle):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h:

Canonical link: <a href="https://commits.webkit.org/279130@main">https://commits.webkit.org/279130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7981de16dfdf4417b43b7b941e990159e6c303

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42715 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2108 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57447 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50111 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45491 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49380 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29850 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7711 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->