### PR TITLE
BBQ needs to move stack results from a call to their canonical location

### DIFF
--- a/JSTests/wasm/stress/many-calls-results-on-stack.js
+++ b/JSTests/wasm/stress/many-calls-results-on-stack.js
@@ -1,0 +1,39 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+
+let wat = `
+(module
+    (func $check (import "a" "check") (param i64))
+
+    (func $foo (result ${"i64 ".repeat(20)})
+        ${"(i64.const 42) ".repeat(20)}
+    )
+
+    (func $bar (result ${"i64 ".repeat(20)})
+        ${"(i64.const 0) ".repeat(20)}
+    )
+
+    (func (export "test")
+        call $foo
+        call $bar
+        ${"(drop) ".repeat(20)}
+        call $check
+        ${"(drop) ".repeat(19)}
+    )
+)
+`;
+
+function check(value)
+{
+    assert.eq(value, 42n);
+}
+
+async function test() {
+    const instance = await instantiate(wat, { a: {check} }, {reference_types: true});
+    const {test} = instance.exports;
+    for (let i = 0; i < 1e5; ++i)
+        test();
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3960,6 +3960,25 @@ void BBQJIT::returnValuesFromCall(Vector<Value, N>& results, const FunctionSigna
                     m_fprSet.add(returnLocation.asFPR(), Width::Width128);
                 }
             }
+        } else {
+            ASSERT(returnLocation.isStackArgument());
+            // FIXME: Ideally, we would leave these values where they are but a subsequent call could clobber them before they are used.
+            // That said, stack results are very rare so this isn't too painful.
+            // Even if we did leave them where they are, we'd need to flush them to their canonical location at the next branch otherwise
+            // we could have something like (assume no result regs for simplicity):
+            // call (result i32 i32) $foo
+            // if (result i32) // Stack: i32(StackArgument:8) i32(StackArgument:0)
+            //   // Stack: i32(StackArgument:8)
+            // else
+            //   call (result i32 i32) $bar // Stack: i32(StackArgument:8) we have to flush the stack argument to make room for the result of bar
+            //   drop // Stack: i32(Stack:X) i32(StackArgument:8) i32(StackArgument:0)
+            //   drop // Stack: i32(Stack:X) i32(StackArgument:8)
+            // end
+            // return // Stack i32(*Conflicting locations*)
+
+            Location canonicalLocation = canonicalSlot(result);
+            emitMoveMemory(result.type(), returnLocation, canonicalLocation);
+            returnLocation = canonicalLocation;
         }
         bind(result, returnLocation);
         results.append(result);


### PR DESCRIPTION
#### 53be00f7a1fc6ceb136d6b838a100821c99691f0
<pre>
BBQ needs to move stack results from a call to their canonical location
<a href="https://bugs.webkit.org/show_bug.cgi?id=271175">https://bugs.webkit.org/show_bug.cgi?id=271175</a>
<a href="https://rdar.apple.com/124060867">rdar://124060867</a>

Reviewed by Yusuke Suzuki.

Right now we can end up clobbering a value, `X`, on the stack in BBQ because it gets left in a
`StackArgument` `Location` after a call. This breaks when a later call before `X` has been consumed
would set the same `StackArgument` location as `X`. The fix is to just always move stack results
to their canonical location. This is probably fine because stack results are super rare in practice.

* JSTests/wasm/stress/many-calls-results-on-stack.js: Added.
(repeat):
(check):
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::returnValuesFromCall):

Originally-landed-as: 272448.770@safari-7618-branch (6d311cd7fefc). <a href="https://rdar.apple.com/128550307">rdar://128550307</a>
Canonical link: <a href="https://commits.webkit.org/279316@main">https://commits.webkit.org/279316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57ef9fc9ac1dfcd7b2a3f0f9e471183a1e769899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3768 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43018 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2435 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1927 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46401 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57919 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52558 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50415 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11589 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30325 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64863 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29160 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12308 "Passed tests") | 
<!--EWS-Status-Bubble-End-->