### PR TITLE
Harden IPC endpoints for decoding images from arbitrary file wrappers when using the attachment API

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script-expected.txt
@@ -1,0 +1,12 @@
+This tests that nonce content attribute is removed from a SVG script element even if it was a pending resource.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testScript.getAttribute("nonce") is ""
+PASS testScript.nonce is "abc"
+PASS testScript.getAttribute("executed") is "true"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Security-Policy: script-src \'nonce-abc\' \'unsafe-eval\'\r\n'
+    'Content-Type: text/html\r\n\r\n'
+    '<!DOCTYPE html>\n'
+    '<html>\n'
+    '<head>\n'
+    '<script nonce="abc" src="../../resources/js-test-pre.js"></script>\n'
+    '<svg xmlns="http://www.w3.org/2000/svg">\n'
+    '<use id="use" href="#testScript"/>\n'
+    '<script nonce="abc">\n'
+    '    use.getBoundingClientRect();\n'
+    '</script>\n'
+    '<script nonce="abc" id="testScript">\n'
+    '    document.currentScript.setAttribute("executed", "true");\n'
+    '</script>\n'
+    '</svg>\n'
+    '<script nonce="abc">\n'
+    '    description("This tests that nonce content attribute is removed from a SVG script element even if it was a pending resource.");\n'
+    '    shouldBeEqualToString(`testScript.getAttribute("nonce")`, "");\n'
+    '    shouldBeEqualToString(`testScript.nonce`, "abc");\n'
+    '    shouldBeEqualToString(`testScript.getAttribute("executed")`, "true");\n'
+    '    successfullyParsed = true;\n'
+    '</script>\n'
+    '<script nonce="abc" src="../../resources/js-test-post.js"></script>\n'
+    '</body>\n'
+    '</html>\n'
+)

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -86,8 +86,8 @@ ScriptElement::ScriptElement(Element& element, bool parserInserted, bool already
 
 void ScriptElement::didFinishInsertingNode()
 {
-    ASSERT(m_parserInserted == ParserInserted::No);
-    prepareScript(); // FIXME: Provide a real starting line number here.
+    if (m_parserInserted == ParserInserted::No)
+        prepareScript(); // FIXME: Provide a real starting line number here.
 }
 
 void ScriptElement::childrenChanged(const ContainerNode::ChildChange& childChange)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -296,7 +296,7 @@ private:
     void registerRedoStep(UndoStep&) final;
     void clearUndoRedoOperations() final { }
 
-    DOMPasteAccessResponse requestDOMPasteAccess(DOMPasteAccessCategory, const String&) final { return DOMPasteAccessResponse::DeniedForGesture; }
+    DOMPasteAccessResponse requestDOMPasteAccess(DOMPasteAccessCategory, FrameIdentifier, const String&) final { return DOMPasteAccessResponse::DeniedForGesture; }
 
     bool canCopyCut(LocalFrame*, bool defaultValue) const final { return defaultValue; }
     bool canPaste(LocalFrame*, bool defaultValue) const final { return defaultValue; }

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "EditorInsertAction.h"
+#include "FrameIdentifier.h"
 #include "SerializedAttachmentData.h"
 #include "TextAffinity.h"
 #include "TextChecking.h"
@@ -114,7 +115,7 @@ public:
     virtual void requestCandidatesForSelection(const VisibleSelection&) { }
     virtual void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) { }
 
-    virtual DOMPasteAccessResponse requestDOMPasteAccess(DOMPasteAccessCategory, const String& originIdentifier) = 0;
+    virtual DOMPasteAccessResponse requestDOMPasteAccess(DOMPasteAccessCategory, FrameIdentifier, const String& originIdentifier) = 0;
 
     // Notify an input method that a composition was voluntarily discarded by WebCore, so that it could clean up too.
     // This function is not called when a composition is closed per a request from an input method.

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -620,7 +620,7 @@ bool LocalFrame::requestDOMPasteAccess(DOMPasteAccessCategory pasteAccessCategor
         if (!client)
             return false;
 
-        auto response = client->requestDOMPasteAccess(pasteAccessCategory, m_doc->originIdentifierForPasteboard());
+        auto response = client->requestDOMPasteAccess(pasteAccessCategory, frameID(), m_doc->originIdentifierForPasteboard());
         gestureToken->didRequestDOMPasteAccess(response);
         switch (response) {
         case DOMPasteAccessResponse::GrantedForCommand:

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1046,12 +1046,12 @@ Node::InsertedIntoAncestorResult SVGElement::insertedIntoAncestor(InsertionType 
     else if (RefPtr parentElement = dynamicDowncast<SVGElement>(parentNode()); parentElement && &parentOfInsertedTree == parentNode())
         parentElement->updateRelativeLengthsInformationForChild(hasRelativeLengths(), *this);
 
+    hideNonce();
+
     if (needsPendingResourceHandling() && insertionType.connectedToDocument && !isInShadowTree()) {
         if (treeScopeForSVGReferences().isIdOfPendingSVGResource(getIdAttribute()))
             return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
     }
-
-    hideNonce();
 
     return InsertedIntoAncestorResult::Done;
 }

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -110,7 +110,7 @@ void WorkerOrWorkletThread::runEventLoop()
 {
     // Does not return until terminated.
     if (auto* runLoop = dynamicDowncast<WorkerDedicatedRunLoop>(m_runLoop.get()))
-        runLoop->run(m_globalScope.get());
+        runLoop->run(RefPtr { m_globalScope }.get());
 }
 
 void WorkerOrWorkletThread::workerOrWorkletThread()

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -67,6 +67,8 @@ public:
     bool isValid() const { return !!m_webPage; }
 
 #if PLATFORM(COCOA)
+    void cloneFileWrapperTo(Attachment&);
+    bool shouldUseFileWrapperIconForDirectory() const;
     void doWithFileWrapper(Function<void(NSFileWrapper *)>&&) const;
     void setFileWrapper(NSFileWrapper *);
     void setFileWrapperAndUpdateContentType(NSFileWrapper *, NSString *contentType);
@@ -111,6 +113,8 @@ private:
     WeakPtr<WebKit::WebPageProxy> m_webPage;
     InsertionState m_insertionState { InsertionState::NotInserted };
     WebCore::AttachmentAssociatedElementType m_associatedElementType { WebCore::AttachmentAssociatedElementType::None };
+    bool m_hasEnclosingImage { false };
+    bool m_isCreatedFromSerializedRepresentation { false };
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -206,8 +206,34 @@ void Attachment::updateFromSerializedRepresentation(Ref<WebCore::SharedBuffer>&&
     if (![fileWrapper isKindOfClass:NSFileWrapper.class])
         return;
 
+    m_isCreatedFromSerializedRepresentation = true;
     setFileWrapperAndUpdateContentType(fileWrapper, contentType);
     m_webPage->updateAttachmentAttributes(*this, [] { });
+}
+
+void Attachment::cloneFileWrapperTo(Attachment& other)
+{
+    other.m_isCreatedFromSerializedRepresentation = m_isCreatedFromSerializedRepresentation;
+
+    Locker locker { m_fileWrapperLock };
+    other.setFileWrapper(m_fileWrapper.get());
+}
+
+bool Attachment::shouldUseFileWrapperIconForDirectory() const
+{
+    if (m_contentType != "public.directory"_s)
+        return false;
+
+    if (m_isCreatedFromSerializedRepresentation)
+        return false;
+
+    {
+        Locker locker { m_fileWrapperLock };
+        if (![m_fileWrapper isDirectory])
+            return false;
+    }
+
+    return true;
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -321,9 +321,7 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
 
 void WebPageProxy::platformCloneAttachment(Ref<API::Attachment>&& fromAttachment, Ref<API::Attachment>&& toAttachment)
 {
-    fromAttachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
-        toAttachment->setFileWrapper(fileWrapper);
-    });
+    fromAttachment->cloneFileWrapperTo(toAttachment);
 }
 
 static RefPtr<WebCore::ShareableBitmap> convertPlatformImageToBitmap(CocoaImage *image, const WebCore::FloatSize& fittingSize)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8502,9 +8502,32 @@ void WebPageProxy::setIsNeverRichlyEditableForTouchBar(bool isNeverRichlyEditabl
 
 #endif
 
-void WebPageProxy::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, const WebCore::IntRect& elementRect, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
+void WebPageProxy::requestDOMPasteAccess(DOMPasteAccessCategory pasteAccessCategory, FrameIdentifier frameID, const IntRect& elementRect, const String& originIdentifier, CompletionHandler<void(DOMPasteAccessResponse)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(m_process, !originIdentifier.isEmpty(), completionHandler(DOMPasteAccessResponse::DeniedForGesture));
+
+    if (auto origin = SecurityOrigin::createFromString(originIdentifier); !origin->isOpaque()) {
+        RefPtr frame = WebFrameProxy::webFrame(frameID);
+        MESSAGE_CHECK_COMPLETION(m_process, frame && frame->page() == this, completionHandler(DOMPasteAccessResponse::DeniedForGesture));
+
+        auto originFromFrame = SecurityOrigin::create(frame->url());
+        MESSAGE_CHECK_COMPLETION(m_process, origin->isSameOriginDomain(originFromFrame), completionHandler(DOMPasteAccessResponse::DeniedForGesture));
+
+        static constexpr auto recentlyRequestedDOMPasteOriginDelay = 1_s;
+        static constexpr auto recentlyRequestedDOMPasteOriginLimit = 10;
+
+        auto currentTime = ApproximateTime::now();
+        m_recentlyRequestedDOMPasteOrigins.removeAllMatching([&](auto& identifierAndTimestamp) {
+            auto& [identifier, lastRequestTime] = identifierAndTimestamp;
+            return identifier == originIdentifier || currentTime - lastRequestTime > recentlyRequestedDOMPasteOriginDelay;
+        });
+        m_recentlyRequestedDOMPasteOrigins.append({ originIdentifier, currentTime });
+
+        if (m_recentlyRequestedDOMPasteOrigins.size() > recentlyRequestedDOMPasteOriginLimit) {
+            completionHandler(DOMPasteAccessResponse::DeniedForGesture);
+            return;
+        }
+    }
 
     m_pageClient->requestDOMPasteAccess(pasteAccessCategory, elementRect, originIdentifier, WTFMove(completionHandler));
 }
@@ -9860,6 +9883,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 #endif
     internals().firstLayerTreeTransactionIdAfterDidCommitLoad = { };
 #endif
+
+    m_recentlyRequestedDOMPasteOrigins = { };
 
     if (m_drawingArea) {
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NowPlayingMetadataObserver.h>
 #include <pal/HysteresisActivity.h>
+#include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/OptionSet.h>
@@ -2691,7 +2692,7 @@ private:
     void setIsNeverRichlyEditableForTouchBar(bool);
 #endif
 
-    void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);
+    void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);
     void willPerformPasteCommand(WebCore::DOMPasteAccessCategory, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 
     // Back/Forward list management
@@ -3234,6 +3235,8 @@ private:
 #if ENABLE(CONTEXT_MENUS)
     RefPtr<WebContextMenuProxy> m_activeContextMenu;
 #endif
+
+    Vector<std::pair<String, ApproximateTime>> m_recentlyRequestedDOMPasteOrigins;
 
 #if PLATFORM(MAC)
     RefPtr<API::HitTestResult> m_lastMouseMoveHitTestResult;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -252,7 +252,7 @@ messages -> WebPageProxy {
     SetIsNeverRichlyEditableForTouchBar(bool isNeverRichlyEditable)
 #endif
 
-    RequestDOMPasteAccess(enum:uint8_t WebCore::DOMPasteAccessCategory pasteAccessCategory, WebCore::IntRect elementRect, String originIdentifier) -> (enum:uint8_t WebCore::DOMPasteAccessResponse response) Synchronous
+    RequestDOMPasteAccess(enum:uint8_t WebCore::DOMPasteAccessCategory pasteAccessCategory, WebCore::FrameIdentifier frameID, WebCore::IntRect elementRect, String originIdentifier) -> (enum:uint8_t WebCore::DOMPasteAccessResponse response) Synchronous
 
     # Find messages
     SetTextIndicatorFromFrame(WebCore::FrameIdentifier frameID, struct WebCore::TextIndicatorData indicator, uint64_t lifetime)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -335,9 +335,9 @@ void WebEditorClient::redo()
     m_page->sendSync(Messages::WebPageProxy::ExecuteUndoRedo(UndoOrRedo::Redo));
 }
 
-WebCore::DOMPasteAccessResponse WebEditorClient::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, const String& originIdentifier)
+WebCore::DOMPasteAccessResponse WebEditorClient::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, WebCore::FrameIdentifier frameID, const String& originIdentifier)
 {
-    return m_page->requestDOMPasteAccess(pasteAccessCategory, originIdentifier);
+    return m_page->requestDOMPasteAccess(pasteAccessCategory, frameID, originIdentifier);
 }
 
 #if !PLATFORM(COCOA) && !USE(GLIB)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -100,7 +100,7 @@ private:
     void registerRedoStep(WebCore::UndoStep&) final;
     void clearUndoRedoOperations() final;
 
-    WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const String& originIdentifier) final;
+    WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const String& originIdentifier) final;
 
     bool canCopyCut(WebCore::LocalFrame*, bool defaultValue) const final;
     bool canPaste(WebCore::LocalFrame*, bool defaultValue) const final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8325,7 +8325,7 @@ void WebPage::showContactPicker(const WebCore::ContactsRequestData& requestData,
     sendWithAsyncReply(Messages::WebPageProxy::ShowContactPicker(requestData), WTFMove(callback));
 }
 
-WebCore::DOMPasteAccessResponse WebPage::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, const String& originIdentifier)
+WebCore::DOMPasteAccessResponse WebPage::requestDOMPasteAccess(DOMPasteAccessCategory pasteAccessCategory, FrameIdentifier frameID, const String& originIdentifier)
 {
 #if PLATFORM(IOS_FAMILY)
     // FIXME: Computing and sending an autocorrection context is a workaround for the fact that autocorrection context
@@ -8337,7 +8337,7 @@ WebCore::DOMPasteAccessResponse WebPage::requestDOMPasteAccess(WebCore::DOMPaste
 
     AXRelayProcessSuspendedNotification(*this);
 
-    auto sendResult = sendSyncWithDelayedReply(Messages::WebPageProxy::RequestDOMPasteAccess(pasteAccessCategory, rectForElementAtInteractionLocation(), originIdentifier));
+    auto sendResult = sendSyncWithDelayedReply(Messages::WebPageProxy::RequestDOMPasteAccess(pasteAccessCategory, frameID, rectForElementAtInteractionLocation(), originIdentifier));
     auto [response] = sendResult.takeReplyOr(WebCore::DOMPasteAccessResponse::DeniedForGesture);
     return response;
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1498,7 +1498,7 @@ public:
         return sendSync(std::forward<T>(message), Seconds::infinity(), sendSyncOptions);
     }
 
-    WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const String& originIdentifier);
+    WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const String& originIdentifier);
     WebCore::IntRect rectForElementAtInteractionLocation() const;
 
     const std::optional<WebCore::Color>& backgroundColor() const { return m_backgroundColor; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -83,7 +83,7 @@ private:
     void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
 
     void setInsertionPasteboard(const String&) final;
-    WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const String&) final { return WebCore::DOMPasteAccessResponse::DeniedForGesture; }
+    WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const String&) final { return WebCore::DOMPasteAccessResponse::DeniedForGesture; }
 
 #if USE(APPKIT)
     void uppercaseWord() final;


### PR DESCRIPTION
#### 2d8b1474ab48e248a1548ed59cf91fd1223b381f
<pre>
Harden IPC endpoints for decoding images from arbitrary file wrappers when using the attachment API
<a href="https://bugs.webkit.org/show_bug.cgi?id=269877">https://bugs.webkit.org/show_bug.cgi?id=269877</a>
<a href="https://rdar.apple.com/99194803">rdar://99194803</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

It&apos;s currently possible for a compromised web process to use two IPC endpoints:

• `WebPageProxy::RegisterAttachmentsFromSerializedData`
• `WebPageProxy::RequestAttachmentIcon`

...in order to force image decoding through an `NSFileWrapper` created from arbitrary data,
underneath a call to `-[NSFileWrapper icon]`. This icon image is only meant to be used to generate
icons for folder attachments (e.g. a bundle icon for bundle directories, or Xcode icon for Xcode
projects), and should only ever be exercised in the case where the file wrapper was created from an
existing file path on the system (as opposed to untrusted data directly from the web process).

As such, we can lock this down by:

1.  Adding a `m_isCreatedFromSerializedRepresentation` flag, to track whether an `API::Attachment`
    was created using an arbitrary serialized representation.

2.  Before asking for `-icon`, verify that the file wrapper doesn&apos;t have the flag set in (1), and
    that the file wrapper is also actually a directory.

* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::updateFromSerializedRepresentation):
(API::Attachment::cloneFileWrapperTo):
(API::Attachment::shouldUseFileWrapperIconForDirectory const):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::platformCloneAttachment):

Add logic here to ensure that a compromised web content process can&apos;t bypass the aforementioned
mitigation by cloning an attachment created from arbitrary data to an attachment that doesn&apos;t have
the `m_isCreatedFromSerializedRepresentation` flag.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAttachmentIcon):

Originally-landed-as: 272448.599@safari-7618-branch (6d9bbe958980). <a href="https://rdar.apple.com/128505199">rdar://128505199</a>
Canonical link: <a href="https://commits.webkit.org/279134@main">https://commits.webkit.org/279134@main</a>
</pre>
----------------------------------------------------------------------
#### 5944980db644fb2ea879bf3e2d6e5efd47156cdc
<pre>
Compromised web process can grant pasteboard access by spamming WebPage::RequestDOMPasteAccess
<a href="https://bugs.webkit.org/show_bug.cgi?id=269769">https://bugs.webkit.org/show_bug.cgi?id=269769</a>
<a href="https://rdar.apple.com/97343267">rdar://97343267</a>

Reviewed by Ryosuke Niwa and Richard Robinson.

It&apos;s currently possible for a compromised web process to send arbitrary `originIdentifiers` through
`requestDOMPasteAccess` to the UI process during programmatic paste. Since the UI process
automatically grants programmatic pasteboard access in the case where the incoming origin ID matches
the origin ID of the current pasteboard content, it&apos;s possible to send a large number of origins
through this IPC endpoint, with the end goal of discovering both (1) which website origin the user
last copied from, and (2) the contents of the pasteboard in the case where the pasteboard copied
from web content in WebKit.

To mitigate this attack vector, we add a `FrameIdentifier` in the IPC endpoint, which is used in the
UI process to verify that:

1.  The incoming frame ID corresponds to a frame underneath the destination page.
2.  The pasteboard origin matches the origin of the frame, unless the pasteboard origin is an opaque
    (null) origin.

Additionally, we throttle pasteboard access requests to a maximum of 10 different domains every 5
seconds, to mitigate another variation on this attack vector where the compromised web process loads
a large number of cross-origin frames and requests pasteboard access on behalf of those origins, in
an attempt to get around the limitations above.

With this change, a compromised web process is only capable of grabbing data for a pasteboard origin
that matches itself, or another origin under the same `WebPage`.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/EditorClient.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::requestDOMPasteAccess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestDOMPasteAccess):

Add the new `MESSAGE_CHECK`s.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::requestDOMPasteAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestDOMPasteAccess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:

Originally-landed-as: 272448.579@safari-7618-branch (be0e10372eb5). <a href="https://rdar.apple.com/128504822">rdar://128504822</a>
Canonical link: <a href="https://commits.webkit.org/279133@main">https://commits.webkit.org/279133@main</a>
</pre>
----------------------------------------------------------------------
#### 9e5283739c9809f145488a20f8a52f09fd3a85f4
<pre>
Flaky crash under WorkerDedicatedRunLoop::runCleanupTasks() during fuzzing
<a href="https://bugs.webkit.org/show_bug.cgi?id=269731">https://bugs.webkit.org/show_bug.cgi?id=269731</a>
<a href="https://rdar.apple.com/121961101">rdar://121961101</a>

Reviewed by Brent Fulgham.

I haven&apos;t been able to reproduce but based on the ASAN report, it looks
like the WorkerOrWorkletGlobalScope is getting destroyed in the middle
of WorkerDedicatedRunLoop::runCleanupTasks(), causing a use-after free
of the context.

To make sure this can&apos;t happen, apply our smart pointer adoption rules
and make sure the WorkerOrWorkletGlobalScope is being protected on the
stack at the call site of WorkerDedicatedRunLoop::run() before passing
it in argument.

* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::runEventLoop):

Originally-landed-as: 272448.578@safari-7618-branch (459d377c63c2). <a href="https://rdar.apple.com/128504577">rdar://128504577</a>
Canonical link: <a href="https://commits.webkit.org/279132@main">https://commits.webkit.org/279132@main</a>
</pre>
----------------------------------------------------------------------
#### 76a6ff4a88da11885fb1c5b8af8b41bf0a7844b5
<pre>
nonce hiding in SVG is buggy
<a href="https://bugs.webkit.org/show_bug.cgi?id=268598">https://bugs.webkit.org/show_bug.cgi?id=268598</a>
<a href="https://rdar.apple.com/122151552">rdar://122151552</a>

Reviewed by Chris Dumez.

The bug was caused by SVGElement::insertedIntoAncestor hiding nonce after it had an early exit for returning
InsertedIntoAncestorResult::NeedsPostInsertionCallback. Fixed the bug by hiding it before this early exit.

* LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script.py: Added.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::didFinishInsertingNode):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::insertedIntoAncestor):

Originally-landed-as: 272448.567@safari-7618-branch (d915a3b6357c). <a href="https://rdar.apple.com/128504044">rdar://128504044</a>
Canonical link: <a href="https://commits.webkit.org/279131@main">https://commits.webkit.org/279131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6bc871dfc285ec572099090d6b9977f131887a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42682 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57399 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27661 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2791 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50075 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49331 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11488 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->