### PR TITLE
[GTK][WPE] Do not display uninitialized WebGL front buffer

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
@@ -82,7 +82,10 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
 
     auto fboSize = m_context.getInternalFramebufferSize();
     Locker locker { proxy.lock() };
-    auto layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(static_cast<GraphicsContextGLTextureMapperANGLE&>(m_context).m_compositorTextureID, fboSize, flags, colorFormat);
+    auto& context = static_cast<GraphicsContextGLTextureMapperANGLE&>(m_context);
+    if (!context.m_isCompositorTextureInitialized)
+        return;
+    auto layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(context.m_compositorTextureID, fboSize, flags, colorFormat);
 #if PLATFORM(GTK) || PLATFORM(WPE)
     layerBuffer->setFence(WTFMove(static_cast<GraphicsContextGLTextureMapperANGLE&>(m_context).m_frameFence));
 #endif

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -314,6 +314,7 @@ void GraphicsContextGLTextureMapperANGLE::swapCompositorTexture()
 #if USE(NICOSIA)
     std::swap(m_textureID, m_compositorTextureID);
 #endif
+    m_isCompositorTextureInitialized = true;
 
     if (m_preserveDrawingBufferTexture) {
         // The context requires the use of an intermediate texture in order to implement preserveDrawingBuffer:true without antialiasing.
@@ -353,6 +354,8 @@ bool GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer()
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);
     GL_BindTexture(textureTarget, m_texture);
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);
+
+    m_isCompositorTextureInitialized = false;
 
     return true;
 }

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -88,6 +88,7 @@ private:
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 
     GCGLuint m_compositorTexture { 0 };
+    bool m_isCompositorTextureInitialized { false };
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     std::unique_ptr<GLFence> m_frameFence;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
@@ -46,6 +46,9 @@ TextureMapperGCGLPlatformLayer::~TextureMapperGCGLPlatformLayer()
 
 void TextureMapperGCGLPlatformLayer::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& matrix, float opacity)
 {
+    if (!m_context.m_isCompositorTextureInitialized)
+        return;
+
     auto attrs = m_context.contextAttributes();
     OptionSet<TextureMapperFlags> flags = TextureMapperFlags::ShouldFlipTexture;
     if (attrs.alpha)


### PR DESCRIPTION
#### 341129414655facbed5a7a46f322b16a93028ac9
<pre>
[GTK][WPE] Do not display uninitialized WebGL front buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=274527">https://bugs.webkit.org/show_bug.cgi?id=274527</a>

Reviewed by Miguel Gomez.

When a page creates a WebGL context, but does not render immediately, we display the compositor
texture from GraphicsContextGLTextureMapperANGLE.
After reshapeDrawingBuffer (glTexImage2D with null data), the contents are undefined as per the
OpenGL specification, and depending on the plaform this may display uninitialized memory.

We now check if the texture is initialized before using it in GCGLANGLELayer::swapBuffersIfNeeded
or TextureMapperGCGLPlatformLayer::paintToTextureMapper.

* Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp:
(Nicosia::GCGLANGLELayer::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::swapCompositorTexture):
(WebCore::GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp:
(WebCore::TextureMapperGCGLPlatformLayer::paintToTextureMapper):

Canonical link: <a href="https://commits.webkit.org/279206@main">https://commits.webkit.org/279206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11e7ce5e566d8f763308e98d0491a70124d17246

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42743 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2136 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23838 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26845 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57477 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50137 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49408 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29882 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7742 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->