### PR TITLE
Add visionOS to the built product archive

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -87,7 +87,7 @@ def main():
 def webkitBuildDirectoryForConfigurationAndPlatform(configuration, platform, fullPlatform='', returnTopLevelDirectory=False, crossTarget=None):
     if 'simulator' in fullPlatform:
         platform = platform + '-simulator'
-    elif platform in ['ios', 'tvos', 'watchos']:
+    elif platform in ['ios', 'tvos', 'visionos', 'watchos']:
         platform = platform + '-device'
     command = ['perl', os.path.join(os.path.dirname(__file__), '..', 'Scripts', 'webkit-build-directory'), '--' + platform, '--' + configuration]
     if returnTopLevelDirectory:
@@ -105,7 +105,7 @@ def determineWebKitBuildDirectories(platform, fullPlatform, configuration, cross
     global _hostBuildDirectory
     _configurationBuildDirectory = webkitBuildDirectoryForConfigurationAndPlatform(configuration, platform, fullPlatform, crossTarget=cross_target)
     _topLevelBuildDirectory = webkitBuildDirectoryForConfigurationAndPlatform(configuration, platform, fullPlatform, returnTopLevelDirectory=True, crossTarget=cross_target)
-    if platform in ['ios', 'tvos', 'watchos']:
+    if platform in ['ios', 'tvos', 'visionos', 'watchos']:
         _hostBuildDirectory = webkitBuildDirectoryForConfigurationAndPlatform(configuration, 'mac')
     else:
         _hostBuildDirectory = _configurationBuildDirectory
@@ -234,12 +234,12 @@ ALWAYS_EXCLUDED_PATTERNS = ('*.a',)
 MINIFIED_EXCLUDED_PATTERNS = (*ALWAYS_EXCLUDED_PATTERNS, '*.dSYM', 'DerivedSources')
 
 def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
-    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'watchos', 'win', 'wincairo', 'wpe')
+    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'visionos', 'watchos', 'win', 'wincairo', 'wpe')
     global _configurationBuildDirectory
 
     print("Archiving built product from directory: %s" % _configurationBuildDirectory)
 
-    if platform in ['ios', 'tvos', 'watchos']:
+    if platform in ['ios', 'tvos', 'visionos' 'watchos']:
         combinedDirectory = os.path.join(_topLevelBuildDirectory, 'combined-mac-and-{}'.format(platform))
         removeDirectoryIfExists(combinedDirectory)
         os.makedirs(combinedDirectory)
@@ -347,14 +347,14 @@ def unzipArchive(directoryToExtractTo, configuration):
 
 
 def extractBuiltProduct(configuration, platform):
-    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'watchos', 'win', 'wincairo', 'wpe')
+    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'visionos', 'watchos', 'win', 'wincairo', 'wpe')
 
     archiveFile = os.path.join(_topLevelBuildDirectory, configuration + '.zip')
 
     removeDirectoryIfExists(_configurationBuildDirectory)
     os.makedirs(_configurationBuildDirectory)
 
-    if platform in ('mac', 'ios', 'tvos', 'watchos'):
+    if platform in ('mac', 'ios', 'visionos', 'tvos', 'watchos'):
         return unzipArchive(_topLevelBuildDirectory, configuration)
     elif platform in ('gtk', 'jsc-only', 'win', 'wincairo', 'wpe'):
         print('Extracting: {}'.format(_configurationBuildDirectory))


### PR DESCRIPTION
#### fefe9454de00f4d8e468aaed165810758345f0f4
<pre>
Add visionOS to the built product archive
<a href="https://bugs.webkit.org/show_bug.cgi?id=274572">https://bugs.webkit.org/show_bug.cgi?id=274572</a>
<a href="https://rdar.apple.com/128587087">rdar://128587087</a>

Unreviewed.

Adding visionOS to the built product archive.

* Tools/CISupport/built-product-archive:
(webkitBuildDirectoryForConfigurationAndPlatform):
(determineWebKitBuildDirectories):
(archiveBuiltProduct):
(extractBuiltProduct):

Canonical link: <a href="https://commits.webkit.org/279207@main">https://commits.webkit.org/279207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c2fda759616d95c3122ca9116f5175709147678

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42823 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2238 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54850 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23929 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2842 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1634 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57622 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50226 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49502 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11515 "Found 1 new test failure: workers/wasm-hashset-many.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30029 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7743 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->