### PR TITLE
Simplify CanvasBase and CanvasRenderingContext

### DIFF
--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -44,7 +44,7 @@ Ref<CustomPaintCanvas> CustomPaintCanvas::create(ScriptExecutionContext& context
 }
 
 CustomPaintCanvas::CustomPaintCanvas(ScriptExecutionContext& context, unsigned width, unsigned height)
-    : CanvasBase(IntSize(width, height), context.noiseInjectionHashSalt())
+    : CanvasBase(Type::CustomPaint, IntSize(width, height), context.noiseInjectionHashSalt())
     , ContextDestructionObserver(&context)
 {
 }
@@ -53,17 +53,17 @@ CustomPaintCanvas::~CustomPaintCanvas()
 {
     notifyObserversCanvasDestroyed();
 
-    m_context = nullptr; // Ensure this goes away before the ImageBuffer.
+    setRenderingContext(nullptr); // Ensure this goes away before the ImageBuffer.
     setImageBuffer(nullptr);
 }
 
 RefPtr<PaintRenderingContext2D> CustomPaintCanvas::getContext()
 {
-    if (m_context)
-        return &downcast<PaintRenderingContext2D>(*m_context);
+    if (renderingContext())
+        return &downcast<PaintRenderingContext2D>(*renderingContext());
 
-    m_context = PaintRenderingContext2D::create(*this);
-    return static_cast<PaintRenderingContext2D*>(m_context.get());
+    setRenderingContext(PaintRenderingContext2D::create(*this));
+    return static_cast<PaintRenderingContext2D*>(renderingContext());
 }
 
 void CustomPaintCanvas::replayDisplayList(GraphicsContext& target)

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -57,9 +57,8 @@ public:
 
     RefPtr<PaintRenderingContext2D> getContext();
 
-    CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
-    GraphicsContext* drawingContext() const final;
-    GraphicsContext* existingDrawingContext() const final;
+    GraphicsContext* drawingContext() const;
+    GraphicsContext* existingDrawingContext() const;
 
     void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
 
@@ -85,7 +84,6 @@ private:
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void replayDisplayListImpl(GraphicsContext& target) const;
 
-    std::unique_ptr<CanvasRenderingContext> m_context;
     mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
     mutable RefPtr<Image> m_copiedImage;
 

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -73,7 +73,6 @@ public:
 
     void setSize(const IntSize& newSize) override;
 
-    CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
     ExceptionOr<std::optional<RenderingContext>> getContext(JSC::JSGlobalObject&, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
 
     CanvasRenderingContext* getContext(const String&);
@@ -168,8 +167,6 @@ private:
     void createImageBuffer() const final;
     void clearImageBuffer() const;
 
-    bool hasCreatedImageBuffer() const final { return m_hasCreatedImageBuffer; }
-
     void setSurfaceSize(const IntSize&);
 
     bool paintsIntoCanvasBuffer() const;
@@ -185,12 +182,9 @@ private:
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
-    std::unique_ptr<CanvasRenderingContext> m_context;
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
     bool m_ignoreReset { false };
-    // m_hasCreatedImageBuffer means we tried to malloc the buffer. We didn't necessarily get it.
-    mutable bool m_hasCreatedImageBuffer { false };
     mutable bool m_didClearImageBuffer { false };
 #if ENABLE(WEBGL)
     bool m_hasRelevantWebGLEventListener { false };

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -133,8 +133,6 @@ public:
 
     void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
 
-    CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
-
     const CSSParserContext& cssParserContext() const final;
 
     ExceptionOr<std::optional<OffscreenRenderingContext>> getContext(JSC::JSGlobalObject&, RenderingContextType, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
@@ -145,8 +143,6 @@ public:
 
     Image* copiedImage() const final;
     void clearCopiedImage() const final;
-
-    bool hasCreatedImageBuffer() const final { return m_hasCreatedImageBuffer; }
 
     SecurityOrigin* securityOrigin() const final;
 
@@ -186,11 +182,8 @@ private:
     void reset();
     void scheduleCommitToPlaceholderCanvas();
 
-    std::unique_ptr<CanvasRenderingContext> m_context;
     RefPtr<OffscreenCanvasPlaceholderData> m_placeholderData;
     mutable RefPtr<Image> m_copiedImage;
-    // m_hasCreatedImageBuffer means we tried to malloc the buffer. We didn't necessarily get it.
-    mutable bool m_hasCreatedImageBuffer { false };
     bool m_detached { false };
     bool m_hasScheduledCommit { false };
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -63,8 +63,9 @@ Lock& CanvasRenderingContext::instancesLock()
     return s_instancesLock;
 }
 
-CanvasRenderingContext::CanvasRenderingContext(CanvasBase& canvas)
-    : m_canvas(canvas)
+CanvasRenderingContext::CanvasRenderingContext(Type type, CanvasBase& canvas)
+    : m_type(type)
+    , m_canvas(canvas)
 {
     Locker locker { instancesLock() };
     instances().add(this);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -57,6 +57,17 @@ class CanvasRenderingContext : public ScriptWrappable, public CanMakeWeakPtr<Can
 public:
     virtual ~CanvasRenderingContext();
 
+    enum class Type : uint8_t {
+        CanvasRenderingContext2D,
+        OffscreenCanvasRenderingContext2D,
+        PaintRenderingContext2D,
+        ImageBitmapRenderingContext,
+        PlaceholderRenderingContext,
+        WebGLRenderingContext,
+        WebGL2RenderingContext,
+        GPUCanvasContext,
+    };
+
     static HashSet<CanvasRenderingContext*>& instances() WTF_REQUIRES_LOCK(instancesLock());
     static Lock& instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 
@@ -65,18 +76,19 @@ public:
 
     CanvasBase& canvasBase() const { return m_canvas; }
 
-    virtual bool is2dBase() const { return false; }
-    virtual bool is2d() const { return false; }
-    virtual bool isWebGL1() const { return false; }
-    virtual bool isWebGL2() const { return false; }
+    bool is2d() const { return m_type == Type::CanvasRenderingContext2D; }
+    bool isOffscreen2d() const { return m_type == Type::OffscreenCanvasRenderingContext2D; }
+    bool isPaint() const { return m_type == Type::PaintRenderingContext2D; }
+    bool is2dBase() const { return is2d() || isOffscreen2d() || isPaint(); }
+    bool isBitmapRenderer() const { return m_type == Type::ImageBitmapRenderingContext; }
+    bool isPlaceholder() const { return m_type == Type::PlaceholderRenderingContext; }
+    bool isWebGL1() const { return m_type == Type::WebGLRenderingContext; }
+    bool isWebGL2() const { return m_type == Type::WebGL2RenderingContext; }
     bool isWebGL() const { return isWebGL1() || isWebGL2(); }
-    virtual bool isWebGPU() const { return false; }
+    bool isWebGPU() const { return m_type == Type::GPUCanvasContext; }
+
     virtual bool isGPUBased() const { return false; }
     virtual bool isAccelerated() const { return false; }
-    virtual bool isBitmapRenderer() const { return false; }
-    virtual bool isPlaceholder() const { return false; }
-    virtual bool isOffscreen2d() const { return false; }
-    virtual bool isPaint() const { return false; }
 
     virtual void clearAccumulatedDirtyRect() { }
 
@@ -118,7 +130,7 @@ public:
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
 protected:
-    explicit CanvasRenderingContext(CanvasBase&);
+    explicit CanvasRenderingContext(Type, CanvasBase&);
     bool taintsOrigin(const CanvasPattern*);
     bool taintsOrigin(const CanvasBase*);
     bool taintsOrigin(const CachedImage*);
@@ -136,6 +148,7 @@ protected:
     void checkOrigin(const URL&);
     void checkOrigin(const CSSStyleImageValue&);
 
+    Type m_type { Type::CanvasRenderingContext2D };
     bool m_isInPreparationForDisplayOrFlush { false };
     bool m_hasActiveInspectorCanvasCallTracer { false };
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<CanvasRenderingContext2D> CanvasRenderingContext2D::create(Canva
 }
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
-    : CanvasRenderingContext2DBase(canvas, WTFMove(settings), usesCSSCompatibilityParseMode)
+    : CanvasRenderingContext2DBase(Type::CanvasRenderingContext2D, canvas, WTFMove(settings), usesCSSCompatibilityParseMode)
 {
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
@@ -56,7 +56,6 @@ public:
 private:
     CanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
 
-    bool is2d() const final { return true; }
     const FontProxy* fontProxy() final;
 
     std::optional<FilterOperations> setFilterStringWithoutUpdatingStyle(const String&) override;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -224,8 +224,8 @@ static TextBaseline fromCanvasTextBaseline(CanvasTextBaseline canvasTextBaseline
     return TopTextBaseline;
 }
 
-CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
-    : CanvasRenderingContext(canvas)
+CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(Type type, CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings, bool usesCSSCompatibilityParseMode)
+    : CanvasRenderingContext(type, canvas)
     , m_stateStack(1)
     , m_usesCSSCompatibilityParseMode(usesCSSCompatibilityParseMode)
     , m_settings(WTFMove(settings))

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -93,7 +93,7 @@ class CanvasRenderingContext2DBase : public CanvasRenderingContext, public Canva
     WTF_MAKE_ISO_ALLOCATED(CanvasRenderingContext2DBase);
     friend class CanvasFilterTargetSwitcher;
 protected:
-    CanvasRenderingContext2DBase(CanvasBase&, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
+    CanvasRenderingContext2DBase(Type, CanvasBase&, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
 
 public:
     virtual ~CanvasRenderingContext2DBase();
@@ -386,7 +386,6 @@ private:
     void applyShadow();
     bool shouldDrawShadows() const;
 
-    bool is2dBase() const final { return true; }
     bool needsPreparationForDisplay() const final;
     void prepareForDisplay() final;
 

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
@@ -32,8 +32,8 @@
 
 namespace WebCore {
 
-GPUBasedCanvasRenderingContext::GPUBasedCanvasRenderingContext(CanvasBase& canvas)
-    : CanvasRenderingContext(canvas)
+GPUBasedCanvasRenderingContext::GPUBasedCanvasRenderingContext(Type type, CanvasBase& canvas)
+    : CanvasRenderingContext(type, canvas)
     , ActiveDOMObject(canvas.scriptExecutionContext())
 {
 }

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -45,7 +45,7 @@ public:
 
     virtual void reshape(int width, int height, int oldWidth, int oldHeight) = 0;
 protected:
-    explicit GPUBasedCanvasRenderingContext(CanvasBase&);
+    explicit GPUBasedCanvasRenderingContext(Type, CanvasBase&);
 
     HTMLCanvasElement* htmlCanvas() const;
     void markCanvasChanged();

--- a/Source/WebCore/html/canvas/GPUCanvasContext.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase&, GPU&)
 #endif
 
 GPUCanvasContext::GPUCanvasContext(CanvasBase& canvas)
-    : GPUBasedCanvasRenderingContext(canvas)
+    : GPUBasedCanvasRenderingContext(Type::GPUCanvasContext, canvas)
 {
 }
 

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -62,8 +62,6 @@ public:
     virtual ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() = 0;
     virtual ExceptionOr<RefPtr<ImageBitmap>> getCurrentTextureAsImageBitmap(ImageBuffer&, bool originClean) = 0;
 
-    bool isWebGPU() const override { return true; }
-
 protected:
     GPUCanvasContext(CanvasBase&);
 };

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -73,8 +73,6 @@ public:
     ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
     ExceptionOr<RefPtr<ImageBitmap>> getCurrentTextureAsImageBitmap(ImageBuffer&, bool originClean) override;
 
-    bool isWebGPU() const override { return true; }
-
 private:
     explicit GPUCanvasContextCocoa(CanvasBase&, GPU&);
 

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<ImageBitmapRenderingContext> ImageBitmapRenderingContext::create
 }
 
 ImageBitmapRenderingContext::ImageBitmapRenderingContext(CanvasBase& canvas, ImageBitmapRenderingContextSettings&& settings)
-    : CanvasRenderingContext(canvas)
+    : CanvasRenderingContext(Type::ImageBitmapRenderingContext, canvas)
     , m_settings(WTFMove(settings))
 {
 }

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -66,7 +66,6 @@ public:
 private:
     ImageBitmapRenderingContext(CanvasBase&, ImageBitmapRenderingContextSettings&&);
 
-    bool isBitmapRenderer() const final { return true; }
     bool isAccelerated() const override;
 
     void setOutputBitmap(RefPtr<ImageBitmap>);

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<OffscreenCanvasRenderingContext2D> OffscreenCanvasRenderingConte
 }
 
 OffscreenCanvasRenderingContext2D::OffscreenCanvasRenderingContext2D(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings)
-    : CanvasRenderingContext2DBase(canvas, WTFMove(settings), false)
+    : CanvasRenderingContext2DBase(Type::OffscreenCanvasRenderingContext2D, canvas, WTFMove(settings), false)
 {
 }
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -53,7 +53,6 @@ public:
 
 private:
     OffscreenCanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&);
-    bool isOffscreen2d() const final { return true; }
     const FontProxy* fontProxy() final;
 };
 

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<PaintRenderingContext2D> PaintRenderingContext2D::create(CanvasB
 }
 
 PaintRenderingContext2D::PaintRenderingContext2D(CanvasBase& canvas)
-    : CanvasRenderingContext2DBase(canvas, { }, false)
+    : CanvasRenderingContext2DBase(Type::PaintRenderingContext2D, canvas, { }, false)
 {
 }
 

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -41,8 +41,6 @@ public:
     CustomPaintCanvas& canvas() const { return downcast<CustomPaintCanvas>(canvasBase()); }
 
 private:
-    bool isPaint() const override { return true; }
-
     PaintRenderingContext2D(CanvasBase&);
 };
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(PlaceholderRenderingContext);
 
 PlaceholderRenderingContext::PlaceholderRenderingContext(CanvasBase& canvas)
-    : CanvasRenderingContext(canvas)
+    : CanvasRenderingContext(Type::PlaceholderRenderingContext, canvas)
 {
     m_imageBufferPipe = ImageBufferPipe::create();
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -44,8 +44,6 @@ public:
     const RefPtr<ImageBufferPipe>& imageBufferPipe() const { return m_imageBufferPipe; }
 
 private:
-    bool isPlaceholder() const final { return true; }
-
     bool isAccelerated() const final { return !!m_imageBufferPipe; }
     bool isGPUBased() const final { return !!m_imageBufferPipe; }
     void setContentsToLayer(GraphicsLayer&);

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -116,6 +116,11 @@ std::unique_ptr<WebGL2RenderingContext> WebGL2RenderingContext::create(CanvasBas
     return std::unique_ptr<WebGL2RenderingContext>(new WebGL2RenderingContext(canvas, WTFMove(attributes)));
 }
 
+WebGL2RenderingContext::WebGL2RenderingContext(CanvasBase& canvas, WebGLContextAttributes&& attributes)
+    : WebGLRenderingContextBase(Type::WebGL2RenderingContext, canvas, WTFMove(attributes))
+{
+}
+
 WebGL2RenderingContext::~WebGL2RenderingContext()
 {
     // Remove all references to WebGLObjects so if they are the last reference

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -260,9 +260,7 @@ public:
     bool isTransformFeedbackActiveAndNotPaused();
 
 private:
-    using WebGLRenderingContextBase::WebGLRenderingContextBase;
-
-    bool isWebGL2() const final { return true; }
+    WebGL2RenderingContext(CanvasBase&, WebGLContextAttributes&&);
 
     void initializeContextState() final;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -117,6 +117,11 @@ std::unique_ptr<WebGLRenderingContext> WebGLRenderingContext::create(CanvasBase&
     return std::unique_ptr<WebGLRenderingContext>(new WebGLRenderingContext(canvas, WTFMove(attributes)));
 }
 
+WebGLRenderingContext::WebGLRenderingContext(CanvasBase& canvas, WebGLContextAttributes&& attributes)
+    : WebGLRenderingContextBase(Type::WebGLRenderingContext, canvas, WTFMove(attributes))
+{
+}
+
 WebGLRenderingContext::~WebGLRenderingContext()
 {
     m_activeQuery = nullptr;

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -41,8 +41,6 @@ public:
 
     ~WebGLRenderingContext();
 
-    bool isWebGL1() const final { return true; }
-
     std::optional<WebGLExtensionAny> getExtension(const String&) final;
     std::optional<Vector<String>> getSupportedExtensions() final;
 
@@ -63,7 +61,7 @@ protected:
     WebGLBindingPoint<WebGLTimerQueryEXT, GraphicsContextGL::TIME_ELAPSED_EXT> m_activeQuery;
 
 private:
-    using WebGLRenderingContextBase::WebGLRenderingContextBase;
+    WebGLRenderingContext(CanvasBase&, WebGLContextAttributes&&);
 };
 
 WebCoreOpaqueRoot root(const WebGLExtension<WebGLRenderingContext>*);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -468,8 +468,8 @@ std::unique_ptr<WebGLRenderingContextBase> WebGLRenderingContextBase::create(Can
     return renderingContext;
 }
 
-WebGLRenderingContextBase::WebGLRenderingContextBase(CanvasBase& canvas, WebGLContextAttributes&& attributes)
-    : GPUBasedCanvasRenderingContext(canvas)
+WebGLRenderingContextBase::WebGLRenderingContextBase(Type type, CanvasBase& canvas, WebGLContextAttributes&& attributes)
+    : GPUBasedCanvasRenderingContext(type, canvas)
     , m_generatedImageCache(4)
     , m_attributes(WTFMove(attributes))
     , m_creationAttributes(m_attributes)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -487,7 +487,7 @@ public:
 
     WeakPtr<WebGLRenderingContextBase> createRefForContextObject();
 protected:
-    WebGLRenderingContextBase(CanvasBase&, WebGLContextAttributes&&);
+    WebGLRenderingContextBase(Type, CanvasBase&, WebGLContextAttributes&&);
 
     friend class EXTDisjointTimerQuery;
     friend class EXTDisjointTimerQueryWebGL2;


### PR DESCRIPTION
#### f44988cce49989354e1c6d4c86e85638e664e3bc
<pre>
Simplify CanvasBase and CanvasRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=274576">https://bugs.webkit.org/show_bug.cgi?id=274576</a>
<a href="https://rdar.apple.com/128588932">rdar://128588932</a>

Reviewed by NOBODY (OOPS!).

Simplify super hot code in CanvasBase and CanvasRenderingContext.

1. CanvasBase now has m_type to dispatch to the major cases efficiently and we use this to devirtualize drawingContext function.
2. Move some of common boolean and renderingContext to CanvasBase to avoid virtual functions.
3. Rename m_context to m_renderingContext since it is accessed via renderingContext() getter.
4. CanvasRenderingContext also gets m_type and type-dispatching functions get devirtualized.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::CanvasBase):
(WebCore::CanvasBase::drawingContext const):
(WebCore::CanvasBase::existingDrawingContext const):
(WebCore::CanvasBase::buffer const):
(WebCore::CanvasBase::setRenderingContext):
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::renderingContext const):
(WebCore::CanvasBase::hasCreatedImageBuffer const):
* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::CustomPaintCanvas):
(WebCore::CustomPaintCanvas::~CustomPaintCanvas):
(WebCore::CustomPaintCanvas::getContext):
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::HTMLCanvasElement):
(WebCore::HTMLCanvasElement::~HTMLCanvasElement):
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::createContext2d):
(WebCore::HTMLCanvasElement::getContext2d):
(WebCore::HTMLCanvasElement::createContextWebGL):
(WebCore::HTMLCanvasElement::getContextWebGL):
(WebCore::HTMLCanvasElement::createContextBitmapRenderer):
(WebCore::HTMLCanvasElement::getContextBitmapRenderer):
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::getContextWebGPU):
(WebCore::HTMLCanvasElement::reset):
(WebCore::HTMLCanvasElement::paintsIntoCanvasBuffer const):
(WebCore::HTMLCanvasElement::paint):
(WebCore::HTMLCanvasElement::isGPUBased const):
(WebCore::HTMLCanvasElement::transferControlToOffscreen):
(WebCore::HTMLCanvasElement::getImageData):
(WebCore::HTMLCanvasElement::toVideoFrame):
(WebCore::HTMLCanvasElement::createImageBuffer const):
(WebCore::HTMLCanvasElement::copiedImage const):
(WebCore::HTMLCanvasElement::clearImageBuffer const):
(WebCore::HTMLCanvasElement::virtualHasPendingActivity const):
(WebCore::HTMLCanvasElement::needsPreparationForDisplay):
(WebCore::HTMLCanvasElement::prepareForDisplay):
(WebCore::HTMLCanvasElement::isControlledByOffscreen const):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::OffscreenCanvas):
(WebCore::OffscreenCanvas::~OffscreenCanvas):
(WebCore::OffscreenCanvas::setSize):
(WebCore::OffscreenCanvas::getContext):
(WebCore::OffscreenCanvas::transferToImageBitmap):
(WebCore::OffscreenCanvas::copiedImage const):
(WebCore::OffscreenCanvas::canDetach const):
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
(WebCore::OffscreenCanvas::reset):
* Source/WebCore/html/OffscreenCanvas.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f44988cce49989354e1c6d4c86e85638e664e3bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53126 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3849 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43069 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2492 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58001 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50469 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46081 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49775 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->