### PR TITLE
[Writing Suggestions] Suggestions are sometimes hard to see in dark mode in Mail

### DIFF
--- a/LayoutTests/css3/color-filters/test-color-filter-with-color-mix-with-semantic-color-expected.html
+++ b/LayoutTests/css3/color-filters/test-color-filter-with-color-mix-with-semantic-color-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<style>
+:root {
+    color-scheme: dark;
+}
+
+div {
+    color: color-mix(in srgb, canvastext 50%, transparent);
+}
+</style>
+<body>
+    <div>Hello world!</div>
+</body>
+</html>

--- a/LayoutTests/css3/color-filters/test-color-filter-with-color-mix-with-semantic-color.html
+++ b/LayoutTests/css3/color-filters/test-color-filter-with-color-mix-with-semantic-color.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ColorFilterEnabled=true ] -->
+<html>
+<style>
+:root {
+    color-scheme: dark;
+}
+
+div {
+    color: color-mix(in srgb, canvastext 50%, transparent);
+    -apple-color-filter: apple-invert-lightness();
+}
+</style>
+<body>
+    <div>Hello world!</div>
+</body>
+</html>

--- a/Source/WebCore/css/color/CSSColorMixResolver.cpp
+++ b/Source/WebCore/css/color/CSSColorMixResolver.cpp
@@ -104,7 +104,11 @@ template<typename InterpolationMethod> static Color mixColorComponentsUsingColor
     if (mixPercentages.alphaMultiplier && !std::isnan(mixedColor.alpha))
         mixedColor.alpha *= (*mixPercentages.alphaMultiplier / 100.0);
 
-    return { mixedColor, Color::Flags::UseColorFunctionSerialization };
+    auto flags = OptionSet { Color::Flags::UseColorFunctionSerialization };
+    if (color1.isSemantic() || color2.isSemantic())
+        flags.add(Color::Flags::Semantic);
+
+    return { mixedColor, flags };
 }
 
 Color mix(const CSSColorMixResolver& colorMix)


### PR DESCRIPTION
#### 5914f6eb8b6de0cf2efbb9aa7b86f7358d47497b
<pre>
[Writing Suggestions] Suggestions are sometimes hard to see in dark mode in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=274610">https://bugs.webkit.org/show_bug.cgi?id=274610</a>
<a href="https://rdar.apple.com/126371613">rdar://126371613</a>

Reviewed by Abrar Rahman Protyasha and Matthieu Dubet.

The color of writing suggestions is specified by

```
color: color-mix(in srgb, currentColor 50%, transparent);
```

which currently looks incorrect when viewed in dark mode in a place where `-apple-color-filter` is used (such as Mail).

This is because the unique combination of `-apple-color-filter` with a color that is created using `color-mix`, which itself
comprises of a color which is a semantic color, has not been explicitly supported. In general, semantic colors are immune from
`-apple-color-filter` due to the early return check of `isSemantic` in `FilterOperations::transformColor`. However, if a
semantic color is inside of a `color-mix` value, the `color-mix` color doesn&apos;t persist the semantic flag, which results in the
filter operation erroneously applying.

Fix by considering a `color-mix` color semantic if either of its constituent colors are semantic.

* LayoutTests/css3/color-filters/test-color-filter-with-color-mix-with-semantic-color-expected.html: Added.
* LayoutTests/css3/color-filters/test-color-filter-with-color-mix-with-semantic-color.html: Added.
* Source/WebCore/css/color/CSSColorMixResolver.cpp:
(WebCore::mixColorComponentsUsingColorInterpolationMethod):

Canonical link: <a href="https://commits.webkit.org/279239@main">https://commits.webkit.org/279239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6337d277f74fb34e38244e17508c5bba4f5c6d68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56146 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3315 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54965 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45635 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1749 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57739 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45835 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11548 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->