### PR TITLE
[WGSL] Struct arguments to entry points are clashing

### DIFF
--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -123,7 +123,6 @@ void NameManglerVisitor::visit(AST::Structure& structure)
     introduceVariable(structure.name(), MangledName::Type);
 
     NameMap fieldMap;
-    m_indexPerType[WTF::enumToUnderlyingType(MangledName::Field)] = 0;
     for (auto& member : structure.members()) {
         Base::visit(member.type());
         auto mangledName = makeMangledName(member.name(), MangledName::Field);

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -18,7 +18,7 @@ struct T {
 }
 
 struct U {
-    // CHECK: array<type\d::PackedType, 1> field0
+    // CHECK: array<type\d::PackedType, 1> field\d
     ts: array<T>,
 }
 

--- a/Source/WebGPU/WGSL/tests/valid/struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/struct.wgsl
@@ -18,3 +18,15 @@ fn main()
 {
     _ = testStructConstructor();
 }
+
+struct S1 {
+@location(0) x: i32,
+}
+
+struct S2 {
+@location(1) x: i32,
+}
+
+@fragment
+fn fragment_main(s1: S1, s2: S2) {
+}


### PR DESCRIPTION
#### 666a7c0243c3384322183eee16c53ef44d7aa0a3
<pre>
[WGSL] Struct arguments to entry points are clashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=274603">https://bugs.webkit.org/show_bug.cgi?id=274603</a>
<a href="https://rdar.apple.com/128625590">rdar://128625590</a>

Reviewed by Mike Wyrzykowski.

Struct parameters of entry point functions get merged into a single struct or
hoisted into a top-level parameter if it&apos;s a builtin. However, when we rename
all variables we also rename all struct fields as `field0...fieldN` for every
struct, so when the fields got merged into a single struct (or hoisted) they
collided. In order to fix this we just make every field unique by never resetting
the field counter.

* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:
* Source/WebGPU/WGSL/tests/valid/struct.wgsl:

Canonical link: <a href="https://commits.webkit.org/279261@main">https://commits.webkit.org/279261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bc0c36847df6b015f533ba02505512071dff778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42885 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26981 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1725 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57715 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50279 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49562 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11559 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->