### PR TITLE
[macOS] WKTextFinderMatch should hold a weak pointer to its client

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -113,8 +113,8 @@ private:
 @end
 
 @implementation WKTextFinderMatch {
-    WKTextFinderClient *_client;
-    NSView *_view;
+    __weak WKTextFinderClient *_client;
+    __weak NSView *_view;
     RetainPtr<NSArray> _rects;
     unsigned _index;
 }
@@ -136,6 +136,7 @@ private:
 
 - (NSView *)containingView
 {
+    // To maintain binary compatibility, this is weakly held even though `containingView` is marked `retain`.
     return _view;
 }
 
@@ -146,7 +147,11 @@ private:
 
 - (void)generateTextImage:(void (^)(NSImage *generatedImage))completionHandler
 {
-    [_client getImageForMatchResult:self completionHandler:completionHandler];
+    RetainPtr strongClient = _client;
+    if (!strongClient)
+        return completionHandler(nil);
+
+    [strongClient getImageForMatchResult:self completionHandler:completionHandler];
 }
 
 - (unsigned)index


### PR DESCRIPTION
#### c6a818caffef1a6f4ccc3d1ffcd573e4c8dc0fd3
<pre>
[macOS] WKTextFinderMatch should hold a weak pointer to its client
<a href="https://bugs.webkit.org/show_bug.cgi?id=274498">https://bugs.webkit.org/show_bug.cgi?id=274498</a>

Reviewed by Aditya Keerthi and Abrar Protyasha.

Use a weak ObjC pointer for the `_client` ivar, instead of a raw pointer.

* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
(-[WKTextFinderMatch generateTextImage:]):

Canonical link: <a href="https://commits.webkit.org/279099@main">https://commits.webkit.org/279099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be84be473ac0a7867215eeac47eb7b8703ddb78d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55785 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2934 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45315 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/23762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1393 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57381 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45433 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11463 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->