### PR TITLE
Update base64EncodeToString() / base64URLEncodeToString() overloads

### DIFF
--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -69,9 +69,6 @@ Vector<uint8_t> base64EncodeToVector(const CString&, Base64EncodeMode = Base64En
 
 WTF_EXPORT_PRIVATE String base64EncodeToString(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
 String base64EncodeToString(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
-String base64EncodeToString(std::span<const char>, Base64EncodeMode = Base64EncodeMode::Default);
-String base64EncodeToString(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
-String base64EncodeToString(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
 WTF_EXPORT_PRIVATE String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
 String base64EncodeToStringReturnNullIfOverflow(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
@@ -95,9 +92,6 @@ Vector<uint8_t> base64URLEncodeToVector(const void*, unsigned);
 
 String base64URLEncodeToString(std::span<const std::byte>);
 String base64URLEncodeToString(std::span<const uint8_t>);
-String base64URLEncodeToString(std::span<const char>);
-String base64URLEncodeToString(const CString&);
-String base64URLEncodeToString(const void*, unsigned);
 
 std::optional<Vector<uint8_t>> base64URLDecode(StringView);
 inline std::optional<Vector<uint8_t>> base64URLDecode(ASCIILiteral literal) { return base64URLDecode(StringView { literal }); }
@@ -144,24 +138,9 @@ inline String base64EncodeToStringReturnNullIfOverflow(std::span<const uint8_t> 
     return base64EncodeToStringReturnNullIfOverflow(std::as_bytes(input), mode);
 }
 
-inline String base64EncodeToString(std::span<const char> input, Base64EncodeMode mode)
-{
-    return base64EncodeToString(std::as_bytes(input), mode);
-}
-
-inline String base64EncodeToString(const CString& input, Base64EncodeMode mode)
-{
-    return base64EncodeToString(input.span(), mode);
-}
-
 inline String base64EncodeToStringReturnNullIfOverflow(const CString& input, Base64EncodeMode mode)
 {
     return base64EncodeToStringReturnNullIfOverflow(input.span(), mode);
-}
-
-inline String base64EncodeToString(const void* input, unsigned length, Base64EncodeMode mode)
-{
-    return base64EncodeToString({ static_cast<const std::byte*>(input), length }, mode);
 }
 
 inline std::optional<Vector<uint8_t>> base64Decode(std::span<const uint8_t> input, Base64DecodeMode mode)
@@ -207,21 +186,6 @@ inline String base64URLEncodeToString(std::span<const std::byte> input)
 inline String base64URLEncodeToString(std::span<const uint8_t> input)
 {
     return base64EncodeToString(input, Base64EncodeMode::URL);
-}
-
-inline String base64URLEncodeToString(std::span<const char> input)
-{
-    return base64EncodeToString(input, Base64EncodeMode::URL);
-}
-
-inline String base64URLEncodeToString(const CString& input)
-{
-    return base64EncodeToString(input, Base64EncodeMode::URL);
-}
-
-inline String base64URLEncodeToString(const void* input, unsigned length)
-{
-    return base64EncodeToString(input, length, Base64EncodeMode::URL);
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(StringView input)

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -40,7 +40,7 @@ Ref<DigitalCredential> DigitalCredential::create(Ref<Uint8Array>&& data, Identit
 DigitalCredential::~DigitalCredential() = default;
 
 DigitalCredential::DigitalCredential(Ref<Uint8Array>&& data, IdentityCredentialProtocol protocol)
-    : BasicCredential(base64URLEncodeToString(data->data(), data->byteLength()), Type::DigitalCredential, Discovery::CredentialStore)
+    : BasicCredential(base64URLEncodeToString(data->span()), Type::DigitalCredential, Discovery::CredentialStore)
     , m_protocol(protocol)
     , m_data(WTFMove(data))
 {

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -59,7 +59,7 @@ AuthenticatorAttachment PublicKeyCredential::authenticatorAttachment() const
 }
 
 PublicKeyCredential::PublicKeyCredential(Ref<AuthenticatorResponse>&& response)
-    : BasicCredential(base64URLEncodeToString(response->rawId()->data(), response->rawId()->byteLength()), Type::PublicKey, Discovery::Remote)
+    : BasicCredential(base64URLEncodeToString(response->rawId()->span()), Type::PublicKey, Discovery::Remote)
     , m_response(WTFMove(response))
 {
 }

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -169,7 +169,7 @@ Ref<ArrayBuffer> buildClientDataJson(ClientDataType type, const BufferSource& ch
         object->setString("type"_s, "webauthn.get"_s);
         break;
     }
-    object->setString("challenge"_s, base64URLEncodeToString(challenge.data(), challenge.length()));
+    object->setString("challenge"_s, base64URLEncodeToString(challenge.span()));
     object->setString("origin"_s, origin.toRawString());
     
     if (!topOrigin.isNull())

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -107,7 +107,7 @@ String WebSocketHandshake::getExpectedWebSocketAccept(const String& secWebSocket
     sha1.addBytes(webSocketKeyGUID);
     SHA1::Digest hash;
     sha1.computeHash(hash);
-    return base64EncodeToString(hash.data(), SHA1::hashSize);
+    return base64EncodeToString(hash);
 }
 
 WebSocketHandshake::WebSocketHandshake(const URL& url, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated)

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
@@ -276,10 +276,10 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit useCryp
         }
         if (UNLIKELY((result.size() != publicKeySize) && (result.size() != privateKeySize)))
             return false;
-        jwk.x = base64URLEncodeToString(result.data() + 1, keySizeInBytes);
-        jwk.y = base64URLEncodeToString(result.data() + keySizeInBytes + 1, keySizeInBytes);
+        jwk.x = base64URLEncodeToString(result.subspan(1, keySizeInBytes));
+        jwk.y = base64URLEncodeToString(result.subspan(keySizeInBytes + 1, keySizeInBytes));
         if (result.size() > publicKeySize)
-            jwk.d = base64URLEncodeToString(result.data() + publicKeySize, keySizeInBytes);
+            jwk.d = base64URLEncodeToString(result.subspan(publicKeySize, keySizeInBytes));
         return true;
     }
 #else
@@ -314,10 +314,10 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit useCryp
 
     if (UNLIKELY((size != publicKeySize) && (size != privateKeySize)))
         return false;
-    jwk.x = base64URLEncodeToString(result.data() + 1, keySizeInBytes);
-    jwk.y = base64URLEncodeToString(result.data() + keySizeInBytes + 1, keySizeInBytes);
+    jwk.x = base64URLEncodeToString(result.subspan(1, keySizeInBytes));
+    jwk.y = base64URLEncodeToString(result.subspan(keySizeInBytes + 1, keySizeInBytes));
     if (size > publicKeySize)
-        jwk.d = base64URLEncodeToString(result.data() + publicKeySize, keySizeInBytes);
+        jwk.d = base64URLEncodeToString(result.subspan(publicKeySize, keySizeInBytes));
     return true;
 }
 

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -519,8 +519,8 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk, UseCryptoKit) const
     if (qMPI) {
         auto q = mpiData(qMPI);
         if (q && q->size() == curveUncompressedPointSize(m_curve)) {
-            jwk.x = base64URLEncodeToString(q->subvector(1, uncompressedFieldElementSize));
-            jwk.y = base64URLEncodeToString(q->subvector(1 + uncompressedFieldElementSize, uncompressedFieldElementSize));
+            jwk.x = base64URLEncodeToString(q->subspan(1, uncompressedFieldElementSize));
+            jwk.y = base64URLEncodeToString(q->subspan(1 + uncompressedFieldElementSize, uncompressedFieldElementSize));
         }
     }
 

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -430,14 +430,14 @@ std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& nod
             }
             SHA1::Digest attrsHash;
             attrsSHA1.computeHash(attrsHash);
-            digest->attrsSHA1 = base64EncodeToString(attrsHash.data(), 10);
+            digest->attrsSHA1 = base64EncodeToString(std::span { attrsHash }.first(10));
             addStringToSHA1(sha1, digest->attrsSHA1);
         }
     }
 
     SHA1::Digest hash;
     sha1.computeHash(hash);
-    digest->sha1 = base64EncodeToString(hash.data(), 10);
+    digest->sha1 = base64EncodeToString(std::span { hash }.first(10));
     if (unusedNodesMap)
         unusedNodesMap->add(digest->sha1, digest.get());
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1052,7 +1052,7 @@ Inspector::Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedC
 
     WTF::Persistence::Encoder encoder;
     WTF::Persistence::Coder<WebCore::CertificateInfo>::encodeForPersistence(encoder, certificate.value());
-    return base64EncodeToString(encoder.buffer(), encoder.bufferSize());
+    return base64EncodeToString(encoder.span());
 }
 
 WebSocket* InspectorNetworkAgent::webSocketForRequestId(const Inspector::Protocol::Network::RequestId& requestId)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -83,6 +83,10 @@
 #include "LegacyWebArchive.h"
 #endif
 
+#if USE(CF)
+#include <wtf/cf/VectorCF.h>
+#endif
+
 
 namespace WebCore {
 
@@ -1229,7 +1233,7 @@ Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
         return makeUnexpected("Could not create web archive for main frame"_s);
 
     RetainPtr<CFDataRef> buffer = archive->rawDataRepresentation();
-    return base64EncodeToString(CFDataGetBytePtr(buffer.get()), CFDataGetLength(buffer.get()));
+    return base64EncodeToString(span(buffer.get()));
 }
 #endif
 

--- a/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "PrivateClickMeasurement.h"
 
+#import <wtf/cocoa/SpanCocoa.h>
+
 #import <pal/cocoa/CryptoKitPrivateSoftLink.h>
 
 namespace WebCore {
@@ -68,7 +70,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
     if (!unlinkableToken.waitingToken)
         return makeString("Did not get a "_s, contextForLogMessage, " unlinkable token waiting token."_s);
 
-    unlinkableToken.valueBase64URL = base64URLEncodeToString([unlinkableToken.waitingToken blindedMessage].bytes, [unlinkableToken.waitingToken blindedMessage].length);
+    unlinkableToken.valueBase64URL = base64URLEncodeToString(span([unlinkableToken.waitingToken blindedMessage]));
     return std::nullopt;
 #else
     UNUSED_PARAM(serverPublicKeyBase64URL);
@@ -117,9 +119,9 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateSecretToken(con
             return makeString("Did not get a "_s, contextForLogMessage, " unlinkable token ready token."_s);
     }
 
-    secretToken.tokenBase64URL = base64URLEncodeToString([unlinkableToken.readyToken tokenContent].bytes, [unlinkableToken.readyToken tokenContent].length);
-    secretToken.keyIDBase64URL = base64URLEncodeToString([unlinkableToken.readyToken keyId].bytes, [unlinkableToken.readyToken keyId].length);
-    secretToken.signatureBase64URL = base64URLEncodeToString([unlinkableToken.readyToken signature].bytes, [unlinkableToken.readyToken signature].length);
+    secretToken.tokenBase64URL = base64URLEncodeToString(span([unlinkableToken.readyToken tokenContent]));
+    secretToken.keyIDBase64URL = base64URLEncodeToString(span([unlinkableToken.readyToken keyId]));
+    secretToken.signatureBase64URL = base64URLEncodeToString(span([unlinkableToken.readyToken signature]));
 
     return std::nullopt;
 #else

--- a/Source/WebCore/page/Base64Utilities.cpp
+++ b/Source/WebCore/page/Base64Utilities.cpp
@@ -38,7 +38,7 @@ ExceptionOr<String> Base64Utilities::btoa(const String& stringToEncode)
     if (!stringToEncode.containsOnlyLatin1())
         return Exception { ExceptionCode::InvalidCharacterError };
 
-    return base64EncodeToString(stringToEncode.latin1());
+    return base64EncodeToString(stringToEncode.latin1().span());
 }
 
 ExceptionOr<String> Base64Utilities::atob(const String& encodedString)

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -215,7 +215,7 @@ static Ref<SharedBuffer> extractKeyidsFromCencInitData(const SharedBuffer& initD
     // "kids"
     // An array of key IDs. Each element of the array is the base64url encoding of the octet sequence containing the key ID value.
     for (unsigned i = 0; i < keyIdCount; i++) {
-        keyIdsArray->pushString(base64URLEncodeToString(&data[index], ClearKey::KeyIDSizeInBytes));
+        keyIdsArray->pushString(base64URLEncodeToString(data.subspan(index, ClearKey::KeyIDSizeInBytes)));
         index += ClearKey::KeyIDSizeInBytes;
     }
 
@@ -567,7 +567,7 @@ void CDMInstanceSessionClearKey::removeSessionData(const String& sessionId, Lice
             auto array = JSON::Array::create();
             for (const auto& key : m_keyStore.values()) {
                 ASSERT(key->id().size() <= std::numeric_limits<unsigned>::max());
-                array->pushString(base64URLEncodeToString(key->id().data(), key->id().size()));
+                array->pushString(base64URLEncodeToString(key->id().span()));
             }
             rootObject->setArray("kids"_s, WTFMove(array));
         }

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
@@ -50,7 +50,7 @@ static String createUniqueFontName()
     GUID fontUuid;
     CoCreateGuid(&fontUuid);
 
-    auto fontName = base64EncodeToString(reinterpret_cast<char*>(&fontUuid), sizeof(fontUuid));
+    auto fontName = base64EncodeToString({ reinterpret_cast<const uint8_t*>(&fontUuid), sizeof(fontUuid) });
     ASSERT(fontName.length() < LF_FACESIZE);
     return fontName;
 }

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -87,8 +87,7 @@ private:
         auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
         digest->addBytes(std::span { certificateData->data, certificateData->len });
 
-        auto hash = digest->computeHash();
-        return base64EncodeToString(hash);
+        return base64EncodeToString(digest->computeHash());
     }
 
     HashSet<String> m_certificates;

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -236,13 +236,13 @@ String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const Str
     auto data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return emptyString();
-    return base64EncodeToString(g_bytes_get_data(data.get(), nullptr), g_bytes_get_size(data.get()));
+    return base64EncodeToString({ static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get()) });
 #elif PLATFORM(WIN)
     auto path = webKitBundlePath(iconName, iconType, "media-controls"_s);
     auto data = FileSystem::readEntireFile(path);
     if (!data)
         return { };
-    return base64EncodeToString(data->data(), data->size());
+    return base64EncodeToString(data->span());
 #else
     return { };
 #endif

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -94,8 +94,7 @@ String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOrig
     auto originString = origin.toString().utf8();
     crypto->addBytes(originString.span());
     crypto->addBytes(salt);
-    auto hash = crypto->computeHash();
-    return base64URLEncodeToString(hash.data(), hash.size());
+    return base64URLEncodeToString(crypto->computeHash());
 }
 
 } // namespace StorageUtilities

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -54,8 +54,7 @@ String SWScriptStorage::sha2Hash(const String& input) const
     crypto->addBytes(m_salt);
     auto inputUTF8 = input.utf8();
     crypto->addBytes(inputUTF8.span());
-    auto hash = crypto->computeHash();
-    return base64URLEncodeToString(hash.data(), hash.size());
+    return base64URLEncodeToString(crypto->computeHash());
 }
 
 String SWScriptStorage::sha2Hash(const URL& input) const

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -498,9 +498,8 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
 
             auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
             crypto->addBytes(publicKeyData->span());
-            auto publicKeyDataHash = crypto->computeHash();
 
-            auto keyID = base64URLEncodeToString(publicKeyDataHash.data(), publicKeyDataHash.size());
+            auto keyID = base64URLEncodeToString(crypto->computeHash());
             if (keyID != attribution.sourceSecretToken()->keyIDBase64URL)
                 return;
 
@@ -518,9 +517,8 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
 
                     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
                     crypto->addBytes(publicKeyData->span());
-                    auto publicKeyDataHash = crypto->computeHash();
 
-                    auto keyID = base64URLEncodeToString(publicKeyDataHash.data(), publicKeyDataHash.size());
+                    auto keyID = base64URLEncodeToString(crypto->computeHash());
                     if (keyID != attribution.attributionTriggerData()->destinationSecretToken->keyIDBase64URL)
                         return;
 
@@ -544,9 +542,8 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
 
         auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
         crypto->addBytes(publicKeyData->span());
-        auto publicKeyDataHash = crypto->computeHash();
 
-        auto keyID = base64URLEncodeToString(publicKeyDataHash.data(), publicKeyDataHash.size());
+        auto keyID = base64URLEncodeToString(crypto->computeHash());
         if (!attribution.attributionTriggerData()->destinationSecretToken || keyID != attribution.attributionTriggerData()->destinationSecretToken->keyIDBase64URL)
             return;
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -87,8 +87,7 @@ static String encode(const String& string, FileSystem::Salt salt)
     auto utf8String = string.utf8();
     crypto->addBytes(utf8String.span());
     crypto->addBytes(salt);
-    auto hash = crypto->computeHash();
-    return base64URLEncodeToString(hash.data(), hash.size());
+    return base64URLEncodeToString(crypto->computeHash());
 }
 
 static String originDirectoryPath(const String& rootPath, const WebCore::ClientOrigin& origin, FileSystem::Salt salt)

--- a/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
+++ b/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
@@ -42,10 +42,10 @@ static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)
     if (!surface)
         return std::nullopt;
 
-    Vector<unsigned char> pngData;
+    Vector<uint8_t> pngData;
     cairo_surface_write_to_png_stream(surface, [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
-        auto* pngData = static_cast<Vector<unsigned char>*>(userData);
-        pngData->append(std::span { data, length });
+        auto* pngData = static_cast<Vector<uint8_t>*>(userData);
+        pngData->append(std::span { reinterpret_cast<const uint8_t*>(data), length });
         return CAIRO_STATUS_SUCCESS;
     }, &pngData);
 

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -356,10 +356,10 @@ static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)
     if (!surface)
         return std::nullopt;
 
-    Vector<unsigned char> pngData;
+    Vector<uint8_t> pngData;
     cairo_surface_write_to_png_stream(surface, [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
-        auto* pngData = static_cast<Vector<unsigned char>*>(userData);
-        pngData->append(std::span { data, length });
+        auto* pngData = static_cast<Vector<uint8_t>*>(userData);
+        pngData->append(std::span { reinterpret_cast<const uint8_t*>(data), length });
         return CAIRO_STATUS_SUCCESS;
     }, &pngData);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -104,7 +104,7 @@ static inline HashSet<String> produceHashSet(const Vector<PublicKeyCredentialDes
     HashSet<String> result;
     for (auto& credentialDescriptor : credentialDescriptors) {
         if (emptyTransportsOrContain(credentialDescriptor.transports, AuthenticatorTransport::Internal) && credentialDescriptor.type == PublicKeyCredentialType::PublicKey && credentialDescriptor.id.length() == credentialIdLength)
-            result.add(base64EncodeToString(credentialDescriptor.id.data(), credentialDescriptor.id.length()));
+            result.add(base64EncodeToString(credentialDescriptor.id.span()));
     }
     return result;
 }
@@ -265,7 +265,7 @@ void LocalAuthenticator::makeCredential()
         if (notFound != m_existingCredentials.findIf([&excludeCredentialIds] (auto& credential) {
             auto* rawId = credential->rawId();
             ASSERT(rawId);
-            return excludeCredentialIds.contains(base64EncodeToString(rawId->data(), rawId->byteLength()));
+            return excludeCredentialIds.contains(base64EncodeToString(rawId->span()));
         })) {
             receiveException({ ExceptionCode::InvalidStateError, "At least one credential matches an entry of the excludeCredentials list in the platform attached authenticator."_s }, WebAuthenticationStatus::LAExcludeCredentialsMatched);
             return;
@@ -624,7 +624,7 @@ void LocalAuthenticator::getAssertion()
         if (allowCredentialIds.isEmpty())
             return credential.copyRef();
         auto* rawId = credential->rawId();
-        if (allowCredentialIds.contains(base64EncodeToString(rawId->data(), rawId->byteLength())))
+        if (allowCredentialIds.contains(base64EncodeToString(rawId->span())))
             return credential.copyRef();
         return nullptr;
     });

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -143,7 +143,7 @@ void MockLocalConnection::filterResponses(Vector<Ref<AuthenticatorAssertionRespo
     for (; itr != responses.end(); ++itr) {
         auto* rawId = itr->get().rawId();
         ASSERT(rawId);
-        auto rawIdBase64 = base64EncodeToString(rawId->data(), rawId->byteLength());
+        auto rawIdBase64 = base64EncodeToString(rawId->span());
         if (rawIdBase64 == preferredCredentialIdBase64)
             break;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -262,7 +262,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
     }, nil));
     auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(makeVector(publicKey.get()));
 
-    auto keyData = base64URLEncodeToString(wrappedKeyBytes.data(), wrappedKeyBytes.size());
+    auto keyData = base64URLEncodeToString(wrappedKeyBytes);
     // The server.
     HTTPServer server([signingParty, &done, connectionCount = signingParty == TokenSigningParty::Source ? 1 : 0, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &secKey] (Connection connection) mutable {
         switch (++connectionCount) {
@@ -295,7 +295,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                         const struct ccrsabssa_ciphersuite *ciphersuite = &ccrsabssa_ciphersuite_rsa4096_sha384;
                         auto blindedSignature = adoptNS([[NSMutableData alloc] initWithLength:modulusNBytes]);
                         ccrsabssa_sign_blinded_message(ciphersuite, rsaPrivateKey, blindedMessage->data(), blindedMessage->size(), static_cast<uint8_t *>([blindedSignature mutableBytes]), [blindedSignature length], rng);
-                        auto unlinkableToken = base64URLEncodeToString([blindedSignature bytes], [blindedSignature length]);
+                        auto unlinkableToken = base64URLEncodeToString(span(blindedSignature.get()));
 
                         // Example response: { "unlinkable_token": "ABCD" }. "ABCD" should be Base64URL encoded.
                         auto response = makeString("HTTP/1.1 200 OK\r\n"

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -561,7 +561,7 @@ void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandle
             sha1.addBytes(webSocketKeyGUID);
             SHA1::Digest hash;
             sha1.computeHash(hash);
-            return base64EncodeToString(hash.data(), SHA1::hashSize);
+            return base64EncodeToString(hash);
         };
 
         connection.send(HTTPResponse(101, {


### PR DESCRIPTION
#### 513f6e7095e6a8730bfd06084c8b3e68a974e856
<pre>
Update base64EncodeToString() / base64URLEncodeToString() overloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=274503">https://bugs.webkit.org/show_bug.cgi?id=274503</a>

Reviewed by Sihui Liu and Darin Adler.

Update base64EncodeToString() / base64URLEncodeToString() overloads to force
the call sites to provide either a `std::span&lt;const std::byte&gt;` or a
`std::span&lt;const uint8_t&gt;`.

This is a step towards our broader std::span adoption and using more consistent
typing to represent bytes.

* Source/WTF/wtf/text/Base64.h:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
(WebCore::PublicKeyCredential::PublicKeyCredential):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::buildClientDataJson):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::getExpectedWebSocketAccept):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformAddFieldElements const):
* Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp:
(WebCore::CryptoKeyEC::platformAddFieldElements const):
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::DOMPatchSupport::createDigest):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::getSerializedCertificate):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::archive):
* Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm:
(WebCore::PrivateClickMeasurement::calculateAndUpdateUnlinkableToken):
(WebCore::PrivateClickMeasurement::calculateAndUpdateSecretToken):
* Source/WebCore/page/Base64Utilities.cpp:
(WebCore::Base64Utilities::btoa):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::extractKeyidsFromCencInitData):
(WebCore::CDMInstanceSessionClearKey::removeSessionData):
* Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp:
(WebCore::createUniqueFontName):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::HostTLSCertificateSet::computeCertificateHash):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType):
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::encodeSecurityOriginForFileName):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::sha2Hash const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::fireConversionRequest):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::encode):
* Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp:
(WebKit::base64EncodedPNGData):
* Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp:
(WebKit::base64EncodedPNGData):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::produceHashSet):
(WebKit::LocalAuthenticator::makeCredential):
(WebKit::LocalAuthenticator::getAssertion):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm:
(WebKit::MockLocalConnection::filterResponses const):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm:
(TestWebKitAPI::TEST(PrivateClickMeasurement, ValidBlindedSecret)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::signUnlinkableTokenAndSendSecretToken):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::Connection::webSocketHandshake):

Canonical link: <a href="https://commits.webkit.org/279138@main">https://commits.webkit.org/279138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3878d98ad7a2bba7f6e51d7bc2268d7a9db09b90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42690 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2075 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1417 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45886 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57405 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52045 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27668 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50081 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49339 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29808 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64351 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7714 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28644 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12210 "Passed tests") | 
<!--EWS-Status-Bubble-End-->