### PR TITLE
[WebGPU] PipelineLayout::errorValidatingBindGroupCompatibility erroneously looks at stage_in vertex buffers counts

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_1323-274609-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1323-274609-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: number of bind groups set(0) is less than the pipeline uses(1)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1323-274609.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1323-274609.html
@@ -1,0 +1,50 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let commandEncoder = device.createCommandEncoder();
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read> o: vec4f;
+
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return o;
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return o;
+}
+`,
+    });
+    let renderPipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts:[]}),
+      vertex: {module, buffers: [{arrayStride: 0, attributes: []}]},
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let view = texture.createView();
+    let renderPassEncoder = commandEncoder.beginRenderPass({colorAttachments: [{view, loadOp: 'clear', storeOp: 'store'}]});
+    renderPassEncoder.setPipeline(renderPipeline);
+    renderPassEncoder.draw(1);
+    renderPassEncoder.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_1323b-274609-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1323b-274609-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: number of bind groups set(0) is less than the pipeline uses(1)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1323b-274609.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1323b-274609.html
@@ -1,0 +1,50 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let commandEncoder = device.createCommandEncoder();
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read> o: vec4f;
+
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return o;
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`,
+    });
+    let renderPipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts:[]}),
+      vertex: {module, buffers: [{arrayStride: 0, attributes: []}]},
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let view = texture.createView();
+    let renderPassEncoder = commandEncoder.beginRenderPass({colorAttachments: [{view, loadOp: 'clear', storeOp: 'store'}]});
+    renderPassEncoder.setPipeline(renderPipeline);
+    renderPassEncoder.draw(1);
+    renderPassEncoder.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_1323c-274609-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1323c-274609-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: number of bind groups set(0) is less than the pipeline uses(1)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1323c-274609.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1323c-274609.html
@@ -1,0 +1,50 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let commandEncoder = device.createCommandEncoder();
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read> o: vec4f;
+
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return o;
+}
+`,
+    });
+    let renderPipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts:[]}),
+      vertex: {module, buffers: [{arrayStride: 0, attributes: []}]},
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let view = texture.createView();
+    let renderPassEncoder = commandEncoder.beginRenderPass({colorAttachments: [{view, loadOp: 'clear', storeOp: 'store'}]});
+    renderPassEncoder.setPipeline(renderPipeline);
+    renderPassEncoder.draw(1);
+    renderPassEncoder.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -283,7 +283,7 @@ NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLa
     auto setBindGroupsSize = bindGroups.size();
     auto& bindGroupLayouts = *m_bindGroupLayouts;
     auto numberOfBindGroupsInPipeline = bindGroupLayouts.size();
-    if (setBindGroupsSize + vertexStageInBufferCount < numberOfBindGroupsInPipeline) {
+    if (setBindGroupsSize < numberOfBindGroupsInPipeline) {
         if (numberOfBindGroupsInPipeline == 1 && !bindGroupLayouts[0]->entries().size())
             return nil;
         return [NSString stringWithFormat:@"number of bind groups set(%u) is less than the pipeline uses(%zu)", setBindGroupsSize, numberOfBindGroupsInPipeline];


### PR DESCRIPTION
#### fdbf2f66e2666d2d77377bf9200f2eed494d7e69
<pre>
[WebGPU] PipelineLayout::errorValidatingBindGroupCompatibility erroneously looks at stage_in vertex buffers counts
<a href="https://bugs.webkit.org/show_bug.cgi?id=274609">https://bugs.webkit.org/show_bug.cgi?id=274609</a>
&lt;radar://128596599&gt;

Reviewed by Dan Glastonbury.

The `+ vertexStageInBufferCount` in the validation is incorrect, removing
it appears to cause zero regressions and fixes the below regression tests.

* LayoutTests/fast/webgpu/repro_1323-274609-expected.txt: Added.
* LayoutTests/fast/webgpu/repro_1323-274609.html: Added.
* LayoutTests/fast/webgpu/repro_1323b-274609-expected.txt: Added.
* LayoutTests/fast/webgpu/repro_1323b-274609.html: Added.
* LayoutTests/fast/webgpu/repro_1323c-274609-expected.txt: Added.
* LayoutTests/fast/webgpu/repro_1323c-274609.html: Added.
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::errorValidatingBindGroupCompatibility const):

Canonical link: <a href="https://commits.webkit.org/279308@main">https://commits.webkit.org/279308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/491cc996ef59c34f70afd000563a0739b7c3b8b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43029 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50424 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46017 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11583 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->