### PR TITLE
"libpas test suit is broken due to recent profile and track allocation mode change"

### DIFF
--- a/Source/bmalloc/libpas/src/chaos/Chaos.cpp
+++ b/Source/bmalloc/libpas/src/chaos/Chaos.cpp
@@ -186,9 +186,10 @@ void threadMain(uintptr_t threadIndex)
                     iso_allocate_common_primitive_with_alignment(
                         targetSize,
                         static_cast<uintptr_t>(1) << uniform_int_distribution<uintptr_t>(
-                            0, maxMemalignShift)(randomGenerator)));
+                            0, maxMemalignShift)(randomGenerator),
+                            pas_non_compact_allocation_mode));
             } else
-                ptr = static_cast<char*>(iso_allocate_common_primitive(targetSize));
+                ptr = static_cast<char*>(iso_allocate_common_primitive(targetSize, pas_non_compact_allocation_mode));
             
             for (uintptr_t i = targetSize; i--;)
                 ptr[i] = static_cast<char>(i + 42);

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap.c
@@ -47,20 +47,20 @@ pas_heap hotbit_common_primitive_heap =
 
 pas_allocator_counts hotbit_allocator_counts;
 
-void* hotbit_try_allocate(size_t size)
+void* hotbit_try_allocate(size_t size, pas_allocation_mode allocation_mode)
 {
-    return hotbit_try_allocate_inline(size);
+    return hotbit_try_allocate_inline(size, allocation_mode);
 }
 
-void* hotbit_try_allocate_with_alignment(size_t size, size_t alignment)
+void* hotbit_try_allocate_with_alignment(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return hotbit_try_allocate_with_alignment_inline(size, alignment);
+    return hotbit_try_allocate_with_alignment_inline(size, alignment, allocation_mode);
 }
 
 void* hotbit_try_reallocate(void* old_ptr, size_t new_size,
-                             pas_reallocate_free_mode free_mode)
+                             pas_reallocate_free_mode free_mode, pas_allocation_mode allocation_mode)
 {
-    return hotbit_try_reallocate_inline(old_ptr, new_size, free_mode);
+    return hotbit_try_reallocate_inline(old_ptr, new_size, free_mode, allocation_mode);
 }
 
 void hotbit_deallocate(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap.h
@@ -27,17 +27,20 @@
 #define HOTBIT_HEAP_H
 
 #include "pas_reallocate_free_mode.h"
+#include "pas_allocation_mode.h"
 
 #if PAS_ENABLE_HOTBIT
 
 PAS_BEGIN_EXTERN_C;
 
-PAS_API void* hotbit_try_allocate(size_t size);
+PAS_API void* hotbit_try_allocate(size_t size, pas_allocation_mode allocation_mode);
 PAS_API void* hotbit_try_allocate_with_alignment(size_t size,
-                                                  size_t alignment);
+                                                  size_t alignment,
+                                                  pas_allocation_mode allocation_mode);
 
 PAS_API void* hotbit_try_reallocate(void* old_ptr, size_t new_size,
-                                     pas_reallocate_free_mode free_mode);
+                                     pas_reallocate_free_mode free_mode,
+                                    pas_allocation_mode allocation_mode);
 
 PAS_API void* hotbit_reallocate(void* old_ptr, size_t new_size,
                                  pas_reallocate_free_mode free_mode);

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h
@@ -59,25 +59,26 @@ PAS_CREATE_TRY_ALLOCATE_INTRINSIC(
     &hotbit_common_primitive_heap_support,
     pas_intrinsic_heap_is_not_designated);
 
-static PAS_ALWAYS_INLINE void* hotbit_try_allocate_inline(size_t size)
+static PAS_ALWAYS_INLINE void* hotbit_try_allocate_inline(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)hotbit_try_allocate_impl(size, 1).begin;
+    return (void*)hotbit_try_allocate_impl(size, 1, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
-hotbit_try_allocate_with_alignment_inline(size_t size, size_t alignment)
+hotbit_try_allocate_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)hotbit_try_allocate_with_alignment_impl(size, alignment).begin;
+    return (void*)hotbit_try_allocate_with_alignment_impl(size, alignment, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
 hotbit_try_reallocate_inline(void* old_ptr, size_t new_size,
-                              pas_reallocate_free_mode free_mode)
+                              pas_reallocate_free_mode free_mode, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_intrinsic(
         old_ptr,
         &hotbit_common_primitive_heap,
         new_size,
+        allocation_mode,
         HOTBIT_HEAP_CONFIG,
         hotbit_try_allocate_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,

--- a/Source/bmalloc/libpas/src/libpas/iso_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap.c
@@ -58,87 +58,95 @@ pas_dynamic_primitive_heap_map iso_primitive_dynamic_heap_map =
 pas_dynamic_primitive_heap_map iso_flex_dynamic_heap_map =
     PAS_DYNAMIC_PRIMITIVE_HEAP_MAP_INITIALIZER(iso_primitive_heap_ref_construct);
 
-void* iso_try_allocate_common_primitive(size_t size)
+void* iso_try_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_common_primitive_inline(size);
+    return iso_try_allocate_common_primitive_inline(size, allocation_mode);
 }
 
-void* iso_try_allocate_common_primitive_with_alignment(size_t size, size_t alignment)
+void* iso_try_allocate_common_primitive_with_alignment(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_common_primitive_with_alignment_inline(size, alignment);
+    return iso_try_allocate_common_primitive_with_alignment_inline(size, alignment, allocation_mode);
 }
 
-void* iso_try_allocate_common_primitive_zeroed(size_t size)
+void* iso_try_allocate_common_primitive_zeroed(size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_common_primitive_zeroed_inline(size);
+    return iso_try_allocate_common_primitive_zeroed_inline(size, allocation_mode);
 }
 
-void* iso_allocate_common_primitive(size_t size)
+void* iso_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_common_primitive_inline(size);
+    return iso_allocate_common_primitive_inline(size, allocation_mode);
 }
 
-void* iso_allocate_common_primitive_with_alignment(size_t size, size_t alignment)
+void* iso_allocate_common_primitive_with_alignment(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_common_primitive_with_alignment_inline(size, alignment);
+    return iso_allocate_common_primitive_with_alignment_inline(size, alignment, allocation_mode);
 }
 
-void* iso_allocate_common_primitive_zeroed(size_t size)
+void* iso_allocate_common_primitive_zeroed(size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_common_primitive_zeroed_inline(size);
+    return iso_allocate_common_primitive_zeroed_inline(size, allocation_mode);
 }
 
 void* iso_try_reallocate_common_primitive(void* old_ptr, size_t new_size,
-                                          pas_reallocate_free_mode free_mode)
+                                          pas_reallocate_free_mode free_mode,
+                                          pas_allocation_mode allocation_mode)
 {
-    return iso_try_reallocate_common_primitive_inline(old_ptr, new_size, free_mode);
+    return iso_try_reallocate_common_primitive_inline(old_ptr, new_size, free_mode, allocation_mode);
 }
 
 void* iso_reallocate_common_primitive(void* old_ptr, size_t new_size,
-                                      pas_reallocate_free_mode free_mode)
+                                      pas_reallocate_free_mode free_mode,
+                                      pas_allocation_mode allocation_mode)
 {
-    return iso_reallocate_common_primitive_inline(old_ptr, new_size, free_mode);
+    return iso_reallocate_common_primitive_inline(old_ptr, new_size, free_mode, allocation_mode);
 }
 
-void* iso_try_allocate_dynamic_primitive(const void* key, size_t size)
+void* iso_try_allocate_dynamic_primitive(const void* key, size_t size, pas_allocation_mode allocation_mode)
 {
     return iso_try_allocate_primitive(
         pas_dynamic_primitive_heap_map_find(
             &iso_primitive_dynamic_heap_map, key, size),
-        size);
+        size, allocation_mode);
 }
 
 void* iso_try_allocate_dynamic_primitive_with_alignment(const void* key,
                                                         size_t size,
-                                                        size_t alignment)
+                                                        size_t alignment,
+                                                        pas_allocation_mode allocation_mode)
 {
     return iso_try_allocate_primitive_with_alignment(
         pas_dynamic_primitive_heap_map_find(
             &iso_primitive_dynamic_heap_map, key, size),
         size,
-        alignment);
+        alignment,
+        allocation_mode);
 }
 
 void* iso_try_allocate_dynamic_primitive_zeroed(const void* key,
-                                                size_t size)
+                                                size_t size,
+                                                pas_allocation_mode allocation_mode)
 {
     return iso_try_allocate_primitive_zeroed(
         pas_dynamic_primitive_heap_map_find(
             &iso_primitive_dynamic_heap_map, key, size),
-        size);
+        size,
+        allocation_mode);
 }
 
 void* iso_try_reallocate_dynamic_primitive(void* old_ptr,
                                            const void* key,
                                            size_t new_size,
-                                           pas_reallocate_free_mode free_mode)
+                                           pas_reallocate_free_mode free_mode,
+                                           pas_allocation_mode allocation_mode)
 {
     return iso_try_reallocate_primitive(
         old_ptr,
         pas_dynamic_primitive_heap_map_find(
             &iso_primitive_dynamic_heap_map, key, new_size),
         new_size,
-        free_mode);
+        free_mode,
+        allocation_mode);
 }
 
 void iso_heap_ref_construct(pas_heap_ref* heap_ref,
@@ -149,48 +157,50 @@ void iso_heap_ref_construct(pas_heap_ref* heap_ref,
     heap_ref->allocator_index = 0;
 }
 
-void* iso_try_allocate(pas_heap_ref* heap_ref)
+void* iso_try_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_inline(heap_ref);
+    return iso_try_allocate_inline(heap_ref, allocation_mode);
 }
 
-void* iso_allocate(pas_heap_ref* heap_ref)
+void* iso_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_inline(heap_ref);
+    return iso_allocate_inline(heap_ref, allocation_mode);
 }
 
-void* iso_try_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* iso_try_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_array_by_count_inline(heap_ref, count, alignment);
+    return iso_try_allocate_array_by_count_inline(heap_ref, count, alignment, allocation_mode);
 }
 
-void* iso_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* iso_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_array_by_count_inline(heap_ref, count, alignment);
+    return iso_allocate_array_by_count_inline(heap_ref, count, alignment, allocation_mode);
 }
 
-void* iso_try_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* iso_try_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_array_by_count_zeroed_inline(heap_ref, count, alignment);
+    return iso_try_allocate_array_by_count_zeroed_inline(heap_ref, count, alignment, allocation_mode);
 }
 
-void* iso_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* iso_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_array_by_count_zeroed_inline(heap_ref, count, alignment);
+    return iso_allocate_array_by_count_zeroed_inline(heap_ref, count, alignment, allocation_mode);
 }
 
 void* iso_try_reallocate_array_by_count(void* old_ptr, pas_heap_ref* heap_ref,
                                         size_t new_count,
-                                        pas_reallocate_free_mode free_mode)
+                                        pas_reallocate_free_mode free_mode,
+                                        pas_allocation_mode allocation_mode)
 {
-    return iso_try_reallocate_array_by_count_inline(old_ptr, heap_ref, new_count, free_mode);
+    return iso_try_reallocate_array_by_count_inline(old_ptr, heap_ref, new_count, free_mode, allocation_mode);
 }
 
 void* iso_reallocate_array_by_count(void* old_ptr, pas_heap_ref* heap_ref,
                                     size_t new_count,
-                                    pas_reallocate_free_mode free_mode)
+                                    pas_reallocate_free_mode free_mode,
+                                    pas_allocation_mode allocation_mode)
 {
-    return iso_reallocate_array_by_count_inline(old_ptr, heap_ref, new_count, free_mode);
+    return iso_reallocate_array_by_count_inline(old_ptr, heap_ref, new_count, free_mode, allocation_mode);
 }
 
 pas_heap* iso_heap_ref_get_heap(pas_heap_ref* heap_ref)
@@ -211,62 +221,68 @@ void iso_primitive_heap_ref_construct(pas_primitive_heap_ref* heap_ref,
 }
 
 void* iso_try_allocate_primitive(pas_primitive_heap_ref* heap_ref,
-                                 size_t size)
+                                 size_t size,
+                                 pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_primitive_inline(heap_ref, size);
+    return iso_try_allocate_primitive_inline(heap_ref, size, allocation_mode);
 }
 
 void* iso_allocate_primitive(pas_primitive_heap_ref* heap_ref,
-                             size_t size)
+                             size_t size,
+                             pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_primitive_inline(heap_ref, size);
+    return iso_allocate_primitive_inline(heap_ref, size, allocation_mode);
 }
 
 void* iso_try_allocate_primitive_zeroed(pas_primitive_heap_ref* heap_ref,
-                                        size_t size)
+                                        size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_primitive_zeroed_inline(heap_ref, size);
+    return iso_try_allocate_primitive_zeroed_inline(heap_ref, size, allocation_mode);
 }
 
 void* iso_allocate_primitive_zeroed(pas_primitive_heap_ref* heap_ref,
-                                    size_t size)
+                                    size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_primitive_zeroed_inline(heap_ref, size);
+    return iso_allocate_primitive_zeroed_inline(heap_ref, size, allocation_mode);
 }
 
 void* iso_try_allocate_primitive_with_alignment(pas_primitive_heap_ref* heap_ref,
                                                 size_t size,
-                                                size_t alignment)
+                                                size_t alignment,
+                                                pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_primitive_with_alignment_inline(heap_ref, size, alignment);
+    return iso_try_allocate_primitive_with_alignment_inline(heap_ref, size, alignment, allocation_mode);
 }
 
 void* iso_allocate_primitive_with_alignment(pas_primitive_heap_ref* heap_ref,
                                             size_t size,
-                                            size_t alignment)
+                                            size_t alignment,
+                                            pas_allocation_mode allocation_mode)
 {
-    return iso_allocate_primitive_with_alignment_inline(heap_ref, size, alignment);
+    return iso_allocate_primitive_with_alignment_inline(heap_ref, size, alignment, allocation_mode);
 }
 
 void* iso_try_reallocate_primitive(void* old_ptr,
                                    pas_primitive_heap_ref* heap_ref,
                                    size_t new_size,
-                                   pas_reallocate_free_mode free_mode)
+                                   pas_reallocate_free_mode free_mode,
+                                   pas_allocation_mode allocation_mode)
 {
-    return iso_try_reallocate_primitive_inline(old_ptr, heap_ref, new_size, free_mode);
+    return iso_try_reallocate_primitive_inline(old_ptr, heap_ref, new_size, free_mode, allocation_mode);
 }
 
 void* iso_reallocate_primitive(void* old_ptr,
                                pas_primitive_heap_ref* heap_ref,
                                size_t new_size,
-                               pas_reallocate_free_mode free_mode)
+                               pas_reallocate_free_mode free_mode,
+                               pas_allocation_mode allocation_mode)
 {
-    return iso_reallocate_primitive_inline(old_ptr, heap_ref, new_size, free_mode);
+    return iso_reallocate_primitive_inline(old_ptr, heap_ref, new_size, free_mode, allocation_mode);
 }
 
-void* iso_try_allocate_for_flex(const void* cls, size_t size)
+void* iso_try_allocate_for_flex(const void* cls, size_t size, pas_allocation_mode allocation_mode)
 {
-    return iso_try_allocate_for_flex_inline(cls, size);
+    return iso_try_allocate_for_flex_inline(cls, size, allocation_mode);
 }
 
 bool iso_has_object(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/iso_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap.h
@@ -29,60 +29,70 @@
 #include "iso_heap_ref.h"
 #include "pas_primitive_heap_ref.h"
 #include "pas_reallocate_free_mode.h"
+#include "pas_allocation_mode.h"
 
 #if PAS_ENABLE_ISO
 
 PAS_BEGIN_EXTERN_C;
 
-PAS_API void* iso_try_allocate_common_primitive(size_t size);
+PAS_API void* iso_try_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode);
 PAS_API void* iso_try_allocate_common_primitive_with_alignment(size_t size,
-                                                               size_t alignment);
+                                                               size_t alignment,
+                                                               pas_allocation_mode allocation_mode);
 
-PAS_API void* iso_try_allocate_common_primitive_zeroed(size_t size);
+PAS_API void* iso_try_allocate_common_primitive_zeroed(size_t size, pas_allocation_mode allocation_mode);
 
-PAS_API void* iso_allocate_common_primitive(size_t size);
+PAS_API void* iso_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode);
 PAS_API void* iso_allocate_common_primitive_with_alignment(size_t size,
-                                                           size_t alignment);
+                                                           size_t alignment,
+                                                           pas_allocation_mode allocation_mode);
 
-PAS_API void* iso_allocate_common_primitive_zeroed(size_t size);
+PAS_API void* iso_allocate_common_primitive_zeroed(size_t size, pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_reallocate_common_primitive(void* old_ptr, size_t new_size,
-                                                  pas_reallocate_free_mode free_mode);
+                                                  pas_reallocate_free_mode free_mode,
+                                                  pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_reallocate_common_primitive(void* old_ptr, size_t new_size,
-                                              pas_reallocate_free_mode free_mode);
+                                              pas_reallocate_free_mode free_mode,
+                                              pas_allocation_mode allocation_mode);
 
-PAS_API void* iso_try_allocate_dynamic_primitive(const void* key, size_t size);
+PAS_API void* iso_try_allocate_dynamic_primitive(const void* key, size_t size, pas_allocation_mode allocation_mode);
 PAS_API void* iso_try_allocate_dynamic_primitive_with_alignment(const void* key,
                                                                 size_t size,
-                                                                size_t alignment);
+                                                                size_t alignment,
+                                                                pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_allocate_dynamic_primitive_zeroed(const void* key,
-                                                        size_t size);
+                                                        size_t size,
+                                                        pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_reallocate_dynamic_primitive(void* old_ptr,
                                                    const void* key,
                                                    size_t new_size,
-                                                   pas_reallocate_free_mode free_mode);
+                                                   pas_reallocate_free_mode free_mode,
+                                                   pas_allocation_mode allocation_mode);
 
 PAS_API void iso_heap_ref_construct(pas_heap_ref* heap_ref,
                                     pas_simple_type type);
 
-PAS_API void* iso_try_allocate(pas_heap_ref* heap_ref);
-PAS_API void* iso_allocate(pas_heap_ref* heap_ref);
+PAS_API void* iso_try_allocate(pas_heap_ref* heap_ref, pas_allocation_mode pas_allocation_mode);
+PAS_API void* iso_allocate(pas_heap_ref* heap_ref, pas_allocation_mode pas_allocation_mode);
 
-PAS_API void* iso_try_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment);
-PAS_API void* iso_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment);
+PAS_API void* iso_try_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
+PAS_API void* iso_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
 
-PAS_API void* iso_try_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment);
-PAS_API void* iso_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment);
+PAS_API void* iso_try_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
+PAS_API void* iso_allocate_array_by_count_zeroed(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_reallocate_array_by_count(void* old_ptr, pas_heap_ref* heap_ref,
                                                 size_t new_count,
-                                                pas_reallocate_free_mode free_mode);
+                                                pas_reallocate_free_mode free_mode,
+                                                pas_allocation_mode allocation_mode);
 PAS_API void* iso_reallocate_array_by_count(void* old_ptr, pas_heap_ref* heap_ref,
                                             size_t new_count,
-                                            pas_reallocate_free_mode free_mode);
+                                            pas_reallocate_free_mode free_mode,
+                                            pas_allocation_mode allocation_mode);
 
 PAS_API pas_heap* iso_heap_ref_get_heap(pas_heap_ref* heap_ref);
 
@@ -90,34 +100,42 @@ PAS_API void iso_primitive_heap_ref_construct(pas_primitive_heap_ref* heap_ref,
                                               pas_simple_type type);
 
 PAS_API void* iso_try_allocate_primitive(pas_primitive_heap_ref* heap_ref,
-                                         size_t size);
+                                         size_t size,
+                                         pas_allocation_mode allocation_mode);
 PAS_API void* iso_allocate_primitive(pas_primitive_heap_ref* heap_ref,
-                                     size_t size);
+                                     size_t size,
+                                     pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_allocate_primitive_zeroed(pas_primitive_heap_ref* heap_ref,
-                                                size_t size);
+                                                size_t size,
+                                                pas_allocation_mode allocation_mode);
 PAS_API void* iso_allocate_primitive_zeroed(pas_primitive_heap_ref* heap_ref,
-                                            size_t size);
+                                            size_t size,
+                                            pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_allocate_primitive_with_alignment(pas_primitive_heap_ref* heap_ref,
                                                         size_t size,
-                                                        size_t alignment);
+                                                        size_t alignment,
+                                                        pas_allocation_mode allocation_mode);
 PAS_API void* iso_allocate_primitive_with_alignment(pas_primitive_heap_ref* heap_ref,
                                                     size_t size,
-                                                    size_t alignment);
+                                                    size_t alignment,
+                                                    pas_allocation_mode allocation_mode);
 
 PAS_API void* iso_try_reallocate_primitive(void* old_ptr,
                                            pas_primitive_heap_ref* heap_ref,
                                            size_t new_size,
-                                           pas_reallocate_free_mode free_mode);
+                                           pas_reallocate_free_mode free_mode,
+                                           pas_allocation_mode allocation_mode);
 PAS_API void* iso_reallocate_primitive(void* old_ptr,
                                        pas_primitive_heap_ref* heap_ref,
                                        size_t new_size,
-                                       pas_reallocate_free_mode free_mode);
+                                       pas_reallocate_free_mode free_mode,
+                                       pas_allocation_mode allocation_mode);
 
 PAS_API pas_heap* iso_primitive_heap_ref_get_heap(pas_primitive_heap_ref* heap_ref);
 
-PAS_API void* iso_try_allocate_for_flex(const void* cls, size_t size);
+PAS_API void* iso_try_allocate_for_flex(const void* cls, size_t size, pas_allocation_mode allocation_mode);
 
 PAS_API bool iso_has_object(void*);
 PAS_API size_t iso_get_allocation_size(void*);

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h
@@ -85,50 +85,51 @@ PAS_CREATE_TRY_ALLOCATE_INTRINSIC(
     &iso_common_primitive_heap_support,
     pas_intrinsic_heap_is_not_designated);
 
-static PAS_ALWAYS_INLINE void* iso_try_allocate_common_primitive_inline(size_t size)
+static PAS_ALWAYS_INLINE void* iso_try_allocate_common_primitive_inline(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_try_allocate_common_primitive_impl(size, 1).begin;
+    return (void*)iso_try_allocate_common_primitive_impl(size, 1, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
-iso_try_allocate_common_primitive_with_alignment_inline(size_t size, size_t alignment)
+iso_try_allocate_common_primitive_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_try_allocate_common_primitive_with_alignment_impl(size, alignment).begin;
+    return (void*)iso_try_allocate_common_primitive_with_alignment_impl(size, alignment, allocation_mode).begin;
 }
 
-static PAS_ALWAYS_INLINE void* iso_try_allocate_common_primitive_zeroed_inline(size_t size)
+static PAS_ALWAYS_INLINE void* iso_try_allocate_common_primitive_zeroed_inline(size_t size, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_allocation_result_zero(
-        iso_try_allocate_common_primitive_impl(size, 1),
+        iso_try_allocate_common_primitive_impl(size, 1, allocation_mode),
         size).begin;
 }
 
-static PAS_ALWAYS_INLINE void* iso_allocate_common_primitive_inline(size_t size)
+static PAS_ALWAYS_INLINE void* iso_allocate_common_primitive_inline(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_allocate_common_primitive_impl(size, 1).begin;
+    return (void*)iso_allocate_common_primitive_impl(size, 1, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
-iso_allocate_common_primitive_with_alignment_inline(size_t size, size_t alignment)
+iso_allocate_common_primitive_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_allocate_common_primitive_with_alignment_impl(size, alignment).begin;
+    return (void*)iso_allocate_common_primitive_with_alignment_impl(size, alignment, allocation_mode).begin;
 }
 
-static PAS_ALWAYS_INLINE void* iso_allocate_common_primitive_zeroed_inline(size_t size)
+static PAS_ALWAYS_INLINE void* iso_allocate_common_primitive_zeroed_inline(size_t size, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_allocation_result_zero(
-        iso_allocate_common_primitive_impl(size, 1),
+        iso_allocate_common_primitive_impl(size, 1, allocation_mode),
         size).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
 iso_try_reallocate_common_primitive_inline(void* old_ptr, size_t new_size,
-                                           pas_reallocate_free_mode free_mode)
+                                           pas_reallocate_free_mode free_mode, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_intrinsic(
         old_ptr,
         &iso_common_primitive_heap,
         new_size,
+        allocation_mode,
         ISO_HEAP_CONFIG,
         iso_try_allocate_common_primitive_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
@@ -137,12 +138,13 @@ iso_try_reallocate_common_primitive_inline(void* old_ptr, size_t new_size,
 
 static PAS_ALWAYS_INLINE void*
 iso_reallocate_common_primitive_inline(void* old_ptr, size_t new_size,
-                                       pas_reallocate_free_mode free_mode)
+                                       pas_reallocate_free_mode free_mode, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_intrinsic(
         old_ptr,
         &iso_common_primitive_heap,
         new_size,
+        allocation_mode,
         ISO_HEAP_CONFIG,
         iso_allocate_common_primitive_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
@@ -156,9 +158,9 @@ PAS_CREATE_TRY_ALLOCATE(
     &iso_allocator_counts,
     pas_allocation_result_set_errno);
 
-static PAS_ALWAYS_INLINE void* iso_try_allocate_inline(pas_heap_ref* heap_ref)
+static PAS_ALWAYS_INLINE void* iso_try_allocate_inline(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_try_allocate_impl(heap_ref).begin;
+    return (void*)iso_try_allocate_impl(heap_ref, allocation_mode).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE(
@@ -168,9 +170,9 @@ PAS_CREATE_TRY_ALLOCATE(
     &iso_allocator_counts,
     pas_allocation_result_crash_on_error);
 
-static PAS_ALWAYS_INLINE void* iso_allocate_inline(pas_heap_ref* heap_ref)
+static PAS_ALWAYS_INLINE void* iso_allocate_inline(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_allocate_impl(heap_ref).begin;
+    return (void*)iso_allocate_impl(heap_ref, allocation_mode).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_ARRAY(
@@ -181,9 +183,9 @@ PAS_CREATE_TRY_ALLOCATE_ARRAY(
     pas_allocation_result_set_errno);
 
 static PAS_ALWAYS_INLINE void*
-iso_try_allocate_array_by_count_inline(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+iso_try_allocate_array_by_count_inline(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_try_allocate_array_impl_by_count(heap_ref, count, alignment).begin;
+    return (void*)iso_try_allocate_array_impl_by_count(heap_ref, count, alignment, allocation_mode).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_ARRAY(
@@ -194,13 +196,13 @@ PAS_CREATE_TRY_ALLOCATE_ARRAY(
     pas_allocation_result_crash_on_error);
 
 static PAS_ALWAYS_INLINE void*
-iso_allocate_array_by_count_inline(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+iso_allocate_array_by_count_inline(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_allocate_array_impl_by_count(heap_ref, count, alignment).begin;
+    return (void*)iso_allocate_array_impl_by_count(heap_ref, count, alignment, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_try_allocate_array_by_count_zeroed_inline(
-    pas_heap_ref* heap_ref, size_t count, size_t alignment)
+    pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
     size_t size;
 
@@ -210,11 +212,11 @@ static PAS_ALWAYS_INLINE void* iso_try_allocate_array_by_count_zeroed_inline(
     }
     
     return (void*)pas_allocation_result_zero(
-        iso_try_allocate_array_impl_by_size(heap_ref, size, alignment), size).begin;
+        iso_try_allocate_array_impl_by_size(heap_ref, size, alignment, allocation_mode), size).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_allocate_array_by_count_zeroed_inline(
-    pas_heap_ref* heap_ref, size_t count, size_t alignment)
+    pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
     size_t size;
     bool did_overflow;
@@ -223,17 +225,19 @@ static PAS_ALWAYS_INLINE void* iso_allocate_array_by_count_zeroed_inline(
     PAS_ASSERT(!did_overflow);
     
     return (void*)pas_allocation_result_zero(
-        iso_allocate_array_impl_by_size(heap_ref, size, alignment), size).begin;
+        iso_allocate_array_impl_by_size(heap_ref, size, alignment, allocation_mode), size).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_try_reallocate_array_by_count_inline(void* old_ptr, pas_heap_ref* heap_ref,
                                                                         size_t new_count,
-                                                                        pas_reallocate_free_mode free_mode)
+                                                                        pas_reallocate_free_mode free_mode,
+                                                                        pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_array_by_count(
         old_ptr,
         heap_ref,
         new_count,
+        allocation_mode,
         ISO_HEAP_CONFIG,
         iso_try_allocate_array_impl_for_realloc,
         &iso_typed_runtime_config.base,
@@ -243,12 +247,14 @@ static PAS_ALWAYS_INLINE void* iso_try_reallocate_array_by_count_inline(void* ol
 
 static PAS_ALWAYS_INLINE void* iso_reallocate_array_by_count_inline(void* old_ptr, pas_heap_ref* heap_ref,
                                                                     size_t new_count,
-                                                                    pas_reallocate_free_mode free_mode)
+                                                                    pas_reallocate_free_mode free_mode,
+                                                                    pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_array_by_count(
         old_ptr,
         heap_ref,
         new_count,
+        allocation_mode,
         ISO_HEAP_CONFIG,
         iso_allocate_array_impl_for_realloc,
         &iso_typed_runtime_config.base,
@@ -264,9 +270,9 @@ PAS_CREATE_TRY_ALLOCATE_PRIMITIVE(
     pas_allocation_result_set_errno);
 
 static PAS_ALWAYS_INLINE void* iso_try_allocate_primitive_inline(pas_primitive_heap_ref* heap_ref,
-                                                                 size_t size)
+                                                                 size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_try_allocate_primitive_impl(heap_ref, size, 1).begin;
+    return (void*)iso_try_allocate_primitive_impl(heap_ref, size, 1, allocation_mode).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_PRIMITIVE(
@@ -277,52 +283,56 @@ PAS_CREATE_TRY_ALLOCATE_PRIMITIVE(
     pas_allocation_result_crash_on_error);
 
 static PAS_ALWAYS_INLINE void* iso_allocate_primitive_inline(pas_primitive_heap_ref* heap_ref,
-                                                             size_t size)
+                                                             size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_allocate_primitive_impl(heap_ref, size, 1).begin;
+    return (void*)iso_allocate_primitive_impl(heap_ref, size, 1, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_try_allocate_primitive_zeroed_inline(pas_primitive_heap_ref* heap_ref,
-                                                                        size_t size)
+                                                                        size_t size, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_allocation_result_zero(
-        iso_try_allocate_primitive_impl(heap_ref, size, 1),
+        iso_try_allocate_primitive_impl(heap_ref, size, 1, allocation_mode),
         size).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_allocate_primitive_zeroed_inline(pas_primitive_heap_ref* heap_ref,
-                                                                    size_t size)
+                                                                    size_t size, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_allocation_result_zero(
-        iso_allocate_primitive_impl(heap_ref, size, 1),
+        iso_allocate_primitive_impl(heap_ref, size, 1, allocation_mode),
         size).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
 iso_try_allocate_primitive_with_alignment_inline(pas_primitive_heap_ref* heap_ref,
                                                  size_t size,
-                                                 size_t alignment)
+                                                 size_t alignment,
+                                                 pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_try_allocate_primitive_impl(heap_ref, size, alignment).begin;
+    return (void*)iso_try_allocate_primitive_impl(heap_ref, size, alignment, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
 iso_allocate_primitive_with_alignment_inline(pas_primitive_heap_ref* heap_ref,
                                              size_t size,
-                                             size_t alignment)
+                                             size_t alignment,
+                                             pas_allocation_mode allocation_mode)
 {
-    return (void*)iso_allocate_primitive_impl(heap_ref, size, alignment).begin;
+    return (void*)iso_allocate_primitive_impl(heap_ref, size, alignment, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_try_reallocate_primitive_inline(void* old_ptr,
                                                                    pas_primitive_heap_ref* heap_ref,
                                                                    size_t new_size,
-                                                                   pas_reallocate_free_mode free_mode)
+                                                                   pas_reallocate_free_mode free_mode,
+                                                                   pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_primitive(
         old_ptr,
         heap_ref,
         new_size,
+        allocation_mode,
         ISO_HEAP_CONFIG,
         iso_try_allocate_primitive_impl_for_realloc,
         &iso_primitive_runtime_config.base,
@@ -333,12 +343,14 @@ static PAS_ALWAYS_INLINE void* iso_try_reallocate_primitive_inline(void* old_ptr
 static PAS_ALWAYS_INLINE void* iso_reallocate_primitive_inline(void* old_ptr,
                                                                pas_primitive_heap_ref* heap_ref,
                                                                size_t new_size,
-                                                               pas_reallocate_free_mode free_mode)
+                                                               pas_reallocate_free_mode free_mode,
+                                                               pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_primitive(
         old_ptr,
         heap_ref,
         new_size,
+        allocation_mode,
         ISO_HEAP_CONFIG,
         iso_allocate_primitive_impl_for_realloc,
         &iso_primitive_runtime_config.base,
@@ -353,13 +365,13 @@ PAS_CREATE_TRY_ALLOCATE_PRIMITIVE(
     &iso_allocator_counts,
     pas_allocation_result_set_errno);
 
-static PAS_ALWAYS_INLINE void* iso_try_allocate_for_flex_inline(const void* cls, size_t size)
+static PAS_ALWAYS_INLINE void* iso_try_allocate_for_flex_inline(const void* cls, size_t size, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_allocation_result_zero(
         iso_try_allocate_for_flex_impl(
             pas_dynamic_primitive_heap_map_find(
                 &iso_flex_dynamic_heap_map, cls, size),
-            size, 1),
+            size, 1, allocation_mode),
         size).begin;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/iso_test_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/iso_test_heap.c
@@ -74,19 +74,19 @@ PAS_CREATE_TRY_ALLOCATE_ARRAY(
     &iso_allocator_counts,
     pas_allocation_result_crash_on_error);
 
-void* iso_test_allocate_common_primitive(size_t size)
+void* iso_test_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_common_primitive(size, 1).begin;
+    return (void*)test_allocate_common_primitive(size, 1, allocation_mode).begin;
 }
 
-void* iso_test_allocate(pas_heap_ref* heap_ref)
+void* iso_test_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_impl(heap_ref).begin;
+    return (void*)test_allocate_impl(heap_ref, allocation_mode).begin;
 }
 
-void* iso_test_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* iso_test_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_array_impl_by_count(heap_ref, count, alignment).begin;
+    return (void*)test_allocate_array_impl_by_count(heap_ref, count, alignment, allocation_mode).begin;
 }
 
 void iso_test_deallocate(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/iso_test_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_test_heap.h
@@ -38,9 +38,9 @@ PAS_BEGIN_EXTERN_C;
 PAS_API extern pas_heap iso_test_common_primitive_heap;
 PAS_API extern pas_intrinsic_heap_support iso_test_common_primitive_heap_support;
 
-PAS_API void* iso_test_allocate_common_primitive(size_t size);
-PAS_API void* iso_test_allocate(pas_heap_ref* heap_ref);
-PAS_API void* iso_test_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment);
+PAS_API void* iso_test_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode);
+PAS_API void* iso_test_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode);
+PAS_API void* iso_test_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
 PAS_API void iso_test_deallocate(void* ptr);
 PAS_API pas_heap* iso_test_heap_ref_get_heap(pas_heap_ref* heap_ref);
 

--- a/Source/bmalloc/libpas/src/libpas/minalign32_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/minalign32_heap.c
@@ -73,19 +73,19 @@ PAS_CREATE_TRY_ALLOCATE_ARRAY(
     &iso_allocator_counts,
     pas_allocation_result_crash_on_error);
 
-void* minalign32_allocate_common_primitive(size_t size)
+void* minalign32_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_common_primitive(size, 1).begin;
+    return (void*)test_allocate_common_primitive(size, 1, allocation_mode).begin;
 }
 
-void* minalign32_allocate(pas_heap_ref* heap_ref)
+void* minalign32_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_impl(heap_ref).begin;
+    return (void*)test_allocate_impl(heap_ref, allocation_mode).begin;
 }
 
-void* minalign32_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* minalign32_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_array_impl_by_count(heap_ref, count, alignment).begin;
+    return (void*)test_allocate_array_impl_by_count(heap_ref, count, alignment, allocation_mode).begin;
 }
 
 void minalign32_deallocate(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/minalign32_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/minalign32_heap.h
@@ -32,15 +32,16 @@
 
 #include "iso_heap.h"
 #include "pas_intrinsic_heap_support.h"
+#include "pas_allocation_mode.h"
 
 PAS_BEGIN_EXTERN_C;
 
 PAS_API extern pas_heap minalign32_common_primitive_heap;
 PAS_API extern pas_intrinsic_heap_support minalign32_common_primitive_heap_support;
 
-PAS_API void* minalign32_allocate_common_primitive(size_t size);
-PAS_API void* minalign32_allocate(pas_heap_ref* heap_ref);
-PAS_API void* minalign32_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment);
+PAS_API void* minalign32_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode);
+PAS_API void* minalign32_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode);
+PAS_API void* minalign32_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
 PAS_API void minalign32_deallocate(void* ptr);
 PAS_API pas_heap* minalign32_heap_ref_get_heap(pas_heap_ref* heap_ref);
 

--- a/Source/bmalloc/libpas/src/libpas/pagesize64k_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pagesize64k_heap.c
@@ -73,19 +73,19 @@ PAS_CREATE_TRY_ALLOCATE_ARRAY(
     &iso_allocator_counts,
     pas_allocation_result_crash_on_error);
 
-void* pagesize64k_allocate_common_primitive(size_t size)
+void* pagesize64k_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_common_primitive(size, 1).begin;
+    return (void*)test_allocate_common_primitive(size, 1, allocation_mode).begin;
 }
 
-void* pagesize64k_allocate(pas_heap_ref* heap_ref)
+void* pagesize64k_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_impl(heap_ref).begin;
+    return (void*)test_allocate_impl(heap_ref, allocation_mode).begin;
 }
 
-void* pagesize64k_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* pagesize64k_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)test_allocate_array_impl_by_count(heap_ref, count, alignment).begin;
+    return (void*)test_allocate_array_impl_by_count(heap_ref, count, alignment, allocation_mode).begin;
 }
 
 void pagesize64k_deallocate(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/pagesize64k_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pagesize64k_heap.h
@@ -38,9 +38,9 @@ PAS_BEGIN_EXTERN_C;
 PAS_API extern pas_heap pagesize64k_common_primitive_heap;
 PAS_API extern pas_intrinsic_heap_support pagesize64k_common_primitive_heap_support;
 
-PAS_API void* pagesize64k_allocate_common_primitive(size_t size);
-PAS_API void* pagesize64k_allocate(pas_heap_ref* heap_ref);
-PAS_API void* pagesize64k_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment);
+PAS_API void* pagesize64k_allocate_common_primitive(size_t size, pas_allocation_mode allocation_mode);
+PAS_API void* pagesize64k_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode);
+PAS_API void* pagesize64k_allocate_array_by_count(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode);
 PAS_API void pagesize64k_deallocate(void* ptr);
 PAS_API pas_heap* pagesize64k_heap_ref_get_heap(pas_heap_ref* heap_ref);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
@@ -41,6 +41,7 @@ enum pas_allocation_mode {
 };
 
 typedef enum pas_allocation_mode pas_allocation_mode;
+typedef enum pas_allocation_mode __pas_allocation_mode;
 
 static inline const char* pas_allocation_mode_get_string(pas_allocation_mode allocation_mode)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
@@ -33,6 +33,8 @@
 
 PAS_BEGIN_EXTERN_C;
 
+#include "pas_allocation_mode.h"
+
 enum pas_scavenger_state {
     pas_scavenger_state_no_thread,
     pas_scavenger_state_polling,

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap.c
@@ -73,27 +73,28 @@ PAS_CREATE_TRY_ALLOCATE_INTRINSIC(
     &thingy_primitive_heap_support,
     pas_intrinsic_heap_is_not_designated);
 
-void* thingy_try_allocate_primitive(size_t size)
+void* thingy_try_allocate_primitive(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)try_allocate_primitive(size, 1).begin;
+    return (void*)try_allocate_primitive(size, 1, allocation_mode).begin;
 }
 
-void* thingy_try_allocate_primitive_zeroed(size_t size)
+void* thingy_try_allocate_primitive_zeroed(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)pas_allocation_result_zero(try_allocate_primitive(size, 1), size).begin;
+    return (void*)pas_allocation_result_zero(try_allocate_primitive(size, 1, allocation_mode), size).begin;
 }
 
-void* thingy_try_allocate_primitive_with_alignment(size_t size, size_t alignment)
+void* thingy_try_allocate_primitive_with_alignment(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)try_allocate_primitive(size, alignment).begin;
+    return (void*)try_allocate_primitive(size, alignment, allocation_mode).begin;
 }
 
-void* thingy_try_reallocate_primitive(void* old_ptr, size_t new_size)
+void* thingy_try_reallocate_primitive(void* old_ptr, size_t new_size, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_intrinsic(
         old_ptr,
         &thingy_primitive_heap,
         new_size,
+        allocation_mode,
         THINGY_HEAP_CONFIG,
         try_allocate_primitive_for_realloc,
         pas_reallocate_disallow_heap_teleport,
@@ -108,15 +109,15 @@ PAS_CREATE_TRY_ALLOCATE(
     pas_allocation_result_identity);
 
 __attribute__((malloc))
-void* thingy_try_allocate(pas_heap_ref* heap_ref)
+void* thingy_try_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
-    return (void*)try_allocate(heap_ref).begin;
+    return (void*)try_allocate(heap_ref, allocation_mode).begin;
 }
 
-void* thingy_try_allocate_zeroed(pas_heap_ref* heap_ref)
+void* thingy_try_allocate_zeroed(pas_heap_ref* heap_ref, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_allocation_result_zero(
-        try_allocate(heap_ref), THINGY_HEAP_CONFIG.get_type_size(heap_ref->type)).begin;
+        try_allocate(heap_ref, allocation_mode), THINGY_HEAP_CONFIG.get_type_size(heap_ref->type)).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_ARRAY(
@@ -127,12 +128,12 @@ PAS_CREATE_TRY_ALLOCATE_ARRAY(
     pas_allocation_result_identity);
 
 __attribute__((malloc))
-void* thingy_try_allocate_array(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* thingy_try_allocate_array(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    return (void*)try_allocate_array_by_count(heap_ref, count, alignment).begin;
+    return (void*)try_allocate_array_by_count(heap_ref, count, alignment, allocation_mode).begin;
 }
 
-void* thingy_try_allocate_zeroed_array(pas_heap_ref* heap_ref, size_t count, size_t alignment)
+void* thingy_try_allocate_zeroed_array(pas_heap_ref* heap_ref, size_t count, size_t alignment, pas_allocation_mode allocation_mode)
 {
     size_t size;
 
@@ -140,7 +141,7 @@ void* thingy_try_allocate_zeroed_array(pas_heap_ref* heap_ref, size_t count, siz
         return NULL;
     
     return (void*)pas_allocation_result_zero(
-        try_allocate_array_by_size(heap_ref, size, alignment), size).begin;
+        try_allocate_array_by_size(heap_ref, size, alignment, allocation_mode), size).begin;
 }
 
 size_t thingy_get_allocation_size(void* ptr)
@@ -149,11 +150,12 @@ size_t thingy_get_allocation_size(void* ptr)
 }
 
 void* thingy_try_reallocate_array(
-    void* old_ptr, pas_heap_ref* heap_ref, size_t new_count)
+    void* old_ptr, pas_heap_ref* heap_ref, size_t new_count, pas_allocation_mode allocation_mode)
 {
     return (void*)pas_try_reallocate_array_by_count(old_ptr,
                                                     heap_ref,
                                                     new_count,
+                                                    allocation_mode,
                                                     THINGY_HEAP_CONFIG,
                                                     try_allocate_array_for_realloc,
                                                     &thingy_typed_runtime_config.base,
@@ -182,9 +184,9 @@ PAS_CREATE_TRY_ALLOCATE_INTRINSIC(
     &thingy_utility_heap_support,
     pas_intrinsic_heap_is_not_designated);
 
-void* thingy_utility_heap_allocate(size_t size)
+void* thingy_utility_heap_allocate(size_t size, pas_allocation_mode allocation_mode)
 {
-    return (void*)utility_heap_allocate(size, 1).begin;
+    return (void*)utility_heap_allocate(size, 1, allocation_mode).begin;
 }
 
 #endif /* PAS_ENABLE_THINGY */

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap.h
@@ -33,6 +33,7 @@
 #include "pas_allocator_counts.h"
 #include "pas_heap_ref.h"
 #include "pas_intrinsic_heap_support.h"
+#include "pas_allocation_mode.h"
 
 #include "thingy_heap_prefix.h"
 
@@ -63,7 +64,7 @@ PAS_API size_t thingy_get_allocation_size(void*);
 
 PAS_API pas_heap* thingy_heap_ref_get_heap(pas_heap_ref* heap_ref);
 
-PAS_API void* thingy_utility_heap_allocate(size_t size);
+PAS_API void* thingy_utility_heap_allocate(size_t size, pas_allocation_mode allocation_mode);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap_prefix.h
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap_prefix.h
@@ -27,31 +27,34 @@ __PAS_BEGIN_EXTERN_C;
 
 #pragma mark - Allocator functions
 
-__PAS_API void* __thingy_try_allocate_primitive(__pas_size_t size);
-__PAS_API void* __thingy_try_allocate_primitive_zeroed(__pas_size_t size);
-__PAS_API void* __thingy_try_allocate_primitive_with_alignment(__pas_size_t size, __pas_size_t alignment);
+__PAS_API void* __thingy_try_allocate_primitive(__pas_size_t size, __pas_allocation_mode allocation_mode);
+__PAS_API void* __thingy_try_allocate_primitive_zeroed(__pas_size_t size, __pas_allocation_mode allocation_mode);
+__PAS_API void* __thingy_try_allocate_primitive_with_alignment(__pas_size_t size, __pas_size_t alignment, __pas_allocation_mode allocation_mode);
 
 __PAS_API void* __thingy_try_reallocate_primitive(
-    void* old_ptr, __pas_size_t new_size);
+    void* old_ptr, __pas_size_t new_size, __pas_allocation_mode allocation_mode);
 
 __attribute__((malloc))
-__PAS_API void* __thingy_try_allocate(__pas_heap_ref* heap_ref);
+__PAS_API void* __thingy_try_allocate(__pas_heap_ref* heap_ref, __pas_allocation_mode allocation_mode);
 
-__PAS_API void* __thingy_try_allocate_zeroed(__pas_heap_ref* heap_ref);
+__PAS_API void* __thingy_try_allocate_zeroed(__pas_heap_ref* heap_ref, __pas_allocation_mode allocation_mode);
 
 /* FIXME: This should take the size, since the caller calculates it anyway. */
 __attribute__((malloc))
 __PAS_API void* __thingy_try_allocate_array(__pas_heap_ref* heap_ref,
                                             __pas_size_t count,
-                                            __pas_size_t alignment);
+                                            __pas_size_t alignment,
+                                            __pas_allocation_mode allocation_mode);
 
 __PAS_API void* __thingy_try_allocate_zeroed_array(__pas_heap_ref* heap_ref,
                                                    __pas_size_t count,
-                                                   __pas_size_t alignment);
+                                                   __pas_size_t alignment,
+                                                   __pas_allocation_mode allocation_mode);
 
 __PAS_API void* __thingy_try_reallocate_array(void* old_ptr,
                                               __pas_heap_ref* heap_ref,
-                                              __pas_size_t new_count);
+                                              __pas_size_t new_count,
+                                              __pas_allocation_mode allocation_mode);
 
 __PAS_API void __thingy_deallocate(void*);
 

--- a/Source/bmalloc/libpas/src/mbmalloc/mbmalloc_bmalloc.c
+++ b/Source/bmalloc/libpas/src/mbmalloc/mbmalloc_bmalloc.c
@@ -35,17 +35,17 @@
 
 void* mbmalloc(size_t size)
 {
-    return bmalloc_try_allocate(size);
+    return bmalloc_try_allocate(size, pas_non_compact_allocation_mode);
 }
 
 void* mbmemalign(size_t alignment, size_t size)
 {
-    return bmalloc_try_allocate_with_alignment(size, alignment);
+    return bmalloc_try_allocate_with_alignment(size, alignment, pas_non_compact_allocation_mode);
 }
 
 void* mbrealloc(void* p, size_t ignored_old_size, size_t new_size)
 {
-    return bmalloc_try_reallocate(p, new_size, pas_reallocate_free_if_successful);
+    return bmalloc_try_reallocate(p, new_size, pas_non_compact_allocation_mode, pas_reallocate_free_if_successful);
 }
 
 void mbfree(void* p, size_t ignored_size)

--- a/Source/bmalloc/libpas/src/mbmalloc/mbmalloc_hotbit.c
+++ b/Source/bmalloc/libpas/src/mbmalloc/mbmalloc_hotbit.c
@@ -35,17 +35,17 @@
 
 void* mbmalloc(size_t size)
 {
-    return hotbit_try_allocate(size);
+    return hotbit_try_allocate(size, pas_non_compact_allocation_mode);
 }
 
 void* mbmemalign(size_t alignment, size_t size)
 {
-    return hotbit_try_allocate_with_alignment(size, alignment);
+    return hotbit_try_allocate_with_alignment(size, alignment, pas_non_compact_allocation_mode);
 }
 
 void* mbrealloc(void* p, size_t ignored_old_size, size_t new_size)
 {
-    return hotbit_try_reallocate(p, new_size, pas_reallocate_free_if_successful);
+    return hotbit_try_reallocate(p, new_size, pas_reallocate_free_if_successful, pas_non_compact_allocation_mode);
 }
 
 void mbfree(void* p, size_t ignored_size)

--- a/Source/bmalloc/libpas/src/mbmalloc/mbmalloc_iso_common_primitive.c
+++ b/Source/bmalloc/libpas/src/mbmalloc/mbmalloc_iso_common_primitive.c
@@ -69,7 +69,7 @@ void* mbmalloc(size_t size)
     if (verbose)
         printf("malloc(%zu)\n", size);
     install_verifier_if_necessary();
-    return iso_try_allocate_common_primitive(size);
+    return iso_try_allocate_common_primitive(size, pas_non_compact_allocation_mode);
 }
 
 void* mbmemalign(size_t alignment, size_t size)
@@ -77,7 +77,7 @@ void* mbmemalign(size_t alignment, size_t size)
     if (verbose)
         printf("memalign(%zu, %zu)\n", alignment, size);
     install_verifier_if_necessary();
-    return iso_try_allocate_common_primitive_with_alignment(size, alignment);
+    return iso_try_allocate_common_primitive_with_alignment(size, alignment, pas_non_compact_allocation_mode);
 }
 
 void* mbrealloc(void* p, size_t ignored_old_size, size_t new_size)
@@ -85,7 +85,7 @@ void* mbrealloc(void* p, size_t ignored_old_size, size_t new_size)
     if (verbose)
         printf("realloc(%p, %zu)\n", p, new_size);
     install_verifier_if_necessary();
-    return iso_try_reallocate_common_primitive(p, new_size, pas_reallocate_free_if_successful);
+    return iso_try_reallocate_common_primitive(p, new_size, pas_reallocate_free_if_successful, pas_non_compact_allocation_mode);
 }
 
 void mbfree(void* p, size_t ignored_size)

--- a/Source/bmalloc/libpas/src/test/BitfitTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BitfitTests.cpp
@@ -108,7 +108,7 @@ void testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
     uintptr_t freedObjectEnd;
 
     for (size_t index = 0; index < numFirstObjects; ++index) {
-        void* ptr = iso_allocate_common_primitive(firstSize);
+        void* ptr = iso_allocate_common_primitive(firstSize, pas_non_compact_allocation_mode);
         if (verbose)
             cout << "Adding first object " << ptr << "\n";
         objects.push_back(ptr);
@@ -125,7 +125,7 @@ void testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
     vector<void*> fillerObjects;
     bool didStartAllocatingInFreedObject = false;
     for (;;) {
-        void* fillerObject = iso_allocate_common_primitive(fillerObjectSize);
+        void* fillerObject = iso_allocate_common_primitive(fillerObjectSize, pas_non_compact_allocation_mode);
         uintptr_t fillerObjectBegin = reinterpret_cast<uintptr_t>(fillerObject);
         uintptr_t fillerObjectEnd = fillerObjectBegin + fillerObjectSize;
         if (verbose)
@@ -146,7 +146,7 @@ void testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
         iso_deallocate(fillerObjects[index]);
 
     for (size_t index = 0; index < numAlignedObjects; ++index) {
-        void* ptr = iso_allocate_common_primitive_with_alignment(alignedSize, alignedSize);;
+        void* ptr = iso_allocate_common_primitive_with_alignment(alignedSize, alignedSize, pas_non_compact_allocation_mode);;
         if (verbose)
             cout << "Allocated aligned object " << ptr << "\n";
     }

--- a/Source/bmalloc/libpas/src/test/BmallocTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BmallocTests.cpp
@@ -34,13 +34,13 @@ namespace {
 
 void testBmallocAllocate()
 {
-    void* mem = bmalloc_try_allocate(100);
+    void* mem = bmalloc_try_allocate(100, pas_non_compact_allocation_mode);
     CHECK(mem);
 }
 
 void testBmallocDeallocate()
 {
-    void* mem = bmalloc_try_allocate(100);
+    void* mem = bmalloc_try_allocate(100, pas_non_compact_allocation_mode);
     CHECK(mem);
     bmalloc_deallocate(mem);
 }

--- a/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
@@ -206,7 +206,7 @@ void testBasicEnumeration() {
     auto size = 25;
     void* arr[size];
     for (auto i = 0; i < size; i++) {
-        arr[i] = bmalloc_try_allocate(1000000);
+        arr[i] = bmalloc_try_allocate(1000000, pas_non_compact_allocation_mode);
         PAS_ASSERT(arr[i]);
     }
 
@@ -230,13 +230,13 @@ void testPGMEnumerationBasic() {
     pas_heap_lock_lock();
 
     size_t alloc_size = 16384;
-    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
     pas_heap_lock_unlock();
@@ -261,13 +261,13 @@ void testPGMEnumerationAddAndFree() {
     pas_heap_lock_lock();
 
     size_t alloc_size = 16384;
-    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
     pas_probabilistic_guard_malloc_deallocate((void*) result.begin);

--- a/Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp
@@ -46,7 +46,7 @@ pas_heap_ref theHeap = BMALLOC_HEAP_REF_INITIALIZER(&theType);
 
 void testPayloadImpl(pas_heap_ref& heap, bool firstRun)
 {
-    void* object = bmalloc_iso_allocate(&heap);
+    void* object = bmalloc_iso_allocate(&heap, pas_non_compact_allocation_mode);
     CHECK(object);
     CHECK_EQUAL(bmalloc_get_allocation_size(object), 48);
 
@@ -58,23 +58,23 @@ void testPayloadImpl(pas_heap_ref& heap, bool firstRun)
         CHECK(!pas_large_expendable_memory_head);
     }
 
-    void* smallArray = bmalloc_iso_allocate_array_by_size(&heap, 100);
+    void* smallArray = bmalloc_iso_allocate_array_by_size(&heap, 100, pas_non_compact_allocation_mode);
     CHECK(smallArray);
     CHECK_EQUAL(bmalloc_get_allocation_size(smallArray), 112);
 
-    void* mediumArray = bmalloc_iso_allocate_array_by_size(&heap, 400);
+    void* mediumArray = bmalloc_iso_allocate_array_by_size(&heap, 400, pas_non_compact_allocation_mode);
     CHECK(mediumArray);
     CHECK_EQUAL(bmalloc_get_allocation_size(mediumArray), 400);
 
-    void* largeArray = bmalloc_iso_allocate_array_by_size(&heap, 2000);
+    void* largeArray = bmalloc_iso_allocate_array_by_size(&heap, 2000, pas_non_compact_allocation_mode);
     CHECK(largeArray);
     CHECK_EQUAL(bmalloc_get_allocation_size(largeArray), 2016);
 
-    void* largerArray = bmalloc_iso_allocate_array_by_size(&heap, 10000);
+    void* largerArray = bmalloc_iso_allocate_array_by_size(&heap, 10000, pas_non_compact_allocation_mode);
     CHECK(largerArray);
     CHECK_EQUAL(bmalloc_get_allocation_size(largerArray), 10752);
 
-    void* largestArray = bmalloc_iso_allocate_array_by_size(&heap, 100000);
+    void* largestArray = bmalloc_iso_allocate_array_by_size(&heap, 100000, pas_non_compact_allocation_mode);
     CHECK(largestArray);
     CHECK_EQUAL(bmalloc_get_allocation_size(largestArray), 100000);
 
@@ -232,7 +232,7 @@ void testRage(unsigned numHeaps, function<unsigned(unsigned)> allocationSize, un
             for (unsigned j = 0; j < count; ++j) {
                 pas_primitive_heap_ref* heap = heaps + deterministicRandomNumber(numHeaps);
                 size_t size = allocationSize(j);
-                void* ptr = bmalloc_allocate_flex(heap, size);
+                void* ptr = bmalloc_allocate_flex(heap, size, pas_non_compact_allocation_mode);
                 CHECK(ptr);
                 CHECK_GREATER_EQUAL(bmalloc_get_allocation_size(ptr), size);
                 CHECK_EQUAL(bmalloc_get_heap(ptr),
@@ -260,12 +260,12 @@ void testRematerializeAfterSearchOfDecommitted()
         new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")));
     pas_heap* heap = bmalloc_flex_heap_ref_get_heap(&heapRef);
 
-    void* ptr = bmalloc_allocate_flex(&heapRef, initialSize);
+    void* ptr = bmalloc_allocate_flex(&heapRef, initialSize, pas_non_compact_allocation_mode);
     CHECK_EQUAL(bmalloc_get_allocation_size(ptr), initialSize);
     CHECK_EQUAL(bmalloc_get_heap(ptr), heap);
     CHECK_EQUAL(heapRef.cached_index, pas_segregated_heap_index_for_size(initialSize, BMALLOC_HEAP_CONFIG));
 
-    ptr = bmalloc_allocate_flex(&heapRef, size);
+    ptr = bmalloc_allocate_flex(&heapRef, size, pas_non_compact_allocation_mode);
     CHECK_EQUAL(bmalloc_get_allocation_size(ptr), size);
     CHECK_EQUAL(bmalloc_get_heap(ptr), heap);
 
@@ -314,10 +314,10 @@ void testBasicSizeClass(unsigned firstSize, unsigned secondSize)
 
     if (verbose)
         cout << "Allocating " << firstSize << "\n";
-    void* ptr = bmalloc_allocate_flex(&heapRef, firstSize);
+    void* ptr = bmalloc_allocate_flex(&heapRef, firstSize, pas_non_compact_allocation_mode);
     if (verbose)
         cout << "Allocating " << secondSize << "\n";
-    bmalloc_allocate_flex(&heapRef, secondSize);
+    bmalloc_allocate_flex(&heapRef, secondSize, pas_non_compact_allocation_mode);
 
     if (verbose)
         cout << "Doing some checks.\n";

--- a/Source/bmalloc/libpas/src/test/HeapRefAllocatorIndexTests.cpp
+++ b/Source/bmalloc/libpas/src/test/HeapRefAllocatorIndexTests.cpp
@@ -35,11 +35,11 @@ void testIsoAllocate(size_t requestedSize, size_t actualSize)
 {
     pas_heap_ref heap = ISO_HEAP_REF_INITIALIZER(requestedSize);
 
-    void* object = iso_allocate(&heap);
+    void* object = iso_allocate(&heap, pas_non_compact_allocation_mode);
     CHECK_EQUAL(iso_get_allocation_size(object), actualSize);
     CHECK_LESS(heap.allocator_index, 10000);
 
-    void* object2 = iso_allocate(&heap);
+    void* object2 = iso_allocate(&heap, pas_non_compact_allocation_mode);
     CHECK_NOT_EQUAL(object, object2);
     CHECK_EQUAL(iso_get_allocation_size(object2), actualSize);
 }
@@ -48,11 +48,11 @@ void testAllocatePrimitive(size_t requestedSize, size_t actualSize)
 {
     pas_primitive_heap_ref heap = ISO_PRIMITIVE_HEAP_REF_INITIALIZER;
 
-    void* object = iso_allocate_primitive(&heap, requestedSize);
+    void* object = iso_allocate_primitive(&heap, requestedSize, pas_non_compact_allocation_mode);
     CHECK_EQUAL(iso_get_allocation_size(object), actualSize);
     CHECK_LESS(heap.base.allocator_index, 10000);
 
-    void* object2 = iso_allocate_primitive(&heap, requestedSize);
+    void* object2 = iso_allocate_primitive(&heap, requestedSize, pas_non_compact_allocation_mode);
     CHECK_NOT_EQUAL(object, object2);
     CHECK_EQUAL(iso_get_allocation_size(object2), actualSize);
 }

--- a/Source/bmalloc/libpas/src/test/IsoDynamicPrimitiveHeapTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoDynamicPrimitiveHeapTests.cpp
@@ -41,18 +41,18 @@ namespace {
 
 void* allocate42(unsigned sizeIndex, const void* key)
 {
-    return iso_try_allocate_dynamic_primitive(key, 42 * (sizeIndex + 1));
+    return iso_try_allocate_dynamic_primitive(key, 42 * (sizeIndex + 1), pas_non_compact_allocation_mode);
 }
 
 void* allocate42WithAlignment(unsigned sizeIndex, const void* key)
 {
-    return iso_try_allocate_dynamic_primitive_with_alignment(key, 42 * (sizeIndex + 1), 32);
+    return iso_try_allocate_dynamic_primitive_with_alignment(key, 42 * (sizeIndex + 1), 32, pas_non_compact_allocation_mode);
 }
 
 void* allocate42Zeroed(unsigned sizeIndex, const void* key)
 {
     char* result = static_cast<char*>(
-        iso_try_allocate_dynamic_primitive_zeroed(key, 42 * (sizeIndex + 1)));
+        iso_try_allocate_dynamic_primitive_zeroed(key, 42 * (sizeIndex + 1), pas_non_compact_allocation_mode));
     for (unsigned i = 42; i--;)
         CHECK(!result[i]);
     return result;
@@ -60,10 +60,10 @@ void* allocate42Zeroed(unsigned sizeIndex, const void* key)
 
 void* reallocate42(unsigned sizeIndex, const void* key)
 {
-    void* result = iso_try_allocate_common_primitive(16);
+    void* result = iso_try_allocate_common_primitive(16, pas_non_compact_allocation_mode);
     CHECK(result);
     return iso_try_reallocate_dynamic_primitive(
-        result, key, 42 * (sizeIndex + 1), pas_reallocate_free_if_successful);
+        result, key, 42 * (sizeIndex + 1), pas_reallocate_free_if_successful, pas_non_compact_allocation_mode);
 }
 
 void testManySizesAndKeys(

--- a/Source/bmalloc/libpas/src/test/IsoHeapPageSharingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapPageSharingTests.cpp
@@ -93,7 +93,7 @@ void testTakePages(unsigned firstObjectSize,
     
     for (size_t index = firstCount; index--;) {
         pas_page_sharing_pool_verify(&pas_physical_page_sharing_pool, pas_lock_is_not_held);
-        void* object = iso_try_allocate(&firstHeapRef);
+        void* object = iso_try_allocate(&firstHeapRef, pas_non_compact_allocation_mode);
         CHECK(object);
         CHECK(!objects.count(object));
         objects.insert(object);
@@ -158,7 +158,7 @@ void testTakePages(unsigned firstObjectSize,
         if (verbose)
             cout << "Allocating.\n";
         
-        void* object = iso_try_allocate(&secondHeapRef);
+        void* object = iso_try_allocate(&secondHeapRef, pas_non_compact_allocation_mode);
 
         if (verbose)
             cout << "Did allocate.\n";
@@ -195,7 +195,7 @@ void testTakePages(unsigned firstObjectSize,
     
     for (size_t index = 0; index < thirdCount; ++index) {
         pas_page_sharing_pool_verify(&pas_physical_page_sharing_pool, pas_lock_is_not_held);
-        void* object = iso_try_allocate(&firstHeapRef);
+        void* object = iso_try_allocate(&firstHeapRef, pas_non_compact_allocation_mode);
         CHECK(object);
         CHECK(!objects.count(object));
         objects.insert(object);
@@ -241,7 +241,7 @@ void testTakePagesFromCorrectHeap(unsigned numHeaps,
     auto allocate = [&] (unsigned i) {
         if (verbose)
             cout << "Allocating i = " << i << ", size = " << sizeFunc(i) << "\n";
-        objects[i] = iso_try_allocate(heapRefs + i);
+        objects[i] = iso_try_allocate((heapRefs + i), pas_non_compact_allocation_mode);
         if (verbose)
             cout << "    Allocated object at " << objects[i] << "\n";
         directories[i] = pas_segregated_size_directory_for_object(
@@ -360,11 +360,11 @@ void testLargeHeapTakesPagesFromCorrectSmallHeap()
     };
     
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_get(&iso_heap_config),
@@ -428,7 +428,7 @@ void testLargeHeapTakesPagesFromCorrectSmallHeap()
     if (verbose)
         cout << "Allocating big object.\n";
     
-    addObject(iso_try_allocate(&heapRefFour));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -485,11 +485,11 @@ void testLargeHeapTakesPagesFromCorrectSmallHeapAllocateAfterFree()
     };
     
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_get(&iso_heap_config),
@@ -522,7 +522,7 @@ void testLargeHeapTakesPagesFromCorrectSmallHeapAllocateAfterFree()
         iso_deallocate(object);
     objects.clear();
     
-    iso_deallocate(checkObject(iso_try_allocate(&heapRefOne)));
+    iso_deallocate(checkObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode)));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_get(&iso_heap_config),
@@ -555,7 +555,7 @@ void testLargeHeapTakesPagesFromCorrectSmallHeapAllocateAfterFree()
     if (verbose)
         cout << "Allocating big object.\n";
     
-    checkObject(iso_try_allocate(&heapRefFour));
+    checkObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -608,13 +608,13 @@ void testLargeHeapTakesPagesFromCorrectSmallHeapWithFancyOrder()
     };
     
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_get(&iso_heap_config),
@@ -678,7 +678,7 @@ void testLargeHeapTakesPagesFromCorrectSmallHeapWithFancyOrder()
     if (verbose)
         cout << "Allocating big object.\n";
     
-    addObject(iso_try_allocate(&heapRefFour));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -733,11 +733,11 @@ void testLargeHeapTakesPagesFromCorrectLargeHeap()
     };
     
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_get(&iso_heap_config),
@@ -801,7 +801,7 @@ void testLargeHeapTakesPagesFromCorrectLargeHeap()
     if (verbose)
         cout << "Allocating big object.\n";
     
-    addObject(iso_try_allocate(&heapRefFour));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -869,11 +869,11 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
     };
     
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_get(&iso_heap_config),
@@ -908,7 +908,7 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
 
     // Use the first heap a decent amount.
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
 
     deleteAllObjects();
 
@@ -943,7 +943,7 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
     if (verbose)
         cout << "Allocating big object.\n";
     
-    checkObject(iso_try_allocate(&heapRefFour));
+    checkObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -1018,11 +1018,11 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
         cout << "Filling up heaps 1-3.\n";
     
     for (size_t size = 0; size < 10000000; size += 2000000)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1069,7 +1069,7 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
         cout << "Filling up heap 1 and emptying it again.\n";
     
     for (size_t size = 0; size < 10000000; size += 2000000)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (void* object : objects)
         iso_deallocate(object);
     objects.clear();
@@ -1101,7 +1101,7 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
     if (verbose)
         cout << "Allocating big object.\n";
     
-    checkObject(iso_try_allocate(&heapRefFour));
+    checkObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -1157,13 +1157,13 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapWithFancyOrder()
     };
     
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1230,7 +1230,7 @@ void testLargeHeapTakesPagesFromCorrectLargeHeapWithFancyOrder()
     if (verbose)
         cout << "Allocating big object.\n";
     
-    addObject(iso_try_allocate(&heapRefFour));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     if (verbose)
         cout << "Did allocate big object.\n";
@@ -1288,10 +1288,10 @@ void testSmallHeapTakesPagesFromCorrectLargeHeap()
     };
     
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
-    addObject(iso_try_allocate(&heapRefFour));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1355,7 +1355,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeap()
     if (verbose)
         cout << "Allocating small object.\n";
     
-    addObject(iso_try_allocate(&heapRefTwo));
+    addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1388,7 +1388,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeap()
     // It's possible that heap four has also been decommitted, if it was adjacent to heap three.
     
     for (size_t size = 512; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1447,12 +1447,12 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapWithFancyOrder()
     };
     
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
-    addObject(iso_try_allocate(&heapRefFour));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 5000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1516,7 +1516,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapWithFancyOrder()
     if (verbose)
         cout << "Allocating small object.\n";
     
-    addObject(iso_try_allocate(&heapRefTwo));
+    addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1549,7 +1549,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapWithFancyOrder()
     // It's possible that heap four has also been decommitted, if it was adjacent to heap three.
     
     for (size_t size = 512; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1612,10 +1612,10 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
     };
     
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
-    addObject(iso_try_allocate(&heapRefFour));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1653,7 +1653,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
                                   pas_lock_is_not_held);
 
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     for (void* object : objects)
         iso_deallocate(object);
     objects.clear();
@@ -1689,7 +1689,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
     if (verbose)
         cout << "Allocating small object.\n";
     
-    checkObject(iso_try_allocate(&heapRefTwo));
+    checkObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1722,7 +1722,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap()
     // It's possible that heap four has also been decommitted, if it was adjacent to heap three.
     
     for (size_t size = 512; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1785,11 +1785,11 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
         objects.push_back(checkObject(object));
     };
     
-    addObject(iso_try_allocate(&heapRefFour));
+    addObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 1000000)
-        addObject(iso_try_allocate(&heapRefThree));
+        addObject(iso_try_allocate(&heapRefThree, pas_non_compact_allocation_mode));
     for (size_t size = 0; size < 10000000; size += 64)
-        addObject(iso_try_allocate(&heapRefOne));
+        addObject(iso_try_allocate(&heapRefOne, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1826,7 +1826,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
                                   pas_lock_is_not_held);
     
-    iso_deallocate(checkObject(iso_try_allocate(&heapRefFour)));
+    iso_deallocate(checkObject(iso_try_allocate(&heapRefFour, pas_non_compact_allocation_mode)));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1859,7 +1859,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
     if (verbose)
         cout << "Allocating small object.\n";
     
-    checkObject(iso_try_allocate(&heapRefTwo));
+    checkObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -1893,7 +1893,7 @@ void testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeH
     CHECK_EQUAL(summaryFour.decommitted, 0);
     
     for (size_t size = 512; size < 10000000; size += 512)
-        addObject(iso_try_allocate(&heapRefTwo));
+        addObject(iso_try_allocate(&heapRefTwo, pas_non_compact_allocation_mode));
     
     pas_baseline_allocator_table_for_all(pas_allocator_scavenge_force_stop_action);
     pas_thread_local_cache_shrink(pas_thread_local_cache_try_get(),
@@ -2074,27 +2074,27 @@ void allocateThingiesImpl(ThingyKind kind, AllocationKind allocateMany)
     switch (kind) {
     case SmallHeapOne:
         for (unsigned i = allocateMany ? 156250 : 1; i--;)
-            addObject(iso_try_allocate(&smallHeapRefOne));
+            addObject(iso_try_allocate(&smallHeapRefOne, pas_non_compact_allocation_mode));
         return;
     case SmallHeapTwo:
         for (unsigned i = allocateMany ? 39062 : 1; i--;)
-            addObject(iso_try_allocate(&smallHeapRefTwo));
+            addObject(iso_try_allocate(&smallHeapRefTwo, pas_non_compact_allocation_mode));
         return;
     case SmallHeapThree:
         for (unsigned i = allocateMany ? 33112 : 1; i--;)
-            addObject(iso_try_allocate(&smallHeapRefThree));
+            addObject(iso_try_allocate(&smallHeapRefThree, pas_non_compact_allocation_mode));
         return;
     case LargeHeapOne:
         for (unsigned i = allocateMany ? 5 : 1; i--;)
-            addObject(iso_try_allocate(&largeHeapRefOne));
+            addObject(iso_try_allocate(&largeHeapRefOne, pas_non_compact_allocation_mode));
         return;
     case LargeHeapTwo:
         for (unsigned i = allocateMany ? 19 : 1; i--;)
-            addObject(iso_try_allocate(&largeHeapRefTwo));
+            addObject(iso_try_allocate(&largeHeapRefTwo, pas_non_compact_allocation_mode));
         return;
     case PrimitiveSmallOne:
         for (unsigned i = allocateMany ? 156250 : 1; i--;) {
-            void* object = addObject(iso_try_allocate_common_primitive(32));
+            void* object = addObject(iso_try_allocate_common_primitive(32, pas_non_compact_allocation_mode));
             
             pas_segregated_size_directory* directory;
             
@@ -2110,7 +2110,7 @@ void allocateThingiesImpl(ThingyKind kind, AllocationKind allocateMany)
         return;
     case PrimitiveSmallTwo:
         for (unsigned i = allocateMany ? 39062 : 1; i--;) {
-            void* object = addObject(iso_try_allocate_common_primitive(128));
+            void* object = addObject(iso_try_allocate_common_primitive(128, pas_non_compact_allocation_mode));
             
             pas_segregated_size_directory* directory;
             
@@ -2126,7 +2126,7 @@ void allocateThingiesImpl(ThingyKind kind, AllocationKind allocateMany)
         return;
     case PrimitiveSmallThree:
         for (unsigned i = allocateMany ? 104166 : 1; i--;) {
-            void* object = addObject(iso_try_allocate_common_primitive(48));
+            void* object = addObject(iso_try_allocate_common_primitive(48, pas_non_compact_allocation_mode));
             
             pas_segregated_size_directory* directory;
             
@@ -2142,7 +2142,7 @@ void allocateThingiesImpl(ThingyKind kind, AllocationKind allocateMany)
         return;
     case PrimitiveLarge:
         for (unsigned i = allocateMany ? 19 : 1; i--;)
-            addObject(iso_try_allocate_common_primitive(254384));
+            addObject(iso_try_allocate_common_primitive(254384, pas_non_compact_allocation_mode));
         return;
     }
     PAS_ASSERT(!"Should not be reached");
@@ -4280,7 +4280,7 @@ void testScavengerEventuallyReturnsMemory(unsigned objectSize,
     vector<void*> objectList;
 
     for (size_t index = count; index--;) {
-        void* object = iso_try_allocate(&heapRef);
+        void* object = iso_try_allocate(&heapRef, pas_non_compact_allocation_mode);
         CHECK(object);
         objectList.push_back(object);
     }
@@ -4326,7 +4326,7 @@ void testScavengerEventuallyReturnsMemoryEvenWithoutManualShrink(unsigned object
     vector<void*> objectList;
 
     for (size_t index = count; index--;) {
-        void* object = iso_try_allocate(&heapRef);
+        void* object = iso_try_allocate(&heapRef, pas_non_compact_allocation_mode);
         CHECK(object);
         objectList.push_back(object);
     }

--- a/Source/bmalloc/libpas/src/test/IsoHeapReservedMemoryTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapReservedMemoryTests.cpp
@@ -58,7 +58,7 @@ void testSizeProgression(size_t startSize,
             cout << "Allocating " << size << "\n";
         
         for (size_t i = countForSize; i--;) {
-            void* object = iso_try_allocate_primitive(&heapRef, size);
+            void* object = iso_try_allocate_primitive(&heapRef, size, pas_non_compact_allocation_mode);
             
             if (shouldSucceed)
                 CHECK(object);

--- a/Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp
+++ b/Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp
@@ -48,7 +48,7 @@ void testLotsOfHeapsAndThreads(unsigned numHeaps, unsigned numThreads, unsigned 
         threads[i] = thread([&] () {
             for (unsigned j = count; j--;) {
                 for (unsigned k = numHeaps; k--;) {
-                    void* ptr = bmalloc_iso_allocate(heaps + k);
+                    void* ptr = bmalloc_iso_allocate(heaps + k, pas_non_compact_allocation_mode);
                     CHECK_EQUAL(pas_get_heap(ptr, BMALLOC_HEAP_CONFIG),
                                 bmalloc_heap_ref_get_heap(heaps + k));
                     bmalloc_deallocate(ptr);

--- a/Source/bmalloc/libpas/src/test/MemalignTests.cpp
+++ b/Source/bmalloc/libpas/src/test/MemalignTests.cpp
@@ -44,7 +44,7 @@ void testMemalignArray(size_t size, size_t typeSize, size_t typeAlignment)
     pas_segregated_view view;
     pas_segregated_size_directory* directory;
 
-    void* ptr = bmalloc_iso_allocate_zeroed_array_by_size(&heapRef, size);
+    void* ptr = bmalloc_iso_allocate_zeroed_array_by_size(&heapRef, size, pas_non_compact_allocation_mode);
     CHECK(ptr);
 
     view = pas_segregated_view_for_object(reinterpret_cast<uintptr_t>(ptr), &bmalloc_heap_config);

--- a/Source/bmalloc/libpas/src/test/RaceTests.cpp
+++ b/Source/bmalloc/libpas/src/test/RaceTests.cpp
@@ -157,7 +157,7 @@ void testLocalAllocatorStopRace(pas_race_test_hook_kind kindToStopOn)
 
     thread thread1 = thread(
         [&] () {
-            void* ptr = iso_allocate(&heap);
+            void* ptr = iso_allocate(&heap, pas_non_compact_allocation_mode);
             CHECK(ptr);
             CHECK(pas_segregated_view_is_exclusive(
                       pas_segregated_view_for_object(
@@ -179,7 +179,7 @@ void testLocalAllocatorStopRace(pas_race_test_hook_kind kindToStopOn)
         globalCond.notify_all();
     }
 
-    void* ptr = iso_allocate(&heap);
+    void* ptr = iso_allocate(&heap, pas_non_compact_allocation_mode);
     if (kindToStopOn == pas_race_test_hook_local_allocator_stop_before_unlock)
         CHECK_EQUAL(ptr, thePtr);
     thread1.join();
@@ -218,7 +218,7 @@ void testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_kind kindToSto
 
     thread thread1 = thread(
         [&] () {
-            void* ptr = iso_allocate(&heap);
+            void* ptr = iso_allocate(&heap, pas_non_compact_allocation_mode);
             CHECK(ptr);
             CHECK(pas_segregated_view_is_exclusive(
                       pas_segregated_view_for_object(
@@ -242,7 +242,7 @@ void testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_kind kindToSto
 
     pas_scavenger_decommit_free_memory();
 
-    void* ptr = iso_allocate(&heap);
+    void* ptr = iso_allocate(&heap, pas_non_compact_allocation_mode);
     if (kindToStopOn == pas_race_test_hook_local_allocator_stop_before_unlock)
         CHECK_EQUAL(ptr, thePtr);
     hookShouldStop = true;

--- a/Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp
+++ b/Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp
@@ -72,7 +72,7 @@ void testTLCDecommit(unsigned numHeaps,
 
     vector<void*> objects;
     for (size_t index = 0; index < numHeaps; ++index) {
-        void* ptr = bmalloc_iso_allocate(heaps + index);
+        void* ptr = bmalloc_iso_allocate(heaps + index, pas_non_compact_allocation_mode);
         CHECK(ptr);
         CHECK_EQUAL(pas_get_heap(ptr, BMALLOC_HEAP_CONFIG),
                     bmalloc_heap_ref_get_heap(heaps + index));
@@ -172,7 +172,7 @@ void testTLCDecommit(unsigned numHeaps,
         pas_lock_is_not_held);
 
     for (size_t index = 0; index < numHeaps; ++index) {
-        void* ptr = bmalloc_iso_allocate(heaps + index);
+        void* ptr = bmalloc_iso_allocate(heaps + index, pas_non_compact_allocation_mode);
         CHECK(ptr);
         CHECK_EQUAL(pas_get_heap(ptr, BMALLOC_HEAP_CONFIG),
                     bmalloc_heap_ref_get_heap(heaps + index));
@@ -225,7 +225,7 @@ void testChaosThenDecommit(unsigned numHeaps, unsigned typeSize, unsigned maxObj
             while (numObjectsNow--) {
                 if (!deterministicRandomNumber(maxFromSameHeap))
                     selectNextHeap();
-                void* ptr = bmalloc_iso_allocate(heapRef);
+                void* ptr = bmalloc_iso_allocate(heapRef, pas_non_compact_allocation_mode);
                 CHECK(ptr);
                 CHECK_EQUAL(pas_get_heap(ptr, BMALLOC_HEAP_CONFIG),
                             bmalloc_heap_ref_get_heap(heapRef));
@@ -269,7 +269,7 @@ vector<void*> prepareToTestDLCDecommitThenStuff(unsigned numHeaps)
         for (size_t objectIndex = pas_segregated_page_number_of_objects(
                  512, BMALLOC_HEAP_CONFIG.small_segregated_config, pas_segregated_page_exclusive_role);
              objectIndex--;) {
-            void* ptr = bmalloc_iso_allocate(heaps + index);
+            void* ptr = bmalloc_iso_allocate(heaps + index, pas_non_compact_allocation_mode);
             CHECK(ptr);
             CHECK_EQUAL(pas_get_heap(ptr, BMALLOC_HEAP_CONFIG),
                         bmalloc_heap_ref_get_heap(heaps + index));
@@ -363,7 +363,7 @@ void testAllocateFromStoppedBaselineImpl()
     pas_heap_ref heapRef = BMALLOC_HEAP_REF_INITIALIZER(
         new bmalloc_type(BMALLOC_TYPE_INITIALIZER(32, 1, "test")));
 
-    void* ptr = bmalloc_iso_allocate(&heapRef);
+    void* ptr = bmalloc_iso_allocate(&heapRef, pas_non_compact_allocation_mode);
     CHECK(ptr);
     pas_segregated_view view = pas_segregated_view_for_object(
         reinterpret_cast<uintptr_t>(ptr), &bmalloc_heap_config);
@@ -389,7 +389,7 @@ void testAllocateFromStoppedBaselineImpl()
     if (verbose)
         cout << "TLC = " << pas_thread_local_cache_try_get() << "\n";
 
-    ptr = bmalloc_iso_allocate(&heapRef);
+    ptr = bmalloc_iso_allocate(&heapRef, pas_non_compact_allocation_mode);
     CHECK(ptr);
 }
 

--- a/Source/bmalloc/libpas/src/test/TSDTests.cpp
+++ b/Source/bmalloc/libpas/src/test/TSDTests.cpp
@@ -46,19 +46,19 @@ void destructor(void* value)
     PAS_UNUSED_PARAM(value);
     for (pthread_key_t key : keys)
         pthread_setspecific(key, "infinite loop");
-    iso_deallocate(iso_allocate_common_primitive(666));
+    iso_deallocate(iso_allocate_common_primitive(666, pas_non_compact_allocation_mode));
     iso_deallocate(iso_reallocate_common_primitive(
-                       iso_allocate_common_primitive(666), 1337, pas_reallocate_free_if_successful));
-    iso_deallocate(iso_allocate(&isoHeap));
-    iso_deallocate(iso_allocate_array_by_count(&isoHeap, 100, 1));
-    iso_deallocate(iso_allocate_array_by_count(&isoHeap, 100, 64));
+                       iso_allocate_common_primitive(666, pas_non_compact_allocation_mode), 1337, pas_reallocate_free_if_successful, pas_non_compact_allocation_mode));
+    iso_deallocate(iso_allocate(&isoHeap, pas_non_compact_allocation_mode));
+    iso_deallocate(iso_allocate_array_by_count(&isoHeap, 100, 1, pas_non_compact_allocation_mode));
+    iso_deallocate(iso_allocate_array_by_count(&isoHeap, 100, 64, pas_non_compact_allocation_mode));
     iso_deallocate(iso_reallocate_array_by_count(
-                       iso_allocate(&isoHeap), &isoHeap, 200, pas_reallocate_free_if_successful));
-    iso_deallocate(iso_allocate_primitive(&isoPrimitiveHeap, 666));
-    iso_deallocate(iso_allocate_primitive_with_alignment(&isoPrimitiveHeap, 128, 64));
+                       iso_allocate(&isoHeap, pas_non_compact_allocation_mode), &isoHeap, 200, pas_reallocate_free_if_successful, pas_non_compact_allocation_mode));
+    iso_deallocate(iso_allocate_primitive(&isoPrimitiveHeap, 666, pas_non_compact_allocation_mode));
+    iso_deallocate(iso_allocate_primitive_with_alignment(&isoPrimitiveHeap, 128, 64, pas_non_compact_allocation_mode));
     iso_deallocate(iso_reallocate_primitive(
-                       iso_allocate_primitive(&isoPrimitiveHeap, 666), &isoPrimitiveHeap, 1337,
-                       pas_reallocate_free_if_successful));
+                       iso_allocate_primitive(&isoPrimitiveHeap, 666, pas_non_compact_allocation_mode), &isoPrimitiveHeap, 1337,
+                       pas_reallocate_free_if_successful, pas_non_compact_allocation_mode));
 }
 
 void testTSD(unsigned numKeysBeforeAllocation,
@@ -104,7 +104,7 @@ void testTSD(unsigned numKeysBeforeAllocation,
                 initializeJSCKeys();
             initializeKeys(numKeysBeforeAllocation);
             for (unsigned i = numAllocations; i--;)
-                iso_deallocate(iso_allocate_common_primitive(allocationSize));
+                iso_deallocate(iso_allocate_common_primitive(allocationSize, pas_non_compact_allocation_mode));
             if (initializeJSCKeysAfterAllocation)
                 initializeJSCKeys();
             initializeKeys(numKeysAfterAllocation);

--- a/Source/bmalloc/libpas/src/test/ViewCacheTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ViewCacheTests.cpp
@@ -51,7 +51,7 @@ void testDisableViewCacheUsingBoundForNoViewCache()
 
     bmalloc_intrinsic_runtime_config.base.directory_size_bound_for_no_view_cache = UINT_MAX;
 
-    bmalloc_deallocate(bmalloc_allocate(42));
+    bmalloc_deallocate(bmalloc_allocate(42, pas_non_compact_allocation_mode));
 }
 
 void testEnableViewCacheAtSomeBoundForNoViewCache(unsigned bound)
@@ -60,7 +60,7 @@ void testEnableViewCacheAtSomeBoundForNoViewCache(unsigned bound)
 
     bmalloc_intrinsic_runtime_config.base.directory_size_bound_for_no_view_cache = bound;
 
-    void* ptr = bmalloc_allocate(42);
+    void* ptr = bmalloc_allocate(42, pas_non_compact_allocation_mode);
     pas_segregated_view view = pas_segregated_view_for_object(
         reinterpret_cast<uintptr_t>(ptr), &bmalloc_heap_config);
     pas_segregated_size_directory* theDirectory = pas_segregated_view_get_size_directory(view);
@@ -71,7 +71,7 @@ void testEnableViewCacheAtSomeBoundForNoViewCache(unsigned bound)
     views.insert(view);
 
     for (;;) {
-        ptr = bmalloc_allocate(42);
+        ptr = bmalloc_allocate(42, pas_non_compact_allocation_mode);
         view = pas_segregated_view_for_object(reinterpret_cast<uintptr_t>(ptr), &bmalloc_heap_config);
         pas_segregated_size_directory* directory = pas_segregated_view_get_size_directory(view);
 


### PR DESCRIPTION
#### 51f42fcfcb404e74af4070bf068805155b889178
<pre>
&quot;libpas test suit is broken due to recent profile and track allocation mode change&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=274554">https://bugs.webkit.org/show_bug.cgi?id=274554</a>
<a href="https://rdar.apple.com/128497967">rdar://128497967</a>

Reviewed by Yusuke Suzuki.

libpas test build fails due to recent change (122419407).
Fixed the files to add allocation mode..

* Source/bmalloc/libpas/src/chaos/Chaos.cpp:
(std::threadMain):
* Source/bmalloc/libpas/src/libpas/hotbit_heap.c:
(hotbit_try_allocate):
(hotbit_try_allocate_with_alignment):
(hotbit_try_reallocate):
* Source/bmalloc/libpas/src/libpas/hotbit_heap.h:
* Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:
(hotbit_try_allocate_inline):
(hotbit_try_allocate_with_alignment_inline):
(hotbit_try_reallocate_inline):
* Source/bmalloc/libpas/src/libpas/iso_heap.c:
(iso_try_allocate_common_primitive):
(iso_try_allocate_common_primitive_with_alignment):
(iso_try_allocate_common_primitive_zeroed):
(iso_allocate_common_primitive):
(iso_allocate_common_primitive_with_alignment):
(iso_allocate_common_primitive_zeroed):
(iso_try_reallocate_common_primitive):
(iso_reallocate_common_primitive):
(iso_try_allocate_dynamic_primitive):
(iso_try_allocate_dynamic_primitive_with_alignment):
(iso_try_allocate_dynamic_primitive_zeroed):
(iso_try_reallocate_dynamic_primitive):
(iso_try_allocate):
(iso_allocate):
(iso_try_allocate_array_by_count):
(iso_allocate_array_by_count):
(iso_try_allocate_array_by_count_zeroed):
(iso_allocate_array_by_count_zeroed):
(iso_try_reallocate_array_by_count):
(iso_reallocate_array_by_count):
(iso_try_allocate_primitive):
(iso_allocate_primitive):
(iso_try_allocate_primitive_zeroed):
(iso_allocate_primitive_zeroed):
(iso_try_allocate_primitive_with_alignment):
(iso_allocate_primitive_with_alignment):
(iso_try_reallocate_primitive):
(iso_reallocate_primitive):
(iso_try_allocate_for_flex):
* Source/bmalloc/libpas/src/libpas/iso_heap.h:
* Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h:
(iso_try_allocate_common_primitive_inline):
(iso_try_allocate_common_primitive_with_alignment_inline):
(iso_try_allocate_common_primitive_zeroed_inline):
(iso_allocate_common_primitive_inline):
(iso_allocate_common_primitive_with_alignment_inline):
(iso_allocate_common_primitive_zeroed_inline):
(iso_try_reallocate_common_primitive_inline):
(iso_reallocate_common_primitive_inline):
(iso_try_allocate_inline):
(iso_allocate_inline):
(iso_try_allocate_array_by_count_inline):
(iso_allocate_array_by_count_inline):
(iso_try_allocate_array_by_count_zeroed_inline):
(iso_allocate_array_by_count_zeroed_inline):
(iso_try_reallocate_array_by_count_inline):
(iso_reallocate_array_by_count_inline):
(iso_try_allocate_primitive_inline):
(iso_allocate_primitive_inline):
(iso_try_allocate_primitive_zeroed_inline):
(iso_allocate_primitive_zeroed_inline):
(iso_try_allocate_primitive_with_alignment_inline):
(iso_allocate_primitive_with_alignment_inline):
(iso_try_reallocate_primitive_inline):
(iso_reallocate_primitive_inline):
(iso_try_allocate_for_flex_inline):
* Source/bmalloc/libpas/src/libpas/iso_test_heap.c:
(iso_test_allocate_common_primitive):
(iso_test_allocate):
(iso_test_allocate_array_by_count):
* Source/bmalloc/libpas/src/libpas/iso_test_heap.h:
* Source/bmalloc/libpas/src/libpas/jit_heap.c:
(jit_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/jit_heap.h:
* Source/bmalloc/libpas/src/libpas/minalign32_heap.c:
(minalign32_allocate_common_primitive):
(minalign32_allocate):
(minalign32_allocate_array_by_count):
* Source/bmalloc/libpas/src/libpas/minalign32_heap.h:
* Source/bmalloc/libpas/src/libpas/pagesize64k_heap.c:
(pagesize64k_allocate_common_primitive):
(pagesize64k_allocate):
(pagesize64k_allocate_array_by_count):
* Source/bmalloc/libpas/src/libpas/pagesize64k_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h:
* Source/bmalloc/libpas/src/libpas/thingy_heap.c:
(thingy_try_allocate_primitive):
(thingy_try_allocate_primitive_zeroed):
(thingy_try_allocate_primitive_with_alignment):
(thingy_try_reallocate_primitive):
(thingy_try_allocate):
(thingy_try_allocate_zeroed):
(thingy_try_allocate_array):
(thingy_try_allocate_zeroed_array):
(thingy_try_reallocate_array):
(thingy_utility_heap_allocate):
* Source/bmalloc/libpas/src/libpas/thingy_heap.h:
* Source/bmalloc/libpas/src/libpas/thingy_heap_prefix.h:
* Source/bmalloc/libpas/src/mbmalloc/mbmalloc_bmalloc.c:
(mbmalloc):
(mbmemalign):
(mbrealloc):
* Source/bmalloc/libpas/src/mbmalloc/mbmalloc_hotbit.c:
(mbmalloc):
(mbmemalign):
(mbrealloc):
* Source/bmalloc/libpas/src/mbmalloc/mbmalloc_iso_common_primitive.c:
(mbmalloc):
(mbmemalign):
(mbrealloc):
* Source/bmalloc/libpas/src/test/BitfitTests.cpp:
(std::testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable):
* Source/bmalloc/libpas/src/test/BmallocTests.cpp:
(std::testBmallocAllocate):
(std::testBmallocDeallocate):
* Source/bmalloc/libpas/src/test/EnumerationTests.cpp:
(std::testBasicEnumeration):
(std::testPGMEnumerationBasic):
(std::testPGMEnumerationAddAndFree):
* Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp:
(std::testPayloadImpl):
(std::testRage):
(std::testRematerializeAfterSearchOfDecommitted):
(std::testBasicSizeClass):
* Source/bmalloc/libpas/src/test/HeapRefAllocatorIndexTests.cpp:
* Source/bmalloc/libpas/src/test/IsoDynamicPrimitiveHeapTests.cpp:
(std::allocate42):
(std::allocate42WithAlignment):
(std::allocate42Zeroed):
(std::reallocate42):
* Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp:
(std::gigacageAllocate):
(std::testAllocationChaos):
* Source/bmalloc/libpas/src/test/IsoHeapPageSharingTests.cpp:
(std::testTakePages):
(std::testTakePagesFromCorrectHeap):
(std::testLargeHeapTakesPagesFromCorrectSmallHeap):
(std::testLargeHeapTakesPagesFromCorrectSmallHeapAllocateAfterFree):
(std::testLargeHeapTakesPagesFromCorrectSmallHeapWithFancyOrder):
(std::testLargeHeapTakesPagesFromCorrectLargeHeap):
(std::testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap):
(std::testLargeHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeHeap):
(std::testLargeHeapTakesPagesFromCorrectLargeHeapWithFancyOrder):
(std::testSmallHeapTakesPagesFromCorrectLargeHeap):
(std::testSmallHeapTakesPagesFromCorrectLargeHeapWithFancyOrder):
(std::testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnSmallHeap):
(std::testSmallHeapTakesPagesFromCorrectLargeHeapAllocateAfterFreeOnAnotherLargeHeap):
(std::allocateThingiesImpl):
(std::testScavengerEventuallyReturnsMemory):
(std::testScavengerEventuallyReturnsMemoryEvenWithoutManualShrink):
* Source/bmalloc/libpas/src/test/IsoHeapPartialAndBaselineTests.cpp:
(std::testSimplePartialAllocations):
(std::testFreeAroundPrimordialStop):
(std::testFreeInterleavedAroundPrimordialStop):
(std::testMultiplePartialsFromDifferentHeapsPerShared):
(std::testMultiplePartialsFromDifferentThreadsPerShared):
(std::testTwoBaselinesEvictions):
* Source/bmalloc/libpas/src/test/IsoHeapReservedMemoryTests.cpp:
(std::testSizeProgression):
* Source/bmalloc/libpas/src/test/JITHeapTests.cpp:
(std::testAllocateShrinkAndAllocate):
(std::testAllocationSize):
* Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp:
(std::testLotsOfHeapsAndThreads):
* Source/bmalloc/libpas/src/test/MemalignTests.cpp:
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::testPGMSingleAlloc):
(std::testPGMMultipleAlloc):
(std::testPGMRealloc):
(std::testPGMErrors):
* Source/bmalloc/libpas/src/test/RaceTests.cpp:
(std::testLocalAllocatorStopRace):
(std::testLocalAllocatorStopRaceAgainstScavenge):
* Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp:
(std::testTLCDecommit):
(std::testChaosThenDecommit):
(std::testAllocateFromStoppedBaselineImpl):
* Source/bmalloc/libpas/src/test/TSDTests.cpp:
(std::destructor):
(std::testTSD):
* Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp:
(std::testFreeListRefillSpans):
(std::testInternalScavenge):
(std::testInternalScavengeFromCorrectDirectory):
(std::testSpuriousEligibility):
(std::testBasicSizeClassNotSet):
(std::testSmallDoubleFree):
(std::testSmallFreeInner):
(std::testSmallFreeNextWithShrink):
(std::testSmallFreeNextWithoutShrink):
(std::testSmallFreeNextBeforeShrink):
(std::testAllocationChaos):
(std::testCombinedAllocationChaos):
(std::testLargeDoubleFree):
(std::testLargeOffsetFree):
(std::testReallocatePrimitive):
(std::testReallocateArray):
* Source/bmalloc/libpas/src/test/ViewCacheTests.cpp:
(std::testDisableViewCacheUsingBoundForNoViewCache):
(std::testEnableViewCacheAtSomeBoundForNoViewCache):

Canonical link: <a href="https://commits.webkit.org/279280@main">https://commits.webkit.org/279280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24b204039150544fbd8adf847705142ca9852cf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52869 "359 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3592 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42912 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24028 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27061 "4 new passes 4 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2959 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1751 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57741 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28010 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3087 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50301 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45844 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49589 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11569 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30149 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64686 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28984 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12278 "Passed tests") | 
<!--EWS-Status-Bubble-End-->