### PR TITLE
WebGPU] Destroyed buffers or textures only invalidate their most recent command buffer

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1762,6 +1762,7 @@ http/tests/webgpu/webgpu/api/validation/buffer/destroy.html [ Pass ]
 http/tests/webgpu/webgpu/api/validation/buffer/mapping.html [ Pass ]
 
 http/tests/webgpu/webgpu/api/validation/queue/submit.html [ Pass ]
+http/tests/webgpu/webgpu/api/validation/queue/destroyed [ Pass ]
 
 # Skip tests until they can be validated to consistently pass in EWS
 http/tests/webgpu/webgpu/idl/constructable.html [ Skip ]

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -32,6 +32,7 @@
 #import <wtf/RangeSet.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUBufferImpl {
@@ -106,6 +107,8 @@ private:
     NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
     bool validateUnmap() const;
     void setState(State);
+    void incrementBufferMapCount();
+    void decrementBufferMapCount();
 
     id<MTLBuffer> m_buffer { nil };
     id<MTLBuffer> m_indirectBuffer { nil };
@@ -129,7 +132,7 @@ private:
     } m_indirectCache;
 
     const Ref<Device> m_device;
-    mutable WeakPtr<CommandEncoder> m_commandEncoder;
+    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
     mutable uint16_t m_max16BitIndex { 0 };
     mutable uint32_t m_max32BitIndex { 0 };
 };

--- a/Source/WebGPU/WebGPU/ExternalTexture.h
+++ b/Source/WebGPU/WebGPU/ExternalTexture.h
@@ -28,6 +28,7 @@
 #import "Device.h"
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUExternalTextureImpl {
@@ -69,7 +70,7 @@ private:
     WGPUColorSpace m_colorSpace;
     const Ref<Device> m_device;
     bool m_destroyed { false };
-    mutable WeakPtr<CommandEncoder> m_commandEncoder;
+    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -64,20 +64,21 @@ ExternalTexture::~ExternalTexture() = default;
 void ExternalTexture::destroy()
 {
     m_destroyed = true;
-    if (m_commandEncoder)
-        m_commandEncoder.get()->makeSubmitInvalid();
-    m_commandEncoder = nullptr;
+    for (auto& commandEncoder : m_commandEncoders)
+        commandEncoder.makeSubmitInvalid();
+
+    m_commandEncoders.clear();
 }
 
 void ExternalTexture::undestroy()
 {
-    m_commandEncoder = nullptr;
+    m_commandEncoders.clear();
     m_destroyed = false;
 }
 
 void ExternalTexture::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoder = commandEncoder;
+    m_commandEncoders.add(commandEncoder);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -30,6 +30,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUQuerySetImpl {
@@ -96,7 +97,7 @@ private:
         Ref<QuerySet> other;
         uint32_t otherIndex;
     };
-    mutable WeakPtr<CommandEncoder> m_cachedCommandEncoder;
+    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
     bool m_destroyed { false };
 };
 

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -100,9 +100,10 @@ void QuerySet::destroy()
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy
     m_visibilityBuffer = nil;
     m_timestampBuffer = nil;
-    if (m_cachedCommandEncoder)
-        m_cachedCommandEncoder.get()->makeSubmitInvalid();
-    m_cachedCommandEncoder = nullptr;
+    for (auto& commandEncoder : m_commandEncoders)
+        commandEncoder.makeSubmitInvalid();
+
+    m_commandEncoders.clear();
 }
 
 void QuerySet::setLabel(String&& label)
@@ -117,7 +118,7 @@ void QuerySet::setOverrideLocation(QuerySet&, uint32_t, uint32_t)
 
 void QuerySet::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_cachedCommandEncoder = commandEncoder;
+    m_commandEncoders.add(commandEncoder);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -31,6 +31,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUTextureImpl {
@@ -152,7 +153,7 @@ private:
     Vector<WeakPtr<TextureView>> m_textureViews;
     bool m_destroyed { false };
     bool m_canvasBacking { false };
-    mutable WeakPtr<CommandEncoder> m_commandEncoder;
+    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2991,13 +2991,13 @@ void Texture::makeCanvasBacking()
 
 void Texture::waitForCommandBufferCompletion()
 {
-    if (auto* commandEncoder = m_commandEncoder.get())
-        commandEncoder->waitForCommandBufferCompletion();
+    for (auto& commandEncoder : m_commandEncoders)
+        commandEncoder.waitForCommandBufferCompletion();
 }
 
 void Texture::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoder = commandEncoder;
+    m_commandEncoders.add(commandEncoder);
     if (!m_canvasBacking && isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }
@@ -3218,9 +3218,11 @@ void Texture::destroy()
         if (view.get())
             view->destroy();
     }
-    if (!m_canvasBacking && m_commandEncoder)
-        m_commandEncoder.get()->makeSubmitInvalid();
-    m_commandEncoder = nullptr;
+    if (!m_canvasBacking) {
+        for (auto& commandEncoder : m_commandEncoders)
+            commandEncoder.makeSubmitInvalid();
+    }
+    m_commandEncoders.clear();
 
     m_textureViews.clear();
 }

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -28,6 +28,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUTextureViewImpl {
@@ -99,7 +100,7 @@ private:
 
     const Ref<Device> m_device;
     Ref<Texture> m_parentTexture;
-    mutable WeakPtr<CommandEncoder> m_commandEncoder;
+    mutable WeakHashSet<CommandEncoder> m_commandEncoders;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -168,15 +168,17 @@ bool TextureView::isValid() const
 void TextureView::destroy()
 {
     m_texture = m_device->placeholderTexture(format());
-    if (m_commandEncoder && !m_parentTexture->isCanvasBacking())
-        m_commandEncoder.get()->makeSubmitInvalid();
+    if (!m_parentTexture->isCanvasBacking()) {
+        for (auto& commandEncoder : m_commandEncoders)
+            commandEncoder.makeSubmitInvalid();
+    }
 
-    m_commandEncoder = nullptr;
+    m_commandEncoders.clear();
 }
 
 void TextureView::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
-    m_commandEncoder = &commandEncoder;
+    m_commandEncoders.add(commandEncoder);
     if (isDestroyed() && !m_parentTexture->isCanvasBacking())
         commandEncoder.makeSubmitInvalid();
 }


### PR DESCRIPTION
#### f84f875285ffcac10237f968c68929d843004cd5
<pre>
WebGPU] Destroyed buffers or textures only invalidate their most recent command buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=274481">https://bugs.webkit.org/show_bug.cgi?id=274481</a>&gt;
&lt;radar://128489902&gt;

Reviewed by Dan Glastonbury.

Destroying a buffer / texture should invalidate all the associated
command encoders / buffers and not just the most recent one.

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::incrementBufferMapCount):
(WebGPU::Buffer::decrementBufferMapCount):
(WebGPU::Buffer::setCommandEncoder const):
(WebGPU::Buffer::destroy):
(WebGPU::Buffer::mapAsync):
(WebGPU::Buffer::unmap):
* Source/WebGPU/WebGPU/ExternalTexture.h:
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::destroy):
(WebGPU::ExternalTexture::undestroy):
(WebGPU::ExternalTexture::setCommandEncoder const):
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::QuerySet::destroy):
(WebGPU::QuerySet::setCommandEncoder const):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::waitForCommandBufferCompletion):
(WebGPU::Texture::setCommandEncoder const):
(WebGPU::Texture::destroy):
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::destroy):
(WebGPU::TextureView::setCommandEncoder const):

Canonical link: <a href="https://commits.webkit.org/279248@main">https://commits.webkit.org/279248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97c1ba3925b2f63a51abbe3d52485f4ba477393

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3482 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42829 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2852 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57629 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50227 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49503 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11553 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->