### PR TITLE
In in-window mode, disable rewind on MSE videos and disable seeking and fast forward on live videos

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -315,6 +315,13 @@ bool MediaControlsHost::inWindowFullscreen() const
     return false;
 }
 
+bool MediaControlsHost::supportsRewind() const
+{
+    if (auto sourceType = this->sourceType())
+        return *sourceType == SourceType::HLS || *sourceType == SourceType::File;
+    return false;
+}
+
 String MediaControlsHost::externalDeviceDisplayName() const
 {
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -84,6 +84,7 @@ public:
     bool shouldForceControlsDisplay() const;
     bool supportsSeeking() const;
     bool inWindowFullscreen() const;
+    bool supportsRewind() const;
 
     enum class ForceUpdate : bool { No, Yes };
     void updateCaptionDisplaySizes(ForceUpdate = ForceUpdate::No);

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -63,6 +63,7 @@ enum DeviceType {
     readonly attribute boolean shouldForceControlsDisplay;
     readonly attribute boolean supportsSeeking;
     readonly attribute boolean inWindowFullscreen;
+    readonly attribute boolean supportsRewind;
 
     readonly attribute DOMString externalDeviceDisplayName;
     readonly attribute DeviceType externalDeviceType;

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -202,7 +202,7 @@ class TimeControl extends LayoutItem
         if (this._loading)
             this._durationOrRemainingTimeLabel().setValueWithNumberOfDigits(NaN, 4);
         else {
-            const shouldShowZeroDurations = isNaN(this._duration) || this._duration === Number.POSITIVE_INFINITY;
+            const shouldShowZeroDurations = isNaN(this._duration) || this._duration > maxNonLiveDuration;
 
             let numberOfDigitsForTimeLabels;
             if (this._duration < TenMinutes)

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+const maxNonLiveDuration = 604800; // 604800 seconds == 1 week
+
 class MediaController
 {
     constructor(shadowRoot, media, host)
@@ -334,9 +336,6 @@ class MediaController
         this.controls = new ControlsClass;
         this.controls.delegate = this;
 
-        if (this.host && this.host.inWindowFullscreen)
-            this._stopPropagationOnClickEvents();
-
         if (this.controls.autoHideController && this.shadowRoot.host && this.shadowRoot.host.dataset.autoHideDelay)
             this.controls.autoHideController.autoHideDelay = this.shadowRoot.host.dataset.autoHideDelay;
 
@@ -354,8 +353,14 @@ class MediaController
 
         this.controls.shouldUseSingleBarLayout = this.controls instanceof InlineMediaControls && this.isYouTubeEmbedWithTitle;
 
-        if (this.host && !this.host.supportsSeeking && this.layoutTraits.isFullscreen)
-            this.controls.timeControl.scrubber.disabled = true;
+        if (this.host && this.host.inWindowFullscreen) {
+            this._stopPropagationOnClickEvents();
+            if (!this.host.supportsSeeking)
+                this.controls.timeControl.scrubber.disabled = true;
+
+            if (!this.host.supportsRewind)
+                this.controls.rewindButton.dropped = true;
+        }
 
         this._updateControlsAvailability();
     }

--- a/Source/WebCore/Modules/modern-media-controls/media/overflow-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/overflow-support.js
@@ -94,7 +94,7 @@ class OverflowSupport extends MediaControllerSupport
 
         let media = this.mediaController.media;
 
-        if (media.duration === Number.POSITIVE_INFINITY && media.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        if (media.duration > maxNonLiveDuration && media.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
             // Do not allow adjustment of the playback rate for live broadcasts.
             return false;
         }

--- a/Source/WebCore/Modules/modern-media-controls/media/seek-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/seek-support.js
@@ -48,7 +48,7 @@ class SeekSupport extends MediaControllerSupport
 
     syncControl()
     {
-        this.control.enabled = this.mediaController.media.duration !== Number.POSITIVE_INFINITY;
+        this.control.enabled = this.mediaController.media.duration <= maxNonLiveDuration;
     }
 
     // Private

--- a/Source/WebCore/Modules/modern-media-controls/media/skip-back-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/skip-back-support.js
@@ -46,7 +46,7 @@ class SkipBackSupport extends MediaControllerSupport
 
     syncControl()
     {
-        this.control.enabled = this.mediaController.media.duration !== Number.POSITIVE_INFINITY;
+        this.control.enabled = this.mediaController.media.duration <= maxNonLiveDuration;
     }
 
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/skip-forward-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/skip-forward-support.js
@@ -46,7 +46,7 @@ class SkipForwardSupport extends MediaControllerSupport
 
     syncControl()
     {
-        this.control.enabled = this.mediaController.media.duration !== Number.POSITIVE_INFINITY;
+        this.control.enabled = this.mediaController.media.duration <= maxNonLiveDuration;
     }
 
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/status-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/status-support.js
@@ -41,7 +41,7 @@ class StatusSupport extends MediaControllerSupport
     syncControl()
     {
         const media = this.mediaController.media;
-        const isLiveBroadcast = media.duration === Number.POSITIVE_INFINITY;
+        const isLiveBroadcast = media.duration > maxNonLiveDuration;
         const canPlayThrough = media.readyState === HTMLMediaElement.HAVE_ENOUGH_DATA && !media.error;
 
         if (!!media.error)


### PR DESCRIPTION
#### dc7f1c2fadad4043a7ad33cf9e15092800805d29
<pre>
In in-window mode, disable rewind on MSE videos and disable seeking and fast forward on live videos
<a href="https://bugs.webkit.org/show_bug.cgi?id=274598">https://bugs.webkit.org/show_bug.cgi?id=274598</a>
<a href="https://rdar.apple.com/126924018">rdar://126924018</a>

Reviewed by Jer Noble.

This patch removes the rewind button in in-window mode if a video source type is not HLS or
a file. It also removes the fast forward button and disables seeking if a video&apos;s duration
is long enough to likely be a live video. This patch uses a threshold of a one week
(604800 seconds).

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::inWindowFullscreen const):
(WebCore::MediaControlsHost::externalDeviceDisplayName const): Deleted.
(WebCore::MediaControlsHost::externalDeviceType const): Deleted.
(WebCore::MediaControlsHost::controlsDependOnPageScaleFactor const): Deleted.
(WebCore::MediaControlsHost::setControlsDependOnPageScaleFactor): Deleted.
(WebCore::MediaControlsHost::generateUUID): Deleted.
(WebCore::MediaControlsHost::shadowRootCSSText): Deleted.
(WebCore::MediaControlsHost::base64StringForIconNameAndType): Deleted.
(WebCore::MediaControlsHost::formattedStringForDuration): Deleted.
(): Deleted.
(WebCore::MediaControlsHost::showMediaControlsContextMenu): Deleted.
(WebCore::MediaControlsHost::sourceType const): Deleted.
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/279471@main">https://commits.webkit.org/279471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91cf0c414f35492064307a6a390e46c6450dc8cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42988 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2397 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24112 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3069 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57870 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3188 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50384 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-after-removing-scroller.tentative.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49687 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30276 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7897 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->