### PR TITLE
[Site Isolation] Prepare to move ProvisionalFrameProxy ownership from WebFrameProxy to API::Navigation

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3219,7 +3219,7 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
                 }
                 if (ownerFrame)
                     initiator = ownerFrame->document();
-                ASSERT(ownerFrame || localFrame->isMainFrame());
+                ASSERT(ownerFrame || localFrame->isMainFrame() || localFrame->settings().siteIsolationEnabled());
             }
         }
         addSameSiteInfoToRequestIfNeeded(request, initiator, page.get());

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "APINavigation.h"
 
+#include "ProvisionalFrameProxy.h"
 #include "WebBackForwardListItem.h"
 #include "WebNavigationState.h"
 #include <WebCore/RegistrableDomain.h>
@@ -118,6 +119,11 @@ bool Navigation::currentRequestIsCrossSiteRedirect() const
 {
     return currentRequestIsRedirect()
         && RegistrableDomain(m_lastNavigationAction.redirectResponse.url()) != RegistrableDomain(m_currentRequest.url());
+}
+
+void Navigation::setProvisionalFrame(WebKit::ProvisionalFrameProxy* provisionalFrame)
+{
+    m_provisionalFrame = provisionalFrame;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -46,6 +46,7 @@ class ResourceResponse;
 }
 
 namespace WebKit {
+class ProvisionalFrameProxy;
 class WebNavigationState;
 }
 
@@ -175,6 +176,9 @@ public:
     WebCore::ProcessIdentifier processID() const { return m_processID; }
     void setProcessID(WebCore::ProcessIdentifier processID) { m_processID = processID; }
 
+    void setProvisionalFrame(WebKit::ProvisionalFrameProxy*);
+    WebKit::ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
+
 private:
     Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier);
     Navigation(WebKit::WebNavigationState&, WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -204,6 +208,7 @@ private:
     bool m_isLoadedWithNavigationShared { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     OptionSet<WebCore::AdvancedPrivacyProtections> m_originatorAdvancedPrivacyProtections;
+    RefPtr<WebKit::ProvisionalFrameProxy> m_provisionalFrame;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -82,6 +82,16 @@ public:
 
     static AuxiliaryProcessCreationParameters auxiliaryProcessParameters();
 
+    enum class Type : uint8_t {
+        GraphicsProcessing,
+        Network,
+#if ENABLE(MODEL_PROCESS)
+        Model,
+#endif
+        WebContent,
+    };
+    virtual Type type() const = 0;
+
     void connect();
     virtual void terminate();
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -132,6 +132,8 @@ public:
 private:
     explicit GPUProcessProxy();
 
+    Type type() const final { return Type::GraphicsProcessing; }
+
     void addSession(const WebsiteDataStore&);
 
     // AuxiliaryProcessProxy

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -68,6 +68,8 @@ public:
 private:
     explicit ModelProcessProxy();
 
+    Type type() const final { return Type::Model; }
+
     void addSession(const WebsiteDataStore&);
 
     // AuxiliaryProcessProxy

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -339,6 +339,8 @@ public:
 private:
     explicit NetworkProcessProxy();
 
+    Type type() const final { return Type::Network; }
+
     void sendCreationParametersToNewProcess();
 
     // AuxiliaryProcessProxy

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -30,35 +30,29 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
-class ProvisionalFrameProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::ProvisionalFrameProxy> : std::true_type { };
-}
-
-namespace WebKit {
 
 class FrameProcess;
 class VisitedLinkStore;
 class WebFrameProxy;
 class WebProcessProxy;
 
-class ProvisionalFrameProxy : public CanMakeWeakPtr<ProvisionalFrameProxy> {
+class ProvisionalFrameProxy : public RefCounted<ProvisionalFrameProxy>, public CanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
+    static Ref<ProvisionalFrameProxy> create(WebFrameProxy&, Ref<FrameProcess>&&);
+
     ~ProvisionalFrameProxy();
 
     WebProcessProxy& process() const;
     Ref<WebProcessProxy> protectedProcess() const;
 
-    Ref<FrameProcess> takeFrameProcess();
+    RefPtr<FrameProcess> takeFrameProcess();
 
 private:
+    ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
+
     WeakRef<WebFrameProxy> m_frame;
-    Ref<FrameProcess> m_frameProcess;
+    RefPtr<FrameProcess> m_frameProcess;
     Ref<VisitedLinkStore> m_visitedLinkStore;
 };
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -155,7 +155,7 @@ public:
     void disconnect();
     void didCreateSubframe(WebCore::FrameIdentifier, const String& frameName);
     ProcessID processID() const;
-    void prepareForProvisionalLoadInProcess(WebProcessProxy&, const API::Navigation&, BrowsingContextGroup&, CompletionHandler<void()>&&);
+    void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, CompletionHandler<void()>&&);
 
     void commitProvisionalFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
 
@@ -169,7 +169,7 @@ public:
     void setProcess(FrameProcess&);
     const FrameProcess& frameProcess() const { return m_frameProcess.get(); }
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
-    std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();
+    RefPtr<ProvisionalFrameProxy> takeProvisionalFrame();
     WebProcessProxy& provisionalLoadProcess();
     void remoteProcessDidTerminate(WebProcessProxy&);
     std::optional<WebCore::PageIdentifier> webPageIDInCurrentProcess();
@@ -215,7 +215,7 @@ private:
     WebCore::FrameIdentifier m_frameID;
     ListHashSet<Ref<WebFrameProxy>> m_childFrames;
     WeakPtr<WebFrameProxy> m_parentFrame;
-    std::unique_ptr<ProvisionalFrameProxy> m_provisionalFrame;
+    RefPtr<ProvisionalFrameProxy> m_provisionalFrame;
 #if ENABLE(CONTENT_FILTERING)
     WebCore::ContentFilterUnblockHandler m_contentFilterUnblockHandler;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2455,6 +2455,7 @@ public:
     bool hasAllowedToRunInTheBackgroundActivity() const;
 
     template<typename M> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&);
+    template<typename M> void sendToWebPageInProcess(WebProcessProxy&, M&&);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setDefaultSpatialTrackingLabel(const String&);
@@ -3048,7 +3049,6 @@ private:
 #endif
 
     template<typename F> decltype(auto) sendToWebPage(std::optional<WebCore::FrameIdentifier>, F&&);
-    template<typename M> void sendToWebPageInProcess(WebProcessProxy&, M&&);
     template<typename M, typename C> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&, C&&);
     template<typename M> IPC::ConnectionSendSyncResult<M> sendSyncToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -519,7 +519,9 @@ public:
     Seconds totalBackgroundTime() const;
     Seconds totalSuspendedTime() const;
 
-protected:
+private:
+    Type type() const final { return Type::WebContent; }
+
     WebProcessProxy(WebProcessPool&, WebsiteDataStore*, IsPrewarmed, WebCore::CrossOriginMode, LockdownMode);
 
     // AuxiliaryProcessProxy
@@ -544,7 +546,6 @@ protected:
 
     void validateFreezerStatus();
 
-private:
     std::optional<Vector<uint8_t>> getWebCryptoMasterKey();
     using WebProcessProxyMap = HashMap<WebCore::ProcessIdentifier, CheckedRef<WebProcessProxy>>;
     static WebProcessProxyMap& allProcessMap();
@@ -796,3 +797,7 @@ private:
 WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebProcessProxy)
+static bool isType(const WebKit::AuxiliaryProcessProxy& process) { return process.type() == WebKit::AuxiliaryProcessProxy::Type::WebContent; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -683,8 +683,6 @@ void WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceErr
     // If we have a load listener, notify it.
     if (LoadListener* loadListener = m_frame->loadListener())
         loadListener->didFailLoad(m_frame.ptr(), error.isCancellation());
-
-    m_frame->destroyProvisionalFrame();
 }
 
 void WebLocalFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7886,13 +7886,13 @@ Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, const Resou
 
     documentLoader->setLastNavigationWasAppInitiated(m_lastNavigationWasAppInitiated);
 
-    if (frame.isMainFrame()) {
+    if (frame.isMainFrame() || m_page->settings().siteIsolationEnabled()) {
         if (m_pendingNavigationID) {
             documentLoader->setNavigationID(m_pendingNavigationID);
             m_pendingNavigationID = 0;
         }
 
-        if (m_pendingWebsitePolicies) {
+        if (m_pendingWebsitePolicies && frame.isMainFrame()) {
             m_allowsContentJavaScriptFromMostRecentNavigation = m_pendingWebsitePolicies->allowsContentJavaScript;
             WebsitePoliciesData::applyToDocumentLoader(WTFMove(*m_pendingWebsitePolicies), documentLoader);
             m_pendingWebsitePolicies = std::nullopt;


### PR DESCRIPTION
#### dd1da9bd8b6e8790757f9a51e654563481e151b1
<pre>
[Site Isolation] Prepare to move ProvisionalFrameProxy ownership from WebFrameProxy to API::Navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=274604">https://bugs.webkit.org/show_bug.cgi?id=274604</a>
<a href="https://rdar.apple.com/128626098">rdar://128626098</a>

Reviewed by Charlie Wolfe.

In order to fix the FIXME comment at the bottom of the SiteIsolation.CancelProvisionalLoad API test,
we need to be able to be cancelling a provisional load in a process at the same time as we are starting
a new provisional load in that same process.  In order to make that work, the ProvisionalFrameProxy
can&apos;t be destroyed when the first provisional load fails.  We will need to move the ProvisionalFrameProxy
ownership to the Navigation, and introduce the possibility of multiple Navigation objects keeping it
alive, so it needs to be RefCounted instead of owned by a unique_ptr.  We also need the message
WebPage::DestroyProvisionalFrame to be sent from the UI process instead of called directly by the web
process because at the time a provisional load failure is being dispatched from the web process,
the web process doesn&apos;t know whether the provisional frame should be destroyed.  I set
loadParameters.navigationID in a few more places so we can get the Navigation object in more places.
I remove the use of WebFrameProxy::provisionalFrame in WebPageProxy::decidePolicyForResponse in favor
of getting the WebProcessProxy from the IPC::Connection, which requires adding a way to get a
WebProcessProxy from an AuxiliaryProcessProxy.  With site isolation on, we will need to set up navigation
identifiers for all frame loads instead of just the main frame, so I do that behind a siteIsolationEnabled
check.  WebFrameProxy::prepareForProvisionalLoadInProcess will need to modify the navigation by setting
its ProvisionalFrameProxy, so I make it non-const.

This is all the set-up I can do without really changing behavior.  An upcoming PR will do the rest of the
more invasive changes to get that test addition to work completely.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setProvisionalFrame):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::provisionalFrame):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::create):
(WebKit::ProvisionalFrameProxy::~ProvisionalFrameProxy):
(WebKit::ProvisionalFrameProxy::takeFrameProcess):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::takeProvisionalFrame):
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::decidePolicyForResponse):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
(isType):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::createDocumentLoader):

Canonical link: <a href="https://commits.webkit.org/279291@main">https://commits.webkit.org/279291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49a22cc55e4d2fee41fa2c5ffc392aceaa735d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42898 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2934 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57718 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50281 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49644 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30126 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7794 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->