### PR TITLE
[JSC] Catch should preserve top expression stack of inline parents in OMG

### DIFF
--- a/JSTests/wasm/stress/catch-should-keep-alive-inline-parent-expression-stack.js
+++ b/JSTests/wasm/stress/catch-should-keep-alive-inline-parent-expression-stack.js
@@ -1,0 +1,46 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (type $outer-type (func (param funcref)))
+    (type $inner-type (func (param externref)))
+    (import "m" "x" (global $x (mut funcref)))
+
+    (func $outer (type $outer-type) (param funcref)
+      try
+        ref.null extern
+        call $inner
+        br 1
+      catch_all
+        return
+      end
+    )
+
+    (func $inner (type $inner-type) (param externref)
+      ref.null func
+      global.get $x
+      call $outer
+      global.set $x
+
+      i32.const 0
+      global.get $x
+      table.set $func-table
+    )
+
+    (table $func-table 8 funcref)
+    (export "outer" (func $outer))
+)
+`;
+
+async function test() {
+    let globalX = new WebAssembly.Global({value: 'anyfunc', mutable: true}, null);
+    const instance = await instantiate(wat, { m: { x: globalX } }, { exceptions: true });
+    const { outer } = instance.exports;
+    for (let i = 0; i < 10; i++) {
+        let result = outer(null, {}, {});
+        assert.eq(result, undefined);
+    }
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4316,6 +4316,8 @@ PatchpointExceptionHandle OMGIRGenerator::preparePatchpointForExceptions(BasicBl
             if (ControlType::isAnyCatch(data))
                 liveValues.append(get(block, data.exception()));
         }
+        for (Variable* value : currentFrame->m_parser->expressionStack())
+            liveValues.append(get(block, value));
     }
 
     patch->effects.exitsSideways = true;
@@ -4392,6 +4394,10 @@ Value* OMGIRGenerator::emitCatchImpl(CatchKind kind, ControlType& data, unsigned
             auto& expressionStack = currentFrame->m_parser->controlStack()[controlIndex].enclosedExpressionStack;
             connectControlAtEntrypoint(indexInBuffer, pointer, controlData, expressionStack, data);
         }
+
+        auto& topControlData = currentFrame->m_parser->controlStack().last().controlData;
+        auto& topExpressionStack = currentFrame->m_parser->expressionStack();
+        connectControlAtEntrypoint(indexInBuffer, pointer, topControlData, topExpressionStack, data);
     }
 
     set(data.exception(), exception);


### PR DESCRIPTION
#### 2ffa1875acb5dd36fe6cd44c1636795e017b7731
<pre>
[JSC] Catch should preserve top expression stack of inline parents in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=271987">https://bugs.webkit.org/show_bug.cgi?id=271987</a>
<a href="https://rdar.apple.com/125145754">rdar://125145754</a>

Reviewed by Justin Michaud.

This patch makes it so we include the top-level expression stack
(m_parser-&gt;expressionStack()) among the values we consider live when figuring
out which values need to be reloaded at a catch entrypoint. Previously, we only
considered the enclosed expression stacks buried in the control entries for
each inline parent, which only captures values live in enclosing blocks and not
the current block being executed.

* JSTests/wasm/stress/catch-should-keep-alive-inline-parent-expression-stack.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::preparePatchpointForExceptions):
(JSC::Wasm::B3IRGenerator::emitCatchImpl):

Originally-landed-as: 272448.849@safari-7618-branch (0b59e3f5e9ff). <a href="https://rdar.apple.com/128550624">rdar://128550624</a>
Canonical link: <a href="https://commits.webkit.org/279265@main">https://commits.webkit.org/279265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7482b4fe4410ba41aa612fb32bfb4427fd52f12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42902 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2317 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2951 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1744 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46216 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57734 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52375 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50295 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49580 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11562 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30142 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64679 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28977 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12275 "Passed tests") | 
<!--EWS-Status-Bubble-End-->