### PR TITLE
Avoid saving extra register for IPInt JS->Wasm wrappers.

### DIFF
--- a/JSTests/wasm/stress/cc-i32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useIPIntWrappers=1")
+//@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture != "arm64" and $architecture != "x86_64"
-//@ runDefault("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useIPIntWrappers=1")
+//@ runDefault("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture != "arm64" and $architecture != "x86_64"
-//@ requireOptions("--useIPIntWrappers=1")
+//@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-memory.js
+++ b/JSTests/wasm/stress/cc-int-to-int-memory.js
@@ -1,5 +1,5 @@
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useIPIntWrappers=1 --dumpDisassembly=0
-//@ requireOptions("--useIPIntWrappers=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-no-jit.js
+++ b/JSTests/wasm/stress/cc-int-to-int-no-jit.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture != "arm64" and $architecture != "x86_64"
-//@ runDefault("-m", "--useJIT=0", "--useWebAssembly=1", "--useIPIntWrappers=1")
+//@ runDefault("-m", "--useJIT=0", "--useWebAssembly=1", "--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-tail-call.js
+++ b/JSTests/wasm/stress/cc-int-to-int-tail-call.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useIPIntWrappers=1", "--useWebAssemblyTailCalls=1")
+//@ requireOptions("--useInterpretedJSEntryWrappers=1", "--useWebAssemblyTailCalls=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int.js
+++ b/JSTests/wasm/stress/cc-int-to-int.js
@@ -1,5 +1,5 @@
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useIPIntWrappers=1 --dumpDisassembly=0
-//@ requireOptions("--useIPIntWrappers=1")
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -411,8 +411,6 @@ RegisterSet RegisterSetBuilder::wasmPinnedRegisters()
         result.add(GPRInfo::wasmContextInstancePointer, IgnoreVectors);
     if constexpr (GPRInfo::wasmBoundsCheckingSizeRegister != InvalidGPRReg)
         result.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
-    if constexpr (GPRInfo::metadataTableRegister != InvalidGPRReg)
-        result.add(GPRInfo::metadataTableRegister, IgnoreVectors);
 #if OS(WINDOWS)
     result.add(GPRInfo::wasmScratchCSR0, IgnoreVectors);
 #endif

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -141,7 +141,7 @@ void initialize()
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
     FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
 
-    if (Options::useIPIntWrappers()) {
+    if (Options::useInterpretedJSEntryWrappers()) {
         FOR_EACH_JS_TO_WASM_WRAPPER_METADATA_OPCODE(VALIDATE_JS_TO_WASM_WRAPPER_ENTRY);
         // Label after last defined opcode
         VALIDATE_JS_TO_WASM_WRAPPER_ENTRY(static_cast<int>(Wasm::JSEntrypointInterpreterCalleeMetadata::InvalidRegister), invalidop);

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -116,7 +116,7 @@ void initialize()
 
         AssemblyCommentRegistry::initialize();
 #if ENABLE(WEBASSEMBLY)
-        if (Options::useWasmIPInt() || Options::useIPIntWrappers())
+        if (Options::useWasmIPInt() || Options::useInterpretedJSEntryWrappers())
             IPInt::initialize();
 #endif
         LLInt::initialize();

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -712,7 +712,7 @@ void Options::notifyOptionsChanged()
     Options::useConcurrentGC() = false;
     Options::forceUnlinkedDFG() = false;
     Options::useWebAssemblySIMD() = false;
-    Options::useIPIntWrappers() = false;
+    Options::useInterpretedJSEntryWrappers() = false;
 #if !CPU(ARM_THUMB2)
     Options::useBBQJIT() = false;
 #endif
@@ -722,7 +722,7 @@ void Options::notifyOptionsChanged()
 #endif
 
 #if ENABLE(C_LOOP) || !CPU(ADDRESS64) || !(CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
-    Options::useIPIntWrappers() = false;
+    Options::useInterpretedJSEntryWrappers() = false;
 #endif
 
 #if !CPU(ARM64)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -579,7 +579,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
     v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
     v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
-    v(Bool, useIPIntWrappers, false, Normal, "Allow IPInt to replace JIT wasm wrappers"_s) \
+    v(Bool, useInterpretedJSEntryWrappers, false, Normal, "Allow some JS->Wasm wrappers to be replaced by jit-less versions."_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     \
     /* Feature Flags */\

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -244,6 +244,9 @@ void BBQPlan::work(CompilationEffort effort)
             }
 
             callee->setEntrypoint(WTFMove(jsToWasmInternalFunction->entrypoint));
+            Locker locker { m_calleeGroup->m_lock };
+            // Note that we can compile the same function with multiple memory modes, which can cause this
+            // race. That's fine, both stubs should do the same thing.
             static_cast<JSEntrypointInterpreterCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
 
             auto result = m_jsToWasmInternalFunctions.add(m_functionIndex, std::tuple { WTFMove(callee), WTFMove(linkBuffer), WTFMove(jsToWasmInternalFunction) });

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -431,7 +431,7 @@ RegisterAtOffsetList* JSEntrypointInterpreterCallee::calleeSaveRegistersImpl()
         RegisterSet registers = RegisterSetBuilder::wasmPinnedRegisters();
 #if CPU(X86_64)
 #elif CPU(ARM64) || CPU(RISCV64)
-        ASSERT(registers.numberOfSetRegisters() == 4);
+        ASSERT(registers.numberOfSetRegisters() == 3);
 #elif CPU(ARM)
 #else
 #error Unsupported architecture.

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -175,7 +175,7 @@ private:
 };
 
 #define FOR_EACH_JS_TO_WASM_WRAPPER_METADATA_OPCODE(macro) \
-/* Load/Store accumulator; followed by (offset from cfr : int8_t) */ \
+/* Load/Store accumulator; followed by (offset from sp (load) or cfr (store): int8_t) */ \
 macro(0, LoadI32) \
 macro(1, LoadI64) \
 macro(2, LoadF32) \
@@ -376,7 +376,10 @@ public:
 
     void setReplacement(RefPtr<Wasm::Callee> callee)
     {
-        ASSERT(!m_replacementCallee);
+        // Note that we can compile the same function with multiple memory modes, which can cause the JS->Wasm stub generator to
+        // race. That's fine, both stubs should do the same thing.
+        if (m_replacementCallee)
+            return;
         ASSERT(callee);
         m_replacementCallee = WTFMove(callee);
     }


### PR DESCRIPTION
#### 7a1fe31ef5a7a4ebdbf52c296d76189fad22dd78
<pre>
Avoid saving extra register for IPInt JS-&gt;Wasm wrappers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274043">https://bugs.webkit.org/show_bug.cgi?id=274043</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Adding this register to the pinned register set causes a bunch of places
to save it. We should just spill it inside the JS-&gt;WASM interpreted entry thunk.

* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::wasmPinnedRegisters):
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::JSEntrypointInterpreterCallee::calleeSaveRegistersImpl):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::makeInterpretedJSToWasmCallee):

Canonical link: <a href="https://commits.webkit.org/279435@main">https://commits.webkit.org/279435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d70c27517cf6539d2c0065fa80d2b2ec831f6c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4007 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55591 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24496 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3550 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2375 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46853 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58368 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3727 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29857 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11660 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30786 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65313 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29629 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12449 "Passed tests") | 
<!--EWS-Status-Bubble-End-->