### PR TITLE
[Navigation] Correct cancelable determination of NavigateEvent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL clicking on an <a> element that navigates same-document targeting a cross-origin window assert_true: cancelable expected true got false
+PASS clicking on an <a> element that navigates same-document targeting a cross-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 Click me
 
-FAIL clicking on an <a> element that navigates same-document targeting a same-origin window assert_true: cancelable expected true got false
+PASS clicking on an <a> element that navigates same-document targeting a same-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using location.href to navigate same-document targeting a cross-origin window assert_true: cancelable expected true got false
+PASS using location.href to navigate same-document targeting a cross-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using location.href to navigate same-document targeting a same-origin window assert_true: cancelable expected true got false
+PASS using location.href to navigate same-document targeting a same-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using window.open() to navigate same-document targeting a cross-origin window assert_true: cancelable expected true got false
+PASS using window.open() to navigate same-document targeting a cross-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using window.open() to navigate same-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
+PASS using window.open() to navigate same-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using window.open() to navigate same-document targeting a same-origin window assert_true: cancelable expected true got false
+PASS using window.open() to navigate same-document targeting a same-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL submitting a <form> element that navigates same-document targeting a cross-origin window assert_true: cancelable expected true got false
+PASS submitting a <form> element that navigates same-document targeting a cross-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL submitting a <form> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
+PASS submitting a <form> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL submitting a <form> element that navigates same-document targeting a same-origin window assert_true: cancelable expected true got false
+PASS submitting a <form> element that navigates same-document targeting a same-origin window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL location API on another window fires navigate event in the target window only assert_true: expected true got false
+PASS location API on another window fires navigate event in the target window only
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL window.open() fires navigate event in target window but not source assert_true: expected true got false
+PASS window.open() fires navigate event in target window but not source
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL clicking on an <a> element that navigates same-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
+PASS clicking on an <a> element that navigates same-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using location.href to navigate same-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
+PASS using location.href to navigate same-document targeting a same-origin-domain (but cross-origin) window
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -594,7 +594,7 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
     bool isSameDocument = destination->sameDocument();
     bool isTraversal = navigationType == NavigationNavigationType::Traverse;
     bool canIntercept = documentCanHaveURLRewritten(*document, destination->url()) && (!isTraversal || isSameDocument);
-    bool canBeCanceled = document->isTopDocument() && isSameDocument; // FIXME: and user involvement is not browser-ui or navigation's relevant global object has transient activation.
+    bool canBeCanceled = !isTraversal || (document->isTopDocument() && isSameDocument); // FIXME: and user involvement is not browser-ui or navigation's relevant global object has transient activation.
     bool hashChange = equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
     auto info = apiMethodTracker ? apiMethodTracker->info : JSC::jsUndefined();
 


### PR DESCRIPTION
#### 072b031414e564e51079e9a3448b5843d0f4492d
<pre>
[Navigation] Correct cancelable determination of NavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=274471">https://bugs.webkit.org/show_bug.cgi?id=274471</a>

Reviewed by Alex Christensen and Darin Adler.

When determining the cancelable flag for NavigateEvent we did not take into account the navigation type [1].

By fixing that we fix navigate-anchor-download.html, navigate-anchor-download-userInitiated.html and can mark two
further tests as passing.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm">https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm</a> (Step 11)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/279109@main">https://commits.webkit.org/279109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3789a22272bff2bf9eb1540c671275d4348a24fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42634 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2025 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57313 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27569 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2714 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 15 flakes 3 failures; Uploaded test results; 10 flakes 2 failures; Compiled WebKit (warnings); layout-tests; Found 2 new test failures: media/track/track-text-track-destructor-crash.html, workers/wasm-hashset-many.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50025 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49278 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->