### PR TITLE
OSV-2022-674: dav1d: use of uninitialized value in cdef_filter_block_c

### DIFF
--- a/LayoutTests/css3/filters/filter-visited-links-expected.html
+++ b/LayoutTests/css3/filters/filter-visited-links-expected.html
@@ -27,9 +27,11 @@
     a {
         color: blue;
         text-decoration: none;
+        background-color: yellow;
     }
     a:visited {
         color: purple;
+        background-color: orange;
     }
 </style>
 <body>

--- a/LayoutTests/css3/filters/filter-visited-links.html
+++ b/LayoutTests/css3/filters/filter-visited-links.html
@@ -27,9 +27,11 @@
     a {
         color: blue;
         text-decoration: none;
+        background-color: yellow;
     }
     a:visited {
         color: purple;
+        background-color: orange;
     }
 </style>
 <body>

--- a/LayoutTests/fast/svg/mutual-recursion-test-expected.txt
+++ b/LayoutTests/fast/svg/mutual-recursion-test-expected.txt
@@ -1,0 +1,2 @@
+This test should not crash
+

--- a/LayoutTests/fast/svg/mutual-recursion-test.html
+++ b/LayoutTests/fast/svg/mutual-recursion-test.html
@@ -1,0 +1,27 @@
+<style></style>
+<div>This test should not crash</div>
+<span id="x3"></span><svg id="x11"><clipPath id="x19"><svg><line marker-end="url(#x22)"></line>
+<switch id="x67"></switch><use id="x16"></use><marker id="x22"><mask clip-path="url(#x19)">
+<script>
+var run_count = 0;
+document.body.offsetHeight;
+x3.outerHTML = x16.outerHTML;
+x67.addEventListener("DOMNodeRemoved",f0);
+f0();
+
+function f0() {
+  run_count++;
+  if (run_count > 3) {
+    if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.notifyDone();
+    }
+    return;
+  }
+  try { document.createElement("span").append(x67); } catch (e) { }
+
+  document.getElementById("x16").insertAdjacentHTML("beforeend",document.getElementById("x11").outerHTML);
+  document.body.offsetHeight;
+  document.styleSheets[0].insertRule("foobar { }");
+}
+</script>

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -5021,18 +5021,18 @@ Node* ByteCodeParser::load(
 
 ObjectPropertyCondition ByteCodeParser::presenceConditionIfConsistent(JSObject* knownBase, UniquedStringImpl* uid, PropertyOffset offset, const StructureSet& set)
 {
-    if (set.isEmpty())
-        return ObjectPropertyCondition();
+    Structure* structure = knownBase->structure();
     unsigned attributes;
-    PropertyOffset firstOffset = set[0]->getConcurrently(uid, attributes);
-    if (firstOffset != offset)
+    PropertyOffset baseOffset = structure->getConcurrently(uid, attributes);
+    if (offset != baseOffset)
         return ObjectPropertyCondition();
-    for (unsigned i = 1; i < set.size(); ++i) {
-        unsigned otherAttributes;
-        PropertyOffset otherOffset = set[i]->getConcurrently(uid, otherAttributes);
-        if (otherOffset != offset || otherAttributes != attributes)
-            return ObjectPropertyCondition();
-    }
+
+    // We need to check set contains knownBase's structure because knownBase's GetOwnPropertySlot could normally prevent access
+    // to this property, for example via a cross-origin restriction check. So unless we've executed this access before we can't assume
+    // just because knownBase has a property uid at offset we're allowed to access.
+    if (!set.contains(structure))
+        return ObjectPropertyCondition();
+
     return ObjectPropertyCondition::presenceWithoutBarrier(knownBase, uid, offset, attributes);
 }
 

--- a/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c
+++ b/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c
@@ -192,13 +192,14 @@ static int create_filter_sbrow(Dav1dFrameContext *const f,
         const int prog_sz = ((f->sbh + 31) & ~31) >> 5;
         if (prog_sz > f->frame_thread.prog_sz) {
             atomic_uint *const prog = realloc(f->frame_thread.frame_progress,
-                                              prog_sz * 2 * sizeof(*prog));
+                                              2 * prog_sz * sizeof(*prog));
             if (!prog) return -1;
             f->frame_thread.frame_progress = prog;
             f->frame_thread.copy_lpf_progress = prog + prog_sz;
             f->frame_thread.prog_sz = prog_sz;
         }
-        memset(f->frame_thread.frame_progress, 0, prog_sz * 2 * sizeof(atomic_uint));
+        memset(f->frame_thread.frame_progress, 0, prog_sz * sizeof(atomic_uint));
+        memset(f->frame_thread.copy_lpf_progress, 0, prog_sz * sizeof(atomic_uint));
         atomic_store(&f->frame_thread.deblock_progress, 0);
     }
     f->frame_thread.next_tile_row[pass & 1] = 0;

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -238,7 +238,7 @@ void InlineBoxPainter::paintDecorations()
     if (!BackgroundPainter::boxShadowShouldBeAppliedToBackground(renderer(), adjustedPaintoffset, BackgroundBleedNone, m_inlineBox))
         paintBoxShadow(ShadowStyle::Normal, paintRect);
 
-    auto color = style.visitedDependentColor(CSSPropertyBackgroundColor);
+    auto color = style.visitedDependentColor(CSSPropertyBackgroundColor, m_paintInfo.paintBehavior);
     auto compositeOp = renderer().document().compositeOperatorForBackgroundColor(color, renderer());
 
     color = style.colorByApplyingColorFilter(color);

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -309,6 +309,10 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
 
 void SVGResources::layoutDifferentRootIfNeeded(const RenderElement& resourcesClient)
 {
+    if (m_inLayoutForDifferentRoot)
+        return;
+
+    SetForScope inLayoutForDifferentRoot(m_inLayoutForDifferentRoot, true);
     const LegacyRenderSVGRoot* clientRoot = nullptr;
 
     auto layoutDifferentRootIfNeeded = [&](LegacyRenderSVGResourceContainer* container) {

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.h
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.h
@@ -144,6 +144,7 @@ private:
     std::unique_ptr<MarkerData> m_markerData;
     std::unique_ptr<FillStrokeData> m_fillStrokeData;
     SingleThreadWeakPtr<LegacyRenderSVGResourceContainer> m_linkedResource;
+    bool m_inLayoutForDifferentRoot { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a3161bf52b5e86b7a2acc0c8c196f918e0b4d902
<pre>
OSV-2022-674: dav1d: use of uninitialized value in cdef_filter_block_c
<a href="https://bugs.webkit.org/show_bug.cgi?id=269405">https://bugs.webkit.org/show_bug.cgi?id=269405</a>
&lt;<a href="https://rdar.apple.com/122849398">rdar://122849398</a>&gt;

Reviewed by Youenn Fablet.

Merge dav1d upstream commit a3a55b18494f5dd1e34f289298f78ffa4f32a25d.

* Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c:
(create_filter_sbrow):

Originally-landed-as: 272448.565@safari-7618-branch (8547ba181fbb). <a href="https://rdar.apple.com/128502897">rdar://128502897</a>
Canonical link: <a href="https://commits.webkit.org/279107@main">https://commits.webkit.org/279107@main</a>
</pre>
----------------------------------------------------------------------
#### c02295c8ab22b97721478d9e0abeb5c647ad29aa
<pre>
[JSC] presenceConditionIfConsistent should check knownBase&apos;s structure is in the structure set
<a href="https://bugs.webkit.org/show_bug.cgi?id=269220">https://bugs.webkit.org/show_bug.cgi?id=269220</a>
<a href="https://rdar.apple.com/122171551">rdar://122171551</a>

Reviewed by Yusuke Suzuki.

This patch rewrites ByteCodeParser::presenceConditionIfConsistent. Now it just checks that the presence condition
we&apos;re trying to create is possible for the knownBase. Additionally, we have to check that the knownBase&apos;s structure
was executed at least once before. This allows us to know if GetOwnPropertySlot ran successfully at least once for
this structure.

* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::presenceConditionIfConsistent):

Originally-landed-as: 272448.563@safari-7618-branch (630351ee51ab). <a href="https://rdar.apple.com/128502736">rdar://128502736</a>
Canonical link: <a href="https://commits.webkit.org/279106@main">https://commits.webkit.org/279106@main</a>
</pre>
----------------------------------------------------------------------
#### 05b6b1285a302f82a9c133577cfad7433090f9b6
<pre>
Break a mutual recursion cycle laying out SVG elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268556">https://bugs.webkit.org/show_bug.cgi?id=268556</a>
<a href="https://rdar.apple.com/118510445">rdar://118510445</a>

Reviewed by shallawa (Said Abou-Hallawa).

Breaks the recursion cycle by having the SVGResource object track if it is already doing layout for a different root.

* LayoutTests/fast/svg/mutual-recursion-test-expected.txt: Added.
* LayoutTests/fast/svg/mutual-recursion-test.html: Added.
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::layoutDifferentRootIfNeeded):
* Source/WebCore/rendering/svg/SVGResources.h:

Originally-landed-as: 272448.561@safari-7618-branch (e14592228595). <a href="https://rdar.apple.com/128502330">rdar://128502330</a>
Canonical link: <a href="https://commits.webkit.org/279105@main">https://commits.webkit.org/279105@main</a>
</pre>
----------------------------------------------------------------------
#### f0fba73ace0f5a4e31e0a16d3b824af0a396a6e9
<pre>
Prevent SVG filters from leaking the background of visited hyperlinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=262337">https://bugs.webkit.org/show_bug.cgi?id=262337</a>
<a href="https://rdar.apple.com/116206368">rdar://116206368</a>

Reviewed by Simon Fraser.

We should prevent websites from learning which sites have been visited via SVG
filters on hyperlinks, per the attack described in <a href="https://arxiv.org/abs/2305.12784.">https://arxiv.org/abs/2305.12784.</a>

This is a follow up for 266683@main. The background color of the visited links
should be ignored when an SVG filter is applied.

* LayoutTests/css3/filters/filter-visited-links-expected.html:
* LayoutTests/css3/filters/filter-visited-links.html:
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paintDecorations):

Originally-landed-as: 272448.560@safari-7618-branch (36df2fc04fb9). <a href="https://rdar.apple.com/128502129">rdar://128502129</a>
Canonical link: <a href="https://commits.webkit.org/279104@main">https://commits.webkit.org/279104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20b26d2a1f7f4143ba910d5dcad20c154fd1fa57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52508 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23758 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2586 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1390 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45857 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57378 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52018 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2763 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11464 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64324 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28617 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12181 "Passed tests") | 
<!--EWS-Status-Bubble-End-->