### PR TITLE
Ensure that the SWServerWorker is in the correct state before finishing installation

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -200,7 +200,10 @@ void SWServerWorker::scriptContextStarted(const std::optional<ServiceWorkerJobDa
 
 void SWServerWorker::didFinishInstall(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, bool wasSuccessful)
 {
-    ASSERT(m_server && this->state() == ServiceWorkerState::Installing);
+    auto state = this->state();
+
+    ASSERT(m_server);
+    ASSERT(state == ServiceWorkerState::Installing);
     if (RefPtr server = m_server.get())
         server->didFinishInstall(jobDataIdentifier, *this, wasSuccessful);
 }


### PR DESCRIPTION
#### 52ef87c03616d187d9130122a5ef13c077e35dc0
<pre>
Ensure that the SWServerWorker is in the correct state before finishing installation
<a href="https://rdar.apple.com/121429889">rdar://121429889</a>

Reviewed by Youenn Fablet.

Ensure that the SWServerWorker is in the expected state and bail if this method is triggered on a SWServerWorker in a different state. This method is callable over CoreIPC passing a ServiceWorkerIdentifier. Passing the ID of a service worker in any other state will reach the RELEASE_ASSERT

* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::didFinishInstall):

Originally-landed-as: 272448.701@safari-7618-branch (be630dbb12c9). rdar://128089504
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ef87c03616d187d9130122a5ef13c077e35dc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52822 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32159 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5309 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56101 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3545 "Hash 52ef87c0 for PR 28991 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55127 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38883 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3270 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/56101 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/3545 "Hash 52ef87c0 for PR 28991 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54920 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/38883 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/5309 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/56101 "Hash 52ef87c0 for PR 28991 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/38883 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/5309 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1704 "Hash 52ef87c0 for PR 28991 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/38883 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/5309 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57694 "Hash 52ef87c0 for PR 28991 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27963 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3051 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/57694 "Hash 52ef87c0 for PR 28991 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29183 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/5309 "Hash 52ef87c0 for PR 28991 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/57694 "Hash 52ef87c0 for PR 28991 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30102 "Hash 52ef87c0 for PR 28991 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28937 "Hash 52ef87c0 for PR 28991 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->