### PR TITLE
[Navigation] Set formData on NavigateEvent

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6930,6 +6930,10 @@ imported/w3c/web-platform-tests/navigation-api/commit-behavior/ [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/ [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/focus-reset/ [ Skip ]
 
+# Tests for sourceElement is not yet part of the HTML spec.
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-requestSubmit.html [ Skip ]
+
+
 # These cross-window tests won't work on ports that don't run on the web-platform.test domains (not glib).
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/ [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
-{"error": {"code": 404, "message": ""}}
+FAIL <form> submission fires navigate event assert_equals: expected "replace" but got "push"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reloading a page created from form submission results in formData of null, not the original form data Test timed out
+PASS reloading a page created from form submission results in formData of null, not the original form data
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-requestSubmit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-requestSubmit-expected.txt
@@ -1,3 +1,6 @@
-FAIL: Timed out waiting for notifyDone to be called
 
-{"error": {"code": 404, "message": ""}}
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT <form> requestSubmit() sets sourceElement Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reloading a page created from form submission results in formData of null, not the original form data Test timed out
+PASS reloading a page created from form submission results in formData of null, not the original form data
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-userInitiated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-userInitiated-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
-{"error": {"code": 404, "message": ""}}
+
+PASS <form> submission fires navigate event
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT <form> submission with a target fires navigate event in target window but not source Test timed out
+PASS <form> submission with a target fires navigate event in target window but not source
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -457,7 +457,7 @@ private:
     void updateNavigationAPIEntries();
     void updateRequestAndAddExtraFields(Frame&, ResourceRequest&, IsMainResource, FrameLoadType, ShouldUpdateAppInitiatedValue, IsServiceWorkerNavigationLoad, WillOpenInNewWindow, Document*);
 
-    bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const NavigationAction&, NavigationHistoryBehavior, bool isSameDocument);
+    bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const NavigationAction&, NavigationHistoryBehavior, bool isSameDocument, FormState* = nullptr);
 
     WeakRef<LocalFrame> m_frame;
     UniqueRef<LocalFrameLoaderClient> m_client;

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -275,7 +275,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
 
     if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
         auto& navigation = document->domWindow()->navigation();
-        if (!navigation.dispatchPushReplaceReloadNavigateEvent(fullURL, stateObjectType == StateObjectType::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true))
+        if (!navigation.dispatchPushReplaceReloadNavigateEvent(fullURL, stateObjectType == StateObjectType::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true, nullptr))
             return { };
     }
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -28,9 +28,11 @@
 
 #include "AbortController.h"
 #include "CallbackResult.h"
+#include "DOMFormData.h"
 #include "ErrorEvent.h"
 #include "EventNames.h"
 #include "Exception.h"
+#include "FormState.h"
 #include "FrameLoadRequest.h"
 #include "FrameLoader.h"
 #include "FrameLoaderTypes.h"
@@ -574,9 +576,8 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
-bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename)
+bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename, FormState* formState)
 {
-    // FIXME: pass in formDataEntryList
     if (hasEntriesAndEventsDisabled()) {
         ASSERT(!m_ongoingAPIMethodTracker);
         ASSERT(!m_upcomingNonTraverseMethodTracker);
@@ -599,6 +600,13 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
     bool hashChange = equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
     auto info = apiMethodTracker ? apiMethodTracker->info : JSC::jsUndefined();
 
+    RefPtr<DOMFormData> formData = nullptr;
+    if (formState && (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace)) {
+        // FIXME: Set submitter element.
+        if (auto domFormData = DOMFormData::create(*scriptExecutionContext(), &formState->form(), nullptr); !domFormData.hasException())
+            formData = domFormData.releaseReturnValue();
+    }
+
     RefPtr abortController = AbortController::create(*scriptExecutionContext());
 
     auto init = NavigateEvent::Init {
@@ -606,7 +614,7 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
         navigationType,
         destination.ptr(),
         abortController->protectedSignal(),
-        nullptr, // FIXME: formData
+        formData,
         downloadRequestFilename,
         info,
         canIntercept,
@@ -725,22 +733,22 @@ bool Navigation::dispatchTraversalNavigateEvent(HistoryItem& historyItem)
     // FIXME: Set destinations state
     Ref destination = NavigationDestination::create(historyItem.url(), WTFMove(destinationEntry), isSameDocument);
 
-    return innerDispatchNavigateEvent(NavigationNavigationType::Traverse, WTFMove(destination), { });
+    return innerDispatchNavigateEvent(NavigationNavigationType::Traverse, WTFMove(destination), { }, nullptr);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-push/replace/reload-navigate-event
-bool Navigation::dispatchPushReplaceReloadNavigateEvent(const URL& url, NavigationNavigationType navigationType, bool isSameDocument)
+bool Navigation::dispatchPushReplaceReloadNavigateEvent(const URL& url, NavigationNavigationType navigationType, bool isSameDocument, FormState* formState)
 {
     // FIXME: Set event's classic history API state to classicHistoryAPIState.
     Ref destination = NavigationDestination::create(url, nullptr, isSameDocument);
-    return innerDispatchNavigateEvent(navigationType, WTFMove(destination), { });
+    return innerDispatchNavigateEvent(navigationType, WTFMove(destination), { }, formState);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-download-request-navigate-event
 bool Navigation::dispatchDownloadNavigateEvent(const URL& url, const String& downloadFilename)
 {
     Ref destination = NavigationDestination::create(url, nullptr, false);
-    return innerDispatchNavigateEvent(NavigationNavigationType::Push, WTFMove(destination), downloadFilename);
+    return innerDispatchNavigateEvent(NavigationNavigationType::Push, WTFMove(destination), downloadFilename, nullptr);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -36,6 +36,7 @@
 
 namespace WebCore {
 
+class FormState;
 class HistoryItem;
 class SerializedScriptValue;
 class NavigateEvent;
@@ -136,7 +137,7 @@ public:
     ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
     bool dispatchTraversalNavigateEvent(HistoryItem&);
-    bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument);
+    bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument, FormState*);
     bool dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename);
 
     void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType);
@@ -155,7 +156,7 @@ private:
     Result performTraversal(const String& key, Navigation::Options, FrameLoadType, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
-    bool innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename);
+    bool innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, FormState*);
 
     RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
     RefPtr<NavigationAPIMethodTracker> addUpcomingTrarveseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);


### PR DESCRIPTION
#### e03a2518eb73ce8bf82bf9870c96fdc1077f9444
<pre>
[Navigation] Set formData on NavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=274561">https://bugs.webkit.org/show_bug.cgi?id=274561</a>

Reviewed by Alex Christensen.

This includes form data in all push/replace events on same-origin-domain form submissions.

The two failing tests are passes except for the navigation type which is an unrelated issue.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-requestSubmit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-userInitiated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::dispatchNavigateEvent):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::dispatchTraversalNavigateEvent):
(WebCore::Navigation::dispatchPushReplaceReloadNavigateEvent):
(WebCore::Navigation::dispatchDownloadNavigateEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/279257@main">https://commits.webkit.org/279257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e52aec7c66cc3fcb36a517c1f641d4d6eb13a68e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42910 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27010 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2966 "Found 1 new test failure: inspector/runtime/execution-context-in-scriptless-page.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48874 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3172 "Found 2 new test failures: inspector/runtime/execution-context-in-scriptless-page.html, media/video-playsinline.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57751 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28020 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3094 "Found 1 new test failure: inspector/runtime/execution-context-in-scriptless-page.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50311 "Found 1 new test failure: inspector/runtime/execution-context-in-scriptless-page.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49598 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30159 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7777 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->