### PR TITLE
Pass additional data for correct TextIndicator styling.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1079,6 +1079,7 @@ def headers_for_type(type):
         'WebKit::TapIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::TextCheckerRequestID': ['"IdentifierTypes.h"'],
         'WebKit::TextIndicatorStyle': ['"TextIndicatorStyle.h"'],
+        'WebKit::TextIndicatorStyleData': ['"TextIndicatorStyle.h"'],
         'WebKit::WebEventType': ['"WebEvent.h"'],
         'WebKit::WebExtensionContextInstallReason': ['"WebExtensionContext.h"'],
         'WebKit::WebExtensionCookieFilterParameters': ['"WebExtensionCookieParameters.h"'],

--- a/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
+++ b/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
@@ -69,4 +69,11 @@ header: "TextIndicatorStyle.h"
     Source,
     Final,
 };
+
+header: "TextIndicatorStyle.h"
+[CustomHeader] struct WebKit::TextIndicatorStyleData {
+    WebKit::TextIndicatorStyle style;
+    WTF::UUID remainingRangeUUID;
+};
+
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1789,15 +1789,15 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-- (void)_addTextIndicatorStyleForID:(NSUUID *)nsUUID withStyleType:(WKTextIndicatorStyleType)styleType
+- (void)_addTextIndicatorStyleForID:(NSUUID *)nsUUID withData:(const WebKit::TextIndicatorStyleData&)data
 {
 #if PLATFORM(IOS_FAMILY)
-    [_contentView addTextIndicatorStyleForID:nsUUID withStyleType:styleType];
+    [_contentView addTextIndicatorStyleForID:nsUUID withStyleType:toWKTextIndicatorStyleType(data.style)];
 #elif PLATFORM(MAC)
     auto uuid = WTF::UUID::fromNSUUID(nsUUID);
     if (!uuid)
         return;
-    _impl->addTextIndicatorStyleForID(*uuid, styleType);
+    _impl->addTextIndicatorStyleForID(*uuid, data);
 #endif
 }
 - (void)_removeTextIndicatorStyleForID:(NSUUID *)nsUUID
@@ -2818,7 +2818,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 #if PLATFORM(IOS_FAMILY)
     [_contentView addTextIndicatorStyleForID:nsUUID.get() withStyleType:WKTextIndicatorStyleTypeInitial];
 #elif PLATFORM(MAC) && ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
-    _impl->addTextIndicatorStyleForID(*uuid, WKTextIndicatorStyleTypeInitial);
+    _impl->addTextIndicatorStyleForID(*uuid, { WebKit::TextIndicatorStyle::Initial, WTF::UUID(WTF::UUID::emptyValue) });
 #endif
     return nsUUID.get();
 #else // ENABLE(UNIFIED_TEXT_REPLACEMENT)
@@ -2840,7 +2840,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 #if PLATFORM(IOS_FAMILY)
     [_contentView addTextIndicatorStyleForID:nsUUID.get() withStyleType:WKTextIndicatorStyleTypeFinal];
 #elif PLATFORM(MAC) && ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
-    _impl->addTextIndicatorStyleForID(*uuid, WKTextIndicatorStyleTypeFinal);
+    _impl->addTextIndicatorStyleForID(*uuid, { WebKit::TextIndicatorStyle::Final, WTF::UUID(WTF::UUID::emptyValue) });
 #endif
     return nsUUID.get();
 #else // ENABLE(UNIFIED_TEXT_REPLACEMENT)
@@ -3812,6 +3812,19 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
         findOptions.add(WebKit::FindOptions::DetermineMatchIndex);
 
     return findOptions;
+}
+
+static inline WKTextIndicatorStyleType toWKTextIndicatorStyleType(WebKit::TextIndicatorStyle style)
+{
+
+    switch (style) {
+    case WebKit::TextIndicatorStyle::Initial:
+        return WKTextIndicatorStyleTypeInitial;
+    case WebKit::TextIndicatorStyle::Source:
+        return WKTextIndicatorStyleTypeSource;
+    case WebKit::TextIndicatorStyle::Final:
+        return WKTextIndicatorStyleTypeFinal;
+    }
 }
 
 - (void)_countStringMatches:(NSString *)string options:(_WKFindOptions)options maxCount:(NSUInteger)maxCount

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -399,7 +399,7 @@ struct PerWebProcessState {
 - (void)_textReplacementSession:(NSUUID *)sessionUUID showInformationForReplacementWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect;
 
 - (void)_textReplacementSession:(NSUUID *)sessionUUID updateState:(WebKit::WebTextReplacementDataState)state forReplacementWithUUID:(NSUUID *)replacementUUID;
-- (void)_addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType;
+- (void)_addTextIndicatorStyleForID:(NSUUID *)uuid withData:(const WebKit::TextIndicatorStyleData&)styleData;
 - (void)_removeTextIndicatorStyleForID:(NSUUID *)uuid;
 
 - (BOOL)_wantsCompleteUnifiedTextReplacementBehavior;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -46,6 +46,7 @@ struct AppHighlight;
 
 namespace WebKit {
 
+struct TextIndicatorStyleData;
 enum class TextIndicatorStyle : uint8_t;
 
 class PageClientImplCocoa : public PageClient {
@@ -99,7 +100,7 @@ public:
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyle) final;
+    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyleData&) final;
     void removeTextIndicatorStyleForID(const WTF::UUID&) final;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -157,9 +157,9 @@ void PageClientImplCocoa::storeAppHighlight(const WebCore::AppHighlight &highlig
 #endif // ENABLE(APP_HIGHLIGHTS)
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-void PageClientImplCocoa::addTextIndicatorStyleForID(const WTF::UUID& uuid, WebKit::TextIndicatorStyle styleType)
+void PageClientImplCocoa::addTextIndicatorStyleForID(const WTF::UUID& uuid, const WebKit::TextIndicatorStyleData& data)
 {
-    [m_webView _addTextIndicatorStyleForID:uuid withStyleType:(WKTextIndicatorStyleType)styleType];
+    [m_webView _addTextIndicatorStyleForID:uuid withData:data];
 }
 
 void PageClientImplCocoa::removeTextIndicatorStyleForID(const WTF::UUID& uuid)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1210,13 +1210,13 @@ void WebPageProxy::enableTextIndicatorStyleForElementWithID(const String& elemen
     send(Messages::WebPage::EnableTextIndicatorStyleForElementWithID(elementID, uuid));
 }
 
-void WebPageProxy::addTextIndicatorStyleForID(const WTF::UUID& uuid, const TextIndicatorStyle styleType, const WebCore::TextIndicatorData& data)
+void WebPageProxy::addTextIndicatorStyleForID(const WTF::UUID& uuid, const TextIndicatorStyleData& styleData, const WebCore::TextIndicatorData& indicatorData)
 {
     MESSAGE_CHECK(uuid.isValid());
 
-    internals().textIndicatorDataForChunk.add(uuid, data);
+    internals().textIndicatorDataForChunk.add(uuid, indicatorData);
 
-    protectedPageClient()->addTextIndicatorStyleForID(uuid, styleType);
+    protectedPageClient()->addTextIndicatorStyleForID(uuid, styleData);
 }
 
 void WebPageProxy::getTextIndicatorForID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -705,7 +705,7 @@ public:
     virtual void storeAppHighlight(const WebCore::AppHighlight&) = 0;
 #endif
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-    virtual void addTextIndicatorStyleForID(const WTF::UUID&, WebKit::TextIndicatorStyle) = 0;
+    virtual void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyleData&) = 0;
     virtual void removeTextIndicatorStyleForID(const WTF::UUID&) = 0;
 #endif
     virtual void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) { }

--- a/Source/WebKit/UIProcess/TextIndicatorStyle.h
+++ b/Source/WebKit/UIProcess/TextIndicatorStyle.h
@@ -25,12 +25,19 @@
 
 #pragma once
 
+#include <wtf/UUID.h>
+
 namespace WebKit {
 
 enum class TextIndicatorStyle : uint8_t {
     Initial,
     Source,
     Final
+};
+
+struct TextIndicatorStyleData {
+    TextIndicatorStyle style;
+    WTF::UUID remainingRangeUUID { WTF::UUID::emptyValue };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WKSTextStyleManager.h
+++ b/Source/WebKit/UIProcess/WKSTextStyleManager.h
@@ -25,14 +25,14 @@
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
 
-#import "WKTextIndicatorStyleType.h"
+#import "TextIndicatorStyle.h"
 
 @protocol WKSTextStyleSourceDelegate;
 
 @interface WKSTextStyleManager : NSObject
 
 - (instancetype)initWithDelegate:(id <WKSTextStyleSourceDelegate>)delegate NS_DESIGNATED_INITIALIZER;
-- (void)addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType;
+- (void)addTextIndicatorStyleForID:(NSUUID *)uuid withData:(WebKit::TextIndicatorStyleData&)data;
 - (void)removeTextIndicatorStyleForID:(NSUUID *)uuid;
 @end
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8669,7 +8669,7 @@ void WebPageProxy::didGetImageForFindMatch(ImageBufferParameters&& parameters, S
     m_findMatchesClient->didGetImageForMatchResult(this, image.ptr(), matchIndex);
 }
 
-void WebPageProxy::setTextIndicatorFromFrame(FrameIdentifier frameID, TextIndicatorData&& indicatorData, uint64_t lifetime)
+void WebPageProxy::setTextIndicatorFromFrame(FrameIdentifier frameID, WebCore::TextIndicatorData&& indicatorData, uint64_t lifetime)
 {
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -482,6 +482,7 @@ struct SessionState;
 struct SubframeProcessPageParameters;
 struct TapIdentifierType;
 struct TextCheckerRequestType;
+struct TextIndicatorStyleData;
 struct TransactionIDType;
 struct URLSchemeTaskParameters;
 struct UserMessage;
@@ -2425,13 +2426,13 @@ public:
     void textReplacementSessionShowInformationForReplacementWithUUIDRelativeToRect(const WTF::UUID& sessionUUID, const WTF::UUID& replacementUUID, WebCore::IntRect selectionBoundsInRootView);
     void textReplacementSessionUpdateStateForReplacementWithUUID(const WTF::UUID& sessionUUID, WebTextReplacementDataState, const WTF::UUID& replacementUUID);
 
-    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyle, const WebCore::TextIndicatorData&);
+    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyleData&, const WebCore::TextIndicatorData&);
     void removeTextIndicatorStyleForID(const WTF::UUID&);
     void enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID&);
     void enableTextIndicatorStyleForElementWithID(const String& elementID, const WTF::UUID&);
 
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
-    void updateTextIndicatorStyleVisibilityForID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
+    void updateTextIndicatorStyleVisibilityForID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
 #endif
 
     void resetVisibilityAdjustmentsForTargetedElements(const Vector<Ref<API::TargetedElementInfo>>&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -521,7 +521,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-    AddTextIndicatorStyleForID(WTF::UUID uuid, enum:uint8_t WebKit::TextIndicatorStyle style, struct WebCore::TextIndicatorData data)
+    AddTextIndicatorStyleForID(WTF::UUID uuid, struct WebKit::TextIndicatorStyleData styleData, struct WebCore::TextIndicatorData indicatorData)
     RemoveTextIndicatorStyleForID(WTF::UUID uuid)
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WKTextIndicatorStyleManager.h
+++ b/Source/WebKit/UIProcess/mac/WKTextIndicatorStyleManager.h
@@ -40,7 +40,7 @@ class WebViewImpl;
 + (BOOL)supportsTextIndicatorStyle;
 
 - (instancetype)initWithWebViewImpl:(WebKit::WebViewImpl&)view;
-- (void)addTextIndicatorStyleForID:(NSUUID *)uuid withStyleType:(WKTextIndicatorStyleType)styleType;
+- (void)addTextIndicatorStyleForID:(NSUUID *)uuid withData:(const WebKit::TextIndicatorStyleData&)data;
 - (void)removeTextIndicatorStyleForID:(NSUUID *)uuid;
 
 - (BOOL)hasActiveTextIndicatorStyle;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -744,7 +744,7 @@ public:
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     bool wantsCompleteUnifiedTextReplacementBehavior() const;
 
-    void addTextIndicatorStyleForID(WTF::UUID, WKTextIndicatorStyleType);
+    void addTextIndicatorStyleForID(WTF::UUID, const WebKit::TextIndicatorStyleData&);
     void removeTextIndicatorStyleForID(WTF::UUID);
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4613,7 +4613,7 @@ void WebViewImpl::removeTextPlaceholder(NSTextPlaceholder *placeholder, bool wil
 }
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-void WebViewImpl::addTextIndicatorStyleForID(WTF::UUID uuid, WKTextIndicatorStyleType styleType)
+void WebViewImpl::addTextIndicatorStyleForID(WTF::UUID uuid, const WebKit::TextIndicatorStyleData& data)
 {
     if (!m_page->preferences().textIndicatorStylingEnabled())
         return;
@@ -4624,7 +4624,7 @@ void WebViewImpl::addTextIndicatorStyleForID(WTF::UUID uuid, WKTextIndicatorStyl
     if (!m_textIndicatorStyleManager)
         m_textIndicatorStyleManager = adoptNS([[WKTextIndicatorStyleManager alloc] initWithWebViewImpl:*this]);
 
-    [m_textIndicatorStyleManager addTextIndicatorStyleForID:uuid withStyleType:styleType];
+    [m_textIndicatorStyleManager addTextIndicatorStyleForID:uuid withData:data];
 }
 
 void WebViewImpl::removeTextIndicatorStyleForID(WTF::UUID uuid)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -89,6 +89,7 @@
 #import <WebCore/ScrollbarTheme.h>
 #import <WebCore/Settings.h>
 #import <WebCore/SharedBuffer.h>
+#import <WebCore/TextIndicator.h>
 #import <WebCore/WebAccessibilityObjectWrapperMac.h>
 #import <WebCore/WheelEventTestMonitor.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -377,7 +377,7 @@ void WebPage::updateTextIndicatorStyleVisibilityForID(const WTF::UUID& uuid, boo
     if (visible) {
         // FIXME: <https://webkit.org/b/274198> Text indicator style logic in WebPage and UnifiedTextReplacementController should be shared.
         if (m_textIndicatorStyleEnablementRanges.contains(uuid)) {
-            m_unifiedTextReplacementController->removeTransparentMarkersForUUID(*sessionRange, uuid);
+            m_unifiedTextReplacementController->removeTransparentMarkersForUUID(uuid);
         } else
             m_unifiedTextReplacementController->removeTransparentMarkersForSession(uuid, RemoveAllMarkersForSession::No);
     } else

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -81,7 +81,7 @@ public:
     std::optional<WebCore::SimpleRange> contextRangeForSessionWithUUID(const WTF::UUID&) const;
     std::optional<WebCore::SimpleRange> contextRangeForSessionOrRangeWithUUID(const WTF::UUID&) const;
 
-    void removeTransparentMarkersForUUID(const WebCore::SimpleRange&, const WTF::UUID&);
+    void removeTransparentMarkersForUUID(const WTF::UUID&);
     void removeTransparentMarkersForSession(const WTF::UUID&, RemoveAllMarkersForSession);
 
 private:
@@ -109,6 +109,7 @@ private:
 
     using TextIndicatorCharacterRange = std::pair<WTF::UUID, WebCore::CharacterRange>;
     Vector<std::pair<WTF::UUID, Vector<TextIndicatorCharacterRange>>> m_textIndicatorCharacterRangesForSessions;
+    Vector<std::pair<WTF::UUID, std::pair<WTF::UUID, WebCore::SimpleRange>>> m_remainingRangesForSessions;
 
     // FIXME: Unify these states into a single `State` struct.
     HashMap<WTF::UUID, Ref<WebCore::Range>> m_contextRanges;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9138,9 +9138,9 @@ void WebPage::lastNavigationWasAppInitiated(CompletionHandler<void(bool)>&& comp
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
 
-void WebPage::addTextIndicatorStyleForID(const WTF::UUID& uuid, const WebKit::TextIndicatorStyle styleType, const WebCore::TextIndicatorData& data)
+void WebPage::addTextIndicatorStyleForID(const WTF::UUID& uuid, const WebKit::TextIndicatorStyleData& styleData, const WebCore::TextIndicatorData& indicatorData)
 {
-    send(Messages::WebPageProxy::AddTextIndicatorStyleForID(uuid, styleType, data));
+    send(Messages::WebPageProxy::AddTextIndicatorStyleForID(uuid, styleData, indicatorData));
 }
 
 void WebPage::removeTextIndicatorStyleForID(const WTF::UUID& uuid)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -405,6 +405,7 @@ struct LoadParameters;
 struct PlatformFontInfo;
 struct PrintInfo;
 struct ProvisionalFrameCreationParameters;
+struct TextIndicatorStyleData;
 struct TextInputContext;
 struct UserMessage;
 struct WebAutocorrectionData;
@@ -1747,7 +1748,7 @@ public:
 
     void enableTextIndicatorStyleAfterElementWithID(const String&, const WTF::UUID&);
     void enableTextIndicatorStyleForElementWithID(const String&, const WTF::UUID&);
-    void addTextIndicatorStyleForID(const WTF::UUID&, WebKit::TextIndicatorStyle, const WebCore::TextIndicatorData&);
+    void addTextIndicatorStyleForID(const WTF::UUID&, const WebKit::TextIndicatorStyleData&, const WebCore::TextIndicatorData&);
     void removeTextIndicatorStyleForID(const WTF::UUID&);
     void createTextIndicatorForRange(const WebCore::SimpleRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void createTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);


### PR DESCRIPTION
#### cc61ebcd1d9dffbc763dfb9d72050db3ea27b594
<pre>
Pass additional data for correct TextIndicator styling.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274505">https://bugs.webkit.org/show_bug.cgi?id=274505</a>
<a href="https://rdar.apple.com/128475613">rdar://128475613</a>

Reviewed by Aditya Keerthi.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/UnifiedTextReplacement.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _addTextIndicatorStyleForID:withData:]):
(-[WKWebView _enableTextIndicatorStylingAfterElementWithID:]):
(-[WKWebView _enableTextIndicatorStylingForElementWithID:]):
(-[WKWebView _addTextIndicatorStyleForID:withStyleType:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::addTextIndicatorStyleForID):
* Source/WebKit/UIProcess/Cocoa/WKTextIndicatorStyleType.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addTextIndicatorStyleForID):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/TextIndicatorStyle.h:
* Source/WebKit/UIProcess/WKSTextStyleManager.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setTextIndicatorFromFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/WKTextIndicatorStyleManager.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::addTextIndicatorStyleForID):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForUUID):
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::contextRangeForSessionOrRangeWithUUID const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::updateTextIndicatorStyleVisibilityForID):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addTextIndicatorStyleForID):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/279165@main">https://commits.webkit.org/279165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/892f93d4e683593fe0133ecd0fe62775a053f85f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3356 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3122 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54731 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23862 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52477 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1515 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57503 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27770 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50153 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49424 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29908 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7730 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->