### PR TITLE
Drop IPC::Encoder::buffer() / bufferSize()

### DIFF
--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -123,7 +123,7 @@ void Encoder::wrapForTesting(UniqueRef<Encoder>&& original)
 
     original->setShouldDispatchMessageWhenWaitingForSyncReply(ShouldDispatchWhenWaitingForSyncReply::Yes);
 
-    *this << std::span(original->buffer(), original->bufferSize());
+    *this << original->span();
 
     Vector<Attachment> attachments = original->releaseAttachments();
     reserve(attachments.size());
@@ -169,12 +169,12 @@ OptionSet<MessageFlags>& Encoder::messageFlags()
 {
     // FIXME: We should probably pass an OptionSet<MessageFlags> into the Encoder constructor instead of encoding defaultMessageFlags then using this to change it later.
     static_assert(sizeof(OptionSet<MessageFlags>::StorageType) == 1, "Encoder uses the first byte of the buffer for message flags.");
-    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer());
+    return *reinterpret_cast<OptionSet<MessageFlags>*>(m_buffer);
 }
 
 const OptionSet<MessageFlags>& Encoder::messageFlags() const
 {
-    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer());
+    return *reinterpret_cast<OptionSet<MessageFlags>*>(m_buffer);
 }
 
 uint8_t* Encoder::grow(size_t alignment, size_t size)

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -87,8 +87,6 @@ public:
         return *this;
     }
 
-    uint8_t* buffer() const { return m_buffer; }
-    size_t bufferSize() const { return m_bufferSize; }
     std::span<const uint8_t> span() const { return { m_buffer, m_bufferSize }; }
 
     void addAttachment(Attachment&&);

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -407,7 +407,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
     size_t messageSizeWithBodyInline = sizeof(MessageInfo) + (outputMessage.attachments().size() * sizeof(AttachmentInfo)) + outputMessage.bodySize();
     if (messageSizeWithBodyInline > messageMaxSize && outputMessage.bodySize()) {
-        RefPtr<WebCore::SharedMemory> oolMessageBody = WebCore::SharedMemory::allocate(outputMessage.bodySize());
+        RefPtr oolMessageBody = WebCore::SharedMemory::allocate(outputMessage.bodySize());
         if (!oolMessageBody)
             return false;
 
@@ -417,7 +417,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
         outputMessage.messageInfo().setBodyOutOfLine();
 
-        memcpy(oolMessageBody->data(), outputMessage.body(), outputMessage.bodySize());
+        memcpySpan(oolMessageBody->mutableSpan(), outputMessage.body());
 
         outputMessage.appendAttachment(handle->releaseHandle());
     }
@@ -485,7 +485,7 @@ bool Connection::sendOutputMessage(UnixMessage& outputMessage)
     }
 
     if (!messageInfo.isBodyOutOfLine() && outputMessage.bodySize()) {
-        iov[iovLength].iov_base = reinterpret_cast<void*>(outputMessage.body());
+        iov[iovLength].iov_base = reinterpret_cast<void*>(outputMessage.body().data());
         iov[iovLength].iov_len = outputMessage.bodySize();
         ++iovLength;
     }

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -287,7 +287,8 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
     // Write the outgoing message.
 
-    if (::WriteFile(m_connectionPipe, encoder->buffer(), encoder->bufferSize(), 0, &m_writeListener.state())) {
+    auto buffer = encoder->span();
+    if (::WriteFile(m_connectionPipe, buffer.data(), buffer.size(), 0, &m_writeListener.state())) {
         // We successfully sent this message.
         return true;
     }

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
@@ -90,7 +90,8 @@ RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&& vector)
 OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)
 {
     __block auto blockEncoder = WTFMove(encoder);
-    auto dispatchData = adoptNS(dispatch_data_create(blockEncoder->buffer(), blockEncoder->bufferSize(), dispatch_get_main_queue(), ^{
+    auto buffer = blockEncoder->span();
+    auto dispatchData = adoptNS(dispatch_data_create(buffer.data(), buffer.size(), dispatch_get_main_queue(), ^{
         // Explicitly clear out the encoder, destroying it.
         blockEncoder.moveToUniquePtr();
     }));

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -587,9 +587,7 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
 bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
 {
     if (message.encoder->messageName() == IPC::MessageName::WebPage_LoadRequestWaitingForProcessLaunch) {
-        auto buffer = message.encoder->buffer();
-        auto bufferSize = message.encoder->bufferSize();
-        auto decoder = IPC::Decoder::create({ buffer, bufferSize }, { });
+        auto decoder = IPC::Decoder::create(message.encoder->span(), { });
         ASSERT(decoder);
         if (!decoder)
             return false;
@@ -607,9 +605,7 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
             ASSERT_NOT_REACHED();
         return false;
     } else if (message.encoder->messageName() == IPC::MessageName::WebPage_GoToBackForwardItemWaitingForProcessLaunch) {
-        auto buffer = message.encoder->buffer();
-        auto bufferSize = message.encoder->bufferSize();
-        auto decoder = IPC::Decoder::create({ buffer, bufferSize }, { });
+        auto decoder = IPC::Decoder::create(message.encoder->span(), { });
         ASSERT(decoder);
         if (!decoder)
             return false;

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -3043,7 +3043,7 @@ void JSMessageListener::willSendMessage(const IPC::Encoder& encoder, OptionSet<I
     RELEASE_ASSERT(m_jsIPC);
     Ref protectOwnerOfThis = *m_jsIPC;
 
-    auto decoder = IPC::Decoder::create({ encoder.buffer(), encoder.bufferSize() }, { });
+    auto decoder = IPC::Decoder::create(encoder.span(), { });
     RunLoop::main().dispatch([this, protectOwnerOfThis = WTFMove(protectOwnerOfThis), decoder = WTFMove(decoder)] {
         auto* globalObject = m_globalObject.get();
         if (!globalObject)

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -65,16 +65,16 @@ public:
     void SetUp() override
     {
         m_encoder = makeUnique<IPC::Encoder>(EncoderDecoderTest::name(), 0);
-        ASSERT_EQ(m_encoder->bufferSize(), headerSize());
+        ASSERT_EQ(m_encoder->span().size(), headerSize());
     }
 
     IPC::Encoder& encoder() const { return *m_encoder; }
     size_t headerSize() const { return 16; }
-    size_t encoderSize() const { return m_encoder->bufferSize(); }
+    size_t encoderSize() const { return m_encoder->span().size(); }
 
     std::unique_ptr<IPC::Decoder> createDecoder() const
     {
-        return IPC::Decoder::create({ m_encoder->buffer(), m_encoder->bufferSize() }, { });
+        return IPC::Decoder::create(m_encoder->span(), { });
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -77,7 +77,7 @@ private:
 
 bool SerializationTestSender::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Decoder*)>&& completionHandler) const
 {
-    auto decoder = IPC::Decoder::create({ encoder->buffer(), encoder->bufferSize() }, encoder->releaseAttachments());
+    auto decoder = IPC::Decoder::create(encoder->span(), encoder->releaseAttachments());
     ASSERT(decoder);
 
     completionHandler(decoder.get());

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -38,7 +38,7 @@ std::optional<T> copyViaEncoder(const T& o)
 {
     IPC::Encoder encoder(static_cast<IPC::MessageName>(78), 0);
     encoder << o;
-    auto decoder = IPC::Decoder::create({ encoder.buffer(), encoder.bufferSize() }, encoder.releaseAttachments());
+    auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
     return decoder->decode<T>();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -235,7 +235,8 @@ OSObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFr
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, protocolVersion);
 
     __block auto blockEncoder = WTFMove(encoder);
-    auto dispatchData = adoptNS(dispatch_data_create(blockEncoder->buffer(), blockEncoder->bufferSize(), dispatch_get_main_queue(), ^{
+    auto buffer = blockEncoder->span();
+    auto dispatchData = adoptNS(dispatch_data_create(buffer.data(), buffer.size(), dispatch_get_main_queue(), ^{
         // Explicitly clear out the encoder, destroying it.
         blockEncoder.moveToUniquePtr();
     }));


### PR DESCRIPTION
#### def81c6ee83a1512181c872a6a8434a4caaed17b
<pre>
Drop IPC::Encoder::buffer() / bufferSize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274568">https://bugs.webkit.org/show_bug.cgi?id=274568</a>

Reviewed by Darin Adler.

Drop IPC::Encoder::buffer() / bufferSize(), in favor of span().

* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::wrapForTesting):
(IPC::Encoder::messageFlags):
(IPC::Encoder::messageFlags const):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::sendOutgoingMessage):
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::encoderToXPCData):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::willSendMessage):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::Encoder&gt;::encoderSize const):
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::Encoder&gt;::createDecoder const):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(SerializationTestSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
(TestWebKitAPI::copyViaEncoder):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):

Canonical link: <a href="https://commits.webkit.org/279231@main">https://commits.webkit.org/279231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e92f757d102c6633212199c58e764952370bc451

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42873 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2291 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23988 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2911 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1697 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27956 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3045 "Found 1 new test failure: webgl/pending/conformance2/glsl3/empty-shader-with-output.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50269 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45786 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30095 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7759 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->