### PR TITLE
Fixed Playstation build break after 279154@main

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -75,7 +75,9 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
 
     Locker locker { m_imageLock };
     if (!m_image) {
+#if PLATFORM(GTK) || PLATFORM(WPE)
         std::unique_ptr<GLFence> fence;
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
         unsigned textureID = 0;
 #if USE(SKIA)
         auto image = nativeImage->platformImage();
@@ -98,7 +100,9 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
             if (!textureID)
                 return;
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
             fence = GLFence::create();
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
         }
 #endif
 
@@ -129,9 +133,13 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
 #elif USE(SKIA)
                 auto image = nativeImage->platformImage();
                 if (image->isTextureBacked()) {
+#if PLATFORM(GTK) || PLATFORM(WPE)
                     fence->wait(WebCore::GLFence::FlushCommands::No);
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
                     texture->copyFromExternalTexture(textureID);
+#if PLATFORM(GTK) || PLATFORM(WPE)
                     fence = GLFence::create();
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
                 } else {
                     SkPixmap pixmap;
                     if (image->peekPixels(&pixmap))


### PR DESCRIPTION
#### 3216dc5420087aadbf282e20672d8b74493f990b
<pre>
Fixed Playstation build break after 279154@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=274559">https://bugs.webkit.org/show_bug.cgi?id=274559</a>

Reviewed by Don Olmstead.

Fix linking error on undefined symbol `WebCore::GLFence::~GLFence()

* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:

Canonical link: <a href="https://commits.webkit.org/279166@main">https://commits.webkit.org/279166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/042b7db11f8eac8b56e68e9fbe20f654a909de0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5193 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3150 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/55987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54807 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/2806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1591 "Failed to checkout and rebase branch from PR 28956") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/2959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57579 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/2948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7731 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->