### PR TITLE
[WPE][Qt6] Introduce QWebEngineProfile equivalent - WPEProfile

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -554,6 +554,7 @@ target_include_directories(WPEInjectedBundle SYSTEM PRIVATE
 if (ENABLE_WPE_QT_API)
     if (USE_QT6)
         list(APPEND WPE_QT_API_INSTALLED_HEADERS
+            ${WEBKIT_DIR}/UIProcess/API/wpe/qt6/WPEQtProfile.h
             ${WEBKIT_DIR}/UIProcess/API/wpe/qt6/WPEQtView.h
             ${WEBKIT_DIR}/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.h
         )
@@ -562,11 +563,12 @@ if (ENABLE_WPE_QT_API)
         #        SHARED here works on Linux and probably some other systems, but
         #        not on MacOS or Windows.
         add_library(qtwpe SHARED
-            UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
             UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp
             UIProcess/API/wpe/qt6/WPEQmlExtensionPlugin.cpp
+            UIProcess/API/wpe/qt6/WPEQtProfile.cpp
             UIProcess/API/wpe/qt6/WPEQtView.cpp
             UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp
+            UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
         )
         set_target_properties(qtwpe PROPERTIES
             OUTPUT_NAME qtwpe
@@ -587,6 +589,7 @@ if (ENABLE_WPE_QT_API)
         )
         target_include_directories(qtwpe PRIVATE
             $<TARGET_PROPERTY:WebKit,INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:WebCore,INCLUDE_DIRECTORIES>
             ${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}
             ${CMAKE_BINARY_DIR}
             ${GLIB_INCLUDE_DIRS}

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfile.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfile.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WPEQtProfile.h"
+
+#include "WPEQtProfilePrivate.h"
+#include "WPEQtView.h"
+
+/*!
+  \qmltype WPEProfile
+  \instantiates WPEQtProfile
+  \inqmlmodule org.wpewebkit.qtwpe
+
+  \brief A utility class resembling QtWebEngineProfile.
+*/
+WPEQtProfile::WPEQtProfile(const QString& httpUserAgent, const QString& httpAcceptLanguage)
+    : d_ptr(new WPEQtProfilePrivate(httpUserAgent, httpAcceptLanguage))
+{
+}
+
+WPEQtProfile::~WPEQtProfile()
+{
+}
+
+/*!
+    \qmlproperty string WPEProfile::httpUserAgent
+
+    The user-agent string sent with HTTP to identify the browser.
+
+    \note On Windows 8.1 and newer, the default user agent will always report
+    "Windows NT 6.2" (Windows 8), unless the application does contain a manifest
+    that declares newer Windows versions as supported.
+*/
+
+/*!
+    \property WPEQtProfile::httpUserAgent
+
+    The user-agent string sent with HTTP to identify the browser.
+*/
+
+QString WPEQtProfile::httpUserAgent() const
+{
+    const Q_D(WPEQtProfile);
+    return d->m_httpUserAgent;
+}
+
+void WPEQtProfile::setHttpUserAgent(const QString& userAgent)
+{
+    Q_D(WPEQtProfile);
+    if (d->m_httpUserAgent == userAgent)
+        return;
+    d->m_httpUserAgent = userAgent;
+    Q_EMIT httpUserAgentChanged();
+}
+
+/*!
+    \qmlproperty string WPEProfile::httpAcceptLanguage
+
+    The value of the Accept-Language HTTP request-header field.
+*/
+
+/*!
+    \property WPEQtProfile::httpAcceptLanguage
+
+    The value of the Accept-Language HTTP request-header field.
+*/
+
+QString WPEQtProfile::httpAcceptLanguage() const
+{
+    Q_D(const WPEQtProfile);
+    return d->m_httpAcceptLanguage;
+}
+
+void WPEQtProfile::setHttpAcceptLanguage(const QString& acceptLanguage)
+{
+    Q_D(WPEQtProfile);
+    if (d->m_httpAcceptLanguage == acceptLanguage)
+        return;
+    d->m_httpAcceptLanguage = acceptLanguage;
+    Q_EMIT httpAcceptLanguageChanged();
+}
+
+#include "moc_WPEQtProfile.cpp"

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfile.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfile.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WPEQtView.h"
+
+#include <QObject>
+
+class WPEQtProfilePrivate;
+
+class Q_DECL_EXPORT WPEQtProfile : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString httpUserAgent READ httpUserAgent WRITE setHttpUserAgent NOTIFY httpUserAgentChanged FINAL)
+    Q_PROPERTY(QString httpAcceptLanguage READ httpAcceptLanguage WRITE setHttpAcceptLanguage NOTIFY httpAcceptLanguageChanged FINAL)
+
+public:
+    WPEQtProfile(const QString& httpUserAgent = "", const QString& httpAcceptLanguage = "*");
+    ~WPEQtProfile();
+
+    QString httpUserAgent() const;
+    void setHttpUserAgent(const QString&);
+
+    QString httpAcceptLanguage() const;
+    void setHttpAcceptLanguage(const QString&);
+
+Q_SIGNALS:
+    void httpUserAgentChanged();
+    void httpAcceptLanguageChanged();
+
+private:
+    Q_DECLARE_PRIVATE(WPEQtProfile)
+    QScopedPointer<WPEQtProfilePrivate> d_ptr;
+};
+

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfilePrivate.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfilePrivate.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2018, 2019, 2021, 2024 Igalia S.L.
- * Copyright (C) 2018, 2019 Zodiac Inflight Innovations
+ * Copyright (C) 2024 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -18,19 +17,24 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "config.h"
-#include "WPEQmlExtensionPlugin.h"
+#pragma once
 
-#include "WPEQtProfile.h"
-#include "WPEQtView.h"
-#include "WPEQtViewLoadRequest.h"
+#include <QString>
 
-void WPEQmlExtensionPlugin::registerTypes(const char* uri)
-{
-    // @uri org.wpewebkit.qtwpe
-    qmlRegisterType<WPEQtProfile>(uri, 1, 0, "WPEProfile");
-    qmlRegisterType<WPEQtView>(uri, 1, 0, "WPEView");
-    qmlRegisterUncreatableType<WPEQtViewLoadRequest>(uri, 1, 0, "WPEViewLoadRequest", QObject::tr("Cannot create separate instance of WPEQtViewLoadRequest"));
-}
+class WPEQtProfilePrivate {
+public:
+    WPEQtProfilePrivate() = default;
 
-#include "moc_WPEQmlExtensionPlugin.cpp"
+    WPEQtProfilePrivate(const QString& httpUserAgent, const QString& httpAcceptLanguage)
+        : m_httpUserAgent(httpUserAgent)
+        , m_httpAcceptLanguage(httpAcceptLanguage)
+    {
+    }
+
+    ~WPEQtProfilePrivate() = default;
+
+    QString m_httpUserAgent;
+    QString m_httpAcceptLanguage;
+};
+
+Q_DECLARE_METATYPE(WPEQtProfilePrivate)

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -27,6 +27,7 @@
 #include <wpe/webkit.h>
 #include <wtf/glib/GRefPtr.h>
 
+class WPEQtProfile;
 class WPEQtViewLoadRequest;
 
 class Q_DECL_EXPORT WPEQtView : public QQuickItem {
@@ -38,6 +39,7 @@ class Q_DECL_EXPORT WPEQtView : public QQuickItem {
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(bool canGoBack READ canGoBack NOTIFY loadingChanged)
     Q_PROPERTY(bool canGoForward READ canGoForward NOTIFY loadingChanged)
+    Q_PROPERTY(WPEQtProfile* profile READ profile WRITE setProfile NOTIFY profileChanged FINAL)
     Q_ENUMS(LoadStatus)
 
 public:
@@ -64,6 +66,9 @@ public:
 
     WebKitWebView* webView() const;
 
+    WPEQtProfile* profile() const;
+    void setProfile(WPEQtProfile*);
+
 public Q_SLOTS:
     void goBack();
     void goForward();
@@ -78,6 +83,7 @@ Q_SIGNALS:
     void titleChanged();
     void loadingChanged(WPEQtViewLoadRequest* loadRequest);
     void loadProgressChanged();
+    void profileChanged();
 
 protected:
     bool errorOccured() const { return m_errorOccured; };
@@ -103,6 +109,8 @@ private Q_SLOTS:
     void configureWindow();
     void createWebView();
     void didUpdateScene();
+    void updateHttpUserAgent();
+    void updateHttpAcceptLanguage();
 
 private:
     QSGNode* updatePaintNode(QSGNode*, UpdatePaintNodeData*) final;
@@ -119,4 +127,5 @@ private:
     QUrl m_baseUrl;
     QSize m_size;
     bool m_errorOccured { false };
+    WPEQtProfile* m_profile { nullptr };
 };


### PR DESCRIPTION
#### caf914e704332c297b0aaa5677798baa50bb08af
<pre>
[WPE][Qt6] Introduce QWebEngineProfile equivalent - WPEProfile
<a href="https://bugs.webkit.org/show_bug.cgi?id=274530">https://bugs.webkit.org/show_bug.cgi?id=274530</a>

Reviewed by NOBODY (OOPS!).

Introuce WPEProfile, an equivalent to QWebEngineProfile in Qt
WebEngine. Currently we only support to override the used HTTP
Accept-Language / User Agent string. QWebEngineProfile supports many
more tweaks, that can be implemented on-demand. The idea is that
WPEProfile can act as drop-in replacment for QWebEngineProfile, just
like WPEView can be used to replace QWebEngineView.

It&apos;s also possible to assign the aformentioned settings from QML
directly:

    WPEView {
        id: web_view
        url: initialUrl
...

        profile: WPEProfile {
            httpAcceptLanguage: &quot;de-DE&quot;
            httpUserAgent: &quot;customString&quot;
        }

Doesn&apos;t affect any other platform, than WPE/Qt6 - no new tests.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQmlExtensionPlugin.cpp:
(WPEQmlExtensionPlugin::registerTypes):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfile.cpp: Added.
(WPEQtProfile::WPEQtProfile):
(WPEQtProfile::~WPEQtProfile):
(WPEQtProfile::httpUserAgent const):
(WPEQtProfile::setHttpUserAgent):
(WPEQtProfile::httpAcceptLanguage const):
(WPEQtProfile::setHttpAcceptLanguage):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfile.h: Added.
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtProfilePrivate.h: Copied from Source/WebKit/UIProcess/API/wpe/qt6/WPEQmlExtensionPlugin.cpp.
(WPEQtProfilePrivate::WPEQtProfilePrivate):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::createWebView):
(WPEQtView::updateHttpAcceptLanguage):
(WPEQtView::updateHttpUserAgent):
(WPEQtView::profile const):
(WPEQtView::setProfile):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caf914e704332c297b0aaa5677798baa50bb08af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3335 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42749 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54710 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23845 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1494 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57482 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50151 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49416 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->