### PR TITLE
Ensure that the SWServerWorker is in the correct state before finishing installation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5406,9 +5406,10 @@ webkit.org/b/239959 ipc/stream-sync-crash-no-timeout.html [ Skip ]
 # The test invokes random messages, potentially produces random results.
 ipc/start-message-testing.html [ Skip ]
 
-# Fixing timeouts is tracked by https://bugs.webkit.org/show_bug.cgi?id=267714 (rdar://120486467)
+# Fixing timeouts/crashes is tracked by https://bugs.webkit.org/show_bug.cgi?id=267714 (rdar://120486467)
 ipc/invalid-fullscreen-enum.html [ Pass Timeout ]
 ipc/invalid-message-to-addTrackBuffer.html [ Pass Timeout ]
+ipc/removeMediaUsageManagerSession-test.html [ Skip ]
 
 # Test is crashing in Debug builds since import.
 webkit.org/b/234977 [ Debug ] imported/w3c/web-platform-tests/dom/events/focus-event-document-move.html [ Skip ]

--- a/LayoutTests/fast/rendering/render-layer-with-providedbacking-crash-expected.txt
+++ b/LayoutTests/fast/rendering/render-layer-with-providedbacking-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/rendering/render-layer-with-providedbacking-crash.html
+++ b/LayoutTests/fast/rendering/render-layer-with-providedbacking-crash.html
@@ -1,0 +1,28 @@
+<html>
+<style>
+    html.changed {
+        -webkit-mask-box-image-source:  url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7);
+    }
+
+    .masked {
+        -webkit-mask-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7);
+    }
+
+    .sticky {
+        position: sticky;
+    }
+</style>
+<script>
+function runTest()
+{
+    document.elementFromPoint(1,0); // probably just forces layout.
+    document.documentElement.classList.add('changed');
+}
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+</head>
+<body onload=runTest()>
+<content class="sticky">
+<div contenteditable="plaintext-only" class="masked">This test passes if it doesn't crash.<div>
+</content>

--- a/LayoutTests/ipc/removeMediaUsageManagerSession-test-expected.txt
+++ b/LayoutTests/ipc/removeMediaUsageManagerSession-test-expected.txt
@@ -1,0 +1,2 @@
+This test should not crash
+

--- a/LayoutTests/ipc/removeMediaUsageManagerSession-test.html
+++ b/LayoutTests/ipc/removeMediaUsageManagerSession-test.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script>
+function fuzz() {
+  if (window.testRunner) {
+      testRunner.waitUntilDone();
+  }
+  var calledParseMessage = false;
+  IPC.addOutgoingMessageListener("UI", (msg) => {
+    if (!calledParseMessage && msg.name == IPC.messages.WebPageProxy_UpdateMediaUsageManagerSessionState.name) {
+      calledParseMessage = true;
+      parseMessage(msg);
+    }
+  });
+
+  video=document.createElement('video');
+  video.src='resources/1080i60_SMPTE_8CH_audible.mov';
+  document.body.appendChild(video);
+  IPC.sendMessage('UI',0,IPC.messages.WebFullScreenManagerProxy_ExitFullScreen.name,[]);
+  IPC.sendMessage('UI',0,IPC.messages.WebFullScreenManagerProxy_BeganExitFullScreen.name,[{type: 'uint32_t',value: 247},{type: 'uint32_t',value: 204},{type: 'uint32_t',value: 4787946},{type: 'uint32_t',value: 713},{type: 'uint32_t',value: 238},{type: 'uint32_t',value: 749},{type: 'uint32_t',value: 30},{type: 'uint32_t',value: 1008}]);
+  window.setTimeout(timeout1,1000);
+}
+
+function parseMessage(msg) {
+  let buf = new Uint8Array(msg.buffer);
+  window.bada = buf;
+  if (buf.length < 0x18) {
+    return -1;
+  }
+
+  let view = new DataView(buf.buffer, 0x10);
+  o17 = view.getBigUint64(0, true);
+}
+function timeout1() {
+  IPC.sendSyncMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_ReachedApplicationCacheOriginQuota.name,0.1,[{type: 'String',value: "text/html"},{type: 'uint64_t',value: 426},{type: 'uint64_t',value: 809}]);
+  video.play();
+  window.setTimeout(timeout2,300);
+}
+function timeout2() {
+  video.play();
+  IPC.sendMessage('UI',0,IPC.messages.WebFullScreenManagerProxy_BeganEnterFullScreen.name,[{type: 'uint32_t',value: 1212623797},{type: 'uint32_t',value: 2099646},{type: 'uint32_t',value: 315},{type: 'uint32_t',value: 204},{type: 'uint32_t',value: 48},{type: 'uint32_t',value: 64},{type: 'uint32_t',value: 3},{type: 'uint32_t',value: 403}]);
+  window.setTimeout(timeout3, 10);
+}
+function timeout3() {
+  IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_RemoveMediaUsageManagerSession.name,[{type: 'uint64_t',value: o17}]);
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.notifyDone();
+  }
+}
+
+</script>
+</head>
+<body onload='fuzz()'></body>
+<div>This test should not crash</div>
+</html>

--- a/LayoutTests/security/schedule-request-object-then-disconnect-crash-expected.txt
+++ b/LayoutTests/security/schedule-request-object-then-disconnect-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/security/schedule-request-object-then-disconnect-crash.html
+++ b/LayoutTests/security/schedule-request-object-then-disconnect-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style id="style"></style>
+<embed id="embed"></embed>
+<div id="picture">
+  <object id="object" data="foo"></object>
+</div>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  var embed = document.getElementById("embed");
+  document.styleSheets[0].insertRule("#picture { content: no-open-quote;}");
+  object.contentDocument.adoptNode(embed);
+  picture.append(style);
+  embed.width;
+
+  document.body.replaceWith("PASS if no crash.");
+</script>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2171,11 +2171,11 @@ bool RenderLayer::cannotBlitToWindow() const
 
 RenderLayer* RenderLayer::transparentPaintingAncestor(const LayerPaintingInfo& info)
 {
-    if (this == info.rootLayer || isComposited())
+    if (this == info.rootLayer || isComposited() || paintsIntoProvidedBacking())
         return nullptr;
     for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         if (ancestor->isStackingContext()) {
-            if (ancestor->isComposited())
+            if (ancestor->isComposited() || ancestor->paintsIntoProvidedBacking())
                 return nullptr;
             if (ancestor->isTransparent())
                 return ancestor;

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -200,12 +200,7 @@ void SWServerWorker::scriptContextStarted(const std::optional<ServiceWorkerJobDa
 
 void SWServerWorker::didFinishInstall(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, bool wasSuccessful)
 {
-    auto state = this->state();
-    if (state == ServiceWorkerState::Redundant)
-        return;
-
-    ASSERT(m_server);
-    RELEASE_ASSERT_WITH_MESSAGE(state == ServiceWorkerState::Installing, "State is %hhu", static_cast<uint8_t>(state));
+    ASSERT(m_server && this->state() == ServiceWorkerState::Installing);
     if (RefPtr server = m_server.get())
         server->didFinishInstall(jobDataIdentifier, *this, wasSuccessful);
 }

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -126,7 +126,7 @@ public:
 
     bool shouldSkipFetchEvent() const { return m_shouldSkipHandleFetch; }
     
-    SWServerRegistration* registration() const;
+    WEBCORE_EXPORT SWServerRegistration* registration() const;
 
     void setHasTimedOutAnyFetchTasks() { m_hasTimedOutAnyFetchTasks = true; }
     bool hasTimedOutAnyFetchTasks() const { return m_hasTimedOutAnyFetchTasks; }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -88,6 +88,8 @@ public:
 
     WebCore::ProcessIdentifier webProcessIdentifier() const final;
     NetworkProcess& networkProcess();
+    void didFinishInstall(const std::optional<WebCore::ServiceWorkerJobDataIdentifier>&, WebCore::ServiceWorkerIdentifier, bool wasSuccessful);
+    void didFinishActivation(WebCore::ServiceWorkerIdentifier);
 
 private:
     // IPC::MessageSender


### PR DESCRIPTION
#### 345a36c5552dab4470ceb58265f42188094d0b0d
<pre>
Ensure that the SWServerWorker is in the correct state before finishing installation
<a href="https://rdar.apple.com/121429889">rdar://121429889</a>

Reviewed by Youenn Fablet.

Ensure that the SWServerWorker is in the expected state and bail if this method is triggered on a SWServerWorker in a different state. This method is callable over CoreIPC passing a ServiceWorkerIdentifier. Passing the ID of a service worker in any other state will reach the RELEASE_ASSERT

* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::didFinishInstall):

Originally-landed-as: 272448.701@safari-7618-branch (be630dbb12c9). <a href="https://rdar.apple.com/128546484">rdar://128546484</a>
Canonical link: <a href="https://commits.webkit.org/279161@main">https://commits.webkit.org/279161@main</a>
</pre>
----------------------------------------------------------------------
#### d8547c86a7407a7a4e6e39c82773391be270d94f
<pre>
Add test case for object loading crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=268771">https://bugs.webkit.org/show_bug.cgi?id=268771</a>
<a href="https://rdar.apple.com/121959099">rdar://121959099</a>

Reviewed by Ryosuke Niwa.

This test case applies to this bug as well as bug 264626, meaning it will crash
without the fix from bug 264626. Note that it makes more sense to land this test
than the one from bug 264626 as that one is flaky and this one is small and
reproduces every time.

* LayoutTests/security/schedule-request-object-then-disconnect-crash-expected.txt: Added.
* LayoutTests/security/schedule-request-object-then-disconnect-crash.html: Added.

Originally-landed-as: 274097.11@webkit-2024.2-embargoed (22a024aa0b40). <a href="https://rdar.apple.com/128546360">rdar://128546360</a>
Canonical link: <a href="https://commits.webkit.org/279160@main">https://commits.webkit.org/279160@main</a>
</pre>
----------------------------------------------------------------------
#### 6398a57fc5a53f9fed588bfd32a13a8f55285ca0
<pre>
Adds a simplified test case to verify an over-release in ScreenTime is fixed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270461">https://bugs.webkit.org/show_bug.cgi?id=270461</a>
<a href="https://rdar.apple.com/115279815">rdar://115279815</a>

Reviewed by David Kilzer.

This test is currently disabled in TestExpectations due to <a href="https://rdar.apple.com/120486467">rdar://120486467</a> (Provide a way to notify WebKitTestRunner when we hit a purposeful MESSAGE_CHECK (267714)).

* LayoutTests/TestExpectations:
* LayoutTests/ipc/removeMediaUsageManagerSession-test-expected.txt: Added.
* LayoutTests/ipc/removeMediaUsageManagerSession-test.html: Added.

Originally-landed-as: 272448.683@safari-7618-branch (6e9c0ea8de57). <a href="https://rdar.apple.com/128546108">rdar://128546108</a>
Canonical link: <a href="https://commits.webkit.org/279159@main">https://commits.webkit.org/279159@main</a>
</pre>
----------------------------------------------------------------------
#### 354d46a613b7dd92b44cd2d770f52127b33e546c
<pre>
RenderLayer : Unbalanced begin/endTransparencyLayers with nested masked elements and backing sharing causes a crash.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269865">https://bugs.webkit.org/show_bug.cgi?id=269865</a>
<a href="https://rdar.apple.com/113144444">rdar://113144444</a>.

Reviewed by Simon Fraser.

In order to balance the begin/endTransparencyLayers call for a TransparencyLayer with nested masked elements and backing sharing, added &apos;provided backing/paint to&apos; into account while doing &apos;ancestor&apos; traversal.

* LayoutTests/fast/rendering/render-layer-with-providedbacking-crash-expected.txt: Added.
* LayoutTests/fast/rendering/render-layer-with-providedbacking-crash.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::transparentPaintingAncestor):

Originally-landed-as: 272448.600@safari-7618-branch (fc090f6ee88d). <a href="https://rdar.apple.com/128545892">rdar://128545892</a>
Canonical link: <a href="https://commits.webkit.org/279158@main">https://commits.webkit.org/279158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/370387d156c8bf7cbd59717254b7e2f06135123a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42748 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54708 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23844 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1492 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57480 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49415 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11500 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->