### PR TITLE
[Unified Text Replacement] When receiving text with a replacement range, a trailing newline can sometimes go missing

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -409,7 +409,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
     // the above check ensures that the full range length expression will never underflow.
 
     auto characterCountDelta = sessionRangeCharacterCount - contextTextCharacterCount;
-    auto resolvedRange = resolveCharacterRange(*sessionRange, { range.location, range.length + characterCountDelta });
+    auto resolvedRange = UnifiedTextReplacementController::resolveCharacterRange(*sessionRange, { range.location, range.length + characterCountDelta });
 
     if (!m_originalDocumentNodes.contains(session.uuid)) {
         auto contents = m_contextRanges.get(session.uuid)->cloneContents();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1189,7 +1189,20 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
             endPosition = nextPosition;
     }
 
-    return makeSimpleRange(contextStartPosition, endPosition);
+    // Strip trailing newlines.
+
+    auto finalRange = makeSimpleRange(contextStartPosition, endPosition);
+    if (!finalRange)
+        return std::nullopt;
+
+    auto text = WebCore::plainText(*finalRange);
+    while (text.endsWith('\n')) {
+        endPosition = WebCore::positionOfNextBoundaryOfGranularity(endPosition, WebCore::TextGranularity::CharacterGranularity, WebCore::SelectionDirection::Backward);
+        finalRange = makeSimpleRange(contextStartPosition, endPosition);
+        text = WebCore::plainText(*finalRange);
+    }
+
+    return finalRange;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 9c2a2b42f8fab8d7d5a776f5e2342772fa2ef6c7
<pre>
[Unified Text Replacement] When receiving text with a replacement range, a trailing newline can sometimes go missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=274504">https://bugs.webkit.org/show_bug.cgi?id=274504</a>
<a href="https://rdar.apple.com/128084320">rdar://128084320</a>

Reviewed by Ryosuke Niwa.

When creating the context, omit any trailing newlines in the first place, since they will not be
actually used, and newlines behave semi-erratically anyways.

* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::autocorrectionContextRange):

Canonical link: <a href="https://commits.webkit.org/279148@main">https://commits.webkit.org/279148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7cd98084919ec0dddbfebea22bd7e6aa5a341c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42688 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26694 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57409 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27672 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2796 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-subset.html, imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content.html, imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50082 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49343 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29812 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7722 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->