### PR TITLE
Address Darin's review feedback on 279097@main

### DIFF
--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp
@@ -165,7 +165,7 @@ RefPtr<SharedMemory> SharedMemory::wrapMap(std::span<const uint8_t> data, Protec
 {
     ASSERT(!data.empty());
 
-    auto sendRight = makeMemoryEntry(data.size(), toVMAddress(static_cast<void*>(const_cast<uint8_t*>(data.data()))), protection, MACH_PORT_NULL);
+    auto sendRight = makeMemoryEntry(data.size(), toVMAddress(const_cast<uint8_t*>(data.data())), protection, MACH_PORT_NULL);
     if (!sendRight)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4428,7 +4428,7 @@ void MediaPlayerPrivateGStreamer::initializationDataEncountered(InitData&& initD
 
         GST_DEBUG("scheduling initializationDataEncountered %s event of size %zu", initData.payloadContainerType().utf8().data(),
             initData.payload()->size());
-        GST_MEMDUMP("init datas", reinterpret_cast<const uint8_t*>(initData.payload()->makeContiguous()->span().data()), initData.payload()->size());
+        GST_MEMDUMP("init datas", initData.payload()->makeContiguous()->span().data(), initData.payload()->size());
         if (player)
             player->initializationDataEncountered(initData.payloadContainerType(), initData.payload()->tryCreateArrayBuffer());
     });

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -98,7 +98,7 @@ Ref<MediaPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>
 
     ASSERT(!m_appendPromise);
     m_appendPromise.emplace();
-    gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->span().data()));
+    gpointer bufferData = const_cast<uint8_t*>(data->span().data());
     auto bufferLength = data->size();
     GRefPtr<GstBuffer> buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(0), bufferData, bufferLength, 0, bufferLength, &data.leakRef(),
         [](gpointer data)


### PR DESCRIPTION
#### 00d92c3139d072e389479b411faf047eb0b6ed00
<pre>
Address Darin&apos;s review feedback on 279097@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=274502">https://bugs.webkit.org/show_bug.cgi?id=274502</a>

Unreviewed, address Darin&apos;s review feedback on 279097@main, which I somewhere failed
to upload before merging the PR.

* Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp:
(WebCore::SharedMemory::wrapMap):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::initializationDataEncountered):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::appendInternal):

Canonical link: <a href="https://commits.webkit.org/279123@main">https://commits.webkit.org/279123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2f62fae5032c0e2f087d749e2fa930fdb75debf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2959 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42687 "Found 35 new test failures: imported/w3c/web-platform-tests/css/css-transforms/huge-length-tiny-scale.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r11f_g11f_b10f-rgb-float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r11f_g11f_b10f-rgb-half_float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r16f-red-float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rg32f-rg-float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb16f-rgb-half_float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb32f-rgb-float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb565-rgb-unsigned_short_5_6_5.html ... (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2077 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29524 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45342 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23776 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2614 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1418 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57406 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27669 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2794 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-old.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-offscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/multiline-span-with-overflowing-text-and-box-decorations.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50079 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45456 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49341 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29809 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7706 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->