### PR TITLE
CanvasBase::makeRenderingResultsAvailable is not called consistently

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -223,7 +223,7 @@ static PixelFormat toPixelFormat(GPUTextureFormat textureFormat)
 }
 
 using ImageDataCallback = Function<void(std::span<const uint8_t>, size_t)>;
-static void getImageBytesFromImageBuffer(ImageBuffer* imageBuffer, const auto& destination, ImageDataCallback&& callback)
+static void getImageBytesFromImageBuffer(const RefPtr<ImageBuffer>& imageBuffer, const auto& destination, ImageDataCallback&& callback)
 {
     if (!imageBuffer)
         return callback({ }, 0);
@@ -331,11 +331,11 @@ static void imageBytesForSource(const auto& source, const auto& destination, Ima
 #endif
 #endif
     }, [&](const RefPtr<HTMLCanvasElement>& canvasElement) -> ResultType {
-        return getImageBytesFromImageBuffer(canvasElement->buffer(), destination, WTFMove(callback));
+        return getImageBytesFromImageBuffer(canvasElement->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No), destination, WTFMove(callback));
     }
 #if ENABLE(OFFSCREEN_CANVAS)
     , [&](const RefPtr<OffscreenCanvas>& offscreenCanvasElement) -> ResultType {
-        return getImageBytesFromImageBuffer(offscreenCanvasElement->buffer(), destination, WTFMove(callback));
+        return getImageBytesFromImageBuffer(offscreenCanvasElement->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No), destination, WTFMove(callback));
     }
 #endif
     );

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -225,8 +225,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         if (!canvas->width() || !canvas->height())
             return Exception { ExceptionCode::InvalidStateError,  "Input canvas has a bad size"_s };
 
-        canvas->makeRenderingResultsAvailable();
-        RefPtr imageBuffer = canvas->buffer();
+        RefPtr imageBuffer = canvas->makeRenderingResultsAvailable();
         if (!imageBuffer)
             return Exception { ExceptionCode::InvalidStateError,  "Input canvas has no image buffer"_s };
 

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -97,13 +97,14 @@ AffineTransform CanvasBase::baseTransform() const
     return m_imageBuffer->baseTransform();
 }
 
-void CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
+RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     if (auto* context = renderingContext()) {
         context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
         if (m_canvasNoiseHashSalt && shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes)
             m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer(), *m_canvasNoiseHashSalt, context->is2d() ? CanvasNoiseInjectionPostProcessArea::DirtyRect : CanvasNoiseInjectionPostProcessArea::FullBuffer);
     }
+    return buffer();
 }
 
 size_t CanvasBase::memoryCost() const

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -95,7 +95,7 @@ public:
 
     virtual AffineTransform baseTransform() const;
 
-    void makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
+    RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
     size_t memoryCost() const;
 #if ENABLE(RESOURCE_USAGE)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1780,14 +1780,11 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
         return { };
 
     Ref protectedCanvas { sourceCanvas };
-    // FIXME: Do this through platform-independent GraphicsContext API.
-    RefPtr buffer = sourceCanvas.buffer();
-    if (!buffer)
-        return { };
-
     checkOrigin(&sourceCanvas);
 
-    sourceCanvas.makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
+    RefPtr buffer = sourceCanvas.makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
+    if (!buffer)
+        return { };
 
     bool repaintEntireCanvas = false;
     if (rectContainsCanvas(normalizedDstRect)) {
@@ -2535,8 +2532,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     if (auto imageData = makeImageDataIfContentsCached(imageDataRect, computedColorSpace))
         return imageData.releaseNonNull();
 
-    canvasBase().makeRenderingResultsAvailable();
-    RefPtr buffer = canvasBase().buffer();
+    RefPtr<ImageBuffer> buffer = canvasBase().makeRenderingResultsAvailable();
     if (!buffer) {
         auto imageData = ImageData::createUninitialized(imageDataRect.width(), imageDataRect.height(), m_settings.colorSpace, settings);
         if (!imageData.hasException())

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -79,7 +79,7 @@ RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const Float
 
     ASSERT(clients().contains(const_cast<RenderElement&>(*renderer)));
     RefPtr element = this->element(renderer->document());
-    if (!element || !element->buffer())
+    if (!element)
         return nullptr;
     return element->copiedImage();
 }


### PR DESCRIPTION
#### c83035adb300082d800e687be6b3d0517d132cbb
<pre>
CanvasBase::makeRenderingResultsAvailable is not called consistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=274517">https://bugs.webkit.org/show_bug.cgi?id=274517</a>
<a href="https://rdar.apple.com/128533924">rdar://128533924</a>

Reviewed by Matt Woodrow.

Inconsistencies:
 - Sometimes buffer() is accessed after the call to makeRenderingResultsAvailable
   This is the intended correct operation.
 - Sometimes buffer() is accessed before the call to makeRenderingResultsAvailable
 - Sometimes buffer() is accessed without the call to makeRenderingResultsAvailable

makeRenderingResultsAvailable() intention is to force rendering results to be
written to the CanvasBase::m_imageBuffer. This includes sometimes applying the
anti-fingerprint noise.

Accessing buffer() before the call prevents makeRenderingResultsAvailable()
being able to replace the internal buffer in future commits.

Accessing buffer() without the call does not guarantee that the rendering
is present in the buffer, for example with WebGL. Also it it does not
apply the potential anti-fingerprint noise.

Fix by:
When HTMLCanvasElement and OffscreenCanvas are used as image source,
call makeRenderingResultsAvailable() to obtain the buffer.
Returning the buffer from makeRenderingResultsAvailable() makes it easier
to understand the access pattern.

This way future work can:
 - Swap the whole buffer when rendering results are read. This will be
   used in WebGL / WebGPU code.
 - Move the backing buffer logic to the respective rendering context
   implementation, where it belongs.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromImageBuffer):
(WebCore::imageBytesForSource):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toDataURL):
(WebCore::HTMLCanvasElement::toBlob):
(WebCore::HTMLCanvasElement::toVideoFrame):
(WebCore::HTMLCanvasElement::copiedImage const):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::convertToBlob):
(WebCore::OffscreenCanvas::copiedImage const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::validateHTMLCanvasElement):
(WebCore::WebGLRenderingContextBase::validateOffscreenCanvas):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::indexForData):
* Source/WebCore/rendering/style/StyleCanvasImage.cpp:
(WebCore::StyleCanvasImage::image const):

Canonical link: <a href="https://commits.webkit.org/279184@main">https://commits.webkit.org/279184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68047c7adf70155a32b79a86c17d1b3cf07b566a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42772 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54746 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45457 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23872 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2752 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1530 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57518 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50161 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29009 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11518 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->