### PR TITLE
Removing unbounded resize of Vector

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -62,9 +62,7 @@
 
 #else // !USE(APPLE_INTERNAL_SDK)
 
-#if HAVE(CFNETWORK_HOSTOVERRIDE)
 #include <Network/Network.h>
-#endif
 
 #if HAVE(PRECONNECT_PING) && defined(__OBJC__)
 
@@ -92,21 +90,32 @@ typedef enum {
 #endif
 #endif // HAVE(LOGGING_PRIVACY_LEVEL)
 
-#if HAVE(NW_PROXY_CONFIG) || HAVE(SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS)
-
 #if OS_OBJECT_USE_OBJC
+OS_OBJECT_DECL(nw_array);
+OS_OBJECT_DECL(nw_object);
 OS_OBJECT_DECL(nw_context);
 OS_OBJECT_DECL(nw_endpoint);
+OS_OBJECT_DECL(nw_resolver);
+OS_OBJECT_DECL(nw_parameters);
 OS_OBJECT_DECL(nw_proxy_config);
 #else
+struct nw_array;
+typedef struct nw_array *nw_array_t;
+struct nw_object;
+typedef struct nw_object *nw_object_t;
 struct nw_context;
 typedef struct nw_context *nw_context_t;
 struct nw_endpoint;
 typedef struct nw_endpoint *nw_endpoint_t;
+struct nw_resolver;
+typedef struct nw_resolver *nw_resolver_t;
+struct nw_parameters;
+typedef struct nw_parameters *nw_parameters_t;
 struct nw_proxy_config;
 typedef struct nw_proxy_config *nw_proxy_config_t;
 #endif // OS_OBJECT_USE_OBJC
 
+#if HAVE(NW_PROXY_CONFIG) || HAVE(SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS)
 typedef void (^nw_context_tracker_lookup_callback_t)(nw_endpoint_t endpoint, const char **tracker_name, const char **tracker_owner, bool *can_block);
 
 #ifdef __cplusplus
@@ -118,6 +127,26 @@ void nw_proxy_config_get_identifier(nw_proxy_config_t, uuid_t out_identifier);
 }
 #endif
 #endif // HAVE(NW_PROXY_CONFIG) || HAVE(SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef enum {
+    nw_resolver_status_invalid = 0,
+    nw_resolver_status_in_progress = 1,
+    nw_resolver_status_complete = 2,
+} nw_resolver_status_t;
+nw_resolver_t nw_resolver_create_with_endpoint(nw_endpoint_t, nw_parameters_t);
+typedef void (^nw_resolver_update_block_t) (nw_resolver_status_t, nw_array_t);
+bool nw_resolver_set_update_handler(nw_resolver_t, dispatch_queue_t, nw_resolver_update_block_t);
+void nw_context_set_privacy_level(nw_context_t, nw_context_privacy_level_t);
+void nw_parameters_set_context(nw_parameters_t, nw_context_t);
+nw_context_t nw_context_create(const char *);
+size_t nw_array_get_count(nw_array_t);
+nw_object_t nw_array_get_object_at_index(nw_array_t, size_t);
+#ifdef __cplusplus
+}
+#endif
 
 typedef CF_ENUM(int64_t, _TimingDataOptions)
 {

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4541,7 +4541,8 @@ private:
             return JSValue();
 
         Vector<RTCCertificate::DtlsFingerprint> fingerprints;
-        fingerprints.reserveInitialCapacity(size);
+        if (!fingerprints.tryReserveInitialCapacity(size))
+            return JSValue();
         for (unsigned i = 0; i < size; i++) {
             CachedStringRef algorithm;
             if (!readStringData(algorithm))

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4451,13 +4451,12 @@ PromisedAttachmentInfo Editor::promisedAttachmentInfo(Element& element)
     if (!attachment)
         return { };
 
-    Vector<String> additionalTypes;
-    Vector<RefPtr<SharedBuffer>> additionalData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>  additionalTypesAndData;
 #if PLATFORM(COCOA)
-    getPasteboardTypesAndDataForAttachment(element, additionalTypes, additionalData);
+    getPasteboardTypesAndDataForAttachment(element, additionalTypesAndData);
 #endif
 
-    return { attachment->uniqueIdentifier(), WTFMove(additionalTypes), WTFMove(additionalData) };
+    return { attachment->uniqueIdentifier(), WTFMove(additionalTypesAndData) };
 }
 
 void Editor::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& data)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -601,7 +601,7 @@ public:
 
     WEBCORE_EXPORT PromisedAttachmentInfo promisedAttachmentInfo(Element&);
 #if PLATFORM(COCOA)
-    void getPasteboardTypesAndDataForAttachment(Element&, Vector<String>& outTypes, Vector<RefPtr<SharedBuffer>>& outData);
+    void getPasteboardTypesAndDataForAttachment(Element&, Vector<std::pair<String, RefPtr<SharedBuffer>>>& outTypesAndData);
 #endif
 #endif
 

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -196,7 +196,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
         pasteboardImage.resourceData = buffer->makeContiguous();
 
     if (!pasteboard.isStatic())
-        client()->getClientPasteboardData(makeRangeSelectingNode(imageElement), pasteboardImage.clientTypes, pasteboardImage.clientData);
+        client()->getClientPasteboardData(makeRangeSelectingNode(imageElement), pasteboardImage.clientTypesAndData);
 
     pasteboard.write(pasteboardImage);
 }

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -288,7 +288,7 @@ private:
     void didEndUserTriggeredSelectionChanges() final { }
     void willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) final { }
     void didWriteSelectionToPasteboard() final { }
-    void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>&, Vector<RefPtr<SharedBuffer>>&) final { }
+    void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<SharedBuffer>>>&) final { }
     void requestCandidatesForSelection(const VisibleSelection&) final { }
     void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) final { }
 

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -111,7 +111,7 @@ public:
     virtual void didEndEditing() = 0;
     virtual void willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) = 0;
     virtual void didWriteSelectionToPasteboard() = 0;
-    virtual void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<SharedBuffer>>& pasteboardData) = 0;
+    virtual void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData) = 0;
     virtual void requestCandidatesForSelection(const VisibleSelection&) { }
     virtual void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) { }
 

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -87,8 +87,7 @@ struct PasteboardWebContent {
     RefPtr<SharedBuffer> dataInAttributedStringFormat;
     String dataInHTMLFormat;
     String dataInStringFormat;
-    Vector<String> clientTypes;
-    Vector<RefPtr<SharedBuffer>> clientData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
 #endif
 #if PLATFORM(GTK)
     String contentOrigin;
@@ -125,8 +124,7 @@ struct PasteboardImage {
 #if !(PLATFORM(GTK) || PLATFORM(WIN))
     RefPtr<SharedBuffer> resourceData;
     String resourceMIMEType;
-    Vector<String> clientTypes;
-    Vector<RefPtr<SharedBuffer>> clientData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
 #endif
     String suggestedName;
     FloatSize imageSize;

--- a/Source/WebCore/platform/PasteboardWriterData.h
+++ b/Source/WebCore/platform/PasteboardWriterData.h
@@ -57,8 +57,7 @@ public:
         RefPtr<SharedBuffer> dataInAttributedStringFormat;
         String dataInHTMLFormat;
         String dataInStringFormat;
-        Vector<String> clientTypes;
-        Vector<RefPtr<SharedBuffer>> clientData;
+        Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
 #endif
     };
 

--- a/Source/WebCore/platform/PromisedAttachmentInfo.h
+++ b/Source/WebCore/platform/PromisedAttachmentInfo.h
@@ -37,8 +37,7 @@ struct PromisedAttachmentInfo {
     String attachmentIdentifier;
 #endif
 
-    Vector<String> additionalTypes;
-    Vector<RefPtr<SharedBuffer>> additionalData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> additionalTypesAndData;
 
     operator bool() const
     {

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -472,9 +472,8 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
     [representationsToRegister addData:[webIOSPastePboardType dataUsingEncoding:NSUTF8StringEncoding] forType:webIOSPastePboardType];
 #endif
 
-    ASSERT(content.clientTypes.size() == content.clientData.size());
-    for (size_t i = 0, size = content.clientTypes.size(); i < size; ++i)
-        [representationsToRegister addData:content.clientData[i]->makeContiguous()->createNSData().get() forType:content.clientTypes[i]];
+    for (size_t i = 0, size = content.clientTypesAndData.size(); i < size; ++i)
+        [representationsToRegister addData:content.clientTypesAndData[i].second->makeContiguous()->createNSData().get() forType:content.clientTypesAndData[i].first];
 
     if (content.dataInWebArchiveFormat) {
         auto webArchiveData = content.dataInWebArchiveFormat->createNSData();
@@ -516,11 +515,8 @@ void PlatformPasteboard::write(const PasteboardImage& pasteboardImage)
 {
     auto representationsToRegister = adoptNS([[WebItemProviderRegistrationInfoList alloc] init]);
 
-    auto& types = pasteboardImage.clientTypes;
-    auto& data = pasteboardImage.clientData;
-    ASSERT(types.size() == data.size());
-    for (size_t i = 0, size = types.size(); i < size; ++i)
-        [representationsToRegister addData:data[i]->createNSData().get() forType:types[i]];
+    for (size_t i = 0, size = pasteboardImage.clientTypesAndData.size(); i < size; ++i)
+        [representationsToRegister addData:pasteboardImage.clientTypesAndData[i].second->createNSData().get() forType:pasteboardImage.clientTypesAndData[i].first];
 
     if (pasteboardImage.resourceData && !pasteboardImage.resourceMIMEType.isEmpty()) {
         auto utiOrMIMEType = pasteboardImage.resourceMIMEType;

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -128,8 +128,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!webContent->dataInStringFormat.isNull())
             [pasteboardItem setString:webContent->dataInStringFormat forType:NSPasteboardTypeString];
 
-        for (unsigned i = 0; i < webContent->clientTypes.size(); ++i)
-            [pasteboardItem setData:webContent->clientData[i]->createNSData().get() forType:toUTIUnlessAlreadyUTI(webContent->clientTypes[i]).get()];
+        for (unsigned i = 0; i < webContent->clientTypesAndData.size(); ++i)
+            [pasteboardItem setData:webContent->clientTypesAndData[i].second->createNSData().get() forType:toUTIUnlessAlreadyUTI(webContent->clientTypesAndData[i].first).get()];
 
         PasteboardCustomData customData;
         customData.setOrigin(webContent->contentOrigin);

--- a/Source/WebKit/Shared/Pasteboard.serialization.in
+++ b/Source/WebKit/Shared/Pasteboard.serialization.in
@@ -35,8 +35,7 @@ header: <WebCore/Pasteboard.h>
 #if !(PLATFORM(GTK) || PLATFORM(WIN))
     RefPtr<WebCore::SharedBuffer> resourceData;
     String resourceMIMEType;
-    Vector<String> clientTypes;
-    Vector<RefPtr<WebCore::SharedBuffer>> clientData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
 #endif
     String suggestedName;
     WebCore::FloatSize imageSize;
@@ -53,8 +52,7 @@ header: <WebCore/Pasteboard.h>
     RefPtr<WebCore::SharedBuffer> dataInAttributedStringFormat;
     String dataInHTMLFormat;
     String dataInStringFormat;
-    Vector<String> clientTypes;
-    Vector<RefPtr<WebCore::SharedBuffer>> clientData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
 #endif
 #if PLATFORM(GTK)
     String contentOrigin;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2593,8 +2593,7 @@ struct WebCore::PromisedAttachmentInfo {
 #if ENABLE(ATTACHMENT_ELEMENT)
     String attachmentIdentifier;
 #endif
-    Vector<String> additionalTypes;
-    Vector<RefPtr<WebCore::SharedBuffer>> additionalData;
+    Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> additionalTypesAndData;
 }
 
 header: <WebCore/SearchPopupMenu.h>

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4273,12 +4273,9 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
 
         [m_view beginDraggingSessionWithItems:@[draggingItem.get()] event:m_lastMouseDownEvent.get() source:(id <NSDraggingSource>)m_view.getAutoreleased()];
 
-        ASSERT(info.additionalTypes.size() == info.additionalData.size());
-        if (info.additionalTypes.size() == info.additionalData.size()) {
-            for (size_t index = 0; index < info.additionalTypes.size(); ++index) {
-                auto nsData = info.additionalData[index]->createNSData();
-                [pasteboard setData:nsData.get() forType:info.additionalTypes[index]];
-            }
+        for (size_t index = 0; index < info.additionalTypesAndData.size(); ++index) {
+            auto nsData = info.additionalTypesAndData[index].second->createNSData();
+            [pasteboard setData:nsData.get() forType:info.additionalTypesAndData[index].first];
         }
         m_page->didStartDrag();
         return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -268,9 +268,21 @@ void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<SimpleR
     m_page->injectedBundleEditorClient().willWriteToPasteboard(*m_page, range);
 }
 
-void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<SharedBuffer>>& pasteboardData)
+void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& range, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData)
 {
+    Vector<String> pasteboardTypes;
+    Vector<RefPtr<WebCore::SharedBuffer>> pasteboardData;
+    for (size_t i = 0; i < pasteboardTypesAndData.size(); ++i) {
+        pasteboardTypes.append(pasteboardTypesAndData[i].first);
+        pasteboardData.append(pasteboardTypesAndData[i].second);
+    }
+
     m_page->injectedBundleEditorClient().getPasteboardDataForRange(*m_page, range, pasteboardTypes, pasteboardData);
+
+    ASSERT(pasteboardTypes.size() == pasteboardData.size());
+    pasteboardTypesAndData.clear();
+    for (size_t i = 0; i < pasteboardTypes.size(); ++i)
+        pasteboardTypesAndData.append(std::make_pair(pasteboardTypes[i], pasteboardData[i]));
 }
 
 bool WebEditorClient::performTwoStepDrop(DocumentFragment& fragment, const SimpleRange& destination, bool isMove)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -94,7 +94,7 @@ private:
     void didEndEditing() final;
     void willWriteSelectionToPasteboard(const std::optional<WebCore::SimpleRange>&) final;
     void didWriteSelectionToPasteboard() final;
-    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
+    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData) final;
     
     void registerUndoStep(WebCore::UndoStep&) final;
     void registerRedoStep(WebCore::UndoStep&) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -80,7 +80,7 @@ private:
     void didEndEditing() final;
     void willWriteSelectionToPasteboard(const std::optional<WebCore::SimpleRange>&) final;
     void didWriteSelectionToPasteboard() final;
-    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
+    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData) final;
 
     void setInsertionPasteboard(const String&) final;
     WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const String&) final { return WebCore::DOMPasteAccessResponse::DeniedForGesture; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -417,7 +417,7 @@ void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<SimpleR
     // Not implemented WebKit, only WebKit2.
 }
 
-void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData)
+void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData)
 {
     // Not implemented WebKit, only WebKit2.
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -874,6 +874,7 @@
 		93F79A5B28E64A07003E7CEB /* websql-database.db in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93F79A5128E649EB003E7CEB /* websql-database.db */; };
 		93F7E86F14DC8E5C00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F7E86E14DC8E5B00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp */; };
 		93FCDB34263631560046DD7D /* SortedArrayMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93FCDB33263631560046DD7D /* SortedArrayMap.cpp */; };
+		946422142BC83114001B42B3 /* SerializedScriptValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */; };
 		95194CC028A5811F00343FDE /* red.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 95194CBF28A580E900343FDE /* red.html */; };
 		9528E5FD279A0341008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9528E5FC279A0338008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm */; };
 		952F7167270BD9CB00D00DCC /* CSSViewportUnits.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCC /* CSSViewportUnits.html */; };
@@ -3061,6 +3062,7 @@
 		93F7E86B14DC8E4D00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NewFirstVisuallyNonEmptyLayoutFrames.cpp; sourceTree = "<group>"; };
 		93F7E86E14DC8E5B00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp; sourceTree = "<group>"; };
 		93FCDB33263631560046DD7D /* SortedArrayMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SortedArrayMap.cpp; sourceTree = "<group>"; };
+		9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SerializedScriptValue.cpp; sourceTree = "<group>"; };
 		95095F1F262FFFA50000D920 /* SampledPageTopColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SampledPageTopColor.mm; sourceTree = "<group>"; };
 		950E4CC0252E75230071659F /* iOSStylusSupport.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = iOSStylusSupport.mm; sourceTree = "<group>"; };
 		95194CBF28A580E900343FDE /* red.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = red.html; sourceTree = "<group>"; };
@@ -4518,6 +4520,7 @@
 				4181C62C255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp */,
 				CDCFA7A91E45122F00C2433D /* SampleMap.cpp */,
 				CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */,
+				9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */,
 				4102EE1627845ED500D6BE74 /* ServiceWorkerRoutines.cpp */,
 				41973B5C1AF22875006C7B36 /* SharedBuffer.cpp */,
 				A17991891E1CA24100A505ED /* SharedBufferTest.cpp */,
@@ -6807,6 +6810,7 @@
 				1C90420C2326E03C00BEF91E /* SelectionByWord.mm in Sources */,
 				9B4B5EA522DEBE19001E3D5A /* SelectionModifyByParagraphBoundary.mm in Sources */,
 				5769C50B1D9B0002000847FB /* SerializedCryptoKeyWrap.mm in Sources */,
+				946422142BC83114001B42B3 /* SerializedScriptValue.cpp in Sources */,
 				4102EE1727845ED500D6BE74 /* ServiceWorkerRoutines.cpp in Sources */,
 				7CCE7ECB1A411A7E00447C4C /* SetAndUpdateCacheModel.mm in Sources */,
 				7CCE7ECC1A411A7E00447C4C /* SetDocumentURI.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <JavaScriptCore/InitializeThreading.h>
+#include <JavaScriptCore/JSCJSValue.h>
+#include <WebCore/IDBBindingUtilities.h>
+#include <WebCore/IDBValue.h>
+#include <WebCore/ParsedContentRange.h>
+#include <WebCore/ParsedRequestRange.h>
+#include <WebCore/ProcessIdentifier.h>
+#include <WebCore/ThreadSafeDataBuffer.h>
+#include <wtf/text/WTFString.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+TEST(WebCore, SerializedScriptValueReadRTCCertificate)
+{
+    WTF::initialize();
+    WTF::initializeMainThread();
+    JSC::initialize();
+    WebCore::Process::identifier();
+
+    std::array<uint8_t, 149> bytes {
+        0x0d, 0x00, 0x00, 0x00, 0x2c, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0xe7, 0x1b, 0x86, 0xc8, 0xd0, 0xdb, 0x71, 0x6a, 0xac, 0x80, 0xf4,
+        0x6f, 0x76, 0xc0, 0x35, 0x5c, 0xc8, 0xc0, 0x4e, 0x49, 0xd8, 0xc4, 0x6d,
+        0x9c, 0x4e, 0x3f, 0xbd, 0x9e, 0xdc, 0xe5, 0xcd, 0x81, 0x5e, 0x71, 0x14,
+        0xb3, 0x1a, 0xad, 0xa3, 0xf5, 0xcf, 0x1f, 0x82, 0x58, 0xd8, 0xca, 0xbe,
+        0xb1, 0x2c, 0xd9, 0xef, 0xde, 0x05, 0x26, 0xef, 0xdc, 0x21, 0x4f, 0x3d,
+        0x20, 0x00, 0x32, 0x4b, 0xd8, 0x85, 0x86, 0xf4, 0x68, 0xb7, 0x1f, 0x71,
+        0xa7, 0xd8, 0x5e, 0x50, 0xcf, 0x9e, 0xc6, 0x91, 0x44, 0x36, 0x41, 0xdc,
+        0x54, 0x68, 0xc8, 0xf8, 0x5f, 0x93, 0xb4, 0x07, 0xfa, 0x73, 0xd7, 0x90,
+        0xa8, 0x9f, 0x07, 0xd2, 0x50, 0x03, 0x5e, 0x05, 0x77, 0x4a, 0x56, 0xdd,
+        0x1e, 0x68, 0xd3, 0x62, 0x8f, 0x58, 0x7e, 0x7c, 0x1e, 0xc6, 0x0f, 0xcc,
+        0x01, 0x6e, 0x88, 0x4b, 0x32
+    };
+
+    Vector<uint8_t> vector { std::span<uint8_t>(bytes) };
+    const WebCore::ThreadSafeDataBuffer value = WebCore::ThreadSafeDataBuffer::create(WTFMove(vector));
+    WebCore::callOnIDBSerializationThreadAndWait([&](auto& globalObject) {
+        auto jsValue = WebCore::deserializeIDBValueToJSValue(globalObject, value);
+        UNUSED_VARIABLE(jsValue);
+    });
+}
+
+}


### PR DESCRIPTION
#### 1d943e49ba8542867bbf3238ada5e64a05201449
<pre>
Removing unbounded resize of Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=272491">https://bugs.webkit.org/show_bug.cgi?id=272491</a>
<a href="https://rdar.apple.com/126132559">rdar://126132559</a>

Reviewed by Alex Christensen.

Resize the vector with an option to fallback to default value.
Test Case has been added to verify the fix.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readRTCCertificate):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/SerializedScriptValue.cpp: Added.
(TestWebKitAPI::TEST):

Originally-landed-as: 272448.906@safari-7618-branch (cb2f03208aa6). <a href="https://rdar.apple.com/128571325">rdar://128571325</a>
Canonical link: <a href="https://commits.webkit.org/279201@main">https://commits.webkit.org/279201@main</a>
</pre>
----------------------------------------------------------------------
#### ee944cef38abdeeb7412f74137811c1e46e106c7
<pre>
Change 2 related Vectors to use Vector Pair to prevent OOB.
<a href="https://rdar.apple.com/122621756">rdar://122621756</a>

Reviewed by Ryosuke Niwa, Alex Christensen and Brady Eidson

Changing two related Vectors to use a Vector pair which means they are always the same length, preventing an OOB on one of the vectors.
* Source/WebKit/Shared/Pasteboard.serialization.in:

Originally-landed-as: 272448.899@safari-7618-branch (48d5c62d7d15). <a href="https://rdar.apple.com/128570706">rdar://128570706</a>
Canonical link: <a href="https://commits.webkit.org/279200@main">https://commits.webkit.org/279200@main</a>
</pre>
----------------------------------------------------------------------
#### d5973196a382a1964fe1eed6843bad33c3aa449b
<pre>
Use nw_context_privacy_level_silent for DNS lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=272190">https://bugs.webkit.org/show_bug.cgi?id=272190</a>
<a href="https://rdar.apple.com/120452086">rdar://120452086</a>

Reviewed by Matthew Finkel, Brent Fulgham and Youenn Fablet.

DNSServiceGetAddrInfo logs the domain name in internal builds, which is undesirable
when using WKWebsiteDataStore.nonPersistentDataStore.  This redacts those logs.
Public OSes should be unaffected.

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::complete):
(WebCore::extractIPAddress):
(WebCore::DNSResolveQueueCFNet::performDNSLookup):
(WebCore::DNSResolveQueueCFNet::stopResolve):
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::addIPAddress): Deleted.
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::receivedIPv4AndIPv6 const): Deleted.
(): Deleted.
(WebCore::dnsLookupCallback): Deleted.

Originally-landed-as: 272448.889@safari-7618-branch (7e9184c87123). <a href="https://rdar.apple.com/128570639">rdar://128570639</a>
Canonical link: <a href="https://commits.webkit.org/279199@main">https://commits.webkit.org/279199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bba81caa1a1459bf162256547d5d9d8ce7e83cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42795 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57568 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50191 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49464 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->