### PR TITLE
Canvas drawImage() API does not throw an exception when the image is in broken state

### DIFF
--- a/LayoutTests/http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled-expected.txt
+++ b/LayoutTests/http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled-expected.txt
@@ -2,6 +2,7 @@ CONSOLE MESSAGE: Blocked script execution in 'http://127.0.0.1:8000/lazyload/res
 CONSOLE MESSAGE: Blocked script execution in 'http://127.0.0.1:8000/lazyload/resources/lazy-load-in-iframe.html' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
 CONSOLE MESSAGE: Blocked script execution in 'http://127.0.0.1:8000/lazyload/resources/lazy-load-in-iframe.html' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
 CONSOLE MESSAGE: Blocked script execution in 'http://127.0.0.1:8000/lazyload/resources/lazy-load-in-iframe.html' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+CONSOLE MESSAGE: InvalidStateError: The HTMLImageElement provided is in the 'broken' state.
 
 PASS Verify that iframe's with scripting off disallow lazy image loading.
 

--- a/LayoutTests/http/tests/lazyload/placeholder.js
+++ b/LayoutTests/http/tests/lazyload/placeholder.js
@@ -7,7 +7,13 @@ function is_image_fully_loaded(image) {
   let canvas = document.createElement('canvas');
   canvas.width = canvas.height = 1;
   let canvasContext = canvas.getContext("2d");
-  canvasContext.drawImage(image, 0, 0);
+
+  try {
+    canvasContext.drawImage(image, 0, 0);
+  } catch (error) {
+    console.error(error);
+  }
+
   let data = canvasContext.getImageData(0, 0, canvas.width, canvas.height).data;
 
   // Fully loaded image should not be a placeholder which is drawn as a

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nonexistent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nonexistent-expected.txt
@@ -1,5 +1,5 @@
 2d.drawImage.nonexistent
 Actual output:
 
-FAIL Canvas test: 2d.drawImage.nonexistent assert_throws_dom: function "function() { ctx.drawImage(img, 0, 0); }" did not throw
+PASS Canvas test: 2d.drawImage.nonexistent
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -424,7 +424,7 @@ private:
     ExceptionOr<void> drawImage(SVGImageElement&, const FloatRect& srcRect, const FloatRect& dstRect);
     ExceptionOr<void> drawImage(SVGImageElement&, const FloatRect& srcRect, const FloatRect& dstRect, const CompositeOperator&, const BlendMode&);
     ExceptionOr<void> drawImage(CanvasBase&, const FloatRect& srcRect, const FloatRect& dstRect);
-    ExceptionOr<void> drawImage(Document&, CachedImage*, const RenderObject*, const FloatRect& imageRect, const FloatRect& srcRect, const FloatRect& dstRect, const CompositeOperator&, const BlendMode&, ImageOrientation = ImageOrientation::Orientation::FromImage);
+    ExceptionOr<void> drawImage(Document&, CachedImage&, const RenderObject*, const FloatRect& imageRect, const FloatRect& srcRect, const FloatRect& dstRect, const CompositeOperator&, const BlendMode&, ImageOrientation = ImageOrientation::Orientation::FromImage);
 #if ENABLE(VIDEO)
     ExceptionOr<void> drawImage(HTMLVideoElement&, const FloatRect& srcRect, const FloatRect& dstRect);
 #endif


### PR DESCRIPTION
#### 6cd33ff4b3a131cdb0b0061bc48daac568537fe4
<pre>
Canvas drawImage() API does not throw an exception when the image is in broken state
<a href="https://bugs.webkit.org/show_bug.cgi?id=274575">https://bugs.webkit.org/show_bug.cgi?id=274575</a>
<a href="https://rdar.apple.com/128588063">rdar://128588063</a>

Reviewed by Kimmo Kinnunen.

If the image source is HTMLOrSVGImageElement and the image in a broken state,
canvas drawImage() should throw an exception.

Canvas image sources specifications:
<a href="https://html.spec.whatwg.org/multipage/canvas.html#image-sources-for-2d-rendering-contexts">https://html.spec.whatwg.org/multipage/canvas.html#image-sources-for-2d-rendering-contexts</a>

* LayoutTests/http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled-expected.txt:
* LayoutTests/http/tests/lazyload/placeholder.js:
(is_image_fully_loaded):
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nonexistent-expected.txt:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/279319@main">https://commits.webkit.org/279319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/103d26084dc5e22e0701c31f566887e350f075bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43048 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1972 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57964 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50448 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11591 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->