### PR TITLE
[JSC] Inlined functions in OMG may have exception handlers

### DIFF
--- a/JSTests/wasm/stress/inlinee-may-have-exception-handlers.js
+++ b/JSTests/wasm/stress/inlinee-may-have-exception-handlers.js
@@ -1,0 +1,84 @@
+import * as assert from '../assert.js';
+import { instantiate } from "../wabt-wrapper.js";
+
+let wat = `
+(module
+    (func $main (export "main")
+        call $catcher
+        i64.const 3127057505886423800
+        i64.const -5049743701649469475
+        i32.const 1279394412
+        i32.const 1249280136
+        i32.const -851957055
+        i32.div_s
+        i32.div_s
+        select (result i64)
+        loop (result i64)
+        i64.const 7052281334997434446
+        f64.const 0x1.f0094d7063744p+967
+        i64.trunc_sat_f64_u
+        i64.rem_s
+        end
+        i64.add
+        f64.convert_i64_s
+        i32.const 993640798
+        i32.const -291103156
+        i32.atomic.rmw.xor offset=36014
+        f32.const 0x1.2e5784p-38
+        i64.const 8981315711995315489
+        i64.const 5932917051412947299
+        i64.const 6207621187208520631
+        i32.const 1636976966
+        select (result i64)
+        i64.ne
+        br 0
+        i32.trunc_sat_f32_u
+        i32.div_s
+        f64.const 0x1.7c35ecf56d865p-116
+        i32.const 1987656988
+        i64.const -1947434429939530388
+        f64.const -0x1.ca05a27b00c85p+372
+        i64.const 5169929820610505455
+        block (param f64 i32 f64 i32 i64 f64 i64)
+        drop
+        drop
+        drop
+        drop
+        drop
+        drop
+        drop
+        end
+    )
+    (func $empty (param i32))
+    (func $catcher (type 0)
+        try
+        i32.const 1
+        call $empty
+        catch_all
+        throw $exc
+        end
+        call $main
+    )
+    (memory 32 64)
+    (tag $exc)
+)
+`;
+
+async function test() {
+    let instance = await instantiate(wat, {}, {threads: true, exceptions: true});
+
+    let caughtCount = 0;
+    for (let i = 0; i < 10; i ++) {
+        try {
+            instance.exports.main();
+        } catch (e) {
+            // We expect to either overflow the stack, or end up throwing $exc back into JavaScript.
+            assert.truthy(e instanceof RangeError || e instanceof WebAssembly.Exception);
+            caughtCount ++;
+        }
+    }
+
+    assert.eq(caughtCount, 10);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/rethrow-should-set-callsite-index.js
+++ b/JSTests/wasm/stress/rethrow-should-set-callsite-index.js
@@ -1,0 +1,40 @@
+import * as assert from '../assert.js';
+import { instantiate } from "../wabt-wrapper.js";
+
+let wat = `
+(module
+    (type (func))
+    (tag $exc (type 0))
+    (func $empty)
+    (func $rethrower
+        try
+            call $empty
+            throw $exc
+        catch_all
+            rethrow 0
+        end
+    )
+    (func $call-rethrower
+        call $rethrower
+    )
+    (export "call_rethrower" (func $call-rethrower))
+)
+`;
+
+async function test() {
+    let instance = await instantiate(wat, {}, {exceptions: true});
+
+    let caughtCount = 0;
+    for (let i = 0; i < 10000; i ++) {
+        try {
+            instance.exports.call_rethrower();
+        } catch (e) {
+            assert.instanceof(e, WebAssembly.Exception);
+            caughtCount ++;
+        }
+    }
+
+    assert.eq(caughtCount, 10000);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/throw-should-set-callsite-index.js
+++ b/JSTests/wasm/stress/throw-should-set-callsite-index.js
@@ -1,0 +1,39 @@
+import * as assert from '../assert.js';
+import { instantiate } from "../wabt-wrapper.js";
+
+let wat = `
+(module
+    (type (func))
+    (tag $exc (type 0))
+    (func $empty)
+    (func $thrower
+        try
+            call $empty
+        catch_all
+        end
+        throw $exc
+    )
+    (func $call-thrower
+        call $thrower
+    )
+    (export "call_thrower" (func $call-thrower))
+)
+`;
+
+async function test() {
+    let instance = await instantiate(wat, {}, {exceptions: true});
+
+    let caughtCount = 0;
+    for (let i = 0; i < 10000; i ++) {
+        try {
+            instance.exports.call_thrower();
+        } catch (e) {
+            assert.instanceof(e, WebAssembly.Exception);
+            caughtCount ++;
+        }
+    }
+
+    assert.eq(caughtCount, 10000);
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmCompilationContext.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationContext.h
@@ -55,6 +55,7 @@ class Procedure { };
 namespace Wasm {
 
 class BBQDisassembler;
+class CalleeGroup;
 class MemoryInformation;
 class OptimizingJITCallee;
 class TierUpCount;

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -45,9 +45,11 @@ struct PatchpointExceptionHandleBase {
 };
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
+
 struct PatchpointExceptionHandle : public PatchpointExceptionHandleBase {
-    PatchpointExceptionHandle(std::optional<bool> hasExceptionHandlers)
+    PatchpointExceptionHandle(std::optional<bool> hasExceptionHandlers, unsigned callSiteIndex)
         : m_hasExceptionHandlers(hasExceptionHandlers)
+        , m_callSiteIndex(callSiteIndex)
     { }
 
     PatchpointExceptionHandle(std::optional<bool> hasExceptionHandlers, unsigned callSiteIndex, unsigned numLiveValues)
@@ -59,27 +61,28 @@ struct PatchpointExceptionHandle : public PatchpointExceptionHandleBase {
     template <typename Generator>
     void generate(CCallHelpers& jit, const B3::StackmapGenerationParams& params, Generator* generator) const
     {
-        if (m_callSiteIndex == s_invalidCallSiteIndex) {
-            if (!m_hasExceptionHandlers || m_hasExceptionHandlers.value())
-                jit.store32(CCallHelpers::TrustedImm32(m_callSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
-            return;
-        }
+        JIT_COMMENT(jit, "Store call site index ", m_callSiteIndex, " at throw or call site.");
+        jit.store32(CCallHelpers::TrustedImm32(m_callSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
-        StackMap values(m_numLiveValues);
-        unsigned paramsOffset = params.size() - m_numLiveValues;
-        unsigned childrenOffset = params.value()->numChildren() - m_numLiveValues;
-        for (unsigned i = 0; i < m_numLiveValues; ++i)
+        if (m_hasExceptionHandlers && !*m_hasExceptionHandlers)
+            return;
+        if (!m_numLiveValues)
+            return;
+
+        StackMap values(*m_numLiveValues);
+        unsigned paramsOffset = params.size() - *m_numLiveValues;
+        unsigned childrenOffset = params.value()->numChildren() - *m_numLiveValues;
+        for (unsigned i = 0; i < *m_numLiveValues; ++i)
             values[i] = OSREntryValue(params[i + paramsOffset], params.value()->child(i + childrenOffset)->type());
 
         generator->addStackMap(m_callSiteIndex, WTFMove(values));
-        JIT_COMMENT(jit, "Store call site index ", m_callSiteIndex, " at throw or call site.");
-        jit.store32(CCallHelpers::TrustedImm32(m_callSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     }
 
     std::optional<bool> m_hasExceptionHandlers;
     unsigned m_callSiteIndex { s_invalidCallSiteIndex };
-    unsigned m_numLiveValues;
+    std::optional<unsigned> m_numLiveValues { };
 };
+
 #else
 
 using PatchpointExceptionHandle = PatchpointExceptionHandleBase;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.h
@@ -49,7 +49,7 @@ namespace JSC {
 
 namespace Wasm {
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(CompilationContext&, OptimizingJITCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, CompilationMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, uint32_t loopIndexForOSREntry, TierUpCount* = nullptr);
+Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(CompilationContext&, OptimizingJITCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, CalleeGroup&, const ModuleInformation&, MemoryMode, CompilationMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, uint32_t loopIndexForOSREntry, TierUpCount* = nullptr);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -114,7 +114,7 @@ void OMGPlan::work(CompilationEffort)
 
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
-    auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_moduleInformation.get(), m_mode, CompilationMode::OMGMode, m_functionIndex, m_hasExceptionHandlers, UINT32_MAX);
+    auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, CompilationMode::OMGMode, m_functionIndex, m_hasExceptionHandlers, UINT32_MAX);
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -107,7 +107,7 @@ void OSREntryPlan::work(CompilationEffort)
 
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
     CompilationContext context;
-    auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_moduleInformation.get(), m_mode, targetCompilationMode, m_functionIndex, m_hasExceptionHandlers, m_loopIndex);
+    auto parseAndCompileResult = parseAndCompileOMG(context, callee.get(), function, signature, unlinkedCalls, m_calleeGroup.get(), m_moduleInformation.get(), m_mode, targetCompilationMode, m_functionIndex, m_hasExceptionHandlers, m_loopIndex);
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };


### PR DESCRIPTION
#### bc5bcf116eef81d7f61706d5e157e921461757ee
<pre>
[JSC] Inlined functions in OMG may have exception handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=272106">https://bugs.webkit.org/show_bug.cgi?id=272106</a>
<a href="https://rdar.apple.com/125181187">rdar://125181187</a>

Reviewed by Justin Michaud and Yusuke Suzuki.

Primarily fixes a bug where any WebAssembly function inlined in OMG was
assumed to not have exception handlers. We now propagate a reference to
the Wasm::CalleeGroup from the OMGPlan/OSREntryPlan to the B3IRGenerator,
and read the hasExceptionHandlers() property from the inlined function&apos;s
callee, similar to how the top-level function&apos;s generator is initialized
in the plan.

In addition to this, we also change when we set the callsite index.
Currently we don&apos;t set the callsite index for any call or throw outside
of a try block, which means that we might throw with an old callsite
index set, and erroneously catch the exception in a previous block. To
fix this, we now set a bool in the IR generator after a try or catch block
ends, and set the callsite index for the first call/throw after a try/catch
ends.

Finally, consistent with BBQ, we don&apos;t write invalid callsite indices
except for during the function prologue (before our first call/throw). We
also don&apos;t write the callsite index at all in the case that we are known
to be in a function without exception handlers.

* JSTests/wasm/stress/inlinee-may-have-exception-handlers.js: Added.
(async test):
* JSTests/wasm/stress/rethrow-should-set-callsite-index.js: Added.
(async test):
* JSTests/wasm/stress/throw-should-set-callsite-index.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::shouldSetCallSiteIndexAfterTry const):
(JSC::Wasm::B3IRGenerator::didSetCallSiteIndexAfterTry):
(JSC::Wasm::B3IRGenerator::B3IRGenerator):
(JSC::Wasm::B3IRGenerator::preparePatchpointForExceptions):
(JSC::Wasm::B3IRGenerator::addThrow):
(JSC::Wasm::B3IRGenerator::addRethrow):
(JSC::Wasm::B3IRGenerator::addEndToUnreachable):
(JSC::Wasm::B3IRGenerator::emitInlineDirectCall):
(JSC::Wasm::parseAndCompileB3):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.h:
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::PatchpointExceptionHandle::PatchpointExceptionHandle):
(JSC::Wasm::PatchpointExceptionHandle::generate const):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):

Originally-landed-as: 272448.917@safari-7618-branch (1e58c9386ed9). <a href="https://rdar.apple.com/128572165">rdar://128572165</a>
Canonical link: <a href="https://commits.webkit.org/279242@main">https://commits.webkit.org/279242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4749eadb2e4f8f16db40a3a4a0b46005ccff5f62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56165 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3334 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54984 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24036 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1768 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/46240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57758 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52399 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28027 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45859 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11550 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64703 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29001 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12282 "Passed tests") | 
<!--EWS-Status-Bubble-End-->