### PR TITLE
Extend FixedVector to allow initialization from a failable generator

### DIFF
--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -75,6 +75,16 @@ public:
         return UniqueRef { *new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, std::forward<Args>(args)...) };
     }
 
+    template<std::invocable<size_t> Generator>
+    static std::unique_ptr<EmbeddedFixedVector> createWithSizeFromGenerator(unsigned size, Generator&& generator)
+    {
+
+        auto result = std::unique_ptr<EmbeddedFixedVector> { new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(typename Base::Failable { }, size, std::forward<Generator>(generator)) };
+        if (result->size() != size)
+            return nullptr;
+        return result;
+    }
+
     UniqueRef<EmbeddedFixedVector> clone() const
     {
         return create(Base::begin(), Base::end());
@@ -107,6 +117,12 @@ private:
     template<typename... Args>
     explicit EmbeddedFixedVector(unsigned size, Args&&... args) // create with given size and constructor arguments for all elements
         : Base(size, std::forward<Args>(args)...)
+    {
+    }
+
+    template<std::invocable<size_t> FailableGenerator>
+    EmbeddedFixedVector(typename Base::Failable failable, unsigned size, FailableGenerator&& generator)
+        : Base(failable, size, std::forward<FailableGenerator>(generator))
     {
     }
 };

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -117,16 +117,16 @@ public:
         return *this;
     }
 
-private:
-    FixedVector(std::unique_ptr<Storage>&& storage)
-        :  m_storage { WTFMove(storage) }
-    { }
-
-public:
     template<typename... Args>
     static FixedVector createWithSizeAndConstructorArguments(size_t size, Args&&... args)
     {
         return FixedVector<T> { size ? Storage::createWithSizeAndConstructorArguments(size, std::forward<Args>(args)...).moveToUniquePtr() : std::unique_ptr<Storage> { nullptr } };
+    }
+
+    template<std::invocable<size_t> Generator>
+    static FixedVector createWithSizeFromGenerator(size_t size, Generator&& generator)
+    {
+        return FixedVector<T> { Storage::createWithSizeFromGenerator(size, std::forward<Generator>(generator)) };
     }
 
     size_t size() const { return m_storage ? m_storage->size() : 0; }
@@ -207,6 +207,10 @@ public:
 
 private:
     friend class JSC::LLIntOffsetsExtractor;
+
+    FixedVector(std::unique_ptr<Storage>&& storage)
+        :  m_storage { WTFMove(storage) }
+    { }
 
     std::unique_ptr<Storage> m_storage;
 };

--- a/Source/WTF/wtf/TrailingArray.h
+++ b/Source/WTF/wtf/TrailingArray.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <type_traits>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
@@ -77,6 +78,33 @@ protected:
     {
         static_assert(std::is_final_v<Derived>);
         VectorTypeOperations<T>::initializeWithArgs(begin(), end(), std::forward<Args>(args)...);
+    }
+
+    // This constructor, which is used via the `Failable` token, will attempt
+    // to initialize the array from the generator. The generator returns
+    // `std::optional` values, and if one is `nullopt`, that indicates a failure.
+    // The constructor sets `m_size` to the index of the most recently successful
+    // item to be added in order for the destructor to destroy the right number
+    // of elements.
+    //
+    // It is the responsibility of the caller to check that `size()` is equal
+    // to the `size` the caller passed in. If it is not, that is failure, and
+    // should be used as appropriate.
+    struct Failable { };
+    template<std::invocable<size_t> Generator>
+    explicit TrailingArray(Failable, unsigned size, Generator&& generator)
+        : m_size(size)
+    {
+        static_assert(std::is_final_v<Derived>);
+
+        for (size_t i = 0; i < m_size; ++i) {
+            if (auto value = generator(i))
+                begin()[i] = WTFMove(*value);
+            else {
+                m_size = i;
+                return;
+            }
+        }
     }
 
     ~TrailingArray()

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -226,6 +226,23 @@ TEST(WTF_FixedVector, MoveAssignVector)
         EXPECT_EQ(index, vec2[index].value());
 }
 
+TEST(WTF_FixedVector, FailableGeneratorConstructor)
+{
+    auto vec1 = FixedVector<MoveOnly>::createWithSizeFromGenerator(4, [](auto index) -> std::optional<MoveOnly> {
+        if (index == 0)
+            return MoveOnly(0);
+        return std::nullopt;
+    });
+    EXPECT_EQ(0U, vec1.size());
+
+    auto vec2 = FixedVector<MoveOnly>::createWithSizeFromGenerator(4, [](auto index) -> std::optional<MoveOnly> {
+        return MoveOnly(index);
+    });
+    EXPECT_EQ(4U, vec2.size());
+    for (unsigned index = 0; index < vec2.size(); ++index)
+        EXPECT_EQ(index, vec2[index].value());
+}
+
 TEST(WTF_FixedVector, Swap)
 {
     FixedVector<unsigned> vec1(3);


### PR DESCRIPTION
#### 6cfd3789faf5b0f12819dbe85a3163b4e099e307
<pre>
Extend FixedVector to allow initialization from a failable generator
<a href="https://bugs.webkit.org/show_bug.cgi?id=274491">https://bugs.webkit.org/show_bug.cgi?id=274491</a>

Reviewed by Darin Adler.

Adds support to FixedVector (or any TrailingArray subtype) being
constructed using a failable generator. A failable generator is an
invocable type that takes an size_t index and returns a std::optional&lt;T&gt;.
If one of the indices fails, the whole construction fails.

This is going to be used to support variadic JS functions like:

  `undefined append((Node or DOMString or TrustedScript)... nodes);`

from ParentNode.idl, once interfaces in IDL unions use Ref rather than
RefPtr. The implementation function will end up being:

  `ExceptionOr&lt;void&gt; append(FixedVector&lt;Ref&lt;Node&gt;, String, Ref&lt;TrustedScript&gt;&gt;&amp;&amp;)`

To call that, the bindings used to create a FixedVector of the
appropriate size, and then insert the items in as they get
converted. That doesn&apos;t work if the items are non-POD types
due to TrailingArray&apos;s constructor calling:

  `VectorTypeOperations&lt;T&gt;::initializeIfNonPOD(begin(), end())`

* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::createWithSizeFromGenerator):
(WTF::FixedVector::FixedVector):
* Source/WTF/wtf/TrailingArray.h:
(WTF::TrailingArray::TrailingArray):
    - Pipe support to the failable constructor. On failure, the
      size is set to 0 and no storage is allocated.

* Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp:
(TestWebKitAPI::TEST(WTF_FixedVector, FailableGeneratorConstructor)):
    - Adds tests using the new constructor.

Canonical link: <a href="https://commits.webkit.org/279089@main">https://commits.webkit.org/279089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7079a2d0010b4813b0a352446c258658d7c0dac5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52484 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55758 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54581 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45301 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2578 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1366 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45833 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57354 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51993 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45418 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11459 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64300 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28591 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12175 "Passed tests") | 
<!--EWS-Status-Bubble-End-->