### PR TITLE
Generate validation for the type of CoreFoundation objects that we deserialize

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -832,11 +832,17 @@ def decode_cf_type(type):
     result.append('    auto result = decoder.decode<' + type.cf_wrapper_type() + '>();')
     result.append('    if (UNLIKELY(!decoder.isValid()))')
     result.append('        return std::nullopt;')
-    cf_method = 'toCF'
     if type.to_cf_method is not None:
-        result.append('    return ' + type.to_cf_method + ';')
+        result.append('    auto cfResult = ' + type.to_cf_method + ';')
     else:
-        result.append('    return result->toCF();')
+        result.append('    auto cfResult = result->toCF();')
+    if type.cf_type != "CFType":
+        result.append('#pragma clang diagnostic push')
+        result.append('#pragma clang diagnostic ignored "-Wdeprecated-declarations"')
+        result.append('    if (CFGetTypeID(cfResult.get()) != ' + type.cf_type + 'GetTypeID())')
+        result.append('        return std::nullopt;')
+        result.append('#pragma clang diagnostic pop')
+    result.append('    return WTFMove(cfResult);')
     return result
 
 def decode_type(type):

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -60,6 +60,7 @@
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
 #include <WebCore/FloatBoxExtent.h>
+#include <WebCore/GenericTypeWrapper.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
@@ -1226,7 +1227,27 @@ std::optional<RetainPtr<CFFooRef>> ArgumentCoder<RetainPtr<CFFooRef>>::decode(De
     auto result = decoder.decode<WebKit::FooWrapper>();
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
-    return result->toCF();
+    auto cfResult = result->toCF();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (CFGetTypeID(cfResult.get()) != CFFooGetTypeID())
+        return std::nullopt;
+#pragma clang diagnostic pop
+    return WTFMove(cfResult);
+}
+
+void ArgumentCoder<CFTypeRef>::encode(Encoder& encoder, CFTypeRef instance)
+{
+    encoder << WebCore::GenericTypeWrapper { instance };
+}
+
+std::optional<RetainPtr<CFTypeRef>> ArgumentCoder<RetainPtr<CFTypeRef>>::decode(Decoder& decoder)
+{
+    auto result = decoder.decode<WebCore::GenericTypeWrapper>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    auto cfResult = result->toCF();
+    return WTFMove(cfResult);
 }
 
 #if USE(CFBAR)
@@ -1245,7 +1266,13 @@ std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(De
     auto result = decoder.decode<WebKit::BarWrapper>();
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
-    return createCFBar(*result);
+    auto cfResult = createCFBar(*result);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (CFGetTypeID(cfResult.get()) != CFBarGetTypeID())
+        return std::nullopt;
+#pragma clang diagnostic pop
+    return WTFMove(cfResult);
 }
 
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -323,6 +323,17 @@ template<> struct ArgumentCoder<RetainPtr<CFFooRef>> {
     static std::optional<RetainPtr<CFFooRef>> decode(Decoder&);
 };
 
+template<> struct ArgumentCoder<CFTypeRef> {
+    static void encode(Encoder&, CFTypeRef);
+};
+template<> struct ArgumentCoder<RetainPtr<CFTypeRef>> {
+    static void encode(Encoder& encoder, const RetainPtr<CFTypeRef>& retainPtr)
+    {
+        ArgumentCoder<CFTypeRef>::encode(encoder, retainPtr.get());
+    }
+    static std::optional<RetainPtr<CFTypeRef>> decode(Decoder&);
+};
+
 #if USE(CFBAR)
 template<> struct ArgumentCoder<CFBarRef> {
     static void encode(Encoder&, CFBarRef);

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -61,6 +61,7 @@
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
 #include <WebCore/FloatBoxExtent.h>
+#include <WebCore/GenericTypeWrapper.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
@@ -424,6 +425,9 @@ Vector<SerializedTypeInfo> allSerializedTypes()
 #endif // ENABLE(DATA_DETECTION)
         { "CFFooRef"_s, {
             { "WebKit::FooWrapper"_s, "wrapper"_s }
+        } },
+        { "CFTypeRef"_s, {
+            { "WebCore::GenericTypeWrapper"_s, "wrapper"_s }
         } },
 #if USE(CFBAR)
         { "CFBarRef"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -267,6 +267,9 @@ secure_coding_headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>
 CFFooRef wrapped by WebKit::FooWrapper {
 }
 
+CFTypeRef wrapped by WebCore::GenericTypeWrapper {
+}
+
 #if USE(CFBAR)
 additional_forward_declaration: typedef struct __CFBar * CFBarRef
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder, FromCFMethod=WebKit::BarWrapper::createFromCF, ToCFMethod=createCFBar(*result)] CFBarRef wrapped by WebKit::BarWrapper {

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -356,7 +356,13 @@ std::optional<RetainPtr<CFStringRef>> ArgumentCoder<RetainPtr<CFStringRef>>::dec
     auto result = decoder.decode<WTF::String>();
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
-    return result->createCFString();
+    auto cfResult = result->createCFString();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (CFGetTypeID(cfResult.get()) != CFStringGetTypeID())
+        return std::nullopt;
+#pragma clang diagnostic pop
+    return WTFMove(cfResult);
 }
 
 #endif


### PR DESCRIPTION
#### 9c8da5624c0eab4b925cc0c70a396499bad5b201
<pre>
Generate validation for the type of CoreFoundation objects that we deserialize
<a href="https://rdar.apple.com/128500993">rdar://128500993</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274492">https://bugs.webkit.org/show_bug.cgi?id=274492</a>

Reviewed by NOBODY (OOPS!).

Better to validate the type of an object is what&apos;s expected than to... not validate it.

* Source/WebKit/Scripts/generate-serializers.py:
(decode_cf_type):

* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;CFTypeRef&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFTypeRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFTypeRef&gt;&gt;::encode):

* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):

* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c8da5624c0eab4b925cc0c70a396499bad5b201

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52480 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31813 "Hash 9c8da562 for PR 28876 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3203 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38331 "Hash 9c8da562 for PR 28876 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42655 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2047 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54577 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/38331 "Hash 9c8da562 for PR 28876 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46773 "Failed to checkout and rebase branch from PR 28876") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23744 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52324 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/38331 "Hash 9c8da562 for PR 28876 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1362 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/38331 "Hash 9c8da562 for PR 28876 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2721 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/mac/aria-combobox-activedescendant.html, accessibility/combobox/mac/combobox-activedescendant-notifications.html, accessibility/combobox/mac/combobox-inherited-role.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57350 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27614 "Hash 9c8da562 for PR 28876 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2747 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/mac/aria-combobox-activedescendant.html, accessibility/combobox/mac/combobox-activedescendant-notifications.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/datetime/input-date-field-labels-and-value-changes.html, accessibility/datetime/input-datetime-local-label-value.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50046 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28840 "Hash 9c8da562 for PR 28876 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49300 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29751 "Hash 9c8da562 for PR 28876 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28587 "Hash 9c8da562 for PR 28876 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->