### PR TITLE
[GStreamer] Move most GStreamerCommon classes implemenations to cpp file

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -181,33 +181,14 @@ using GstMappedBuffer = GstBufferMapper<GstMapInfo, gst_buffer_map, gst_buffer_u
 class GstMappedOwnedBuffer : public GstMappedBuffer, public ThreadSafeRefCounted<GstMappedOwnedBuffer> {
 
 public:
-    static RefPtr<GstMappedOwnedBuffer> create(GRefPtr<GstBuffer>&& buffer)
-    {
-        auto* mappedBuffer = new GstMappedOwnedBuffer(WTFMove(buffer));
-        if (!mappedBuffer->isValid()) {
-            delete mappedBuffer;
-            return nullptr;
-        }
-
-        return adoptRef(mappedBuffer);
-    }
-
-    static RefPtr<GstMappedOwnedBuffer> create(const GRefPtr<GstBuffer>& buffer)
-    {
-        return create(GRefPtr(buffer));
-    }
+    static RefPtr<GstMappedOwnedBuffer> create(GRefPtr<GstBuffer>&&);
+    static RefPtr<GstMappedOwnedBuffer> create(const GRefPtr<GstBuffer>&);
 
     // This GstBuffer is [ transfer none ], meaning the reference
     // count is increased during the life of this object.
-    static RefPtr<GstMappedOwnedBuffer> create(GstBuffer* buffer)
-    {
-        return create(GRefPtr(buffer));
-    }
+    static RefPtr<GstMappedOwnedBuffer> create(GstBuffer*);
 
-    virtual ~GstMappedOwnedBuffer()
-    {
-        unmapEarly();
-    }
+    virtual ~GstMappedOwnedBuffer();
 
     Ref<SharedBuffer> createSharedBuffer();
 
@@ -223,80 +204,24 @@ class GstMappedFrame {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(GstMappedFrame);
 public:
-    GstMappedFrame(GstBuffer* buffer, GstVideoInfo* info, GstMapFlags flags)
-    {
-        gst_video_frame_map(&m_frame, info, buffer, flags);
-    }
+    GstMappedFrame(GstBuffer*, GstVideoInfo*, GstMapFlags);
+    GstMappedFrame(const GRefPtr<GstSample>&, GstMapFlags);
 
-    GstMappedFrame(const GRefPtr<GstSample>& sample, GstMapFlags flags)
-    {
-        GstVideoInfo info;
-        if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get())))
-            return;
+    ~GstMappedFrame();
 
-        gst_video_frame_map(&m_frame, &info, gst_sample_get_buffer(sample.get()), flags);
-    }
+    GstVideoFrame* get();
 
-    ~GstMappedFrame()
-    {
-        // FIXME: Make this un-conditional when the minimum GStreamer dependency version is >= 1.22.
-        if (m_frame.buffer)
-            gst_video_frame_unmap(&m_frame);
-    }
+    uint8_t* componentData(int) const;
+    int componentStride(int) const;
 
-    GstVideoFrame* get()
-    {
-        RELEASE_ASSERT(isValid());
-        return &m_frame;
-    }
+    GstVideoInfo* info();
 
-    uint8_t* ComponentData(int comp) const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_COMP_DATA(&m_frame, comp);
-    }
+    int width() const;
+    int height() const;
 
-    int ComponentStride(int stride) const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_COMP_STRIDE(&m_frame, stride);
-    }
-
-    GstVideoInfo* info()
-    {
-        RELEASE_ASSERT(isValid());
-        return &m_frame.info;
-    }
-
-    int width() const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_WIDTH(&m_frame);
-    }
-
-    int height() const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_HEIGHT(&m_frame);
-    }
-
-    int format() const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_FORMAT(&m_frame);
-    }
-
-    void* planeData(uint32_t planeIndex) const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_PLANE_DATA(&m_frame, planeIndex);
-    }
-
-    int planeStride(uint32_t planeIndex) const
-    {
-        RELEASE_ASSERT(isValid());
-        return GST_VIDEO_FRAME_PLANE_STRIDE(&m_frame, planeIndex);
-    }
+    int format() const;
+    void* planeData(uint32_t) const;
+    int planeStride(uint32_t) const;
 
     bool isValid() const { return m_frame.buffer; }
     explicit operator bool() const { return m_frame.buffer; }
@@ -309,52 +234,12 @@ private:
 class GstMappedAudioBuffer {
     WTF_MAKE_NONCOPYABLE(GstMappedAudioBuffer);
 public:
+    GstMappedAudioBuffer(GstBuffer*, GstAudioInfo, GstMapFlags);
+    GstMappedAudioBuffer(GRefPtr<GstSample>, GstMapFlags);
+    ~GstMappedAudioBuffer();
 
-    GstMappedAudioBuffer(GstBuffer* buffer, GstAudioInfo info, GstMapFlags flags)
-    {
-        m_isValid = gst_audio_buffer_map(&m_buffer, &info, buffer, flags);
-    }
-
-    GstMappedAudioBuffer(GRefPtr<GstSample> sample, GstMapFlags flags)
-    {
-        GstAudioInfo info;
-
-        if (!gst_audio_info_from_caps(&info, gst_sample_get_caps(sample.get()))) {
-            m_isValid = false;
-            return;
-        }
-
-        m_isValid = gst_audio_buffer_map(&m_buffer, &info, gst_sample_get_buffer(sample.get()), flags);
-    }
-
-    GstAudioBuffer* get()
-    {
-        if (!m_isValid) {
-            GST_INFO("Invalid buffer, returning NULL");
-
-            return nullptr;
-        }
-
-        return &m_buffer;
-    }
-
-    GstAudioInfo* info()
-    {
-        if (!m_isValid) {
-            GST_INFO("Invalid frame, returning NULL");
-
-            return nullptr;
-        }
-
-        return &m_buffer.info;
-    }
-
-    ~GstMappedAudioBuffer()
-    {
-        if (m_isValid)
-            gst_audio_buffer_unmap(&m_buffer);
-        m_isValid = false;
-    }
+    GstAudioBuffer* get();
+    GstAudioInfo* info();
 
     explicit operator bool() const { return m_isValid; }
 
@@ -362,7 +247,6 @@ private:
     GstAudioBuffer m_buffer;
     bool m_isValid { false };
 };
-
 
 void connectSimpleBusMessageCallback(GstElement*, Function<void(GstMessage*)>&& = [](GstMessage*) { });
 void disconnectSimpleBusMessageCallback(GstElement*);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -466,12 +466,12 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
         auto widthUV = GST_VIDEO_FRAME_COMP_WIDTH(inputFrame.get(), 1);
         PlaneLayout planeLayoutUV { spanPlaneLayoutUV.destinationOffset, spanPlaneLayoutUV.destinationStride ? spanPlaneLayoutUV.destinationStride : widthUV };
 
-        auto planeY = inputFrame.ComponentData(0);
-        auto bytesPerRowY = inputFrame.ComponentStride(0);
+        auto planeY = inputFrame.componentData(0);
+        auto bytesPerRowY = inputFrame.componentStride(0);
         copyPlane(destination.data(), planeY, bytesPerRowY, spanPlaneLayoutY);
 
-        auto planeUV = inputFrame.ComponentData(1);
-        auto bytesPerRowUV = inputFrame.ComponentStride(1);
+        auto planeUV = inputFrame.componentData(1);
+        auto bytesPerRowUV = inputFrame.componentStride(1);
         copyPlane(destination.data(), planeUV, bytesPerRowUV, spanPlaneLayoutUV);
 
         Vector<PlaneLayout> planeLayouts;
@@ -485,8 +485,8 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
         auto spanPlaneLayoutY = computedPlaneLayout[0];
         auto widthY = GST_VIDEO_FRAME_COMP_WIDTH(inputFrame.get(), 0);
         PlaneLayout planeLayoutY { spanPlaneLayoutY.destinationOffset, spanPlaneLayoutY.destinationStride ? spanPlaneLayoutY.destinationStride : widthY };
-        auto planeY = inputFrame.ComponentData(0);
-        auto bytesPerRowY = inputFrame.ComponentStride(0);
+        auto planeY = inputFrame.componentData(0);
+        auto bytesPerRowY = inputFrame.componentStride(0);
         copyPlane(destination.data(), planeY, bytesPerRowY, spanPlaneLayoutY);
 
         auto spanPlaneLayoutU = computedPlaneLayout[1];
@@ -496,12 +496,12 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
         auto spanPlaneLayoutV = computedPlaneLayout[2];
         PlaneLayout planeLayoutV { spanPlaneLayoutV.destinationOffset, spanPlaneLayoutV.destinationStride ? spanPlaneLayoutV.destinationStride : widthUV / 2 };
 
-        auto planeU = inputFrame.ComponentData(1);
-        auto bytesPerRowU = inputFrame.ComponentStride(1);
+        auto planeU = inputFrame.componentData(1);
+        auto bytesPerRowU = inputFrame.componentStride(1);
         copyPlane(destination.data(), planeU, bytesPerRowU, spanPlaneLayoutU);
 
-        auto planeV = inputFrame.ComponentData(2);
-        auto bytesPerRowV = inputFrame.ComponentStride(2);
+        auto planeV = inputFrame.componentData(2);
+        auto bytesPerRowV = inputFrame.componentStride(2);
         copyPlane(destination.data(), planeV, bytesPerRowV, spanPlaneLayoutV);
 
         Vector<PlaneLayout> planeLayouts;
@@ -513,8 +513,8 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
             auto spanPlaneLayoutA = computedPlaneLayout[3];
             auto widthA = GST_VIDEO_FRAME_COMP_WIDTH(inputFrame.get(), 3);
             PlaneLayout planeLayoutA { spanPlaneLayoutA.destinationOffset, spanPlaneLayoutA.destinationStride ? spanPlaneLayoutA.destinationStride : widthA };
-            auto planeA = inputFrame.ComponentData(3);
-            auto bytesPerRowA = inputFrame.ComponentStride(3);
+            auto planeA = inputFrame.componentData(3);
+            auto bytesPerRowA = inputFrame.componentStride(3);
             copyPlane(destination.data(), planeA, bytesPerRowA, spanPlaneLayoutA);
             planeLayouts.append(planeLayoutA);
         }
@@ -529,7 +529,7 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
             planeLayout = computedPlaneLayout[0];
         GstMappedBuffer mappedBuffer(inputBuffer, GST_MAP_READ);
         auto plane = mappedBuffer.data();
-        auto bytesPerRow = inputFrame.ComponentStride(0);
+        auto bytesPerRow = inputFrame.componentStride(0);
         copyPlane(destination.data(), plane, bytesPerRow, planeLayout);
         Vector<PlaneLayout> planeLayouts;
         planeLayouts.append({ planeLayout.destinationOffset, planeLayout.destinationStride ? planeLayout.destinationStride : 4 * inputFrame.width() });

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -118,12 +118,12 @@ rtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::To
 
         ASSERT(videoConverter);
         gst_video_converter_frame(videoConverter.get(), inFrame.get(), outFrame.get());
-        return webrtc::I420Buffer::Copy(outFrame.width(), outFrame.height(), outFrame.ComponentData(0), outFrame.ComponentStride(0),
-            outFrame.ComponentData(1), outFrame.ComponentStride(1), outFrame.ComponentData(2), outFrame.ComponentStride(2));
+        return webrtc::I420Buffer::Copy(outFrame.width(), outFrame.height(), outFrame.componentData(0), outFrame.componentStride(0),
+            outFrame.componentData(1), outFrame.componentStride(1), outFrame.componentData(2), outFrame.componentStride(2));
     }
 
-    return webrtc::I420Buffer::Copy(inFrame.width(), inFrame.height(), inFrame.ComponentData(0), inFrame.ComponentStride(0),
-        inFrame.ComponentData(1), inFrame.ComponentStride(1), inFrame.ComponentData(2), inFrame.ComponentStride(2));
+    return webrtc::I420Buffer::Copy(inFrame.width(), inFrame.height(), inFrame.componentData(0), inFrame.componentStride(0),
+        inFrame.componentData(1), inFrame.componentStride(1), inFrame.componentData(2), inFrame.componentStride(2));
 }
 
 }


### PR DESCRIPTION
#### e67dd6f289db6671b04a9f74c47dc54cd266c257
<pre>
[GStreamer] Move most GStreamerCommon classes implemenations to cpp file
<a href="https://bugs.webkit.org/show_bug.cgi?id=274524">https://bugs.webkit.org/show_bug.cgi?id=274524</a>

Reviewed by Xabier Rodriguez-Calvar.

The GStreamerCommon.h file is included in many other files, so any change there triggers ~950
compile jobs on an incremental build. The template classes were left in the header, moving them to
the cpp file would increase verbosity too much. Also driving-by a couple GstMappedFrame methods were
renamed, adopting the camelCase style.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::GstMappedOwnedBuffer::create):
(WebCore::GstMappedOwnedBuffer::~GstMappedOwnedBuffer):
(WebCore::GstMappedOwnedBuffer::createSharedBuffer):
(WebCore::GstMappedFrame::GstMappedFrame):
(WebCore::GstMappedFrame::~GstMappedFrame):
(WebCore::GstMappedFrame::get):
(WebCore::GstMappedFrame::componentData const):
(WebCore::GstMappedFrame::componentStride const):
(WebCore::GstMappedFrame::info):
(WebCore::GstMappedFrame::width const):
(WebCore::GstMappedFrame::height const):
(WebCore::GstMappedFrame::format const):
(WebCore::GstMappedFrame::planeData const):
(WebCore::GstMappedFrame::planeStride const):
(WebCore::GstMappedAudioBuffer::GstMappedAudioBuffer):
(WebCore::GstMappedAudioBuffer::~GstMappedAudioBuffer):
(WebCore::GstMappedAudioBuffer::get):
(WebCore::GstMappedAudioBuffer::info):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::unmapFunction):
(WebCore::GstMappedOwnedBuffer::create): Deleted.
(WebCore::GstMappedOwnedBuffer::~GstMappedOwnedBuffer): Deleted.
(WebCore::GstMappedFrame::GstMappedFrame): Deleted.
(WebCore::GstMappedFrame::~GstMappedFrame): Deleted.
(WebCore::GstMappedFrame::get): Deleted.
(WebCore::GstMappedFrame::ComponentData const): Deleted.
(WebCore::GstMappedFrame::ComponentStride const): Deleted.
(WebCore::GstMappedFrame::info): Deleted.
(WebCore::GstMappedFrame::width const): Deleted.
(WebCore::GstMappedFrame::height const): Deleted.
(WebCore::GstMappedFrame::format const): Deleted.
(WebCore::GstMappedFrame::planeData const): Deleted.
(WebCore::GstMappedFrame::planeStride const): Deleted.
(WebCore::GstMappedAudioBuffer::GstMappedAudioBuffer): Deleted.
(WebCore::GstMappedAudioBuffer::get): Deleted.
(WebCore::GstMappedAudioBuffer::info): Deleted.
(WebCore::GstMappedAudioBuffer::~GstMappedAudioBuffer): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::copyTo):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::GStreamerVideoFrameLibWebRTC::ToI420):

Canonical link: <a href="https://commits.webkit.org/279191@main">https://commits.webkit.org/279191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65736854913bcb0ee220d9971e537467ea3f0865

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3224 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2258 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54877 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23957 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2873 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1661 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57649 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45752 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11524 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->