### PR TITLE
[run-webkit-tests] Tests which fail and then crash on retry aren't flakey

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
@@ -310,20 +310,13 @@ def summarize_results(port_obj, expectations_by_type, initial_results, retry_res
                 test_dict['report'] = 'MISSING'
         elif test_name in initial_results.unexpected_results_by_name:
             if retry_results and test_name in retry_results.unexpected_results_by_name:
+                num_regressions += 1
+                test_dict['report'] = 'REGRESSION'
                 retry_result_type = retry_results.unexpected_results_by_name[test_name].type
                 if result_type != retry_result_type:
-                    if enabled_pixel_tests_in_retry and result_type == test_expectations.TEXT and (retry_result_type == test_expectations.IMAGE_PLUS_TEXT or retry_result_type == test_expectations.MISSING):
-                        if retry_result_type == test_expectations.MISSING:
-                            num_missing += 1
-                        num_regressions += 1
-                        test_dict['report'] = 'REGRESSION'
-                    else:
-                        num_flaky += 1
-                        test_dict['report'] = 'FLAKY'
                     actual.append(keywords[retry_result_type])
-                else:
-                    num_regressions += 1
-                    test_dict['report'] = 'REGRESSION'
+                    if enabled_pixel_tests_in_retry and result_type == test_expectations.TEXT and retry_result_type == test_expectations.MISSING:
+                        num_missing += 1
             elif retry_results and test_name in retry_results.expected_results_by_name:
                 retry_result_name = keywords[retry_results.expected_results_by_name[test_name].type]
                 if retry_result_name not in actual:

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -107,12 +107,12 @@ class TestList(object):
 #
 # These numbers may need to be updated whenever we add or delete tests.
 #
-TOTAL_TESTS = 88
+TOTAL_TESTS = 90
 TOTAL_SKIPS = 12
-TOTAL_RETRIES = 13
+TOTAL_RETRIES = 15
 
 UNEXPECTED_PASSES = 6
-UNEXPECTED_FAILURES = 19
+UNEXPECTED_FAILURES = 21
 
 
 def unit_test_list():
@@ -269,6 +269,8 @@ layer at (0,0) size 800x34
     tests.add('corner-cases/ews/directory-skipped/timeout.html', timeout=True)
     tests.add('corner-cases/ews/directory-flaky/failure.html', expected_text='ok-txt', actual_text='text_fail-txt')
     tests.add('corner-cases/ews/directory-flaky/timeout.html', timeout=True)
+    tests.add('corner-cases/multiple-failures/failure-crash.html', expected_text='ok-txt', actual_text='text_fail-txt')
+    tests.add('corner-cases/multiple-failures/failure-timeout.html', expected_text='ok-txt', actual_text='text_fail-txt')
 
     tests.add('imported/w3c/web-platform-tests/some/new.html',
         expected_text=None, actual_text='ok', actual_image=None, actual_checksum=None)
@@ -338,6 +340,7 @@ Bug(test) failures/unexpected/pass.html [ Failure ]
 Bug(test) passes/skipped/skip.html [ Skip ]
 Bug(test) corner-cases/ews/directory-skipped [ Skip ]
 Bug(test) corner-cases/ews/directory-flaky [ Pass Timeout Failure ]
+Bug(test) corner-cases/multiple-failures/failure-timeout.html [ Pass Timeout ]
 """)
     w3c_resources_path = LAYOUT_TEST_DIR + '/imported/w3c/resources/'
     if not filesystem.exists(w3c_resources_path + 'resource-files.json'):
@@ -615,9 +618,16 @@ class TestDriver(Driver):
         audio = None
         actual_text = test.actual_text
 
-        if 'flaky' in test_name and not test_name in self._port._flakes:
+        if 'flaky' in test_name and test_name not in self._port._flakes:
             self._port._flakes.add(test_name)
             actual_text = 'flaky text failure'
+
+        if 'multiple-failures' in test_name:
+            if 'crash' in test_name and test_name in self._port._flakes:
+                test.crash = True
+            if 'timeout' in test_name and test_name in self._port._flakes:
+                test.timeout = True
+            self._port._flakes.add(test_name)
 
         if actual_text and test_args and test_name == 'passes/args.html':
             actual_text = actual_text + ' ' + ' '.join(test_args)


### PR DESCRIPTION
#### ca4e82e8dd0a7ea4c7729cc2785457318acd96d5
<pre>
[run-webkit-tests] Tests which fail and then crash on retry aren&apos;t flakey
<a href="https://bugs.webkit.org/show_bug.cgi?id=265066">https://bugs.webkit.org/show_bug.cgi?id=265066</a>
<a href="https://rdar.apple.com/118578976">rdar://118578976</a>

Reviewed by Aakash Jain.

* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(summarize_results): Tests that have unexpected behavior on retry that differs from the original
failure aren&apos;t &quot;flaky&quot;, they are still regressions and should be treated that way.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.serial_test_basic): Resolve the Fixme.
(RunTest.serial_test_run_singly_actually_runs_tests): Ditto.
(RunTest.test_retrying_multiple_failures):
(RunTest.test_retrying_multiple_failures_expected):
* Tools/Scripts/webkitpy/port/test.py: Add support for tests whose behavior changes on retry.

Canonical link: <a href="https://commits.webkit.org/279220@main">https://commits.webkit.org/279220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a6a0b6c7fd7ff4fcd6d2d89d67336408facab04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42625 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2011 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23710 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52264 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26603 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2519 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.* (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57290 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50013 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49265 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29691 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7755 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->