### PR TITLE
Fix :is(:host) both as a subject and as an ancestor

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7416,14 +7416,6 @@ imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.
 # webkit.org/b/229520 CSS @scope unimplemented
 imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]
 
-# :is(:host) https://bugs.webkit.org/show_bug.cgi?id=264628
-imported/w3c/web-platform-tests/css/css-nesting/host-nesting-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-nesting/host-nesting-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-nesting/host-nesting-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/host-is-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/host-is-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/host-is-005.html [ ImageOnlyFailure ]
-
 webkit.org/b/263923 animations/transition-and-animation-2.html [ Failure Pass ]
 
 # CloseWatcher related timeouts

--- a/LayoutTests/fast/css/host-matching-expected.html
+++ b/LayoutTests/fast/css/host-matching-expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<style>
+.test {
+  background-color: green;
+  width: 30px;
+  height: 30px;
+  margin: 10px;
+}
+</style>
+<div id="host1" class="test"> </div>
+<div id="host2" class="test"> </div>
+<div id="host3" class="test"> </div>
+<div id="host4" class="test"> </div>
+<div id="host5" class="test"> </div>
+<div id="host6" class="test"> </div>
+<div id="host5" class="test"> </div>
+<div id="host6" class="test"> </div>

--- a/LayoutTests/fast/css/host-matching.html
+++ b/LayoutTests/fast/css/host-matching.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<div id="host1"> </div>
+<div id="host2"> </div>
+<div id="host3"> </div>
+<div id="host4"> </div>
+<div id="host5"> </div>
+<div id="host6"> </div>
+<div id="host7"> </div>
+<div><div id="host8"> </div></div>
+<script>
+  host1.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      .nested {
+        background-color: red;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :is(:host) .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host2.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      .nested {
+        background-color: red;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :is(foo,:host) .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host3.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :not(:host) .nested {
+        background-color: red;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host4.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      .nested {
+        background-color: red;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :is(:is(:host)) .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host5.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      div {
+        background-color: red;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :is(:host(div)) .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host6.innerHTML = `
+    <style>
+      .nested {
+        background-color: red;
+      }
+      :is(:host, #host6) .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host7.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      div {
+        background-color: red;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :is(:host, :host) .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+
+  host8.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      .nested {
+        background-color: green;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+      :is(div) .nested {
+        background-color: red;
+        width: 30px;
+        height: 30px;
+        margin: 10px;
+      }
+    </style>
+    <div class="nested"></div>
+  `;
+</script>

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -736,7 +736,7 @@ CSSSelector::RareData::RareData(const RareData& other)
         this->selectorList = makeUnique<CSSSelectorList>(*other.selectorList);
 };
 
-auto CSSSelector::RareData::deepCopy() const -> Ref<RareData> 
+auto CSSSelector::RareData::deepCopy() const -> Ref<RareData>
 {
     return adoptRef(*new RareData (*this));
 }
@@ -864,6 +864,11 @@ bool CSSSelector::hasExplicitPseudoClassScope() const
     };
 
     return visitAllSimpleSelectors(check);
+}
+
+bool CSSSelector::isHostPseudoClass() const
+{
+    return match() == Match::PseudoClass && pseudoClass() == PseudoClass::Host;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -157,6 +157,7 @@ public:
     bool matchesPseudoElement() const;
     bool isSiblingSelector() const;
     bool isAttributeSelector() const;
+    bool isHostPseudoClass() const;
 
     Relation relation() const { return static_cast<Relation>(m_relation); }
     Match match() const { return static_cast<Match>(m_match); }

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -83,6 +83,7 @@ struct SelectorChecker::LocalContext {
     bool hasSelectionPseudo { false };
     bool hasViewTransitionPseudo { false };
     bool mustMatchHostPseudoClass { false };
+    bool matchedHostPseudoClass { false };
 };
 
 static inline void addStyleRelation(SelectorChecker::CheckingContext& checkingContext, const Element& element, Style::Relation::Type type, unsigned value = 1)
@@ -213,6 +214,7 @@ bool SelectorChecker::matchHostPseudoClass(const CSSSelector& selector, const El
         return false;
 
     if (auto* selectorList = selector.selectorList()) {
+        ASSERT(selectorList->listSize() == 1);
         LocalContext context(*selectorList->first(), element, VisitedMatchType::Enabled, std::nullopt);
         context.inFunctionalPseudoClass = true;
         context.pseudoElementEffective = false;
@@ -268,13 +270,11 @@ static SelectorChecker::LocalContext localContextForParent(const SelectorChecker
         return updatedContext;
     }
 
-    // Move to the shadow host if matching :host and the parent is the shadow root.
-    if (context.selector->match() == CSSSelector::Match::PseudoClass && context.selector->pseudoClass() == CSSSelector::PseudoClass::Host) {
-        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(context.element->parentNode())) {
-            updatedContext.element = shadowRoot->host();
-            updatedContext.mustMatchHostPseudoClass = true;
-            return updatedContext;
-        }
+    // Move to the shadow host if the parent is the shadow root and mark that we must match :host
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(context.element->parentNode())) {
+        updatedContext.element = shadowRoot->host();
+        updatedContext.mustMatchHostPseudoClass = true;
+        return updatedContext;
     }
 
     updatedContext.element = context.element->parentElement();
@@ -287,7 +287,7 @@ static SelectorChecker::LocalContext localContextForParent(const SelectorChecker
 // * SelectorFailsLocally     - the selector fails for the element e
 // * SelectorFailsAllSiblings - the selector fails for e and any sibling of e
 // * SelectorFailsCompletely  - the selector fails for e and any sibling or ancestor of e
-SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& checkingContext, const LocalContext& context, PseudoIdSet& dynamicPseudoIdSet) const
+SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& checkingContext, LocalContext& context, PseudoIdSet& dynamicPseudoIdSet) const
 {
     MatchType matchType = MatchType::Element;
 
@@ -336,8 +336,12 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
     // Prepare next selector
     const CSSSelector* leftSelector = context.selector->tagHistory();
-    if (!leftSelector)
+    if (!leftSelector) {
+        if (context.mustMatchHostPseudoClass && !context.matchedHostPseudoClass)
+            return MatchResult::fails(Match::SelectorFailsCompletely);
+
         return MatchResult::matches(matchType);
+    }
 
     LocalContext nextContext(context);
     nextContext.selector = leftSelector;
@@ -695,7 +699,7 @@ static inline bool tagMatches(const Element& element, const CSSSelector& simpleS
     return namespaceURI == starAtom() || namespaceURI == element.namespaceURI();
 }
 
-bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalContext& context, MatchType& matchType) const
+bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& context, MatchType& matchType) const
 {
     const Element& element = *context.element;
     const CSSSelector& selector = *context.selector;
@@ -704,7 +708,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         // :host doesn't combine with anything except pseudo elements.
         bool isHostPseudoClass = selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClass() == CSSSelector::PseudoClass::Host;
         bool isPseudoElement = selector.match() == CSSSelector::Match::PseudoElement;
-        if (!isHostPseudoClass && !isPseudoElement)
+        // We can early return when we know it's neither :host, a compound like :is(:host), a pseudo-element.
+        if (!isHostPseudoClass && !isPseudoElement && !selector.selectorList())
             return false;
     }
 
@@ -881,15 +886,16 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 bool hasMatchedAnything = false;
 
                 MatchType localMatchType = MatchType::VirtualPseudoElementOnly;
-                for (const CSSSelector* subselector = selector.selectorList()->first(); subselector; subselector = CSSSelectorList::next(subselector)) {
+                for (const auto& subselector : *selector.selectorList()) {
                     LocalContext subcontext(context);
                     subcontext.inFunctionalPseudoClass = true;
                     subcontext.pseudoElementEffective = context.pseudoElementEffective;
-                    subcontext.selector = subselector;
-                    subcontext.firstSelectorOfTheFragment = subselector;
+                    subcontext.selector = &subselector;
+                    subcontext.firstSelectorOfTheFragment = &subselector;
                     subcontext.pseudoElementIdentifier = std::nullopt;
                     PseudoIdSet localDynamicPseudoIdSet;
                     MatchResult result = matchRecursively(checkingContext, subcontext, localDynamicPseudoIdSet);
+                    context.matchedHostPseudoClass |= subcontext.matchedHostPseudoClass;
 
                     // Pseudo elements are not valid inside :is()/:matches()
                     if (localDynamicPseudoIdSet)
@@ -1118,7 +1124,10 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         case CSSSelector::PseudoClass::Host: {
             if (!context.mustMatchHostPseudoClass)
                 return false;
-            return matchHostPseudoClass(selector, element, checkingContext);
+            if (!matchHostPseudoClass(selector, element, checkingContext))
+                return false;
+            context.matchedHostPseudoClass = true;
+            return true;
         }
         case CSSSelector::PseudoClass::Defined:
             return isDefinedElement(element);

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -111,8 +111,8 @@ public:
     struct LocalContext;
     
 private:
-    MatchResult matchRecursively(CheckingContext&, const LocalContext&, PseudoIdSet&) const;
-    bool checkOne(CheckingContext&, const LocalContext&, MatchType&) const;
+    MatchResult matchRecursively(CheckingContext&, LocalContext&, PseudoIdSet&) const;
+    bool checkOne(CheckingContext&, LocalContext&, MatchType&) const;
     bool matchSelectorList(CheckingContext&, const LocalContext&, const Element&, const CSSSelectorList&) const;
     bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelector&) const;
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1127,7 +1127,7 @@ void CSSSelectorParser::prependTypeSelectorIfNeeded(const AtomString& namespaceP
     // ::cue), we need a universal selector to set the combinator
     // (relation) on in the cases where there are no simple selectors preceding
     // the pseudo element.
-    bool isHostPseudo = compoundSelector.isHostPseudoSelector();
+    bool isHostPseudo = compoundSelector.isHostPseudoClass();
     if (isHostPseudo && elementName.isNull() && namespacePrefix.isNull())
         return;
     if (tag != anyQName() || isHostPseudo || isShadowDOM)

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -277,10 +277,7 @@ std::unique_ptr<MutableCSSSelector> MutableCSSSelector::releaseTagHistory()
     return WTFMove(m_tagHistory);
 }
 
-bool MutableCSSSelector::isHostPseudoSelector() const
-{
-    return match() == CSSSelector::Match::PseudoClass && pseudoClass() == CSSSelector::PseudoClass::Host;
-}
+
 
 bool MutableCSSSelector::startsWithExplicitCombinator() const
 {
@@ -289,4 +286,3 @@ bool MutableCSSSelector::startsWithExplicitCombinator() const
 }
 
 }
-

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -84,7 +84,7 @@ public:
 
     bool matchesPseudoElement() const;
 
-    bool isHostPseudoSelector() const;
+    bool isHostPseudoClass() const { return m_selector->isHostPseudoClass(); }
 
     bool hasExplicitNestingParent() const;
     bool hasExplicitPseudoClassScope() const;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -323,12 +323,20 @@ void ElementRuleCollector::matchHostPseudoClassRules(CascadeLevel level)
     if (!shadowRules)
         return;
 
-    auto& shadowHostRules = shadowRules->hostPseudoClassRules();
-    if (shadowHostRules.isEmpty())
-        return;
+    auto collect = [&] (const auto& rules) {
+        if (rules.isEmpty())
+            return;
 
-    MatchRequest hostMatchRequest { *shadowRules, ScopeOrdinal::Shadow };
-    collectMatchingRulesForList(&shadowHostRules, hostMatchRequest);
+        MatchRequest hostMatchRequest { *shadowRules, ScopeOrdinal::Shadow };
+        collectMatchingRulesForList(&rules, hostMatchRequest);
+    };
+
+    if (shadowRules->hasHostPseudoClassRulesInUniversalBucket()) {
+        if (auto* universalRules = shadowRules->universalRules())
+            collect(*universalRules);
+    }
+
+    collect(shadowRules->hostPseudoClassRules());
 }
 
 void ElementRuleCollector::matchSlottedPseudoElementRules(CascadeLevel level)

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -115,6 +115,7 @@ public:
     bool hasAttributeRules() const { return !m_attributeLocalNameRules.isEmpty(); }
     bool hasUserAgentPartRules() const { return !m_userAgentPartRules.isEmpty(); }
     bool hasHostPseudoClassRulesMatchingInShadowTree() const { return m_hasHostPseudoClassRulesMatchingInShadowTree; }
+    bool hasHostPseudoClassRulesInUniversalBucket() const { return m_hasHostPseudoClassRulesInUniversalBucket; }
 
     static constexpr auto cascadeLayerPriorityForPresentationalHints = std::numeric_limits<CascadeLayerPriority>::min();
     static constexpr auto cascadeLayerPriorityForUnlayered = std::numeric_limits<CascadeLayerPriority>::max();
@@ -227,6 +228,7 @@ private:
 
     bool m_hasHostPseudoClassRulesMatchingInShadowTree { false };
     bool m_hasViewportDependentMediaQueries { false };
+    bool m_hasHostPseudoClassRulesInUniversalBucket { false };
 };
 
 inline const RuleSet::RuleDataVector* RuleSet::attributeRules(const AtomString& key, bool isHTMLName) const


### PR DESCRIPTION
#### b2e941c46d19000ece893d2f79e9ff52fda755a5
<pre>
Fix :is(:host) both as a subject and as an ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=264628">https://bugs.webkit.org/show_bug.cgi?id=264628</a>
<a href="https://rdar.apple.com/118582384">rdar://118582384</a>

Reviewed by Antti Koivisto.

As ancestor: we always follow the Shadow DOM host, and check a posteriori
that we have successfully matched an :host pseudoclass.

As subject: rules containg compound :host will not end up in the host bucket
but in the universal bucket of the shadow host, we mark those as such and collect them when needed.

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/host-matching-expected.html: Added.
* LayoutTests/fast/css/host-matching.html: Added.
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::RareData::deepCopy const):
(WebCore::CSSSelector::isHostPseudoClass const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHostPseudoClass const):
(WebCore::localContextForParent):
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::prependTypeSelectorIfNeeded):
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::isHostPseudoSelector const): Deleted.
* Source/WebCore/css/parser/MutableCSSSelector.h:
(WebCore::MutableCSSSelector::isHostPseudoClass const):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchHostPseudoClassRules):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::hasHostPseudoClassSubjectInSelectorList):
(WebCore::Style::isHostSelectorMatchingInShadowTree):
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::hasHostPseudoClassRulesInUniversalBucket const):

Canonical link: <a href="https://commits.webkit.org/281963@main">https://commits.webkit.org/281963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ebf9b464735d8eb76ae11e876a25b100bbac23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49682 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8384 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10528 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10986 "Build is being retried. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57277 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4515 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36690 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->