### PR TITLE
[Remote Inspection] Add the ability to target elements based on selector information

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -65,13 +65,22 @@ public:
 private:
     void cleanUpAdjustmentClientRects();
 
-    void applyVisibilityAdjustmentFromSelectors(Document&);
+    void applyVisibilityAdjustmentFromSelectors();
+
+    struct FindElementFromSelectorsResult {
+        RefPtr<Element> element;
+        String lastSelectorIncludingPseudo;
+    };
+    FindElementFromSelectorsResult findElementFromSelectors(const TargetedElementSelectors&);
+
+    RefPtr<Document> mainDocument() const;
 
     void dispatchVisibilityAdjustmentStateDidChange();
     void selectorBasedVisibilityAdjustmentTimerFired();
 
     std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(FloatPoint location, bool shouldIgnorePointerEventsNone);
     std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(const String& searchText);
+    std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(const TargetedElementSelectors&);
 
     Vector<TargetedElementInfo> extractTargets(Vector<Ref<Node>>&&, RefPtr<Element>&& innerElement, bool canIncludeNearbyElements);
 

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -47,7 +47,7 @@ struct TargetedElementAdjustment {
 };
 
 struct TargetedElementRequest {
-    std::variant<FloatPoint, String> data;
+    std::variant<FloatPoint, String, TargetedElementSelectors> data;
     bool canIncludeNearbyElements { true };
     bool shouldIgnorePointerEventsNone { true };
 };
@@ -68,6 +68,7 @@ struct TargetedElementInfo {
     bool isNearbyTarget { true };
     bool isPseudoElement { false };
     bool isInShadowTree { false };
+    bool isInVisibilityAdjustmentSubtree { false };
     bool hasAudibleMedia { false };
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -898,7 +898,7 @@ header: <WebCore/ElementTargetingTypes.h>
 
 header: <WebCore/ElementTargetingTypes.h>
 [CustomHeader] struct WebCore::TargetedElementRequest {
-    std::variant<WebCore::FloatPoint, String> data
+    std::variant<WebCore::FloatPoint, String, WebCore::TargetedElementSelectors> data
     bool canIncludeNearbyElements
     bool shouldIgnorePointerEventsNone
 };
@@ -920,6 +920,7 @@ header: <WebCore/ElementTargetingTypes.h>
     bool isNearbyTarget
     bool isPseudoElement
     bool isInShadowTree
+    bool isInVisibilityAdjustmentSubtree
     bool hasAudibleMedia
 };
 

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -62,6 +62,7 @@ public:
     bool isNearbyTarget() const { return m_info.isNearbyTarget; }
     bool isPseudoElement() const { return m_info.isPseudoElement; }
     bool isInShadowTree() const { return m_info.isInShadowTree; }
+    bool isInVisibilityAdjustmentSubtree() const { return m_info.isInVisibilityAdjustmentSubtree; }
     bool hasAudibleMedia() const { return m_info.hasAudibleMedia; }
 
     const HashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }

--- a/Source/WebKit/UIProcess/API/APITargetedElementRequest.cpp
+++ b/Source/WebKit/UIProcess/API/APITargetedElementRequest.cpp
@@ -44,12 +44,9 @@ void TargetedElementRequest::setPoint(WebCore::FloatPoint point)
     m_request.data = point;
 }
 
-WTF::String TargetedElementRequest::searchText() const
+void TargetedElementRequest::setSelectors(WebCore::TargetedElementSelectors&& selectors)
 {
-    if (!std::holds_alternative<WTF::String>(m_request.data))
-        return { };
-
-    return std::get<WTF::String>(m_request.data);
+    m_request.data = WTFMove(selectors);
 }
 
 void TargetedElementRequest::setSearchText(WTF::String&& searchText)

--- a/Source/WebKit/UIProcess/API/APITargetedElementRequest.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementRequest.h
@@ -48,8 +48,8 @@ public:
     WebCore::FloatPoint point() const;
     void setPoint(WebCore::FloatPoint);
 
-    WTF::String searchText() const;
     void setSearchText(WTF::String&&);
+    void setSelectors(WebCore::TargetedElementSelectors&&);
 
 private:
     WebCore::TargetedElementRequest m_request;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -46,6 +46,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic, readonly, getter=isNearbyTarget) BOOL nearbyTarget;
 @property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
 @property (nonatomic, readonly, getter=isInShadowTree) BOOL inShadowTree;
+@property (nonatomic, readonly, getter=isInVisibilityAdjustmentSubtree) BOOL inVisibilityAdjustmentSubtree;
 @property (nonatomic, readonly) BOOL hasAudibleMedia;
 @property (nonatomic, readonly) NSSet<NSURL *> *mediaAndLinkURLs;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -153,6 +153,11 @@
     return _info->isNearbyTarget();
 }
 
+- (BOOL)isInVisibilityAdjustmentSubtree
+{
+    return _info->isInVisibilityAdjustmentSubtree();
+}
+
 - (NSSet<NSURL *> *)mediaAndLinkURLs
 {
     RetainPtr result = adoptNS([NSMutableSet<NSURL *> new]);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h
@@ -36,9 +36,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 - (instancetype)initWithPoint:(CGPoint)point;
 - (instancetype)initWithSearchText:(NSString *)searchText;
-
-@property (nonatomic, readonly) CGPoint point;
-@property (nonatomic, readonly, nullable, copy) NSString *searchText;
+- (instancetype)initWithSelectors:(NSArray<NSSet<NSString *> *> *)selectors;
 
 @property (nonatomic) BOOL canIncludeNearbyElements;
 @property (nonatomic) BOOL shouldIgnorePointerEventsNone;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
@@ -70,6 +70,25 @@
     return self;
 }
 
+- (instancetype)initWithSelectors:(NSArray<NSSet<NSString *> *> *)nsSelectorsForElement
+{
+    if (!(self = [self init]))
+        return nil;
+
+    WebCore::TargetedElementSelectors selectorsForElement;
+    selectorsForElement.reserveInitialCapacity(nsSelectorsForElement.count);
+    for (NSSet<NSString *> *nsSelectors in nsSelectorsForElement) {
+        HashSet<String> selectors;
+        selectors.reserveInitialCapacity(nsSelectors.count);
+        for (NSString *selector in nsSelectors)
+            selectors.add(selector);
+        selectorsForElement.append(WTFMove(selectors));
+    }
+
+    _request->setSelectors(WTFMove(selectorsForElement));
+    return self;
+}
+
 - (BOOL)canIncludeNearbyElements
 {
     return _request->canIncludeNearbyElements();
@@ -88,16 +107,6 @@
 - (void)setShouldIgnorePointerEventsNone:(BOOL)value
 {
     _request->setShouldIgnorePointerEventsNone(value);
-}
-
-- (NSString *)searchText
-{
-    return _request->searchText();
-}
-
-- (CGPoint)point
-{
-    return _request->point();
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -39,6 +39,7 @@
 
 - (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoAt:(CGPoint)point;
 - (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoWithText:(NSString *)searchText;
+- (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoWithSelectors:(NSArray<NSSet<NSString *> *> *)selectors;
 - (BOOL)adjustVisibilityForTargets:(NSArray<_WKTargetedElementInfo *> *)targets;
 - (BOOL)resetVisibilityAdjustmentsForTargets:(NSArray<_WKTargetedElementInfo *> *)elements;
 - (void)expectSingleTargetedSelector:(NSString *)expectedSelector at:(CGPoint)point;
@@ -70,6 +71,12 @@
 - (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoWithText:(NSString *)searchText
 {
     auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithSearchText:searchText]);
+    return [self targetedElementInfo:request.get()];
+}
+
+- (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoWithSelectors:(NSArray<NSSet<NSString *> *> *)selectors
+{
+    auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithSelectors:selectors]);
     return [self targetedElementInfo:request.get()];
 }
 
@@ -336,6 +343,37 @@ TEST(ElementTargeting, AdjustVisibilityFromSelectors)
         EXPECT_FALSE(pixelReader.at(x, y) == WebCore::Color::white);
         EXPECT_EQ([webView numberOfVisibilityAdjustmentRects], 0U);
     }
+}
+
+TEST(ElementTargeting, RequestElementsFromSelectors)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 480)]);
+
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
+    [preferences _setVisibilityAdjustmentSelectors:[NSSet setWithObjects:
+        @".fixed.container"
+        , @"DIV.absolute.bottom-right"
+        , @"DIV.absolute.bottom-left"
+        , @"DIV.absolute.top-right"
+        , nil]];
+
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
+    __block bool didAdjustVisibility = false;
+    [delegate setWebViewDidAdjustVisibilityWithSelectors:^(WKWebView *, NSArray<NSString *> *selectors) {
+        didAdjustVisibility = true;
+    }];
+    [webView setUIDelegate:delegate.get()];
+    [webView synchronouslyLoadTestPageNamed:@"element-targeting-2" preferences:preferences.get()];
+    Util::run(&didAdjustVisibility);
+
+    RetainPtr targets = [webView targetedElementInfoWithSelectors:@[
+        [NSSet setWithObjects:@"DIV.absolute.bottom-right", @"#no-match", @".also-no-match", nil]
+    ]];
+
+    RetainPtr target = [targets firstObject];
+    EXPECT_EQ(1U, [targets count]);
+    EXPECT_WK_STREQ("DIV.absolute.bottom-right", [target selectorsIncludingShadowHosts].firstObject.firstObject);
+    EXPECT_TRUE([target isInVisibilityAdjustmentSubtree]);
 }
 
 TEST(ElementTargeting, AdjustVisibilityFromPseudoSelectors)


### PR DESCRIPTION
#### 9b7b8ded8fa6f6aa85d72ec5f68bee3252c00a81
<pre>
[Remote Inspection] Add the ability to target elements based on selector information
<a href="https://bugs.webkit.org/show_bug.cgi?id=274532">https://bugs.webkit.org/show_bug.cgi?id=274532</a>

Reviewed by Aditya Keerthi.

Add the ability to target elements based on compound selectors (i.e. selectors including all shadow
hosts). Additionally, expose a new property on targeted element info to indicate whether or not the
element is inside of an adjustment subtree.

See below for more details.

Test: ElementTargeting.RequestElementsFromSelectors

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::findTargets):
(WebCore::ElementTargetingController::findNodes):

Add `WebCore::TargetedElementSelectors` as a new type of targeted element request data, alongside
a point in root view coordinates and a search string. Add a new `findNodes()` implementation for
this targeted element selectors list. Build on top of the `findElementFromSelectors` method (see
below for more details).

(WebCore::ElementTargetingController::extractTargets):

Drive-by adjustment: only target elements if they&apos;re non-empty. This can otherwise happen in the
case where the list of candidates was derived from ascending the DOM when performing a text search.

(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
(WebCore::resolveSelectorToQuery):

Pull this out into a separate static helper function, so we can use it from both methods below.

(WebCore::ElementTargetingController::applyVisibilityAdjustmentFromSelectors):

Pull logic out of this method, and into `findElementFromSelectors`. Also, remove the document
argument (which was only ever the main document), and instead just retrieve the main document from
the `m_page` (or exit early if it&apos;s null).

(WebCore::ElementTargetingController::findElementFromSelectors):

Factor out logic for mapping a list of compound selectors (including all shadow hosts) into a
separate private method, so that it can be reused in multiple places in this class.

(WebCore::ElementTargetingController::mainDocument const):

Avoid some code duplication by adding a private helper method to return the main document, through
`m_page`.

(WebCore::ElementTargetingController::selectorBasedVisibilityAdjustmentTimerFired):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Add the new IPC types.

* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/APITargetedElementRequest.cpp:
(API::TargetedElementRequest::setSelectors):
(API::TargetedElementRequest::searchText const): Deleted.

Remove an unused getter for `-searchText`, along with support in the API object.

* Source/WebKit/UIProcess/API/APITargetedElementRequest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo isInVisibilityAdjustmentSubtree]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm:
(-[_WKTargetedElementRequest initWithSelectors:]):

Add a new initializer that takes a compound selector representing the element to target.

(-[_WKTargetedElementRequest searchText]): Deleted.
(-[_WKTargetedElementRequest point]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(-[WKWebView targetedElementInfoWithSelectors:]):
(TestWebKitAPI::TEST(ElementTargeting, RequestElementsFromSelectors)):

Add a new API test to exercise the change.

(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityFromPseudoSelectors)):

Canonical link: <a href="https://commits.webkit.org/279178@main">https://commits.webkit.org/279178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4b7307b4647477ca033b11e280f6e7c5b707e80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55959 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3106 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2188 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54779 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23888 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2772 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1563 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57551 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2919 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45615 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11512 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->