### PR TITLE
[UnifiedPDF] Low resolution background layer is flickered after resizing has finished.

### DIFF
--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -83,7 +83,7 @@ public:
     virtual void willRepaintAllTiles(TiledBacking&, TileGridIdentifier) = 0;
     virtual void willRemoveGrid(TiledBacking&, TileGridIdentifier) = 0;
     virtual void coverageRectDidChange(TiledBacking&, const FloatRect&) = 0;
-    virtual void tilingScaleFactorDidChange(TiledBacking&, float) = 0;
+    virtual void tilingScaleFactorDidChange(TiledBacking&, float oldScaleFactor, float newScaleFactor) = 0;
 };
 
 
@@ -104,6 +104,8 @@ public:
     virtual void setCoverageRect(const FloatRect&) = 0;
     virtual FloatRect coverageRect() const = 0;
     virtual bool tilesWouldChangeForCoverageRect(const FloatRect&) const = 0;
+
+    virtual bool containsCoverageRect(Vector<TileIndex>) const = 0;
 
     virtual void setTiledScrollingIndicatorPosition(const FloatPoint&) = 0;
     virtual void setTopContentInset(float) = 0;

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -157,10 +157,11 @@ void TileController::setContentsScale(float contentsScale)
     }
 
     auto oldScale = tileGrid().scale();
-    tileGrid().setScale(scale);
 
     if (m_client && scale != oldScale)
-        m_client->tilingScaleFactorDidChange(*this, scale);
+        m_client->tilingScaleFactorDidChange(*this, oldScale, scale);
+
+    tileGrid().setScale(scale);
 
     tileGrid().setNeedsDisplay();
 }
@@ -732,6 +733,26 @@ double TileController::retainedTileBackingStoreMemory() const
 IntRect TileController::tileCoverageRect() const
 {
     return tileGrid().tileCoverageRect();
+}
+
+bool TileController::containsCoverageRect(Vector<TileIndex> tileIndices) const
+{
+    auto coverageRect = m_coverageRect;
+    coverageRect.scale(tilingScaleFactor());
+
+    TileIndex coverageTopLeft, coverageBottomRight;
+    if (tileGrid().getTileIndexRangeForRect(IntRect(coverageRect), coverageTopLeft, coverageBottomRight)) {
+        auto coverageTilesCount = (coverageBottomRight.x() - coverageTopLeft.x() + 1) * (coverageBottomRight.y() - coverageTopLeft.y() + 1);
+        auto coverageTilesContained = 0;
+
+        for (auto tileIndex : tileIndices) {
+            if (tileIndex.x() >= coverageTopLeft.x() && tileIndex.x() <= coverageBottomRight.x()
+                && tileIndex.y() >= coverageTopLeft.y() && tileIndex.y() <= coverageBottomRight.y())
+                coverageTilesContained++;
+        }
+        return coverageTilesContained == coverageTilesCount;
+    }
+    return false;
 }
 
 PlatformCALayer* TileController::tiledScrollingIndicatorLayer()

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -92,6 +92,8 @@ public:
     FloatRect coverageRect() const final { return m_coverageRect; }
     std::optional<FloatRect> layoutViewportRect() const { return m_layoutViewportRect; }
 
+    bool containsCoverageRect(Vector<TileIndex>) const final;
+
     void setTileSizeUpdateDelayDisabledForTesting(bool) final;
 
     unsigned blankPixelCount() const;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -108,11 +108,12 @@ public:
         bool hasStaleContent { false };
     };
 
+    bool getTileIndexRangeForRect(const IntRect&, TileIndex& topLeft, TileIndex& bottomRight) const;
+
 private:
     void setTileNeedsDisplayInRect(const TileIndex&, TileInfo&, const IntRect& repaintRectInTileCoords, const IntRect& coverageRectInTileCoords);
 
     IntRect rectForTileIndex(const TileIndex&) const;
-    bool getTileIndexRangeForRect(const IntRect&, TileIndex& topLeft, TileIndex& bottomRight) const;
 
     enum class CoverageType { PrimaryTiles, SecondaryTiles };
     IntRect ensureTilesForRect(const FloatRect&, CoverageType);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -141,7 +141,7 @@ private:
     void willRemoveTile(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileIndex) final;
     void willRepaintAllTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
     void coverageRectDidChange(WebCore::TiledBacking&, const WebCore::FloatRect&) final;
-    void tilingScaleFactorDidChange(WebCore::TiledBacking&, float) final;
+    void tilingScaleFactorDidChange(WebCore::TiledBacking&, float oldScaleFactor, float newScaleFactor) final;
     void willRemoveGrid(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
 
     void enqueueTilePaintIfNecessary(const TileForGrid&, const WebCore::FloatRect& tileRect, const std::optional<WebCore::FloatRect>& clipRect = { });
@@ -189,6 +189,23 @@ private:
         TileRenderInfo tileInfo;
     };
     HashMap<TileForGrid, RenderedTile> m_rendereredTiles;
+
+    class StaleTileState {
+    public:
+        explicit StaleTileState(float scaleFactor);
+
+        void setStaleTiles(HashMap<TileForGrid, RenderedTile>& staleTiles) { m_staleTiles = std::exchange(staleTiles, { }); }
+        HashMap<TileForGrid, RenderedTile>& staleTiles() { return m_staleTiles; }
+
+        void setTilingScaleFactor(float tilingScaleFactor) { m_scaleFactor = tilingScaleFactor; }
+        float tilingScaleFactor() const { return m_scaleFactor; }
+
+    private:
+        HashMap<TileForGrid, RenderedTile> m_staleTiles;
+        float m_scaleFactor;
+    };
+
+    std::optional<StaleTileState> m_staleTileState;
 
     using PDFPageIndexSet = HashSet<PDFDocumentLayout::PageIndex, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
     using PDFPageIndexToPreviewHash = HashMap<PDFDocumentLayout::PageIndex, PagePreviewRequest, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;


### PR DESCRIPTION
#### f83ba80ac524945460601b327aa82d6c0bcbd039
<pre>
[UnifiedPDF] Low resolution background layer is flickered after resizing has finished.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270041">https://bugs.webkit.org/show_bug.cgi?id=270041</a>
<a href="https://rdar.apple.com/123566595">rdar://123566595</a>

Reviewed by NOBODY (OOPS!).

The TiledBacking has a set of callbacks it uses to inform its client, in
this case the async renderer, of various tile grid mutations. One mutation
that is particularly problematic is changing the tiling scale factor.
This causes the TiledBacking to execute a series of its callbacks which
has the async renderer throw away its cached tile renderings. This
results in a flickering of the low resolution page background layer
while it waits for new content to get rendered.

At a high level, in order to fix the occurrence of this flickering we
must keep around and keep painting the old tiles while we wait for the
new content to finish rendering. We will then replace the stale content
with the new tiles.

In order to accomplish this we add a new StaleTileState which will hold
onto the stale tiles along with a scale factor to use for painting. This
new state will get initialized in four different places if it is not
already:
- willRepaintTile
- willRemoveTile
- willRepaintAllTiles
- tilingScaleFactorDidChange

In relation to this specific bug the first time this state is created
is when handling the tilingScaleFactorDidChange callback. This is
(at least now with the change in this patch) the first callback that
the TiledBacking calls when this change occurs. The async renderer will
take this opportunity to cache the previous scale factor, which is
needed because we will need it to properly translate the tile rects to
painting space when comparing them with the page bounds.

Afterwards, the TiledBacking will call willRepaintAllTiles and we will
then cache all of the tiles in the previously initialized state.

At some point later the TileGrid will revalidate its tiles which
may result it in calling willRepaintTile or willRemoveTile. The reason
why we may need to recreate the StaleTileState in these callbacks is
because we may have already received new content to show while waiting
for this revalidation to occur.

In our main painting loop we will check to see if we have stale content
to consider. If we do we will first try to see if our set of currently
rendered tiles is enough to paint. We do this by passing the tile indices of
the rendered tiles to the TiledBacking to compare with the coverage
rect. The TiledBacking will tell us if its coverage rect is completely
contained within the set of tiles we gave it. If this is the case
then the async renderer will destroy its StaleTileState and paint the
newly rendered content. Otherwise, it will painted the stale tiles it is
holding onto.

* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setContentsScale):
(WebCore::TileController::containsCoverageRect const):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::willRepaintAllTiles):
(WebKit::AsyncPDFRenderer::tilingScaleFactorDidChange):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
(WebKit::AsyncPDFRenderer::StaleTileState::StaleTileState):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f83ba80ac524945460601b327aa82d6c0bcbd039

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56169 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3613 "Hash f83ba80a for PR 29021 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42914 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/3613 "Hash f83ba80a for PR 29021 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2983 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50307 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49594 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->