### PR TITLE
[WGSL] Fix failing wgslc tests

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -113,5 +113,6 @@ enum class ParameterRole : uint8_t;
 enum class StructureRole : uint8_t;
 enum class UnaryOperation : uint8_t;
 enum class VariableFlavor : uint8_t;
+enum class VariableRole : uint8_t;
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -43,6 +43,7 @@ enum class ParameterRole : uint8_t {
     UserDefined,
     StageIn,
     BindGroup,
+    PackedResource,
 };
 
 class Parameter final : public Node {

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -47,6 +47,11 @@ enum class VariableFlavor : uint8_t {
     Var,
 };
 
+enum class VariableRole : uint8_t {
+    UserDefined,
+    PackedResource,
+};
+
 class Variable final : public Declaration {
     WGSL_AST_BUILDER_NODE(Variable);
     friend AttributeValidator;
@@ -60,6 +65,10 @@ public:
     NodeKind kind() const override;
     VariableFlavor flavor() const { return m_flavor; };
     VariableFlavor& flavor() { return m_flavor; };
+
+    VariableRole role() const { return m_role; }
+    VariableRole& role() { return m_role; }
+
     Identifier& name() override { return m_name; }
     Identifier& originalName() { return m_originalName; }
     Attribute::List& attributes() { return m_attributes; }
@@ -85,7 +94,7 @@ private:
         : Variable(span, flavor, WTFMove(name), { }, type, initializer, { })
     { }
 
-    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr qualifier, Expression::Ptr type, Expression::Ptr initializer, Attribute::List&& attributes)
+    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr qualifier, Expression::Ptr type, Expression::Ptr initializer, Attribute::List&& attributes, VariableRole role = VariableRole::UserDefined)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_originalName(m_name)
@@ -94,6 +103,7 @@ private:
         , m_type(type)
         , m_initializer(initializer)
         , m_flavor(flavor)
+        , m_role(role)
     {
         ASSERT(m_type || m_initializer);
     }
@@ -107,6 +117,7 @@ private:
     Expression::Ptr m_type;
     Expression::Ptr m_initializer;
     VariableFlavor m_flavor;
+    VariableRole m_role;
     Expression::Ptr m_referenceType { nullptr };
 
     // Computed properties

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -79,6 +79,14 @@ public:
     void setUsesUnpackArray() { m_usesUnpackArray = true; }
     void clearUsesUnpackArray() { m_usesUnpackArray = false; }
 
+    bool usesPackVector() const { return m_usesPackVector; }
+    void setUsesPackVector() { m_usesPackVector = true; }
+    void clearUsesPackVector() { m_usesPackVector = false; }
+
+    bool usesUnpackVector() const { return m_usesUnpackVector; }
+    void setUsesUnpackVector() { m_usesUnpackVector = true; }
+    void clearUsesUnpackVector() { m_usesUnpackVector = false; }
+
     bool usesWorkgroupUniformLoad() const { return m_usesWorkgroupUniformLoad; }
     void setUsesWorkgroupUniformLoad() { m_usesWorkgroupUniformLoad = true; }
 
@@ -263,6 +271,8 @@ private:
     bool m_usesExternalTextures { false };
     bool m_usesPackArray { false };
     bool m_usesUnpackArray { false };
+    bool m_usesPackVector { false };
+    bool m_usesUnpackVector { false };
     bool m_usesWorkgroupUniformLoad { false };
     bool m_usesDivision { false };
     bool m_usesModulo { false };

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -80,13 +80,13 @@ fn testAssignment() -> i32
     at2 = at;
 
     // array of vec3
-    // CHECK-NEXT: local\d+ = global\d+;
+    // CHECK-NEXT: local\d+ = __unpack\(global\d+\);
     var av = av1;
-    // CHECK-NEXT: local\d+ = global\d+;
+    // CHECK-NEXT: local\d+ = __unpack\(global\d+\);
     av = av1;
     // CHECK-NEXT: global\d+ = global\d+;
     av1 = av2;
-    // CHECK-NEXT: global\d+ = local\d+;
+    // CHECK-NEXT: global\d+ = __pack\(local\d+\);
     av2 = av;
 
     return 0;
@@ -101,10 +101,10 @@ fn testFieldAccess() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = global\d+\.field\d\.x;
     // CHECK-NEXT: global\d+\.field\d\.x = global\d+\.field\d\.x;
     // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
+    // CHECK-NEXT: global\d+\.field\d = __unpack\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
     // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
-    // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
-    // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
+    // CHECK-NEXT: global\d+\.field\d = __unpack\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
     // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
     // CHECK-NEXT: global\d+\.field\d = global\d+\.field\d;
@@ -210,10 +210,10 @@ fn testBinaryOperations() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = \(2u \* global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d\.x = \(2u \* global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d = \(2. \* global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = \(2. \* float3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = \(2. \* __unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = \(2. \* global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(2u \* global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = \(2u \* uint3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = \(2u \* __unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = \(2u \* global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(2. \* global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(2u \* global\d+\.field\d\);
@@ -239,10 +239,10 @@ fn testBinaryOperations() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = \(2u \* global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d\.x = \(2u \* global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d = \(2. \* global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = \(2. \* float3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = \(2. \* __unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = \(2. \* global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(2u \* global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = \(2u \* uint3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = \(2u \* __unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = \(2u \* global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(2. \* global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(2u \* global\d+\.field\d\);
@@ -299,7 +299,7 @@ fn testUnaryOperations() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = \(-global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d\.x = \(-global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d = \(-global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = \(-float3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = \(-__unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = \(-global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(-global\d+\.field\d\);
     t.v2f.x = -t1.v2f.x;
@@ -314,7 +314,7 @@ fn testUnaryOperations() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = \(-global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d\.x = \(-global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d = \(-global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = \(-float3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = \(-__unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = \(-global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = \(-global\d+\.field\d\);
     t1.v2f.x = -t2.v2f.x;
@@ -352,10 +352,10 @@ fn testCall() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = abs\(global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d\.x = abs\(global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = abs\(float3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = abs\(__unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = abs\(uint3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = abs\(__unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
@@ -381,10 +381,10 @@ fn testCall() -> i32
     // CHECK-NEXT: global\d+\.field\d\.x = abs\(global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d\.x = abs\(global\d+\.field\d\.x\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = abs\(float3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = abs\(__unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
-    // CHECK-NEXT: global\d+\.field\d = abs\(uint3\(global\d+\.field\d\)\);
+    // CHECK-NEXT: global\d+\.field\d = abs\(__unpack\(global\d+\.field\d\)\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);
     // CHECK-NEXT: global\d+\.field\d = abs\(global\d+\.field\d\);


### PR DESCRIPTION
#### 8cb609477c197cfc25fd66fab6f51b7017c7e8dd
<pre>
[WGSL] Fix failing wgslc tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=274479">https://bugs.webkit.org/show_bug.cgi?id=274479</a>
<a href="https://rdar.apple.com/128485179">rdar://128485179</a>

Reviewed by Mike Wyrzykowski.

There were 2 issues after 278991@main:
- we emitted definitions for `__unpack(PackedVec3)` even when we didn&apos;t emit
  the PackedVec3 struct
- in a previous patch we tried skipping some explicit pack/unpack calls for
  vec3/packed_vec3, but that doesn&apos;t work for PackedVec3, so we can no longer
  skip these calls.

* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTParameter.h:
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::packStructResource):
(WGSL::RewriteGlobalVariables::packArrayResource):
(WGSL::RewriteGlobalVariables::insertMaterializations):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::shouldPackType const):
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesPackVector const):
(WGSL::ShaderModule::setUsesPackVector):
(WGSL::ShaderModule::clearUsesPackVector):
(WGSL::ShaderModule::usesUnpackVector const):
(WGSL::ShaderModule::setUsesUnpackVector):
(WGSL::ShaderModule::clearUsesUnpackVector):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/279141@main">https://commits.webkit.org/279141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4baf3ab3dff62aa9e43278178ee55fc776318d90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3301 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42716 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2109 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23808 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1460 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57448 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50112 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49394 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->