### PR TITLE
REGRESSION (278960@main?): [ MacOS iOS ] 8X imported/w3c/web-platform-tests/navigation-api are consistently failing and 1 is crashing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6925,7 +6925,7 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-l
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html [ Failure ]
 
 # Crash caused by detach.
-imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-detach-in-onnavigate.html [ Crash Failure ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-detach-in-onnavigate.html [ Skip ]
 
 # General flakes, almost exclusively on mac-wk2-stress.
 imported/w3c/web-platform-tests/navigation-api/currententrychange-event/anchor-click.html [ Failure Pass ]
@@ -6952,6 +6952,7 @@ imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bf
 imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/state/cross-document-getState-undefined.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/basic.html [ Failure Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html [ Skip ]
 
 # -- View Transitions -- #
 # Reftest failures:

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
@@ -1,4 +1,6 @@
 
 
-PASS A traversal that redirects from same-origin to cross-origin fires the navigate event
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT A traversal that redirects from same-origin to cross-origin fires the navigate event Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-expected.txt
@@ -1,6 +1,6 @@
 
-PASS <a> fires navigate and populates downloadRequest with ''
-PASS <a> fires navigate and populates downloadRequest with 'filename'
-PASS <area> fires navigate and populates downloadRequest with ''
-PASS <area> fires navigate and populates downloadRequest with 'filename'
+FAIL <a> fires navigate and populates downloadRequest with '' assert_true: expected true got false
+FAIL <a> fires navigate and populates downloadRequest with 'filename' assert_true: expected true got false
+FAIL <area> fires navigate and populates downloadRequest with '' assert_true: expected true got false
+FAIL <area> fires navigate and populates downloadRequest with 'filename' assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated-expected.txt
@@ -1,4 +1,4 @@
 Click me
 
-PASS <a download> click fires navigate event
+FAIL <a download> click fires navigate event assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-detach-in-onnavigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-detach-in-onnavigate-expected.txt
@@ -1,4 +1,5 @@
 
+Harness Error (TIMEOUT), message = null
 
-FAIL window detach inside a navigate event signals event.signal promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'promise.then')"
+TIMEOUT window detach inside a navigate event signals event.signal Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Basic tests for navigation.currentEntry assert_not_equals: got disallowed value "http://web-platform.test:8800/navigation-api/navigation-history-entry/current-basic.html#6"
+FAIL Basic tests for navigation.currentEntry assert_not_equals: got disallowed value "http://localhost:8800/navigation-api/navigation-history-entry/current-basic.html#6"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.entries() behavior when multiple windows navigate. assert_not_equals: got disallowed value "http://localhost:8800/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows.html"
+FAIL navigation.entries() behavior when multiple windows navigate. assert_equals: expected 2 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-detach-in-onnavigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-detach-in-onnavigate-expected.txt
@@ -1,2 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT navigate() promise rejections when detaching an iframe inside onnavigate Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_throws_dom: function "() => { throw committedReason; }" threw undefined with type "undefined", not an object
 
 
 FAIL reload() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError" assert_equals: expected 1 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL A sandboxed iframe can use its sibling's navigation object to call navigate(), as long as allow-same-origin is present assert_equals: expected "http://localhost:8800/navigation-api/navigation-methods/sandboxing-navigate-parent.html#2" but got "http://localhost:8800/navigation-api/navigation-methods/sandboxing-navigate-parent.html"
+PASS A sandboxed iframe can use its sibling's navigation object to call navigate(), as long as allow-same-origin is present
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -431,13 +431,15 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
         return;
 
     RefPtr oldCurrentEntry = currentEntry();
-    ASSERT(oldCurrentEntry);
+    if (!oldCurrentEntry)
+        return;
 
     Vector<Ref<NavigationHistoryEntry>> disposedEntries;
 
     if (navigationType == NavigationNavigationType::Traverse) {
         m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, item);
-        ASSERT(m_currentEntryIndex);
+        if (!m_currentEntryIndex)
+            return;
     } else if (navigationType == NavigationNavigationType::Push) {
         m_currentEntryIndex = *m_currentEntryIndex + 1;
         for (size_t i = *m_currentEntryIndex; i < m_entries.size(); i++)


### PR DESCRIPTION
#### 5461787f10d0223437708a773ac72f6d684c0f53
<pre>
REGRESSION (278960@main?): [ MacOS iOS ] 8X imported/w3c/web-platform-tests/navigation-api are consistently failing and 1 is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=274475">https://bugs.webkit.org/show_bug.cgi?id=274475</a>
<a href="https://rdar.apple.com/128479544">rdar://128479544</a>

Unreviewed.

Change some failing assertions to early returns and update tests.
This code is in an off-by-default experimental feature.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-detach-in-onnavigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-detach-in-onnavigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::updateForNavigation):

Canonical link: <a href="https://commits.webkit.org/279073@main">https://commits.webkit.org/279073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb3101a1952f4ca1dca7c9813e18f8af240c97dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55722 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2870 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54544 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23722 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1330 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57318 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45383 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7684 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->