### PR TITLE
Credential Management API shouldn't allow method calls on non-fully active docs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS non-fully active document behavior for CredentialsContainer
+

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Credential Management API Test: non-fully active document</title>
+<link
+  rel="help"
+  href="https://github.com/w3c/webappsec-credential-management"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+  <iframe></iframe>
+</body>
+<script>
+  promise_setup(async () => {
+    const iframe = document.querySelector("iframe");
+    await new Promise((resolve) => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "about:blank";
+      document.body.appendChild(iframe);
+    });
+  });
+
+  promise_test(async (t) => {
+    const iframe = document.querySelector("iframe");
+    
+    // The signal check happens after the fully active check.
+    // This allows us to confirm the the right error is thrown
+    // and in the right order.
+    const controller = new iframe.contentWindow.AbortController();
+    const signal = controller.signal;
+    controller.abort();
+
+    // Steal all the needed references.
+    const { credentials } = iframe.contentWindow.navigator;
+    const DOMExceptionCtor = iframe.contentWindow.DOMException;
+
+    // No longer fully active.
+    iframe.remove();
+
+    // Try to get credentials while not fully active...
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      DOMExceptionCtor,
+      credentials.get({ signal }),
+      "Expected NotAllowedError for get() on non-fully-active document"
+    );
+
+    // Try to create credentials while not fully active...
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      DOMExceptionCtor,
+      credentials.create({ signal }),
+      "Expected NotAllowedError for create() on non-fully-active document"
+    );
+
+    // Try to prevent silent access while not fully active...
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      DOMExceptionCtor,
+      credentials.preventSilentAccess(),
+      "Expected NotAllowedError for preventSilentAccess() on non-fully-active document"
+    );
+  }, "non-fully active document behavior for CredentialsContainer");
+</script>


### PR DESCRIPTION
#### 0864a389355ba989dff35cd5012e4a5caed4c292
<pre>
Credential Management API shouldn&apos;t allow method calls on non-fully active docs
<a href="https://bugs.webkit.org/show_bug.cgi?id=274444">https://bugs.webkit.org/show_bug.cgi?id=274444</a>
<a href="https://rdar.apple.com/128595290">rdar://128595290</a>

Reviewed by Pascoe.

Adds fully active checks specified in:
<a href="https://github.com/w3c/webappsec-credential-management/pull/230">https://github.com/w3c/webappsec-credential-management/pull/230</a>

* LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html: Added.
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::preventSilentAccess const):
(WebCore::CredentialsContainer::performCommonChecks):

Canonical link: <a href="https://commits.webkit.org/279309@main">https://commits.webkit.org/279309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a480dc611ecbe08db6db34a2a7f635e0e50607

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42841 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23954 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57646 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50238 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49516 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11584 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->