### PR TITLE
Rename SecurityOrigin::passesFileCheck per FIXME

### DIFF
--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -288,12 +288,12 @@ bool SecurityOrigin::isSameOriginDomain(const SecurityOrigin& other) const
     }
 
     if (canAccess && isLocal())
-        canAccess = passesFileCheck(other);
+        canAccess = hasLocalUnseparatedPath(other);
 
     return canAccess;
 }
 
-bool SecurityOrigin::passesFileCheck(const SecurityOrigin& other) const
+bool SecurityOrigin::hasLocalUnseparatedPath(const SecurityOrigin& other) const
 {
     ASSERT(isLocal() && other.isLocal());
 
@@ -613,7 +613,7 @@ bool SecurityOrigin::isSameSchemeHostPort(const SecurityOrigin& other) const
     if (m_data != other.m_data)
         return false;
 
-    if (isLocal() && !passesFileCheck(other))
+    if (isLocal() && !hasLocalUnseparatedPath(other))
         return false;
 
     return true;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -213,8 +213,7 @@ private:
     explicit SecurityOrigin(SecurityOriginData&&);
     void initializeShared(const URL&);
 
-    // FIXME: Rename this function to something more semantic.
-    bool passesFileCheck(const SecurityOrigin&) const;
+    bool hasLocalUnseparatedPath(const SecurityOrigin&) const;
 
     // This method checks that the scheme for this origin is an HTTP-family
     // scheme, e.g. HTTP and HTTPS.


### PR DESCRIPTION
#### d21d6c8a867c39ca99c7491895b5f3f30e2b0577
<pre>
Rename SecurityOrigin::passesFileCheck per FIXME
<a href="https://bugs.webkit.org/show_bug.cgi?id=274540">https://bugs.webkit.org/show_bug.cgi?id=274540</a>
<a href="https://rdar.apple.com/128554006">rdar://128554006</a>

Reviewed by Tim Horton.

Rename SecurityOrigin::passesFileCheck to SecurityOrigin::hasLocalUnseparatedPath to better describe the functionality and address a long standing FIXME

* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::isSameOriginDomain const):
(WebCore::SecurityOrigin::hasLocalUnseparatedPath const):
(WebCore::SecurityOrigin::isSameSchemeHostPort const):
(WebCore::SecurityOrigin::passesFileCheck const): Deleted.
* Source/WebCore/page/SecurityOrigin.h:

Canonical link: <a href="https://commits.webkit.org/279287@main">https://commits.webkit.org/279287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756aa3b10d1c6c5f8b858e5c98675899b6982e08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42767 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50163 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11573 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->