### PR TITLE
[CSS] Allow ruledata bucketing for functional pseudoclass like :is(), :not(), ...

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -564,6 +564,15 @@ void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVe
 
     for (unsigned i = 0, size = rules->size(); i < size; ++i) {
         const auto& ruleData = rules->data()[i];
+        const auto* selector = ruleData.selector();
+        ASSERT(selector);
+        // RuleData is actually an interface for a single CSSSelector
+        // The key is the triplet CSSSelector* + selectorIndex + selectorListIndex
+        // CSSSelector* is the actual identifier (from this triplet)
+        auto alreadyProcessed = m_processedSelector.contains(selector);
+        if (alreadyProcessed)
+            continue;
+        m_processedSelector.add(selector);
 
         if (UNLIKELY(!ruleData.isEnabled()))
             continue;

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -32,7 +32,11 @@
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
-namespace WebCore::Style {
+namespace WebCore {
+
+class CSSSelector;
+
+namespace Style {
 
 class ScopeRuleSets;
 struct MatchRequest;
@@ -131,6 +135,7 @@ private:
     SelectorChecker::Mode m_mode { SelectorChecker::Mode::ResolvingStyle };
 
     Vector<MatchedRule, 64> m_matchedRules;
+    HashSet<const CSSSelector*> m_processedSelector;
     size_t m_matchedRuleTransferIndex { 0 };
 
     // Output.
@@ -141,4 +146,6 @@ private:
     PseudoIdSet m_matchedPseudoElementIds;
 };
 
-}
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -74,18 +74,18 @@ public:
     void disableSelectorFiltering() { m_descendantSelectorIdentifierHashes[0] = 0; }
 
 private:
-    RefPtr<const StyleRule> m_styleRule;
+    const RefPtr<const StyleRule> m_styleRule;
     // Keep in sync with RuleFeature's selectorIndex and selectorListIndex size.
-    unsigned m_selectorIndex : 16;
-    unsigned m_selectorListIndex : 16;
+    const unsigned m_selectorIndex : 16;
+    const unsigned m_selectorListIndex : 16;
     // If we have more rules than 2^bitcount here we'll get confused about rule order.
-    unsigned m_position : 21;
-    unsigned m_matchBasedOnRuleHash : 3;
-    unsigned m_canMatchPseudoElement : 1;
-    unsigned m_containsUncommonAttributeSelector : 1;
-    unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
-    unsigned m_propertyAllowlist : 2;
-    unsigned m_isStartingStyle : 1;
+    const unsigned m_position : 21;
+    const unsigned m_matchBasedOnRuleHash : 3;
+    const unsigned m_canMatchPseudoElement : 1;
+    const unsigned m_containsUncommonAttributeSelector : 1;
+    const unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
+    const unsigned m_propertyAllowlist : 2;
+    const unsigned m_isStartingStyle : 1;
     unsigned m_isEnabled : 1;
     SelectorFilter::Hashes m_descendantSelectorIdentifierHashes;
 };


### PR DESCRIPTION
#### 63864ccffa1978c30cefa326a2b986d1b9124fc6
<pre>
[CSS] Allow ruledata bucketing for functional pseudoclass like :is(), :not(), ...
<a href="https://bugs.webkit.org/show_bug.cgi?id=274497">https://bugs.webkit.org/show_bug.cgi?id=274497</a>
<a href="https://rdar.apple.com/128504903">rdar://128504903</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/RuleData.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63864ccffa1978c30cefa326a2b986d1b9124fc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/22975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21229 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55682 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36144 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/41843 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/17984 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/19750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/63772 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18329 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76019 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14437 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17569 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63395 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/60616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63331 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11359 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/4983 "Found 2 new test failures: imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html tiled-drawing/scrolling/fixed-background/fixed-body-background-zoomed.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/186 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/46493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/47770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->