### PR TITLE
[visionOS] Audio coming from wrong location in fullscreen mode

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6737,10 +6737,8 @@ void HTMLMediaElement::visibilityStateChanged()
 
     updateSleepDisabling();
     mediaSession().visibilityChanged();
-    if (RefPtr player = m_player) {
-        auto page = document().page();
-        player->setPageIsVisible(!m_elementIsHidden, page ? page->sceneIdentifier() : ""_s);
-    }
+    if (RefPtr player = m_player)
+        player->setPageIsVisible(!m_elementIsHidden);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
@@ -7733,7 +7731,7 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     player->setShouldDisableHDR(shouldDisableHDR());
     player->setMuted(effectiveMuted());
     RefPtr page = document().page();
-    player->setPageIsVisible(!m_elementIsHidden, page ? page->sceneIdentifier() : ""_s);
+    player->setPageIsVisible(!m_elementIsHidden);
     player->setVisibleInViewport(isVisibleInViewport());
     schedulePlaybackControlsManagerUpdate();
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -357,6 +357,22 @@ String convertEnumerationToString(AudioSessionRoutingArbitrationClient::DefaultR
     return values[static_cast<size_t>(enumerationValue)];
 }
 
+String convertEnumerationToString(AudioSession::SoundStageSize size)
+{
+    static const NeverDestroyed<String> values[] = {
+        MAKE_STATIC_STRING_IMPL("Automatic"),
+        MAKE_STATIC_STRING_IMPL("Small"),
+        MAKE_STATIC_STRING_IMPL("Medium"),
+        MAKE_STATIC_STRING_IMPL("Large"),
+    };
+    static_assert(!static_cast<size_t>(AudioSession::SoundStageSize::Automatic), "AudioSession::SoundStageSize::Automatic is not 0 as expected");
+    static_assert(static_cast<size_t>(AudioSession::SoundStageSize::Small) == 1, "AudioSession::SoundStageSize::Small is not 1 as expected");
+    static_assert(static_cast<size_t>(AudioSession::SoundStageSize::Medium) == 2, "AudioSession::SoundStageSize::Medium is not 2 as expected");
+    static_assert(static_cast<size_t>(AudioSession::SoundStageSize::Large) == 3, "AudioSession::SoundStageSize::Large is not 3 as expected");
+    ASSERT(static_cast<size_t>(size) < std::size(values));
+    return values[static_cast<size_t>(size)];
+}
+
 }
 
 #endif // USE(AUDIO_SESSION)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -79,6 +79,13 @@ enum class AudioSessionMode : uint8_t {
     MoviePlayback,
 };
 
+enum class AudioSessionSoundStageSize : uint8_t {
+    Automatic,
+    Small,
+    Medium,
+    Large,
+};
+
 class AudioSession;
 class AudioSessionRoutingArbitrationClient;
 class AudioSessionInterruptionObserver;
@@ -161,6 +168,13 @@ public:
 
     bool isInterrupted() const { return m_isInterrupted; }
 
+    virtual void setSceneIdentifier(const String&) { }
+    virtual const String& sceneIdentifier() const { return nullString(); }
+
+    using SoundStageSize = AudioSessionSoundStageSize;
+    virtual void setSoundStageSize(SoundStageSize) { }
+    virtual SoundStageSize soundStageSize() const { return SoundStageSize::Automatic; }
+
 protected:
     friend class NeverDestroyed<AudioSession>;
     AudioSession();
@@ -219,6 +233,7 @@ WEBCORE_EXPORT String convertEnumerationToString(AudioSession::CategoryType);
 WEBCORE_EXPORT String convertEnumerationToString(AudioSession::Mode);
 WEBCORE_EXPORT String convertEnumerationToString(AudioSessionRoutingArbitrationClient::RoutingArbitrationError);
 WEBCORE_EXPORT String convertEnumerationToString(AudioSessionRoutingArbitrationClient::DefaultRouteChanged);
+WEBCORE_EXPORT String convertEnumerationToString(AudioSession::SoundStageSize);
 
 } // namespace WebCore
 
@@ -264,6 +279,14 @@ struct LogArgument<WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteCh
     static String toString(const WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged changed)
     {
         return convertEnumerationToString(changed);
+    }
+};
+
+template <>
+struct LogArgument<WebCore::AudioSession::SoundStageSize> {
+    static String toString(const WebCore::AudioSession::SoundStageSize size)
+    {
+        return convertEnumerationToString(size);
     }
 };
 

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -64,8 +64,18 @@ private:
     bool isMuted() const final;
     void handleMutedStateChange() final;
 
+    void updateSpatialExperience();
+
+    void setSceneIdentifier(const String&) final;
+    const String& sceneIdentifier() const final { return m_sceneIdentifier; }
+
+    void setSoundStageSize(SoundStageSize) final;
+    SoundStageSize soundStageSize() const final { return m_soundStageSize; }
+
     String m_lastSetPreferredAudioDeviceUID;
     RetainPtr<WebInterruptionObserverHelper> m_interruptionObserverHelper;
+    String m_sceneIdentifier;
+    SoundStageSize m_soundStageSize { SoundStageSize::Automatic };
 };
 
 }

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -371,6 +371,61 @@ void AudioSessionIOS::handleMutedStateChange()
 {
 }
 
+void AudioSessionIOS::updateSpatialExperience()
+{
+#if PLATFORM(VISION)
+    AVAudioSessionSoundStageSize size = [&] {
+        switch (m_soundStageSize) {
+        case AudioSession::SoundStageSize::Automatic:
+            return AVAudioSessionSoundStageSizeAutomatic;
+        case AudioSession::SoundStageSize::Small:
+            return AVAudioSessionSoundStageSizeSmall;
+        case AudioSession::SoundStageSize::Medium:
+            return AVAudioSessionSoundStageSizeMedium;
+        case AudioSession::SoundStageSize::Large:
+            return AVAudioSessionSoundStageSizeLarge;
+        };
+    }();
+    NSError *error = nil;
+    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    if (m_sceneIdentifier.length()) {
+        [session setIntendedSpatialExperience:AVAudioSessionSpatialExperienceHeadTracked options:@{
+            @"AVAudioSessionSpatialExperienceOptionSoundStageSize" : @(size),
+            @"AVAudioSessionSpatialExperienceOptionAnchoringStrategy" : @(AVAudioSessionAnchoringStrategyScene),
+            @"AVAudioSessionSpatialExperienceOptionSceneIdentifier" : (NSString *)m_sceneIdentifier
+        } error:&error];
+    } else {
+        [session setIntendedSpatialExperience:AVAudioSessionSpatialExperienceHeadTracked options:@{
+            @"AVAudioSessionSpatialExperienceOptionSoundStageSize" : @(size),
+            @"AVAudioSessionSpatialExperienceOptionAnchoringStrategy" : @(AVAudioSessionAnchoringStrategyAutomatic)
+        } error:&error];
+    }
+
+    if (error)
+        ALWAYS_LOG(error.localizedDescription.UTF8String);
+#endif
+}
+
+void AudioSessionIOS::setSceneIdentifier(const String& sceneIdentifier)
+{
+    if (m_sceneIdentifier == sceneIdentifier)
+        return;
+    m_sceneIdentifier = sceneIdentifier;
+    ALWAYS_LOG(LOGIDENTIFIER, sceneIdentifier);
+
+    updateSpatialExperience();
+}
+
+void AudioSessionIOS::setSoundStageSize(SoundStageSize size)
+{
+    if (m_soundStageSize == size)
+        return;
+    m_soundStageSize = size;
+    ALWAYS_LOG(LOGIDENTIFIER, size);
+
+    updateSpatialExperience();
+}
+
 }
 
 #endif // USE(AUDIO_SESSION) && PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -53,6 +53,8 @@ class TimeRanges;
 class PlaybackSessionModelClient;
 struct MediaSelectionOption;
 
+enum class AudioSessionSoundStageSize : uint8_t;
+
 enum class PlaybackSessionModelExternalPlaybackTargetType : uint8_t {
     TargetTypeNone,
     TargetTypeAirPlay,
@@ -134,6 +136,8 @@ public:
     virtual bool isPictureInPictureSupported() const = 0;
     virtual bool isPictureInPictureActive() const = 0;
     virtual bool isInWindowFullscreenActive() const { return false; }
+    virtual AudioSessionSoundStageSize soundStageSize() const = 0;
+    virtual void setSoundStageSize(AudioSessionSoundStageSize) = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual const void* logIdentifier() const { return nullptr; }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -112,6 +112,8 @@ public:
     bool isPictureInPictureSupported() const final;
     bool isPictureInPictureActive() const final;
     bool isInWindowFullscreenActive() const final;
+    AudioSessionSoundStageSize soundStageSize() const final { return m_soundStageSize; }
+    void setSoundStageSize(AudioSessionSoundStageSize size) final { m_soundStageSize = size; }
 
 private:
     WEBCORE_EXPORT PlaybackSessionModelMediaElement();
@@ -130,6 +132,7 @@ private:
     HashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
+    AudioSessionSoundStageSize m_soundStageSize;
 
     double playbackStartedTime() const;
     void updateMediaSelectionOptions();

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
@@ -41,12 +41,12 @@ public:
     WEBCORE_EXPORT void setTrackRepresentationContentsScale(float);
     WEBCORE_EXPORT void setTrackRepresentationHidden(bool);
 
-    WEBCORE_EXPORT CALayer* captionsLayer();
+    WEBCORE_EXPORT virtual CALayer* captionsLayer();
     WEBCORE_EXPORT void setCaptionsFrame(const CGRect&);
     WEBCORE_EXPORT virtual void setupCaptionsLayer(CALayer *parent, const FloatSize&);
     WEBCORE_EXPORT void removeCaptionsLayer();
 
-private:
+protected:
     RetainPtr<CALayer> m_captionsLayer;
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -131,7 +131,7 @@ public:
     bool hasVideo() const final { return false; }
     bool hasAudio() const final { return false; }
 
-    void setPageIsVisible(bool, String&&) final { }
+    void setPageIsVisible(bool) final { }
 
     void seekToTarget(const SeekTarget&) final { }
     bool seeking() const final { return false; }
@@ -1092,10 +1092,10 @@ void MediaPlayer::setPresentationSize(const IntSize& size)
     m_private->setPresentationSize(size);
 }
 
-void MediaPlayer::setPageIsVisible(bool visible, String&& sceneIdentifier)
+void MediaPlayer::setPageIsVisible(bool visible)
 {
     m_pageIsVisible = visible;
-    m_private->setPageIsVisible(visible, WTFMove(sceneIdentifier));
+    m_private->setPageIsVisible(visible);
 }
 
 void MediaPlayer::setVisibleForCanvas(bool visible)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -400,7 +400,7 @@ public:
 #endif
     void cancelLoad();
 
-    void setPageIsVisible(bool, String&& sceneIdentifier = ""_s);
+    void setPageIsVisible(bool);
     void setVisibleForCanvas(bool);
     bool isVisibleForCanvas() const { return m_visibleForCanvas; }
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -119,7 +119,7 @@ public:
     virtual bool hasVideo() const = 0;
     virtual bool hasAudio() const = 0;
 
-    virtual void setPageIsVisible(bool, String&& sceneIdentifier = ""_s) = 0;
+    virtual void setPageIsVisible(bool) = 0;
     virtual void setVisibleForCanvas(bool visible) { setPageIsVisible(visible); }
     virtual void setVisibleInViewport(bool) { }
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -591,7 +591,7 @@ void MediaPlayerPrivateAVFoundation::updateStates()
         setUpVideoRendering();
 }
 
-void MediaPlayerPrivateAVFoundation::setPageIsVisible(bool visible, String&&)
+void MediaPlayerPrivateAVFoundation::setPageIsVisible(bool visible)
 {
     if (m_visible == visible)
         return;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -183,7 +183,7 @@ protected:
     FloatSize naturalSize() const override;
     bool hasVideo() const override { return m_cachedHasVideo; }
     bool hasAudio() const override { return m_cachedHasAudio; }
-    void setPageIsVisible(bool, String&& sceneIdentifier) final;
+    void setPageIsVisible(bool) final;
     MediaTime duration() const override;
     MediaTime currentTime() const override = 0;
     void seekToTarget(const SeekTarget&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -214,7 +214,7 @@ private:
     bool hasVideo() const override;
     bool hasAudio() const override;
 
-    void setPageIsVisible(bool, String&& sceneIdentifier) final;
+    void setPageIsVisible(bool) final;
 
     MediaTime duration() const override;
     MediaTime startTime() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -430,7 +430,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::hasAudio() const
     return m_mediaSourcePrivate->hasAudio();
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible, String&& sceneIdentifier)
+void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
 {
     if (m_visible == visible)
         return;
@@ -448,29 +448,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible, String
         }
     }
 
-#if PLATFORM(VISION)
-    NSError *error = nil;
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
-    if (!visible) {
-        if (NSString *sceneId = sceneIdentifier; sceneId.length) {
-            [session setIntendedSpatialExperience:AVAudioSessionSpatialExperienceHeadTracked options:@{
-                @"AVAudioSessionSpatialExperienceOptionSoundStageSize" : @(AVAudioSessionSoundStageSizeAutomatic),
-                @"AVAudioSessionSpatialExperienceOptionAnchoringStrategy" : @(AVAudioSessionAnchoringStrategyScene),
-                @"AVAudioSessionSpatialExperienceOptionSceneIdentifier" : sceneId
-            } error:&error];
-        }
-    } else {
-        [session setIntendedSpatialExperience:AVAudioSessionSpatialExperienceHeadTracked options:@{
-            @"AVAudioSessionSpatialExperienceOptionSoundStageSize" : @(AVAudioSessionSoundStageSizeAutomatic),
-            @"AVAudioSessionSpatialExperienceOptionAnchoringStrategy" : @(AVAudioSessionAnchoringStrategyAutomatic)
-        } error:&error];
-    }
-
-    if (error)
-        ALWAYS_LOG(error.localizedDescription.UTF8String);
-#else
-    UNUSED_PARAM(sceneIdentifier);
-#endif
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -131,7 +131,7 @@ private:
     bool hasVideo() const override;
     bool hasAudio() const override;
 
-    void setPageIsVisible(bool, String&& sceneIdentifier) final;
+    void setPageIsVisible(bool) final;
     void setVisibleForCanvas(bool) final;
     void setVisibleInViewport(bool) final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -644,7 +644,7 @@ bool MediaPlayerPrivateMediaStreamAVFObjC::hasAudio() const
     return !m_audioTrackMap.isEmpty();
 }
 
-void MediaPlayerPrivateMediaStreamAVFObjC::setPageIsVisible(bool isVisible, String&&)
+void MediaPlayerPrivateMediaStreamAVFObjC::setPageIsVisible(bool isVisible)
 {
     if (m_isPageVisible == isVisible)
         return;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -117,7 +117,7 @@ private:
     bool hasVideo() const final { return m_hasVideo; }
     bool hasAudio() const final { return m_hasAudio; }
 
-    void setPageIsVisible(bool, String&& sceneIdentifier) final;
+    void setPageIsVisible(bool) final;
 
     MediaTime timeFudgeFactor() const { return { 1, 10 }; }
     MediaTime currentTime() const final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -314,7 +314,7 @@ bool MediaPlayerPrivateWebM::timeIsProgressing() const
     return m_isPlaying && [m_synchronizer rate];
 }
 
-void MediaPlayerPrivateWebM::setPageIsVisible(bool visible, String&&)
+void MediaPlayerPrivateWebM::setPageIsVisible(bool visible)
 {
     if (m_visible == visible)
         return;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -162,7 +162,7 @@ public:
     void setMuted(bool) final;
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
-    void setPageIsVisible(bool visible, String&&) final { m_visible = visible; }
+    void setPageIsVisible(bool visible) final { m_visible = visible; }
     void setVisibleInViewport(bool isVisible) final;
     void setPresentationSize(const IntSize&) final;
     MediaTime duration() const override;

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -77,7 +77,7 @@ public:
     bool hasVideo() const final { return false; };
     bool hasAudio() const final { return false; };
 
-    void setPageIsVisible(bool, String&&) final { };
+    void setPageIsVisible(bool) final { };
 
     bool seeking() const final { return false; }
     void seekToTarget(const SeekTarget&) final { }

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -255,7 +255,7 @@ bool MediaPlayerPrivateMediaFoundation::hasAudio() const
     return m_hasAudio;
 }
 
-void MediaPlayerPrivateMediaFoundation::setPageIsVisible(bool visible, String&&)
+void MediaPlayerPrivateMediaFoundation::setPageIsVisible(bool visible)
 {
     m_visible = visible;
 }

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -80,7 +80,7 @@ public:
     bool hasVideo() const final;
     bool hasAudio() const final;
 
-    void setPageIsVisible(bool, String&&) final;
+    void setPageIsVisible(bool) final;
 
     bool seeking() const final;
     void seekToTarget(const SeekTarget&) final;

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -178,6 +178,8 @@ private:
     void setVolume(double) final;
     void setPlayingOnSecondScreen(bool) final;
     void setVideoReceiverEndpoint(const VideoReceiverEndpoint&) final { }
+    AudioSessionSoundStageSize soundStageSize() const final { return AudioSessionSoundStageSize::Automatic; }
+    void setSoundStageSize(AudioSessionSoundStageSize) final { }
 
     // PlaybackSessionModelClient
     void durationChanged(double) override;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -146,7 +146,7 @@ bool MockMediaPlayerMediaSource::hasAudio() const
     return m_mediaSourcePrivate ? m_mediaSourcePrivate->hasAudio() : false;
 }
 
-void MockMediaPlayerMediaSource::setPageIsVisible(bool, String&&)
+void MockMediaPlayerMediaSource::setPageIsVisible(bool)
 {
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -84,7 +84,7 @@ private:
     FloatSize naturalSize() const override;
     bool hasVideo() const override;
     bool hasAudio() const override;
-    void setPageIsVisible(bool, String&& sceneIdentifier) final;
+    void setPageIsVisible(bool) final;
     void seekToTarget(const SeekTarget&) final;
     bool seeking() const final;
     bool paused() const override;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -75,7 +75,9 @@ RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
         session.maximumNumberOfOutputChannels(),
         session.preferredBufferSize(),
         session.isMuted(),
-        m_active
+        m_active,
+        m_sceneIdentifier,
+        m_soundStageSize,
     };
 }
 
@@ -113,6 +115,7 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
         configurationChanged();
 
     audioSessionManager().updatePresentingProcesses();
+    audioSessionManager().updateSpatialExperience();
 }
 
 void RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride(std::optional<bool>&& value)
@@ -146,6 +149,18 @@ void RemoteAudioSessionProxy::beginInterruptionRemote()
 void RemoteAudioSessionProxy::endInterruptionRemote(AudioSession::MayResume mayResume)
 {
     audioSessionManager().endInterruptionRemote(mayResume);
+}
+
+void RemoteAudioSessionProxy::setSceneIdentifier(const String& sceneIdentifier)
+{
+    m_sceneIdentifier = sceneIdentifier;
+    audioSessionManager().updateSpatialExperience();
+}
+
+void RemoteAudioSessionProxy::setSoundStageSize(AudioSession::SoundStageSize size)
+{
+    m_soundStageSize = size;
+    audioSessionManager().updateSpatialExperience();
 }
 
 RemoteAudioSessionProxyManager& RemoteAudioSessionProxy::audioSessionManager()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -74,6 +74,12 @@ public:
     void beginInterruption();
     void endInterruption(WebCore::AudioSession::MayResume);
 
+    const String& sceneIdentifier() const { return m_sceneIdentifier; }
+    void setSceneIdentifier(const String&);
+
+    WebCore::AudioSession::SoundStageSize soundStageSize() const { return m_soundStageSize; }
+    void setSoundStageSize(WebCore::AudioSession::SoundStageSize);
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
@@ -105,6 +111,8 @@ private:
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };
     WebCore::AudioSession::Mode m_mode { WebCore::AudioSession::Mode::Default };
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
+    WebCore::AudioSession::SoundStageSize m_soundStageSize { WebCore::AudioSession::SoundStageSize::Automatic };
+    String m_sceneIdentifier;
     size_t m_preferredBufferSize { 0 };
     bool m_active { false };
     bool m_isInterrupted { false };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -36,6 +36,9 @@ messages -> RemoteAudioSessionProxy NotRefCounted {
 
     BeginInterruptionRemote()
     EndInterruptionRemote(WebCore::AudioSession::MayResume flags)
+
+    SetSceneIdentifier(String sceneIdentifier)
+    SetSoundStageSize(enum:uint8_t WebCore::AudioSession::SoundStageSize size)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -138,6 +138,24 @@ void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()
         AudioSession::sharedSession().setPreferredBufferSize(preferredBufferSize);
 }
 
+void RemoteAudioSessionProxyManager::updateSpatialExperience()
+{
+    String sceneIdentifier;
+    std::optional<AudioSession::SoundStageSize> maxSize;
+    for (auto& proxy : m_proxies) {
+        if (!proxy.isActive())
+            continue;
+
+        if (!maxSize || proxy.soundStageSize() > *maxSize) {
+            maxSize = proxy.soundStageSize();
+            sceneIdentifier = proxy.sceneIdentifier();
+        }
+    }
+
+    AudioSession::sharedSession().setSceneIdentifier(sceneIdentifier);
+    AudioSession::sharedSession().setSoundStageSize(maxSize.value_or(AudioSession::SoundStageSize::Automatic));
+}
+
 bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude)
 {
     for (auto& proxy : m_proxies) {

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -59,6 +59,7 @@ public:
 
     void updateCategory();
     void updatePreferredBufferSizeForProcess();
+    void updateSpatialExperience();
 
     bool tryToSetActiveForProcess(RemoteAudioSessionProxy&, bool);
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -289,10 +289,10 @@ void RemoteMediaPlayerProxy::prepareForRendering()
     m_player->prepareForRendering();
 }
 
-void RemoteMediaPlayerProxy::setPageIsVisible(bool visible, String&& sceneIdentifier)
+void RemoteMediaPlayerProxy::setPageIsVisible(bool visible)
 {
     ALWAYS_LOG(LOGIDENTIFIER, visible);
-    m_player->setPageIsVisible(visible, WTFMove(sceneIdentifier));
+    m_player->setPageIsVisible(visible);
 }
 
 void RemoteMediaPlayerProxy::setShouldMaintainAspectRatio(bool maintainRatio)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -166,7 +166,7 @@ public:
     void setPreservesPitch(bool);
     void setPitchCorrectionAlgorithm(WebCore::MediaPlayer::PitchCorrectionAlgorithm);
 
-    void setPageIsVisible(bool, String&& sceneIdentifier);
+    void setPageIsVisible(bool);
     void setShouldMaintainAspectRatio(bool);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void setVideoFullscreenGravity(WebCore::MediaPlayerEnums::VideoGravity);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -48,7 +48,7 @@ messages -> RemoteMediaPlayerProxy {
     SetPitchCorrectionAlgorithm(enum:uint8_t WebCore::MediaPlayerPitchCorrectionAlgorithm algorithm)
 
     PrepareForRendering()
-    SetPageIsVisible(bool visible, String sceneIdentifier)
+    SetPageIsVisible(bool visible)
     SetShouldMaintainAspectRatio(bool maintainAspectRatio)
     AcceleratedRenderingStateChanged(bool canBeAccelerated)
     SetShouldDisableSleep(bool disable)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -30,6 +30,7 @@
 #include <WebCore/VideoPresentationInterfaceIOS.h>
 
 OBJC_CLASS LMPlayableViewController;
+OBJC_CLASS WKCaptionLayerLayoutManager;
 OBJC_CLASS WKSLinearMediaPlayer;
 
 namespace WebCore {
@@ -71,6 +72,7 @@ private:
     bool isExternalPlaybackActive() const final { return false; }
     bool willRenderToLayer() const final { return false; }
     AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
+    CALayer *captionsLayer() final;
     void setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize&) final;
     LMPlayableViewController *playableViewController() final;
 
@@ -78,6 +80,11 @@ private:
     void ensurePlayableViewController();
 
     RetainPtr<LMPlayableViewController> m_playerViewController;
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    String m_spatialTrackingLabel;
+    RetainPtr<CALayer> m_spatialTrackingLayer;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -32,9 +32,28 @@
 #import "PlaybackSessionInterfaceLMK.h"
 #import "WKSLinearMediaPlayer.h"
 #import "WKSLinearMediaTypes.h"
+#import <QuartzCore/CALayer.h>
 #import <UIKit/UIKit.h>
+#import <WebCore/AudioSession.h>
+#import <WebCore/Color.h>
 #import <WebCore/WebAVPlayerLayerView.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/UUID.h>
+
+@interface WKLinearMediaKitCaptionsLayer : CALayer
+@end
+
+@implementation WKLinearMediaKitCaptionsLayer
+- (void)layoutSublayers
+{
+    ASSERT(self.sublayers.count <= 1);
+    for (CALayer* sublayer in self.sublayers)
+        sublayer.frame = CGRectMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds), 0, 0);
+
+    [super layoutSublayers];
+}
+@end
 
 namespace WebKit {
 
@@ -87,13 +106,25 @@ void VideoPresentationInterfaceLMK::invalidatePlayerViewController()
 void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     playbackSessionInterface().startObservingNowPlayingMetadata();
-    [linearMediaPlayer() enterFullscreenWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+    [linearMediaPlayer() enterFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (BOOL success, NSError *error) {
+        if (auto* playbackSessionModel = playbackSessionInterface().playbackSessionModel()) {
+            playbackSessionModel->setSpatialTrackingLabel(m_spatialTrackingLabel);
+            playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Large);
+        }
+        completionHandler(success, error);
+    }).get()];
 }
 
 void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     playbackSessionInterface().stopObservingNowPlayingMetadata();
-    [linearMediaPlayer() exitFullscreenWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+    [linearMediaPlayer() exitFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (BOOL success, NSError *error) {
+        if (auto* playbackSessionModel = playbackSessionInterface().playbackSessionModel()) {
+            playbackSessionModel->setSpatialTrackingLabel(nullString());
+            playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Automatic);
+        }
+        completionHandler(success, error);
+    }).get()];
 }
 
 UIViewController *VideoPresentationInterfaceLMK::playerViewController() const
@@ -109,6 +140,25 @@ void VideoPresentationInterfaceLMK::setContentDimensions(const WebCore::FloatSiz
 void VideoPresentationInterfaceLMK::setShowsPlaybackControls(bool showsPlaybackControls)
 {
     linearMediaPlayer().showsPlaybackControls = showsPlaybackControls;
+}
+
+CALayer *VideoPresentationInterfaceLMK::captionsLayer()
+{
+    if (m_captionsLayer)
+        return m_captionsLayer.get();
+
+    m_captionsLayer = adoptNS([[WKLinearMediaKitCaptionsLayer alloc] init]);
+    [m_captionsLayer setName:@"Captions Layer"];
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    m_spatialTrackingLayer = adoptNS([[CALayer alloc] init]);
+    [m_spatialTrackingLayer setSeparatedState:kCALayerSeparatedStateTracked];
+    m_spatialTrackingLabel = makeString("VideoPresentationInterfaceLMK Label: "_s, createVersion4UUIDString());
+    [m_spatialTrackingLayer setValue:(NSString *)m_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
+    [m_captionsLayer addSublayer:m_spatialTrackingLayer.get()];
+#endif
+
+    return m_captionsLayer.get();
 }
 
 void VideoPresentationInterfaceLMK::setupCaptionsLayer(CALayer *, const WebCore::FloatSize& initialSize)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4678,6 +4678,13 @@ enum class WebCore::AudioSessionMode : uint8_t {
     MoviePlayback,
 };
 
+enum class WebCore::AudioSessionSoundStageSize : uint8_t {
+    Automatic,
+    Small,
+    Medium,
+    Large,
+};
+
 [Nested] enum class WebCore::AudioSession::MayResume : bool;
 
 enum class WebCore::AudioSessionRoutingArbitrationError : uint8_t {

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -144,6 +144,9 @@ private:
     bool isPictureInPictureActive() const final { return m_pictureInPictureActive; }
     bool isInWindowFullscreenActive() const final { return m_isInWindowFullscreenActive; }
 
+    WebCore::AudioSessionSoundStageSize soundStageSize() const final { return m_soundStageSize; }
+    void setSoundStageSize(WebCore::AudioSessionSoundStageSize) final;
+
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void* identifier) { m_logIdentifier = identifier; }
     const void* logIdentifier() const final { return m_logIdentifier; }
@@ -183,6 +186,7 @@ private:
     bool m_pictureInPictureActive { false };
     bool m_isInWindowFullscreenActive { false };
     WebCore::VideoReceiverEndpoint m_videoReceiverEndpoint;
+    WebCore::AudioSessionSoundStageSize m_soundStageSize { 0 };
 
 #if !RELEASE_LOG_DISABLED
     const void* m_logIdentifier { nullptr };
@@ -280,6 +284,7 @@ private:
 #endif
     void addNowPlayingMetadataObserver(PlaybackSessionContextIdentifier, const WebCore::NowPlayingMetadataObserver&);
     void removeNowPlayingMetadataObserver(PlaybackSessionContextIdentifier, const WebCore::NowPlayingMetadataObserver&);
+    void setSoundStageSize(PlaybackSessionContextIdentifier, WebCore::AudioSessionSoundStageSize);
 
     void uncacheVideoReceiverEndpoint(PlaybackSessionContextIdentifier);
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -117,6 +117,16 @@ void PlaybackSessionModelContext::removeNowPlayingMetadataObserver(const WebCore
         m_manager->removeNowPlayingMetadataObserver(m_contextId, nowPlayingInfo);
 }
 
+void PlaybackSessionModelContext::setSoundStageSize(WebCore::AudioSessionSoundStageSize size)
+{
+    if (m_soundStageSize == size)
+        return;
+
+    m_soundStageSize = size;
+    if (m_manager)
+        m_manager->setSoundStageSize(m_contextId, size);
+}
+
 void PlaybackSessionModelContext::play()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
@@ -879,6 +889,12 @@ void PlaybackSessionManagerProxy::removeNowPlayingMetadataObserver(PlaybackSessi
 {
     if (RefPtr page = m_page.get())
         page->removeNowPlayingMetadataObserver(nowPlayingInfo);
+}
+
+void PlaybackSessionManagerProxy::setSoundStageSize(PlaybackSessionContextIdentifier contextId, WebCore::AudioSessionSoundStageSize size)
+{
+    if (m_page)
+        m_page->send(Messages::PlaybackSessionManager::SetSoundStageSize(contextId, size));
 }
 
 bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -704,7 +704,7 @@ void MediaPlayerPrivateRemote::prepareForRendering()
     connection().send(Messages::RemoteMediaPlayerProxy::PrepareForRendering(), m_id);
 }
 
-void MediaPlayerPrivateRemote::setPageIsVisible(bool visible, String&& sceneIdentifier)
+void MediaPlayerPrivateRemote::setPageIsVisible(bool visible)
 {
     if (m_pageIsVisible == visible)
         return;
@@ -712,7 +712,7 @@ void MediaPlayerPrivateRemote::setPageIsVisible(bool visible, String&& sceneIden
     ALWAYS_LOG(LOGIDENTIFIER, visible);
 
     m_pageIsVisible = visible;
-    connection().send(Messages::RemoteMediaPlayerProxy::SetPageIsVisible(visible, WTFMove(sceneIdentifier)), m_id);
+    connection().send(Messages::RemoteMediaPlayerProxy::SetPageIsVisible(visible), m_id);
 }
 
 void MediaPlayerPrivateRemote::setShouldMaintainAspectRatio(bool maintainRatio)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -298,7 +298,7 @@ private:
     bool hasVideo() const final;
     bool hasAudio() const final;
 
-    void setPageIsVisible(bool, String&& sceneIdentifier) final;
+    void setPageIsVisible(bool) final;
 
     MediaTime getStartDate() const final;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -217,6 +217,18 @@ void RemoteAudioSession::endInterruptionForTesting()
     ensureConnection().send(Messages::RemoteAudioSessionProxy::TriggerEndInterruptionForTesting(), { });
 }
 
+void RemoteAudioSession::setSceneIdentifier(const String& sceneIdentifier)
+{
+    configuration().sceneIdentifier = sceneIdentifier;
+    ensureConnection().send(Messages::RemoteAudioSessionProxy::SetSceneIdentifier(sceneIdentifier), { });
+}
+
+void RemoteAudioSession::setSoundStageSize(AudioSession::SoundStageSize size)
+{
+    configuration().soundStageSize = size;
+    ensureConnection().send(Messages::RemoteAudioSessionProxy::SetSoundStageSize(size), { });
+}
+
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -101,6 +101,12 @@ private:
     void endInterruptionForTesting() final;
     void clearInterruptionFlagForTesting() final { m_isInterruptedForTesting = false; }
 
+    void setSceneIdentifier(const String&) final;
+    const String& sceneIdentifier() const final { return configuration().sceneIdentifier; }
+
+    void setSoundStageSize(SoundStageSize) final;
+    SoundStageSize soundStageSize() const final { return configuration().soundStageSize; }
+
     const RemoteAudioSessionConfiguration& configuration() const;
     RemoteAudioSessionConfiguration& configuration();
     void initializeConfigurationIfNecessary();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
@@ -40,6 +40,8 @@ struct RemoteAudioSessionConfiguration {
     size_t preferredBufferSize { 0 };
     bool isMuted { false };
     bool isActive { false };
+    String sceneIdentifier;
+    WebCore::AudioSessionSoundStageSize soundStageSize { WebCore::AudioSessionSoundStageSize::Automatic };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -31,6 +31,8 @@ struct WebKit::RemoteAudioSessionConfiguration {
     size_t preferredBufferSize;
     bool isMuted;
     bool isActive;
+    String sceneIdentifier;
+    WebCore::AudioSessionSoundStageSize soundStageSize;
 };
     
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5191,6 +5191,7 @@ void WebPage::videoControlsManagerDidChange()
 #if PLATFORM(IOS_FAMILY)
 void WebPage::setSceneIdentifier(String&& sceneIdentifier)
 {
+    AudioSession::sharedSession().setSceneIdentifier(sceneIdentifier);
     m_page->setSceneIdentifier(WTFMove(sceneIdentifier));
 }
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -49,6 +49,7 @@ class MessageReceiver;
 
 namespace WebCore {
 class Node;
+enum class AudioSessionSoundStageSize : uint8_t;
 }
 
 namespace WebKit {
@@ -184,10 +185,13 @@ private:
     void setVolume(PlaybackSessionContextIdentifier, double volume);
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool value);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
+    void setSoundStageSize(PlaybackSessionContextIdentifier, WebCore::AudioSessionSoundStageSize);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setSpatialTrackingLabel(PlaybackSessionContextIdentifier, const String&);
 #endif
+
+    void forEachModel(Function<void(WebCore::PlaybackSessionModel&)>&&);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
@@ -47,6 +47,7 @@ messages -> PlaybackSessionManager {
     SetVolume(WebKit::PlaybackSessionContextIdentifier contextId, double volume)
     SetPlayingOnSecondScreen(WebKit::PlaybackSessionContextIdentifier contextId, bool value)
     SendRemoteCommand(WebKit::PlaybackSessionContextIdentifier contextId, enum:uint8_t WebCore::PlatformMediaSessionRemoteControlCommandType type, struct WebCore::PlatformMediaSession::RemoteCommandArgument argument)
+    SetSoundStageSize(WebKit::PlaybackSessionContextIdentifier contextId, enum:uint8_t WebCore::AudioSession::SoundStageSize size)
 #if HAVE(SPATIAL_TRACKING_LABEL)
     SetSpatialTrackingLabel(WebKit::PlaybackSessionContextIdentifier contextId, String label)
 #endif

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -579,12 +579,32 @@ void PlaybackSessionManager::sendRemoteCommand(PlaybackSessionContextIdentifier 
     ensureModel(contextId).sendRemoteCommand(command, argument);
 }
 
+void PlaybackSessionManager::setSoundStageSize(PlaybackSessionContextIdentifier contextId, WebCore::AudioSessionSoundStageSize size)
+{
+    ensureModel(contextId).setSoundStageSize(size);
+    auto maxSize = size;
+    forEachModel([&] (auto& model) {
+        if (model.soundStageSize() > maxSize)
+            maxSize = model.soundStageSize();
+    });
+    AudioSession::sharedSession().setSoundStageSize(maxSize);
+}
+
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void PlaybackSessionManager::setSpatialTrackingLabel(PlaybackSessionContextIdentifier contextId, const String& label)
 {
     ensureModel(contextId).setSpatialTrackingLabel(label);
 }
 #endif
+
+void PlaybackSessionManager::forEachModel(Function<void(PlaybackSessionModel&)>&& callback)
+{
+    for (auto& [model, interface] : m_contextMap.values()) {
+        UNUSED_PARAM(interface);
+        if (model)
+            callback(*model);
+    }
+}
 
 #if !RELEASE_LOG_DISABLED
 void PlaybackSessionManager::sendLogIdentifierForMediaElement(HTMLMediaElement& mediaElement)


### PR DESCRIPTION
#### 89ffa3deb5e76c98593f533a16ea7c5fa211597f
<pre>
[visionOS] Audio coming from wrong location in fullscreen mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=274529">https://bugs.webkit.org/show_bug.cgi?id=274529</a>
<a href="https://rdar.apple.com/127009932">rdar://127009932</a>

Reviewed by Andy Estes.

When video playback goes into native fullscreen, the rendering path switches from being CALayer-backed
to being Entity/VideoTarget-backed. This switch means the system loses the connection between the layer&apos;s
location in space, and the audio associated with that layer. In order to restore that connection, add
a separated layer containing a spatial tracking label as a sublayer of the captions layer we provide to
the native fullscreen presentation, and that tracking label will be passed all the down to the GPU process.

Now that video playback is correctly spatialized in fullscreen, we also need to increase the soundstage
size to &quot;Large&quot; when in fullscreen as well. Previously this was only managed by individual players, and
only MSE-backed players. Instead, pull responsibility for setting the soundstage size up into the UI
process, and propogate that setting down to the GPU process by calculating a &quot;maximum&quot; soundstage size
at both the WebContent and GPU process level.

Since setting the soundstage size also requires a UIScene identifier, that will be pulled out from
MediaPlayer and passed alongside the soundstage size.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::visibilityStateChanged):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/audio/AudioSession.h:
(WTF::LogArgument&lt;WebCore::AudioSession::SoundStageSize&gt;::toString):
* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::updateSpatialExperience):
(WebCore::AudioSessionIOS::setSceneIdentifier):
(WebCore::AudioSessionIOS::setSoundStageSize):
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::setPageIsVisible):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::setPageIsVisible):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setPageIsVisible):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setPageIsVisible):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::setPageIsVisible):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::configuration):
(WebKit::RemoteAudioSessionProxy::tryToSetActive):
(WebKit::RemoteAudioSessionProxy::setSceneIdentifier):
(WebKit::RemoteAudioSessionProxy::setSoundStageSize):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
(WebKit::RemoteAudioSessionProxy::sceneIdentifier const):
(WebKit::RemoteAudioSessionProxy::soundStageSize const):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateSpatialExperience):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setPageIsVisible):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(-[WKLinearMediaKitCaptionsLayer layoutSublayers]):
(WebKit::VideoPresentationInterfaceLMK::presentFullscreen):
(WebKit::VideoPresentationInterfaceLMK::dismissFullscreen):
(WebKit::VideoPresentationInterfaceLMK::captionsLayer):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::setSoundStageSize):
(WebKit::PlaybackSessionManagerProxy::setSoundStageSize):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setPageIsVisible):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::setSceneIdentifier):
(WebKit::RemoteAudioSession::setSoundStageSize):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setSceneIdentifier):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::setSoundStageSize):
(WebKit::PlaybackSessionManager::forEachModel):

Canonical link: <a href="https://commits.webkit.org/279214@main">https://commits.webkit.org/279214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ead3abc75772ec24fff6ab37ac58f62b2e21b83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52674 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42783 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2185 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23883 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2767 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1556 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57544 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50176 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45608 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49450 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11538 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->