### PR TITLE
[WebAudio] Use-after-free in WebCore::AudioBufferSourceNode::renderFromBuffer

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/copyTo-same-decoder-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/copyTo-same-decoder-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test copyTo on different contexts
+

--- a/LayoutTests/http/wpt/webcodecs/copyTo-same-decoder.html
+++ b/LayoutTests/http/wpt/webcodecs/copyTo-same-decoder.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+const WORKER_CODE = `self.onmessage = event => {
+    const frames = event.data;
+
+    frames.a.copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    frames.b.copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    frames.c.copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    frames.d.copyTo(new ArrayBuffer(1024 * 1024 * 4));
+
+    frames.a.close();
+    frames.b.close();
+    frames.d.close();
+    frames.d.close();
+};
+self.postMessage('ready');
+`
+
+promise_test(async () => {
+    const encodedFrames = [];
+    let resolve, reject;
+    const encoderPromise = new Promise((res,rej) => {
+        resolve = res;
+        reject = rej;
+     });
+
+    for (const size of [2, 1024]) {
+        const encoder = new VideoEncoder({
+            output: chunk => {
+                encodedFrames.push(chunk);
+                if (encodedFrames.length === 2)
+                    resolve();
+            },
+            error: e => reject(e),
+        });
+        setTimeout(() => {
+            reject("timed out waiting for encoded chunks");
+        }, 5000);
+        encoder.configure({
+            codec: 'vp8',
+            width: size,
+            height: size,
+            bitrate: 10e6,
+            framerate: 1,
+        });
+
+        const frame = new VideoFrame(new ArrayBuffer(size * size * 4), {format: 'RGBA', codedWidth: size, codedHeight: size, timestamp: 0});
+        encoder.encode(frame, {keyFrame: false});
+        frame.close();
+    }
+    await encoderPromise;
+
+    const decoderPromise = new Promise((res,rej) => {
+        resolve = res;
+        reject = rej;
+     });
+
+    const frames = [];
+    const decoder = new VideoDecoder({
+        output: frame => {
+            frames.push(frame);
+            if (frames.length === 8)
+                resolve();
+        },
+        error: e => reject(e),
+    });
+    setTimeout(() => {
+        reject("timed out waiting for decoded frames");
+    }, 5000);
+
+    decoder.configure({
+        codec: 'vp8',
+        codedWidth: 16,
+        codedHeight: 16,
+    });
+
+    for (let i = 0; i < 4; ++i) {
+        decoder.decode(encodedFrames[0]);
+        decoder.decode(encodedFrames[1]);
+    }
+
+    await decoderPromise;
+
+    const worker = new Worker(URL.createObjectURL(new Blob([WORKER_CODE])));
+    await new Promise(resolve => worker.onmessage = resolve);
+
+    worker.postMessage({a: frames[0], b: frames[1], c: frames[2], d: frames[3]}, [frames[0], frames[1], frames[2], frames[3]]);
+
+    frames[4].copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    frames[5].copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    frames[6].copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    frames[7].copyTo(new ArrayBuffer(1024 * 1024 * 4));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    frames[4].close();
+    frames[5].close();
+    frames[6].close();
+    frames[7].close();
+}, "Test copyTo on different contexts");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -59,6 +59,8 @@ public:
     size_t length() const { return hasDetachedChannelBuffer() ? 0 : m_originalLength; }
     double duration() const { return length() / static_cast<double>(sampleRate()); }
 
+    void markBuffersAsNonDetachable();
+
     // Channel data access
     unsigned numberOfChannels() const { return m_channels.size(); }
     ExceptionOr<JSC::JSValue> getChannelData(JSDOMGlobalObject&, unsigned channelIndex);

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -409,6 +409,15 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
     return true;
 }
 
+void AudioBufferSourceNode::acquireBufferContent()
+{
+    ASSERT(isMainThread());
+
+    // FIXME: We should implement https://www.w3.org/TR/webaudio/#acquire-the-content.
+    if (m_buffer)
+        m_buffer->markBuffersAsNonDetachable();
+}
+
 ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer>&& buffer)
 {
     ASSERT(isMainThread());
@@ -445,6 +454,9 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
     // In case the buffer gets set after playback has started, we need to clamp the grain parameters now.
     if (m_isGrain)
         adjustGrainParameters();
+
+    if (isPlayingOrScheduled())
+        acquireBufferContent();
 
     return { };
 }
@@ -513,6 +525,7 @@ ExceptionOr<void> AudioBufferSourceNode::startPlaying(double when, double grainO
 
     adjustGrainParameters();
 
+    acquireBufferContent();
     m_playbackState = SCHEDULED_STATE;
 
     return { };

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -83,6 +83,8 @@ public:
 private:
     AudioBufferSourceNode(BaseAudioContext&);
 
+    void acquireBufferContent() WTF_REQUIRES_LOCK(m_processLock);
+
     double tailTime() const final { return 0; }
     double latencyTime() const final { return 0; }
 


### PR DESCRIPTION
#### 7d0a50fadc7c19bf49866aaa29380fdc6f6738a5
<pre>
[WebAudio] Use-after-free in WebCore::AudioBufferSourceNode::renderFromBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=272607">https://bugs.webkit.org/show_bug.cgi?id=272607</a>
<a href="https://rdar.apple.com/126326144">rdar://126326144</a>

Reviewed by Yusuke Suzuki.

The JS on the main thread can detach the AudioBuffer&apos;s channels while
it is being read by the audio rendering thread, causing use-after-frees.

In a previous fix attempt, we starting copying the AudioBuffer&apos;s channels
so that the audio thread would read a copy instead. However, the increased
memory usage resulted in increased jetsams on gaming sites.

As a temporary stop gap measure, this patch simply marks the AudioBuffer&apos;s
channels as non-detachable to prevent the issue. This is not quite spec
compliant but it addresses the security issue until we can implement the
specification correctly without causing jetsams.

* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::markBuffersAsNonDetachable):
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::acquireBufferContent):
(WebCore::AudioBufferSourceNode::setBufferForBindings):
(WebCore::AudioBufferSourceNode::startPlaying):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:

Originally-landed-as: 272448.925@safari-7618-branch (4201e96638f0). <a href="https://rdar.apple.com/128572657">rdar://128572657</a>
Canonical link: <a href="https://commits.webkit.org/279197@main">https://commits.webkit.org/279197@main</a>
</pre>
----------------------------------------------------------------------
#### 6ae06410764e65994ee9d4c50e1811caa6348ddf
<pre>
Race condition in LibWebRTCVPXInternalVideoDecoder::pixelBufferPool leading to memory corruption
<a href="https://rdar.apple.com/125957410">rdar://125957410</a>

Reviewed by Chris Dumez.

Add a lock to make sure creation of the pixel buffer happens correctly.

* LayoutTests/http/wpt/webcodecs/copyTo-same-decoder-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/copyTo-same-decoder.html: Added.
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::createPixelBuffer):
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):

Originally-landed-as: 272448.909@safari-7618-branch (b50f1990af6e). <a href="https://rdar.apple.com/128572002">rdar://128572002</a>
Canonical link: <a href="https://commits.webkit.org/279196@main">https://commits.webkit.org/279196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2767d7a80ab6daecbd7ef63c8cab6ad71f807ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55972 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42792 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2791 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50187 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49459 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11532 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->