### PR TITLE
[SVG] Faster property access for <rect> and <circle>

### DIFF
--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -51,6 +51,17 @@ Ref<SVGCircleElement> SVGCircleElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGCircleElement(tagName, document));
 }
 
+SVGAnimatedProperty* SVGCircleElement::propertyForAttribute(const QualifiedName& name) const
+{
+    if (name == SVGNames::cxAttr)
+        return m_cx.ptr();
+    if (name == SVGNames::cyAttr)
+        return m_cy.ptr();
+    if (name == SVGNames::rAttr)
+        return m_r.ptr();
+    return nullptr;
+}
+
 void SVGCircleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -43,7 +43,9 @@ private:
     SVGCircleElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCircleElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) const;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -265,4 +265,3 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGElement)
     static bool isType(const WebCore::EventTarget& eventTarget) { return eventTarget.isNode() && static_cast<const WebCore::Node&>(eventTarget).isSVGElement(); }
     static bool isType(const WebCore::Node& node) { return node.isSVGElement(); }
 SPECIALIZE_TYPE_TRAITS_END()
-

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -28,6 +28,7 @@
 #include "NodeName.h"
 #include "RenderSVGRect.h"
 #include "SVGElementInlines.h"
+#include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -53,6 +54,23 @@ inline SVGRectElement::SVGRectElement(const QualifiedName& tagName, Document& do
 Ref<SVGRectElement> SVGRectElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGRectElement(tagName, document));
+}
+
+SVGAnimatedProperty* SVGRectElement::propertyForAttribute(const QualifiedName& name) const
+{
+    if (name == SVGNames::xAttr)
+        return m_x.ptr();
+    if (name == SVGNames::yAttr)
+        return m_y.ptr();
+    if (name == SVGNames::widthAttr)
+        return m_width.ptr();
+    if (name == SVGNames::heightAttr)
+        return m_height.ptr();
+    if (name == SVGNames::rxAttr)
+        return m_rx.ptr();
+    if (name == SVGNames::ryAttr)
+        return m_ry.ptr();
+    return nullptr;
 }
 
 void SVGRectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -49,7 +49,9 @@ private:
     SVGRectElement(const QualifiedName&, Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRectElement, SVGGeometryElement>;
+    friend PropertyRegistry;
 
+    SVGAnimatedProperty* propertyForAttribute(const QualifiedName&) const;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
 


### PR DESCRIPTION
#### ce1ed5b53fe6cf9e093f6797798bff4d263fb078
<pre>
[SVG] Faster property access for &lt;rect&gt; and &lt;circle&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=273293">https://bugs.webkit.org/show_bug.cgi?id=273293</a>
<a href="https://rdar.apple.com/127085305">rdar://127085305</a>

Reviewed by Simon Fraser, Sam Weinig and Yusuke Suzuki.

This patch avoids looking for the property via the PropertyRegistry hashmap.
It&apos;s a small improvement on MotionMark on Intel.

* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::propertyForAttribute const):
* Source/WebCore/svg/SVGCircleElement.h:
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::propertyForAttribute const):
* Source/WebCore/svg/SVGRectElement.h:
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::requires):
(WebCore::SVGPropertyOwnerRegistry::fastAnimatedPropertyLookup):

Canonical link: <a href="https://commits.webkit.org/279304@main">https://commits.webkit.org/279304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b17fbb150d5fdad9afacbfc2060365252b9c823

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3515 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24163 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3131 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1947 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57939 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3243 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46029 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7800 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->