### PR TITLE
Use native promise for CacheStorageConnection::remove

### DIFF
--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -43,7 +43,8 @@ public:
 
     using OpenPromise = NativePromise<DOMCacheEngine::CacheIdentifierOperationResult, DOMCacheEngine::Error>;
     virtual Ref<OpenPromise> open(const ClientOrigin&, const String& cacheName) = 0;
-    virtual void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) = 0;
+    using RemovePromise = NativePromise<bool, DOMCacheEngine::Error>;
+    virtual Ref<RemovePromise> remove(DOMCacheIdentifier) = 0;
     virtual void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) = 0;
 
     virtual void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) = 0;

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -276,7 +276,7 @@ void DOMCacheStorage::doRemove(const String& name, DOMPromiseDeferred<IDLBoolean
         return;
     }
 
-    m_connection->remove(m_caches[position]->identifier(), [this, name, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this)](const auto& result) mutable {
+    scriptExecutionContext()->enqueueTaskWhenSettled(m_connection->remove(m_caches[position]->identifier()), TaskSource::DOMManipulation, [this, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this)](const auto& result) mutable {
         if (!result.has_value())
             promise.reject(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), result.error()));
         else

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -47,7 +47,7 @@ private:
 
     // WebCore::CacheStorageConnection.
     Ref<OpenPromise> open(const ClientOrigin&, const String& cacheName) final;
-    void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
+    Ref<RemovePromise> remove(DOMCacheIdentifier) final;
     void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) final;
 
     void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final;
@@ -59,7 +59,6 @@ private:
     void lockStorage(const ClientOrigin&) final;
     void unlockStorage(const ClientOrigin&) final;
 
-    void removeCompleted(uint64_t requestIdentifier, const DOMCacheEngine::RemoveCacheIdentifierOrError&);
     void retrieveCachesCompleted(uint64_t requestIdentifier, DOMCacheEngine::CacheInfosOrError&&);
     void retrieveRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::CrossThreadRecordsOrError&&);
     void deleteRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordIdentifiersOrError&&);
@@ -69,7 +68,6 @@ private:
 
     Ref<CacheStorageConnection> m_mainThreadConnection;
 
-    HashMap<uint64_t, DOMCacheEngine::RemoveCacheIdentifierCallback> m_removeCachePendingRequests;
     HashMap<uint64_t, DOMCacheEngine::CacheInfosCallback> m_retrieveCachesPendingRequests;
     HashMap<uint64_t, DOMCacheEngine::CrossThreadRecordsCallback> m_retrieveRecordsPendingRequests;
     HashMap<uint64_t, DOMCacheEngine::RecordIdentifiersCallback> m_batchDeleteAndPutPendingRequests;

--- a/Source/WebCore/page/CacheStorageProvider.h
+++ b/Source/WebCore/page/CacheStorageProvider.h
@@ -43,7 +43,7 @@ public:
         }
 
         Ref<OpenPromise> open(const ClientOrigin&, const String&) final { return OpenPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
-        void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final { }
+        Ref<RemovePromise> remove(DOMCacheIdentifier) final { return RemovePromise::createAndReject(DOMCacheEngine::Error::Stopped); }
         void retrieveCaches(const ClientOrigin&, uint64_t, DOMCacheEngine::CacheInfosCallback&&) final { }
         void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final { }
         void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -60,9 +60,11 @@ auto WebCacheStorageConnection::open(const WebCore::ClientOrigin& origin, const 
     });
 }
 
-void WebCacheStorageConnection::remove(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
+auto WebCacheStorageConnection::remove(WebCore::DOMCacheIdentifier cacheIdentifier) -> Ref<RemovePromise>
 {
-    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageRemoveCache(cacheIdentifier), WTFMove(callback));
+    return connection().sendWithPromisedReply(Messages::NetworkStorageManager::CacheStorageRemoveCache(cacheIdentifier))->whenSettled(RunLoop::current(), [](auto&& result) {
+        return result ? RemovePromise::createAndSettle(WTFMove(result.value())) : RemovePromise::createAndReject(WebCore::DOMCacheEngine::Error::Internal);
+    });
 }
 
 void WebCacheStorageConnection::retrieveCaches(const WebCore::ClientOrigin& origin, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&& callback)

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -56,7 +56,7 @@ private:
 
     // WebCore::CacheStorageConnection
     Ref<OpenPromise> open(const WebCore::ClientOrigin&, const String& cacheName) final;
-    void remove(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
+    Ref<RemovePromise> remove(WebCore::DOMCacheIdentifier) final;
     void retrieveCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&) final;
 
     void retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&) final;


### PR DESCRIPTION
#### 0200b038d629471c44af42122601f71e35e26982
<pre>
Use native promise for CacheStorageConnection::remove
<a href="https://rdar.apple.com/128529826">rdar://128529826</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274514">https://bugs.webkit.org/show_bug.cgi?id=274514</a>

Reviewed by Sihui Liu.

Refactoring to use native promise for CacheStorageConnection::remove allows to simplify code.
This might pave the way towards sending IPC message to the network process from the worker thread directly as well.

* Source/WebCore/Modules/cache/CacheStorageConnection.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::doRemove):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::remove):
(WebCore::WorkerCacheStorageConnection::clearPendingRequests):
(WebCore::WorkerCacheStorageConnection::removeCompleted): Deleted.
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:
* Source/WebCore/page/CacheStorageProvider.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::remove):
(WebKit::WebCacheStorageConnection::retrieveCaches): Deleted.
(WebKit::WebCacheStorageConnection::retrieveRecords): Deleted.
(WebKit::WebCacheStorageConnection::batchDeleteOperation): Deleted.
(WebKit::WebCacheStorageConnection::batchPutOperation): Deleted.
(WebKit::WebCacheStorageConnection::reference): Deleted.
(WebKit::WebCacheStorageConnection::dereference): Deleted.
(WebKit::WebCacheStorageConnection::lockStorage): Deleted.
(WebKit::WebCacheStorageConnection::unlockStorage): Deleted.
(WebKit::WebCacheStorageConnection::clearMemoryRepresentation): Deleted.
(WebKit::WebCacheStorageConnection::engineRepresentation): Deleted.
(WebKit::WebCacheStorageConnection::updateQuotaBasedOnSpaceUsage): Deleted.
(WebKit::WebCacheStorageConnection::networkProcessConnectionClosed): Deleted.

Canonical link: <a href="https://commits.webkit.org/279192@main">https://commits.webkit.org/279192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c9ec51bdb78347ae8dbf0ee8c3cbcbf195bc9fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3230 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2265 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54882 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29842 "Build is in progress. Recent messages:") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23962 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1666 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3019 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45757 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11528 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->