### PR TITLE
Drop some function overloads in Base64.h

### DIFF
--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -64,8 +64,6 @@ WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<LChar
 
 WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
 Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
-Vector<uint8_t> base64EncodeToVector(std::span<const char>, Base64EncodeMode = Base64EncodeMode::Default);
-Vector<uint8_t> base64EncodeToVector(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
 
 WTF_EXPORT_PRIVATE String base64EncodeToString(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
 String base64EncodeToString(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
@@ -76,8 +74,6 @@ String base64EncodeToStringReturnNullIfOverflow(const CString&, Base64EncodeMode
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(std::span<const std::byte>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(StringView, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 std::optional<Vector<uint8_t>> base64Decode(std::span<const uint8_t>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
-std::optional<Vector<uint8_t>> base64Decode(std::span<const char>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
-std::optional<Vector<uint8_t>> base64Decode(const void*, unsigned, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 
 WTF_EXPORT_PRIVATE String base64DecodeToString(StringView, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 
@@ -86,9 +82,6 @@ WTF_EXPORT_PRIVATE String base64DecodeToString(StringView, Base64DecodeMode = Ba
 
 Vector<uint8_t> base64URLEncodeToVector(std::span<const std::byte>);
 Vector<uint8_t> base64URLEncodeToVector(std::span<const uint8_t>);
-Vector<uint8_t> base64URLEncodeToVector(std::span<const char>);
-Vector<uint8_t> base64URLEncodeToVector(const CString&);
-Vector<uint8_t> base64URLEncodeToVector(const void*, unsigned);
 
 String base64URLEncodeToString(std::span<const std::byte>);
 String base64URLEncodeToString(std::span<const uint8_t>);
@@ -97,35 +90,19 @@ std::optional<Vector<uint8_t>> base64URLDecode(StringView);
 inline std::optional<Vector<uint8_t>> base64URLDecode(ASCIILiteral literal) { return base64URLDecode(StringView { literal }); }
 std::optional<Vector<uint8_t>> base64URLDecode(std::span<const std::byte>);
 std::optional<Vector<uint8_t>> base64URLDecode(std::span<const uint8_t>);
-std::optional<Vector<uint8_t>> base64URLDecode(std::span<const char>);
-std::optional<Vector<uint8_t>> base64URLDecode(const void*, unsigned);
 
 // Versions for use with StringBuilder / makeString.
 
 Base64Specification base64Encoded(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
 Base64Specification base64Encoded(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
-Base64Specification base64Encoded(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
-Base64Specification base64Encoded(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
 Base64Specification base64URLEncoded(std::span<const std::byte>);
 Base64Specification base64URLEncoded(std::span<const uint8_t>);
-Base64Specification base64URLEncoded(const CString&);
-Base64Specification base64URLEncoded(const void*, unsigned);
 
 
 inline Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t> input, Base64EncodeMode mode)
 {
     return base64EncodeToVector(std::as_bytes(input), mode);
-}
-
-inline Vector<uint8_t> base64EncodeToVector(std::span<const char> input, Base64EncodeMode mode)
-{
-    return base64EncodeToVector(std::as_bytes(input), mode);
-}
-
-inline Vector<uint8_t> base64EncodeToVector(const CString& input, Base64EncodeMode mode)
-{
-    return base64EncodeToVector(input.span(), mode);
 }
 
 inline String base64EncodeToString(std::span<const uint8_t> input, Base64EncodeMode mode)
@@ -148,32 +125,12 @@ inline std::optional<Vector<uint8_t>> base64Decode(std::span<const uint8_t> inpu
     return base64Decode(std::as_bytes(input), mode);
 }
 
-inline std::optional<Vector<uint8_t>> base64Decode(std::span<const char> input, Base64DecodeMode mode)
-{
-    return base64Decode(std::as_bytes(input), mode);
-}
-
-inline std::optional<Vector<uint8_t>> base64Decode(const void* input, unsigned length, Base64DecodeMode mode)
-{
-    return base64Decode({ static_cast<const std::byte*>(input), length }, mode);
-}
-
 inline Vector<uint8_t> base64URLEncodeToVector(std::span<const std::byte> input)
 {
     return base64EncodeToVector(input, Base64EncodeMode::URL);
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(std::span<const uint8_t> input)
-{
-    return base64EncodeToVector(input, Base64EncodeMode::URL);
-}
-
-inline Vector<uint8_t> base64URLEncodeToVector(std::span<const char> input)
-{
-    return base64EncodeToVector(input, Base64EncodeMode::URL);
-}
-
-inline Vector<uint8_t> base64URLEncodeToVector(const CString& input)
 {
     return base64EncodeToVector(input, Base64EncodeMode::URL);
 }
@@ -201,16 +158,6 @@ inline std::optional<Vector<uint8_t>> base64URLDecode(std::span<const std::byte>
 inline std::optional<Vector<uint8_t>> base64URLDecode(std::span<const uint8_t> input)
 {
     return base64Decode(input, Base64DecodeMode::URL);
-}
-
-inline std::optional<Vector<uint8_t>> base64URLDecode(std::span<const char> input)
-{
-    return base64Decode(input, Base64DecodeMode::URL);
-}
-
-inline std::optional<Vector<uint8_t>> base64URLDecode(const void* input, unsigned length)
-{
-    return base64Decode(input, length, Base64DecodeMode::URL);
 }
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType c)
@@ -256,16 +203,6 @@ inline Base64Specification base64Encoded(std::span<const uint8_t> input, Base64E
     return base64Encoded(std::as_bytes(input), mode);
 }
 
-inline Base64Specification base64Encoded(const CString& input, Base64EncodeMode mode)
-{
-    return base64Encoded(input.span(), mode);
-}
-
-inline Base64Specification base64Encoded(const void* input, unsigned length, Base64EncodeMode mode)
-{
-    return base64Encoded({ static_cast<const std::byte*>(input), length }, mode);
-}
-
 inline Base64Specification base64URLEncoded(std::span<const std::byte> input)
 {
     return base64Encoded(input, Base64EncodeMode::URL);
@@ -274,16 +211,6 @@ inline Base64Specification base64URLEncoded(std::span<const std::byte> input)
 inline Base64Specification base64URLEncoded(std::span<const uint8_t> input)
 {
     return base64Encoded(input, Base64EncodeMode::URL);
-}
-
-inline Base64Specification base64URLEncoded(const CString& input)
-{
-    return base64Encoded(input, Base64EncodeMode::URL);
-}
-
-inline Base64Specification base64URLEncoded(const void* input, unsigned length)
-{
-    return base64Encoded(input, length, Base64EncodeMode::URL);
 }
 
 template<> class StringTypeAdapter<Base64Specification> {

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -245,7 +245,7 @@ bool isPlayReadySanitizedInitializationData(const SharedBuffer& buffer)
         return false;
 
     xmlChar* encodedKeyID = xmlNodeGetContent(keyIDNode->nodeTab[0]);
-    std::optional<Vector<uint8_t>> decodedKeyID = base64Decode(encodedKeyID, xmlStrlen(encodedKeyID));
+    std::optional<Vector<uint8_t>> decodedKeyID = base64Decode({ reinterpret_cast<const uint8_t*>(encodedKeyID), static_cast<size_t>(xmlStrlen(encodedKeyID)) });
     xmlFree(encodedKeyID);
     if (!decodedKeyID)
         return false;

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -33,6 +33,7 @@
 #import <wtf/CryptographicUtilities.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cf/VectorCF.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/Base64.h>
@@ -173,7 +174,7 @@ static std::optional<Vector<uint8_t>> findMasterKey()
         return std::nullopt;
     }
     RetainPtr<CFDataRef> keyData = adoptCF(keyDataRef);
-    return base64Decode(CFDataGetBytePtr(keyData.get()), CFDataGetLength(keyData.get()));
+    return base64Decode(span(keyData.get()));
 }
 
 std::optional<Vector<uint8_t>> defaultWebCryptoMasterKey()

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -358,7 +358,7 @@ void FileReaderLoader::convertToText()
 
 void FileReaderLoader::convertToDataURL()
 {
-    m_stringResult = makeString("data:"_s, m_dataType.isEmpty() ? "application/octet-stream"_s : m_dataType, ";base64,"_s, base64Encoded(m_rawData ? m_rawData->data() : nullptr, m_bytesLoaded));
+    m_stringResult = makeString("data:"_s, m_dataType.isEmpty() ? "application/octet-stream"_s : m_dataType, ";base64,"_s, base64Encoded(m_rawData ? m_rawData->span().first(m_bytesLoaded) : std::span<const uint8_t>()));
 }
 
 bool FileReaderLoader::isCompleted() const

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1907,7 +1907,7 @@ static String computeContentSecurityPolicySHA256Hash(const Element& element)
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     cryptoDigest->addBytes(content.span());
     auto digest = cryptoDigest->computeHash();
-    return makeString("sha256-"_s, base64Encoded(digest.data(), digest.size()));
+    return makeString("sha256-"_s, base64Encoded(digest));
 }
 
 Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int depth)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
@@ -56,7 +56,7 @@ static void markupText(GMarkupParseContext*, const gchar* text, gsize textLength
 {
     GMarkupParseContextUserData* userData = static_cast<GMarkupParseContextUserData*>(userDataPtr);
     if (userData->isParsingPssh) {
-        std::optional<Vector<uint8_t>> pssh = base64Decode(text, textLength);
+        auto pssh = base64Decode({ reinterpret_cast<const uint8_t*>(text), textLength });
         if (pssh.has_value())
             userData->pssh = SharedBuffer::create(WTFMove(*pssh));
     }

--- a/Source/WebCore/platform/network/CredentialBase.cpp
+++ b/Source/WebCore/platform/network/CredentialBase.cpp
@@ -98,7 +98,7 @@ bool CredentialBase::compare(const Credential& a, const Credential& b)
 String CredentialBase::serializationForBasicAuthorizationHeader() const
 {
     auto credentialStringData = makeString(m_user, ':', m_password).utf8();
-    return makeString("Basic "_s, base64Encoded(credentialStringData));
+    return makeString("Basic "_s, base64Encoded(credentialStringData.span()));
 }
 
 auto CredentialBase::nonPlatformData() const -> NonPlatformData

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -210,7 +210,7 @@ void RemoteInspectorClient::setBackendCommands(const char* backendCommands)
         return;
     }
 
-    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(backendCommands, strlen(backendCommands)));
+    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(span8(backendCommands)));
 }
 
 void RemoteInspectorClient::connectionDidClose()

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -207,7 +207,7 @@ void RemoteInspectorClient::setBackendCommands(const Event& event)
     if (!event.message || event.message->isEmpty())
         return;
 
-    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(event.message->utf8()));
+    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(event.message->utf8().span()));
 }
 
 void RemoteInspectorClient::setTargetList(const Event& event)

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -169,16 +169,16 @@ TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCo
 WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
 {
 #if USE(CAIRO)
-    Vector<unsigned char> output;
+    Vector<uint8_t> output;
     cairo_surface_write_to_png_stream(mainWebView()->windowSnapshotImage(), [](void* output, const unsigned char* data, unsigned length) -> cairo_status_t {
-        reinterpret_cast<Vector<unsigned char>*>(output)->append(std::span { data, length });
+        reinterpret_cast<Vector<uint8_t>*>(output)->append(std::span { reinterpret_cast<const uint8_t*>(data), length });
         return CAIRO_STATUS_SUCCESS;
     }, &output);
-    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(output.data(), output.size()));
+    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(output.span()));
 #elif USE(SKIA)
     sk_sp<SkImage> image(mainWebView()->windowSnapshotImage());
     auto data = SkPngEncoder::Encode(nullptr, image.get(), { });
-    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(data->data(), data->size()));
+    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(std::span { static_cast<const uint8_t*>(data->data()), data->size() }));
 #endif
     return adoptWK(WKStringCreateWithUTF8CString(uri.utf8().data()));
 }

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -157,16 +157,16 @@ TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCo
 WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
 {
 #if USE(CAIRO)
-    Vector<unsigned char> output;
+    Vector<uint8_t> output;
     cairo_surface_write_to_png_stream(mainWebView()->windowSnapshotImage(), [](void* output, const unsigned char* data, unsigned length) -> cairo_status_t {
-        reinterpret_cast<Vector<unsigned char>*>(output)->append(std::span { data, length });
+        reinterpret_cast<Vector<uint8_t>*>(output)->append(std::span { reinterpret_cast<const uint8_t*>(data), length });
         return CAIRO_STATUS_SUCCESS;
     }, &output);
-    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(output.data(), output.size()));
+    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(output.span()));
 #elif USE(SKIA)
     sk_sp<SkImage> image(mainWebView()->windowSnapshotImage());
     auto data = SkPngEncoder::Encode(nullptr, image.get(), { });
-    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(data->data(), data->size()));
+    auto uri = makeString("data:image/png;base64,"_s, base64Encoded(std::span { static_cast<const uint8_t*>(data->data()), data->size() }));
 #endif
     return adoptWK(WKStringCreateWithUTF8CString(uri.utf8().data()));
 }


### PR DESCRIPTION
#### a101a7b4075a1abad19b13def372be7986031ddc
<pre>
Drop some function overloads in Base64.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=274556">https://bugs.webkit.org/show_bug.cgi?id=274556</a>

Reviewed by Sihui Liu and Darin Adler.

Drop some function overloads in Base64.h. This is a step towards std::span
adoption and using more consistent typing for representing bytes.

* Source/WTF/wtf/text/Base64.h:
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::isPlayReadySanitizedInitializationData):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::findMasterKey):
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::convertToDataURL):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::computeContentSecurityPolicySHA256Hash):
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp:
(WebCore::markupText):
* Source/WebCore/platform/network/CredentialBase.cpp:
(WebCore::CredentialBase::serializationForBasicAuthorizationHeader const):

Canonical link: <a href="https://commits.webkit.org/279251@main">https://commits.webkit.org/279251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c9d2f85cd39e55179424abf4580c2e2120de477

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56211 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3380 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55030 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/3013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1814 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/46286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/3169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57804 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/52445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7771 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29047 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12291 "Passed tests") | 
<!--EWS-Status-Bubble-End-->