### PR TITLE
[UnifiedPDF] Crash in UnifiedPDFPlugin::repaintForIncrementalLoad() loading charbonnelchocolates.com page

### DIFF
--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-display-none-iframe-expected.txt
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-display-none-iframe-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash

--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-display-none-iframe.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-display-none-iframe.html
@@ -1,31 +1,33 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-50">
     <style>
         iframe {
+            display: none;
             width: 700px;
             height: 500px;
             border: 1px solid black;
         }
     </style>
     <script>
-        if (window.testRunner)
+        if (window.testRunner) {
             testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+        }
         
         function testComplete()
         {
-            const pdfFadeInDelay = 250;
             requestAnimationFrame(() => {
                 setTimeout(() => {
                     if (window.testRunner)
                         testRunner.notifyDone();
-                }, pdfFadeInDelay);
+                }, 0);
             });
         }
     </script>
 </head>
 <body>
+    <p>This test should not crash</p>
     <iframe onload="testComplete()" src="/resources/network-simulator.py?test=pdf-load&path=/pdf/resources/linearized.pdf&chunksize=1024&chunkdelay=16"></iframe>
 </body>
 </html>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -595,11 +595,12 @@ void UnifiedPDFPlugin::incrementalLoadingRepaintTimerFired()
 
 void UnifiedPDFPlugin::repaintForIncrementalLoad()
 {
-    auto coverageRect = FloatRect { { }, m_documentLayout.contentsSize() };
+    if (!m_pdfDocument)
+        return;
 
+    auto coverageRect = FloatRect { { }, m_documentLayout.contentsSize() };
     if (auto* tiledBacking = m_contentsLayer->tiledBacking()) {
         coverageRect = tiledBacking->coverageRect();
-
         coverageRect = convertDown(CoordinateSpace::Contents, CoordinateSpace::PDFDocumentLayout, coverageRect);
     }
 


### PR DESCRIPTION
#### 35f09068c7e287e8b5466353a7cb742e33b8492a
<pre>
[UnifiedPDF] Crash in UnifiedPDFPlugin::repaintForIncrementalLoad() loading charbonnelchocolates.com page
<a href="https://bugs.webkit.org/show_bug.cgi?id=274563">https://bugs.webkit.org/show_bug.cgi?id=274563</a>
<a href="https://rdar.apple.com/128316806">rdar://128316806</a>

Reviewed by Abrar Rahman Protyasha.

repaintForIncrementalLoad() can get called before the main thread has a PDFDocument or has created any layers,
so early return in that case. This web page has a `display:none` iframe with PDF contents, which triggered
this crash.

* LayoutTests/http/tests/pdf/linearized-pdf-in-display-none-iframe-expected.txt: Added.
* LayoutTests/http/tests/pdf/linearized-pdf-in-display-none-iframe.html: Copied from LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html.
* LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::repaintForIncrementalLoad):

Canonical link: <a href="https://commits.webkit.org/279203@main">https://commits.webkit.org/279203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e702195a87cec67e9df4728fd59a9aa96bae24d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3446 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42807 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23911 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57593 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50202 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11534 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29998 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->