### PR TITLE
[UnifiedPDF] Add the concept of "rows" to PDFDocumentLayout

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -483,6 +483,8 @@ private:
     PDFDocumentLayout::PageIndex pageForScrollSnapIdentifier(WebCore::ElementIdentifier) const;
     void determineCurrentlySnappedPage();
 
+    std::optional<PDFLayoutRow> visibleRow() const;
+
     WebCore::FloatSize centeringOffset() const;
 
     struct ScrollAnchoringInfo {


### PR DESCRIPTION
#### 19697c5f3ef870f6c4ab84937a06156ee11d0a53
<pre>
[UnifiedPDF] Add the concept of &quot;rows&quot; to PDFDocumentLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=274496">https://bugs.webkit.org/show_bug.cgi?id=274496</a>
<a href="https://rdar.apple.com/128504528">rdar://128504528</a>

Reviewed by Abrar Rahman Protyasha.

Discrete (non-scrolling) mode makes heavy use of the &quot;row&quot; concept, where
a row is a set of one or two pages viewed together. So introduce PDFLayoutRow,
and pass an optional row argument to nearestPageIndexForDocumentPoint().

Other namespace-related cleanup and utility additions for rows.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::isSinglePageDisplayMode):
(WebKit::PDFDocumentLayout::isTwoUpDisplayMode):
(WebKit::PDFDocumentLayout::isScrollingDisplayMode):
(WebKit::PDFDocumentLayout::isDiscreteDisplayMode):
(WebKit::PDFDocumentLayout::isSinglePageDisplayMode const):
(WebKit::PDFDocumentLayout::isTwoUpDisplayMode const):
(WebKit::PDFDocumentLayout::isScrollingDisplayMode const):
(WebKit::PDFDocumentLayout::isDiscreteDisplayMode const):
(WebKit::PDFLayoutRow::numPages const):
(WebKit::PDFLayoutRow::containsPage const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::isRightPageIndex const):
(WebKit::PDFDocumentLayout::isLastPageIndex const):
(WebKit::PDFDocumentLayout::lastPageIndex const):
(WebKit::PDFDocumentLayout::isFirstPageOfRow const):
(WebKit::PDFDocumentLayout::indexForPage const):
(WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint const):
(WebKit::PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset const):
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::rowCount const):
(WebKit::PDFDocumentLayout::rows const):
(WebKit::PDFDocumentLayout::rowForPageIndex const):
(WebKit::PDFDocumentLayout::rowIndexForPageIndex const):
(WebKit::PDFDocumentLayout::layoutBoundsForRow const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::visibleRow const):
(WebKit::UnifiedPDFPlugin::shouldDisplayPage):
(WebKit::UnifiedPDFPlugin::indexForCurrentPageInView const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::continueAutoscroll):

Canonical link: <a href="https://commits.webkit.org/279135@main">https://commits.webkit.org/279135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aa5f3888245e3712c72b7f0420fa9b71f8536a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55772 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3221 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42664 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2056 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29480 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23753 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26660 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50055 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49310 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11489 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->