### PR TITLE
[Remote Inspection] Right click > Toggle Visibility sometimes fails to reveal hidden elements

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -90,6 +90,7 @@ private:
     ApproximateTime m_startTimeForSelectorBasedVisibilityAdjustment;
     Timer m_selectorBasedVisibilityAdjustmentTimer;
     Vector<std::pair<ElementIdentifier, TargetedElementSelectors>> m_visibilityAdjustmentSelectors;
+    Vector<TargetedElementSelectors> m_initialVisibilityAdjustmentSelectors;
     Region m_adjustmentClientRegion;
     Region m_repeatedAdjustmentClientRegion;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_adjustedElements;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -181,4 +181,25 @@
     return _info->hasAudibleMedia();
 }
 
+- (NSString *)debugDescription
+{
+    auto firstSelector = [&]() -> String {
+        auto& allSelectors = _info->selectors();
+        if (allSelectors.isEmpty())
+            return { };
+
+        if (allSelectors.last().isEmpty())
+            return { };
+
+        // Most relevant selector for the final target element (after all enclosing shadow
+        // roots have been resolved).
+        return allSelectors.last().first();
+    }();
+
+    auto bounds = _info->boundsInRootView();
+    return [NSString stringWithFormat:@"<%@ %p \"%@\" at {{%.0f,%.0f},{%.0f,%.0f}}>"
+        , self.class, self, (NSString *)firstSelector
+        , bounds.x(), bounds.y(), bounds.width(), bounds.height()];
+}
+
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -374,6 +374,12 @@ TEST(ElementTargeting, RequestElementsFromSelectors)
     EXPECT_EQ(1U, [targets count]);
     EXPECT_WK_STREQ("DIV.absolute.bottom-right", [target selectorsIncludingShadowHosts].firstObject.firstObject);
     EXPECT_TRUE([target isInVisibilityAdjustmentSubtree]);
+
+    didAdjustVisibility = false;
+
+    [webView resetVisibilityAdjustmentsForTargets:targets.get()];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_FALSE(didAdjustVisibility);
 }
 
 TEST(ElementTargeting, AdjustVisibilityFromPseudoSelectors)


### PR DESCRIPTION
#### 6ddb740bdea7c4f3d92623dea99d7771f79c5a21
<pre>
[Remote Inspection] Right click &gt; Toggle Visibility sometimes fails to reveal hidden elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=274586">https://bugs.webkit.org/show_bug.cgi?id=274586</a>

Reviewed by Aditya Keerthi.

Make a couple of minor adjustments to undo initial visibility adjustment rules when Web Inspector
resets &quot;Toggle Visibility&quot; state for targeted elements.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
(WebCore::ElementTargetingController::reset):
(WebCore::ElementTargetingController::resetVisibilityAdjustments):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo debugDescription]):

Also, add a `-debugDescription` to make debug logging more useful.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, RequestElementsFromSelectors)):

Canonical link: <a href="https://commits.webkit.org/279213@main">https://commits.webkit.org/279213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93fe682b2c05e5e210a56189303de4d375774885

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3255 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2285 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54906 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23981 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2907 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1690 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57679 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3038 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45782 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11537 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->