### PR TITLE
REGRESSION (277166@main): [iOS] Search doesn’t highlight text being searched in Mail

### DIFF
--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ArgumentCoders.h"
-#include <WebCore/FrameIdentifier.h>
 #include <wtf/HashTraits.h>
 #include <wtf/text/WTFString.h>
 
@@ -35,7 +34,7 @@ namespace WebKit {
 struct WebFoundTextRange {
     uint64_t location { 0 };
     uint64_t length { 0 };
-    WebCore::FrameIdentifier frameIdentifier;
+    AtomString frameIdentifier;
     uint64_t order { 0 };
 
     bool operator==(const WebFoundTextRange& other) const;
@@ -54,7 +53,7 @@ struct WebFoundTextRangeHash {
 template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebKit::WebFoundTextRange> {
     static WebKit::WebFoundTextRange emptyValue() { return { }; }
 
-    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) WebCore::FrameIdentifier { HashTableDeletedValue }; }
+    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) AtomString { HashTableDeletedValue }; }
     static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.frameIdentifier.isHashTableDeletedValue(); }
 };
 

--- a/Source/WebKit/Shared/WebFoundTextRange.serialization.in
+++ b/Source/WebKit/Shared/WebFoundTextRange.serialization.in
@@ -23,6 +23,6 @@
 struct WebKit::WebFoundTextRange {
     uint64_t location;
     uint64_t length;
-    WebCore::FrameIdentifier frameIdentifier;
+    AtomString frameIdentifier;
     uint64_t order;
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -117,7 +117,6 @@
 #import <WebCore/FloatQuad.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/FontAttributeChanges.h>
-#import <WebCore/FrameIdentifier.h>
 #import <WebCore/InputMode.h>
 #import <WebCore/KeyEventCodesIOS.h>
 #import <WebCore/KeyboardScroll.h>
@@ -553,7 +552,7 @@ constexpr double fasterTapSignificantZoomThreshold = 0.8;
 
 @property (nonatomic) NSUInteger location;
 @property (nonatomic) NSUInteger length;
-@property (nonatomic) WebCore::FrameIdentifier frameIdentifier;
+@property (nonatomic, copy) NSString *frameIdentifier;
 @property (nonatomic) NSUInteger order;
 
 + (WKFoundTextRange *)foundTextRangeWithWebFoundTextRange:(WebKit::WebFoundTextRange)range;
@@ -14684,6 +14683,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)dealloc
 {
+    [_frameIdentifier release];
     [super dealloc];
 }
 


### PR DESCRIPTION
#### a1f1924291fba68c7494c7e2b67b31753f8ae9bd
<pre>
REGRESSION (277166@main): [iOS] Search doesn’t highlight text being searched in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=274571">https://bugs.webkit.org/show_bug.cgi?id=274571</a>
<a href="https://rdar.apple.com/127888785">rdar://127888785</a>

Reviewed by Tim Horton and Charlie Wolfe.

277166@main replaced unique frame names with `FrameIdentifier` in
`WebFoundTextRange`. While this is a generally desirable change as site
isolation is developed, it is currently incompatible with `UIFindInteraction`
support for Mail.

Mail performs searches using a pool of offscreen web views, to avoid creating
one webview per email in a thread. Consequently, Mail relies on the fact that
a `WebFoundTextRange` acquired from one web view, can be reused to highlight
matches in a different web view with the same web content.

The use of `FrameIdentifier` breaks this functionality, as it is a unique
identifier that will never match across web views with the same content. On the
other hand, frame names match since they are in tree order.

For now, fix by reverting 277166@main, and add a test to document support for
the behavior that Mail relies on. Eventually, an alternate solution will be
needed to support site isolation. However, that will also require rearchitecting
WebKit&apos;s implementation of `UITextSearching`.

* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::constructDeletedValue):
* Source/WebKit/Shared/WebFoundTextRange.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKFoundTextRange dealloc]):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::documentForFoundTextRange const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST(WebKit, FindAndHighlightDifferentWebViews)):

Canonical link: <a href="https://commits.webkit.org/279205@main">https://commits.webkit.org/279205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e666a961f6fd5c522ba26891dbd9f972014acb92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3476 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42824 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2237 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57623 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50222 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49498 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11536 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->