### PR TITLE
[WebGPU] RenderPassEncoder::errorValidatingDrawIndexed accesses m_pipeline without checking if it exists

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2140,6 +2140,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-274290.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-128396311.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-128396311.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-274622.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-274622.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-274622-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-274622-expected.txt
@@ -1,0 +1,9 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+     0                0
+     8                0
+validation error:
+buffer length is 16 which is less than required bufferSize of 4294967295
+done
+

--- a/LayoutTests/fast/webgpu/fuzz-274622.html
+++ b/LayoutTests/fast/webgpu/fuzz-274622.html
@@ -1,0 +1,26 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+onload = async () => {
+let adapter = await navigator.gpu.requestAdapter({});
+let device = await adapter.requestDevice({});
+let texture = device.createTexture({format: 'r32uint', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let renderPassDescriptor = {
+  colorAttachments: [{
+    view: texture.createView(),
+    clearValue: [0, 0, 0, 0],
+    loadOp: 'clear', storeOp: 'store',
+  }],
+};
+let commandEncoder = device.createCommandEncoder();
+let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 4});
+renderPassEncoder.setIndexBuffer(indexBuffer, 'uint32');
+renderPassEncoder.drawIndexed(1);
+globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -107,6 +107,7 @@ public:
 
     static constexpr auto startIndexForFragmentDynamicOffsets = 3;
     static constexpr uint32_t defaultSampleMask = UINT32_MAX;
+    static constexpr uint32_t invalidVertexCount = UINT32_MAX;
 
     bool validateDepthStencilState(bool depthReadOnly, bool stencilReadOnly) const;
     Device& device() const { return m_device; }

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -514,10 +514,11 @@ uint32_t RenderBundleEncoder::computeMininumVertexCount() const
     if (!m_pipeline)
         return 0;
 
-    uint32_t minVertexCount = UINT32_MAX;
+    uint32_t minVertexCount = invalidVertexCount;
     auto& requiredBufferIndices = m_pipeline->requiredBufferIndices();
     for (auto& [bufferIndex, bufferData] : requiredBufferIndices) {
-        RELEASE_ASSERT(bufferIndex < m_vertexBuffers.size());
+        if (bufferIndex >= m_vertexBuffers.size())
+            return invalidVertexCount;
         auto& vertexBuffer = m_vertexBuffers[bufferIndex];
         auto bufferSize = vertexBuffer.size;
         auto stride = bufferData.stepMode == WGPUVertexStepMode_Vertex ? bufferData.stride : 1;


### PR DESCRIPTION
#### 93f762e0815d769aa5730b0e78f946178770b54f
<pre>
[WebGPU] RenderPassEncoder::errorValidatingDrawIndexed accesses m_pipeline without checking if it exists
<a href="https://bugs.webkit.org/show_bug.cgi?id=274622">https://bugs.webkit.org/show_bug.cgi?id=274622</a>
&lt;radar://128640505&gt;

Reviewed by Tadeu Zagallo.

m_pipeline may be null, need to check it before accessing the WeakPtr.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-274622-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-274622.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::computeMininumVertexCount const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::computeMininumVertexCount const):
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::errorValidatingDrawIndexed const):

Canonical link: <a href="https://commits.webkit.org/279284@main">https://commits.webkit.org/279284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/513aba573f1e02bd08836fc1536aacdf4879b78d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42921 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2333 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57773 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50317 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49605 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11571 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->