### PR TITLE
[JSC] Use ThrowScope to catch exceptions thrown by getSet and getMap

### DIFF
--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -118,54 +118,72 @@ ALWAYS_INLINE static JSMap* getMap(JSGlobalObject* globalObject, JSValue thisVal
 
 JSC_DEFINE_HOST_FUNCTION(mapProtoFuncClear, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSMap* map = getMap(globalObject, callFrame->thisValue());
-    if (!map)
-        return JSValue::encode(jsUndefined());
-    map->clear(globalObject->vm());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    map->clear(vm);
     return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapProtoFuncDelete, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSMap* map = getMap(globalObject, callFrame->thisValue());
-    if (!map)
-        return JSValue::encode(jsUndefined());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
     return JSValue::encode(jsBoolean(map->remove(globalObject, callFrame->argument(0))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapProtoFuncGet, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSMap* map = getMap(globalObject, callFrame->thisValue());
-    if (!map)
-        return JSValue::encode(jsUndefined());
-    return JSValue::encode(map->get(globalObject, callFrame->argument(0)));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(map->get(globalObject, callFrame->argument(0))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapProtoFuncHas, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSMap* map = getMap(globalObject, callFrame->thisValue());
-    if (!map)
-        return JSValue::encode(jsUndefined());
-    return JSValue::encode(jsBoolean(map->has(globalObject, callFrame->argument(0))));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(map->has(globalObject, callFrame->argument(0)))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapProtoFuncSet, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue thisValue = callFrame->thisValue();
     JSMap* map = getMap(globalObject, thisValue);
-    if (!map)
-        return JSValue::encode(jsUndefined());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
     map->set(globalObject, callFrame->argument(0), callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
     return JSValue::encode(thisValue);
 }
 
 inline JSValue createMapIteratorObject(JSGlobalObject* globalObject, CallFrame* callFrame, IterationKind kind)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue thisValue = callFrame->thisValue();
     JSMap* map = getMap(globalObject, thisValue);
-    if (!map)
-        return jsUndefined();
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+
     return JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map, kind);
 }
 
@@ -186,9 +204,12 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncEntries, (JSGlobalObject* globalObject, Cal
 
 JSC_DEFINE_HOST_FUNCTION(mapProtoFuncSize, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSMap* map = getMap(globalObject, callFrame->thisValue());
-    if (!map)
-        return JSValue::encode(jsUndefined());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
     return JSValue::encode(jsNumber(map->size()));
 }
 

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -121,54 +121,72 @@ ALWAYS_INLINE static JSSet* getSet(JSGlobalObject* globalObject, JSValue thisVal
 
 JSC_DEFINE_HOST_FUNCTION(setProtoFuncAdd, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue thisValue = callFrame->thisValue();
     JSSet* set = getSet(globalObject, thisValue);
-    if (!set)
-        return JSValue::encode(jsUndefined());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
     set->add(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
     return JSValue::encode(thisValue);
 }
 
 JSC_DEFINE_HOST_FUNCTION(setProtoFuncClear, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSSet* set = getSet(globalObject, callFrame->thisValue());
-    if (!set)
-        return JSValue::encode(jsUndefined());
-    set->clear(globalObject->vm());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    set->clear(vm);
     return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(setProtoFuncDelete, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSSet* set = getSet(globalObject, callFrame->thisValue());
-    if (!set)
-        return JSValue::encode(jsUndefined());
-    return JSValue::encode(jsBoolean(set->remove(globalObject, callFrame->argument(0))));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(set->remove(globalObject, callFrame->argument(0)))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(setProtoFuncHas, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSSet* set = getSet(globalObject, callFrame->thisValue());
-    if (!set)
-        return JSValue::encode(jsUndefined());
-    return JSValue::encode(jsBoolean(set->has(globalObject, callFrame->argument(0))));
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(set->has(globalObject, callFrame->argument(0)))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(setProtoFuncSize, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSSet* set = getSet(globalObject, callFrame->thisValue());
-    if (!set)
-        return JSValue::encode(jsUndefined());
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
     return JSValue::encode(jsNumber(set->size()));
 }
 
 inline JSValue createSetIteratorObject(JSGlobalObject* globalObject, CallFrame* callFrame, IterationKind kind)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     JSValue thisValue = callFrame->thisValue();
     JSSet* set = getSet(globalObject, thisValue);
-    if (!set)
-        return jsUndefined();
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+
     return JSSetIterator::create(vm, globalObject->setIteratorStructure(), set, kind);
 }
 


### PR DESCRIPTION
#### 102781a12435d7f2c2bd85b7b08e69e96eb61606
<pre>
[JSC] Use ThrowScope to catch exceptions thrown by getSet and getMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=274618">https://bugs.webkit.org/show_bug.cgi?id=274618</a>
<a href="https://rdar.apple.com/128638541">rdar://128638541</a>

Reviewed by Yusuke Suzuki.

Stop checking nullptr&apos;s for handling exceptions and
use ThrowScope instead.

* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::createMapIteratorObject):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::createSetIteratorObject):

Canonical link: <a href="https://commits.webkit.org/279337@main">https://commits.webkit.org/279337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b6b516703d6718ca1cd051750594b8b055da193

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42989 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3061 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1870 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46344 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57862 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50379 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49681 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30268 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64805 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7818 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29103 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12303 "Passed tests") | 
<!--EWS-Status-Bubble-End-->