### PR TITLE
[GTK] Deprecate WebKitWebContext:use-system-appearance-for-scrollbars property

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -361,7 +361,9 @@ static void webkitWebContextGetProperty(GObject* object, guint propID, GValue* v
         g_value_set_boolean(value, context->priv->psonEnabled);
         break;
     case PROP_USE_SYSTEM_APPEARANCE_FOR_SCROLLBARS:
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         g_value_set_boolean(value, webkit_web_context_get_use_system_appearance_for_scrollbars(context));
+        ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 #endif
     case PROP_TIME_ZONE_OVERRIDE:
@@ -394,7 +396,9 @@ static void webkitWebContextSetProperty(GObject* object, guint propID, const GVa
         context->priv->psonEnabled = g_value_get_boolean(value);
         break;
     case PROP_USE_SYSTEM_APPEARANCE_FOR_SCROLLBARS:
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         webkit_web_context_set_use_system_appearance_for_scrollbars(context, g_value_get_boolean(value));
+        ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 #endif
     case PROP_MEMORY_PRESSURE_SETTINGS: {
@@ -575,13 +579,15 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
      * consistency, or when consistency with other applications is required too.
      *
      * Since: 2.30
+     *
+     * Deprecated: 2.46
      */
     sObjProperties[PROP_USE_SYSTEM_APPEARANCE_FOR_SCROLLBARS] =
         g_param_spec_boolean(
             "use-system-appearance-for-scrollbars",
             nullptr, nullptr,
-            TRUE,
-            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+            FALSE,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_DEPRECATED));
 #endif
 
     /**
@@ -1930,7 +1936,11 @@ void webkit_web_context_send_message_to_all_extensions(WebKitWebContext* context
  *
  * Set the #WebKitWebContext:use-system-appearance-for-scrollbars property.
  *
+ * This is now deprecated and when WebKit is built with Skia this method does nothing.
+ *
  * Since: 2.30
+ *
+ * Deprecated: 2.46
  */
 void webkit_web_context_set_use_system_appearance_for_scrollbars(WebKitWebContext* context, gboolean enabled)
 {
@@ -1949,8 +1959,8 @@ void webkit_web_context_set_use_system_appearance_for_scrollbars(WebKitWebContex
     context->priv->processPool->configuration().setUseSystemAppearanceForScrollbars(enabled);
     context->priv->processPool->sendToAllProcesses(Messages::WebProcess::SetUseSystemAppearanceForScrollbars(enabled));
 #else
-    // FIXME: deprecate this when switching to Skia.
-    UNUSED_PARAM(enabled);
+    if (enabled)
+        g_warning("WebKitWebContext:use-system-appearance-for-scrollbars property is deprecated and does nothing");
 #endif
 }
 
@@ -1963,6 +1973,8 @@ void webkit_web_context_set_use_system_appearance_for_scrollbars(WebKitWebContex
  * Returns: %TRUE if scrollbars are rendering using the system appearance, or %FALSE otherwise
  *
  * Since: 2.30
+ *
+ * Deprecated: 2.46
  */
 gboolean webkit_web_context_get_use_system_appearance_for_scrollbars(WebKitWebContext* context)
 {
@@ -1971,7 +1983,6 @@ gboolean webkit_web_context_get_use_system_appearance_for_scrollbars(WebKitWebCo
 #if USE(CAIRO)
     return context->priv->useSystemAppearanceForScrollbars;
 #else
-    // FIXME: deprecate this when switching to Skia.
     return FALSE;
 #endif
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -411,11 +411,11 @@ webkit_web_context_send_message_to_all_extensions   (WebKitWebContext           
                                                      WebKitUserMessage             *message);
 
 #if PLATFORM(GTK) && !USE(GTK4)
-WEBKIT_API void
+WEBKIT_DEPRECATED void
 webkit_web_context_set_use_system_appearance_for_scrollbars (WebKitWebContext      *context,
                                                              gboolean               enabled);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED gboolean
 webkit_web_context_get_use_system_appearance_for_scrollbars (WebKitWebContext      *context);
 #endif
 

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -844,7 +844,6 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
     WebKitWebContext *webContext = g_object_new(WEBKIT_TYPE_WEB_CONTEXT,
         "website-data-manager", manager,
         "process-swap-on-cross-site-navigation-enabled", TRUE,
-        "use-system-appearance-for-scrollbars", FALSE,
         "time-zone-override", timeZone,
         NULL);
     g_object_unref(manager);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -140,7 +140,6 @@ public:
             "website-data-manager", websiteDataManager.get(),
 #if PLATFORM(GTK)
             "process-swap-on-cross-site-navigation-enabled", TRUE,
-            "use-system-appearance-for-scrollbars", FALSE,
 #endif
             "memory-pressure-settings", s_memoryPressureSettings,
             nullptr)));


### PR DESCRIPTION
#### eeec86ec49d848faa827d880428392d20c1a0af0
<pre>
[GTK] Deprecate WebKitWebContext:use-system-appearance-for-scrollbars property
<a href="https://bugs.webkit.org/show_bug.cgi?id=274383">https://bugs.webkit.org/show_bug.cgi?id=274383</a>

Reviewed by Michael Catanzaro.

Rendering system scrollbars requires cairo, so it&apos;s impossible to
support this with skia.

* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkit_web_context_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Tools/MiniBrowser/gtk/main.c:
(activate):
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::Test):

Canonical link: <a href="https://commits.webkit.org/279253@main">https://commits.webkit.org/279253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58826dc1927bac45aea35ed656f3770b4653b0e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42850 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2269 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54889 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45568 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23965 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2885 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1673 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50251 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49531 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30068 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7773 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->