### PR TITLE
[WPE][GTK] Add assertions for the LayerTreeHost methods to document the expected thread

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -58,7 +58,9 @@ public:
         virtual void willRenderFrame() = 0;
         virtual void clearIfNeeded() = 0;
         virtual void didRenderFrame(uint32_t) = 0;
+#if !HAVE(DISPLAY_LINK)
         virtual void displayDidRefresh(WebCore::PlatformDisplayID) = 0;
+#endif
     };
 
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -141,9 +141,10 @@ private:
     void willRenderFrame() override;
     void clearIfNeeded() override;
     void didRenderFrame(uint32_t) override;
-    void displayDidRefresh(WebCore::PlatformDisplayID) override;
 
 #if !HAVE(DISPLAY_LINK)
+    void displayDidRefresh(WebCore::PlatformDisplayID) override;
+
     // ThreadedDisplayRefreshMonitor::Client
     void requestDisplayRefreshMonitorUpdate() override;
     void handleDisplayRefreshMonitorUpdate(bool hasBeenRescheduled) override;


### PR DESCRIPTION
#### 37dcdc0d30755faa468e7ef7028156f334834e66
<pre>
[WPE][GTK] Add assertions for the LayerTreeHost methods to document the expected thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=274460">https://bugs.webkit.org/show_bug.cgi?id=274460</a>

Reviewed by NOBODY (OOPS!).

Add ASSERT calls to verify the thread the code is being executed.

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::updateScene):
(WebKit::LayerTreeHost::frameComplete):
(WebKit::LayerTreeHost::nativeSurfaceHandleForCompositing):
(WebKit::LayerTreeHost::didCreateGLContext):
(WebKit::LayerTreeHost::willDestroyGLContext):
(WebKit::LayerTreeHost::didDestroyGLContext):
(WebKit::LayerTreeHost::resize):
(WebKit::LayerTreeHost::willRenderFrame):
(WebKit::LayerTreeHost::clearIfNeeded):
(WebKit::LayerTreeHost::didRenderFrame):
(WebKit::LayerTreeHost::displayDidRefresh):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37dcdc0d30755faa468e7ef7028156f334834e66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3478 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42826 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45535 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23933 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26934 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50224 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45728 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49500 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-policy (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->