### PR TITLE
[Navigation] Set serialized state on navigation history items

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-info-and-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-info-and-state-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() with info and state promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigation.currentEntry.getState().statevar')"
+PASS navigate() with info and state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-info-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-info-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() variant with only info undefined is not an object (evaluating 'i.contentWindow.navigation.currentEntry.getState().key')
+FAIL reload() variant with only info assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-no-args-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-no-args-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() variant with no state or info undefined is not an object (evaluating 'i.contentWindow.navigation.currentEntry.getState().key')
+FAIL reload() variant with no state or info assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-and-info-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-and-info-expected.txt
@@ -1,4 +1,6 @@
 
 
-FAIL reload() variant with info and new state undefined is not an object (evaluating 'i.contentWindow.navigation.currentEntry.getState().key')
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT reload() variant with info and new state Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-undefined-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-undefined-expected.txt
@@ -1,4 +1,6 @@
 
 
-FAIL reload() variant with info and state: undefined counts the same as not present (because of Web IDL dictionary semantics), so preserves the state undefined is not an object (evaluating 'i.contentWindow.navigation.currentEntry.getState().key')
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT reload() variant with info and state: undefined counts the same as not present (because of Web IDL dictionary semantics), so preserves the state Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.pushState() undefined is not an object (evaluating 'navigation.currentEntry.getState().data')
+PASS entry.getState() after history.pushState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.replaceState() undefined is not an object (evaluating 'navigation.currentEntry.getState().data')
+FAIL entry.getState() after history.replaceState() assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-navigation-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-navigation-api-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL entry.getState() behavior after navigating away using the navigation API, then back assert_not_equals: got disallowed value undefined
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT entry.getState() behavior after navigating away using the navigation API, then back Test timed out
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -412,11 +412,12 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry
-void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTracker, NavigationHistoryEntry* entry)
+void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTracker, NavigationHistoryEntry* entry, NavigationNavigationType navigationType)
 {
     ASSERT(entry);
     apiMethodTracker->committedToEntry = entry;
-    // FIXME: 2. If apiMethodTracker's serialized state is not null, then set nhe's session history entry's navigation API state to apiMethodTracker's serialized state.
+    if (navigationType != NavigationNavigationType::Traverse)
+        apiMethodTracker->committedToEntry->setState(WTFMove(apiMethodTracker->serializedState));
 
     if (apiMethodTracker->finishedBeforeCommit)
         resolveFinishedPromise(apiMethodTracker);
@@ -452,7 +453,7 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
         m_entries[*m_currentEntryIndex] = NavigationHistoryEntry::create(protectedScriptExecutionContext().get(), WTFMove(item));
 
     if (m_ongoingAPIMethodTracker)
-        notifyCommittedToEntry(m_ongoingAPIMethodTracker.get(), currentEntry());
+        notifyCommittedToEntry(m_ongoingAPIMethodTracker.get(), currentEntry(), navigationType);
 
     auto currentEntryChangeEvent = NavigationCurrentEntryChangeEvent::create(eventNames().currententrychangeEvent, {
         { false, false, false }, navigationType, oldCurrentEntry

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -164,7 +164,7 @@ private:
     void rejectFinishedPromise(NavigationAPIMethodTracker*, Exception&&, JSC::JSValue exceptionObject);
     void abortOngoingNavigation(NavigateEvent&);
     void promoteUpcomingAPIMethodTracker(const String& destinationKey);
-    void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*);
+    void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
     Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);
 
     std::optional<size_t> m_currentEntryIndex;


### PR DESCRIPTION
#### 5fb3db45a58f172e9c8335f1da4133031e10ca58
<pre>
[Navigation] Set serialized state on navigation history items
<a href="https://bugs.webkit.org/show_bug.cgi?id=274535">https://bugs.webkit.org/show_bug.cgi?id=274535</a>

Reviewed by Alex Christensen.

Set serialized state on navigation history items as part of step 2 of the
&quot;notify about the committed-to entry&quot; algorithm [1].

The test changes are progressions, i.e. assertions involving state now pass but the test
may run into some failure later.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry">https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-info-and-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-info-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-no-args-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-and-info-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-undefined-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-replaceState-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::notifyCommittedToEntry):
(WebCore::Navigation::updateForNavigation):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/279222@main">https://commits.webkit.org/279222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64162bdcb02aa7c5741abdd1479b927dd9ab3c8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3266 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2294 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54916 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23990 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1700 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57690 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3047 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45790 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11542 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->