### PR TITLE
Remove WKProcessGroupDelegate

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.h
@@ -30,20 +30,6 @@
 
 @class WKProcessGroup;
 
-@protocol WKProcessGroupDelegate <NSObject>
-@optional
-
-- (id)processGroupWillCreateConnectionToWebProcessPlugIn:(WKProcessGroup *)processGroup;
-
-@required
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)processGroup:(WKProcessGroup *)processGroup didCreateConnectionToWebProcessPlugIn:(WKConnection *)connection;
-#pragma clang diagnostic pop
-
-@end
-
 WK_CLASS_DEPRECATED_WITH_REPLACEMENT("WKProcessPool", macos(10.10, 10.14.4), ios(8.0, 12.2))
 @interface WKProcessGroup : NSObject
 
@@ -51,7 +37,5 @@ WK_CLASS_DEPRECATED_WITH_REPLACEMENT("WKProcessPool", macos(10.10, 10.14.4), ios
 - (id)initWithInjectedBundleURL:(NSURL *)bundleURL andCustomClassesForParameterCoder:(NSSet *)classesForCoder;
 
 #pragma mark Delegates
-
-@property (nonatomic, weak) id <WKProcessGroupDelegate> delegate;
 
 @end


### PR DESCRIPTION
#### 52fa87c753c32f6c3987c0965fee4a19ad31479e
<pre>
Remove WKProcessGroupDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=274490">https://bugs.webkit.org/show_bug.cgi?id=274490</a>
<a href="https://rdar.apple.com/128499406">rdar://128499406</a>

Reviewed by Brady Eidson.

Its last use was removed in <a href="https://rdar.apple.com/127167483">rdar://127167483</a>
It was used to provide a WKConnection to the application for communication with the
injected bundle.  That has been completely replaced by _WKRemoteObjectRegistry.

* Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm:
(-[WKProcessGroup initWithInjectedBundleURL:]):
(-[WKProcessGroup initWithInjectedBundleURL:andCustomClassesForParameterCoder:]):
(didCreateConnection): Deleted.
(getInjectedBundleInitializationUserData): Deleted.
(-[WKProcessGroup delegate]): Deleted.
(-[WKProcessGroup setDelegate:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/279088@main">https://commits.webkit.org/279088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa674a2cf4e974d2da31bda361b11ee92989daba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2897 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23740 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1357 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27604 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50041 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45404 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7691 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->