### PR TITLE
[GStreamer] Silence GstVideoFrame leaks

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -26,7 +26,6 @@
 #include "GStreamerRegistryScanner.h"
 #include "ImageGStreamer.h"
 #include "MediaSampleGStreamer.h"
-#include "NotImplemented.h"
 #include "RuntimeApplicationChecks.h"
 #include "VideoFrameGStreamer.h"
 #include <gst/base/gsttypefindhelper.h>
@@ -40,6 +39,14 @@ GST_DEBUG_CATEGORY(webkit_image_decoder_debug);
 
 static Lock s_decoderLock;
 static Vector<RefPtr<ImageDecoderGStreamer>> s_imageDecoders;
+
+static void ensureDebugCategoryIsInitialized()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_image_decoder_debug, "webkitimagedecoder", 0, "WebKit image decoder");
+    });
+}
 
 void teardownGStreamerImageDecoders()
 {
@@ -60,7 +67,7 @@ public:
     {
         if (!m_image)
             return nullptr;
-        return m_image->image().nativeImage()->platformImage();
+        return m_image->image();
     }
     void dropImage()
     {
@@ -76,8 +83,8 @@ public:
 private:
     ImageDecoderGStreamerSample(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize)
         : MediaSampleGStreamer(WTFMove(sample), presentationSize, { })
+        , m_frame(VideoFrameGStreamer::createWrappedSample(this->sample()))
     {
-        m_frame = VideoFrameGStreamer::create(GRefPtr(platformSample().sample.gstSample), presentationSize);
         m_image = m_frame->convertToImage();
     }
 
@@ -109,11 +116,7 @@ RefPtr<ImageDecoderGStreamer> ImageDecoderGStreamer::create(FragmentedSharedBuff
 ImageDecoderGStreamer::ImageDecoderGStreamer(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption, GammaAndColorProfileOption)
     : m_mimeType(mimeType)
 {
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        GST_DEBUG_CATEGORY_INIT(webkit_image_decoder_debug, "webkitimagedecoder", 0, "WebKit image decoder");
-    });
-
+    ensureDebugCategoryIsInitialized();
     static Atomic<uint32_t> decoderId;
     GRefPtr<GstElement> parsebin = gst_element_factory_make("parsebin", makeString("image-decoder-parser-"_s, decoderId.exchangeAdd(1)).utf8().data());
     m_parserHarness = GStreamerElementHarness::create(WTFMove(parsebin), [](auto&, auto&&) { }, [this](auto& pad) -> RefPtr<GStreamerElementHarness> {

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
@@ -21,23 +21,20 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
-#include "BitmapImage.h"
 #include "FloatRect.h"
 #include "GStreamerCommon.h"
+#include "PlatformImage.h"
 
-#include <gst/gst.h>
 #include <gst/video/video-frame.h>
 
-#include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
+#include <wtf/Forward.h>
 
 namespace WebCore {
 class IntSize;
 
 class ImageGStreamer : public RefCounted<ImageGStreamer> {
 public:
-    static Ref<ImageGStreamer> createImage(GRefPtr<GstSample>&& sample)
+    static Ref<ImageGStreamer> create(GRefPtr<GstSample>&& sample)
     {
         return adoptRef(*new ImageGStreamer(WTFMove(sample)));
     }
@@ -45,11 +42,7 @@ public:
 
     operator bool() const { return !!m_image; }
 
-    BitmapImage& image()
-    {
-        ASSERT(m_image);
-        return *m_image.get();
-    }
+    PlatformImagePtr image() const { return m_image; }
 
     void setCropRect(FloatRect rect) { m_cropRect = rect; }
     FloatRect rect()
@@ -57,7 +50,7 @@ public:
         ASSERT(m_image);
         if (!m_cropRect.isEmpty())
             return FloatRect(m_cropRect);
-        return FloatRect(0, 0, m_image->size().width(), m_image->size().height());
+        return FloatRect(0, 0, m_size.width(), m_size.height());
     }
 
     bool hasAlpha() const { return m_hasAlpha; }
@@ -65,12 +58,13 @@ public:
 private:
     ImageGStreamer(GRefPtr<GstSample>&&);
     GRefPtr<GstSample> m_sample;
-    RefPtr<BitmapImage> m_image;
+    PlatformImagePtr m_image;
     FloatRect m_cropRect;
 #if USE(CAIRO)
     GstVideoFrame m_videoFrame;
     bool m_frameMapped { false };
 #endif
+    FloatSize m_size;
     bool m_hasAlpha { false };
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
@@ -74,6 +74,8 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     int height = GST_VIDEO_FRAME_HEIGHT(&m_videoFrame);
     RefPtr<cairo_surface_t> surface;
 
+    m_size = { static_cast<float>(width), static_cast<float>(height) };
+
     if (m_hasAlpha || componentSwapRequired) {
         uint8_t* surfaceData = static_cast<uint8_t*>(fastMalloc(height * stride));
         uint8_t* surfacePixel = surfaceData;
@@ -156,7 +158,7 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
         surface = adoptRef(cairo_image_surface_create_for_data(bufferData, CAIRO_FORMAT_ARGB32, width, height, stride));
 
     ASSERT(cairo_surface_status(surface.get()) == CAIRO_STATUS_SUCCESS);
-    m_image = BitmapImage::create(WTFMove(surface));
+    m_image = WTFMove(surface);
 
     if (GstVideoCropMeta* cropMeta = gst_buffer_get_video_crop_meta(buffer))
         setCropRect(FloatRect(cropMeta->x, cropMeta->y, cropMeta->width, cropMeta->height));

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h
@@ -54,6 +54,8 @@ public:
     PlatformSample::Type platformSampleType() const override { return PlatformSample::GStreamerSampleType; }
     void dump(PrintStream&) const override;
 
+    const GRefPtr<GstSample>& sample() const { return m_sample; }
+
 protected:
     MediaSampleGStreamer(GRefPtr<GstSample>&&, const FloatSize& presentationSize, TrackID);
     virtual ~MediaSampleGStreamer() = default;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -24,6 +24,7 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
+#include "BitmapImage.h"
 #include "GLContext.h"
 #include "GStreamerCommon.h"
 #include "GraphicsContext.h"
@@ -82,7 +83,7 @@ static RefPtr<ImageGStreamer> convertSampleToImage(const GRefPtr<GstSample>& sam
     if (!convertedSample)
         return nullptr;
 
-    return ImageGStreamer::createImage(WTFMove(convertedSample));
+    return ImageGStreamer::create(WTFMove(convertedSample));
 }
 
 RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
@@ -540,7 +541,7 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
     callback({ });
 }
 
-void VideoFrame::paintInContext(GraphicsContext & context, const FloatRect& destination, const ImageOrientation& destinationImageOrientation, bool shouldDiscardAlpha)
+void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& destination, const ImageOrientation& destinationImageOrientation, bool shouldDiscardAlpha)
 {
     auto image = convertSampleToImage(downcast<VideoFrameGStreamer>(*this).sample());
     if (!image)
@@ -549,7 +550,11 @@ void VideoFrame::paintInContext(GraphicsContext & context, const FloatRect& dest
     auto imageRect = image->rect();
     auto source = destinationImageOrientation.usesWidthAsHeight() ? FloatRect(imageRect.location(), imageRect.size().transposedSize()) : imageRect;
     auto compositeOperator = !shouldDiscardAlpha && image->hasAlpha() ? CompositeOperator::SourceOver : CompositeOperator::Copy;
-    context.drawImage(image->image(), destination, source, { compositeOperator, destinationImageOrientation });
+    auto platformImage = image->image();
+    auto bitmapImage = BitmapImage::create(WTFMove(platformImage));
+    if (!bitmapImage)
+        return;
+    context.drawImage(*bitmapImage.get(), destination, source, { compositeOperator, destinationImageOrientation });
 }
 
 uint32_t VideoFrameGStreamer::pixelFormat() const


### PR DESCRIPTION
#### f6f7e5b1258f62f62681fbf0e34fefe8c12369bb
<pre>
[GStreamer] Silence GstVideoFrame leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=274257">https://bugs.webkit.org/show_bug.cgi?id=274257</a>
&lt;<a href="https://rdar.apple.com/problem/128454923">rdar://problem/128454923</a>&gt;

Reviewed by Xabier Rodriguez-Calvar.

The ImageGStreamer no longer holds a BitmapImage, but a PlatformImagePtr. A BitmapImage is now
created by VideoFrameGStreamer when painting is required. The ImageGStreamerSkia implementation no
longer holds the mapped GstVideoFrame because that keeps un-necessary references and file
descriptors open, the needed plane data is copied instead.

* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ensureDebugCategoryIsInitialized):
(WebCore::ImageDecoderGStreamer::ImageDecoderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h:
(WebCore::ImageGStreamer::create):
(WebCore::ImageGStreamer::image const):
(WebCore::ImageGStreamer::rect):
(WebCore::ImageGStreamer::createImage): Deleted.
(WebCore::ImageGStreamer::image): Deleted.
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.h:
(WebCore::MediaSampleGStreamer::sample const):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::convertSampleToImage):
(WebCore::VideoFrame::paintInContext):

Canonical link: <a href="https://commits.webkit.org/279190@main">https://commits.webkit.org/279190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9300e26848fd69a00a233ffcdfdc479ef8c14b9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3223 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23956 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1660 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57648 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27917 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45751 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11525 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->