### PR TITLE
REGRESSION: Bad flashing scrolling msn.com article when search field has focus (content-visibility)

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/visual-viewport-dimensions-during-scroll-with-keyboard-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/visual-viewport-dimensions-during-scroll-with-keyboard-expected.txt
@@ -1,0 +1,8 @@
+PASS numEqualOfEqualVisualViewportRects is not numIterations
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Tests that the visual viewport rect is updated during a scroll with the keyboard up.
+
+
+

--- a/LayoutTests/fast/visual-viewport/ios/visual-viewport-dimensions-during-scroll-with-keyboard.html
+++ b/LayoutTests/fast/visual-viewport/ios/visual-viewport-dimensions-during-scroll-with-keyboard.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+
+<html>
+<head>
+    <meta name="viewport" content="initial-scale=1.0">
+    <style>
+        .spacer-above {
+            background-color: silver;
+            height: 600px;
+        }
+        .spacer-below {
+            background-color: silver;
+            height: 4000px;
+        }
+        input {
+            display: block;
+            margin: 60px 30px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        function getScrollDownUIScript()
+        {
+            return `(function() {
+                uiController.immediateScrollToOffset(0, 300);
+            })();`;
+        }
+
+        function getFocusInputUIScript(x, y)
+        {
+            return `(function() {
+
+                uiController.didShowKeyboardCallback = function() {
+                    uiController.doAfterNextStablePresentationUpdate(function() {
+                        uiController.uiScriptComplete();
+                    });
+                };
+                uiController.singleTapAtPoint(${x}, ${y}, function() {});
+            })();`;
+        }
+
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+            
+            await new Promise(resolve => testRunner.runUIScript(getScrollDownUIScript(), resolve));
+            var rect = document.getElementById('input').getBoundingClientRect();
+            await new Promise(resolve => testRunner.runUIScript(getFocusInputUIScript(rect.left, rect.top + document.scrollingElement.scrollTop), resolve));
+            window.scrollTo({
+                top: 1000,
+                behavior: 'smooth',
+            });
+
+            numEqualOfEqualVisualViewportRects = 0;
+            numIterations = 0;
+            var currentVisualViewportRect = JSON.stringify(internals.visualViewportRect());
+            while (window.scrollY != 1000) {
+                await new Promise(resolve  => requestAnimationFrame(resolve));
+                numIterations++;
+
+                var newVisualViewportRect = JSON.stringify(internals.visualViewportRect());
+                if (currentVisualViewportRect == newVisualViewportRect) {
+                    numEqualOfEqualVisualViewportRects += 1;
+                } else {
+                    break;
+                }
+            }
+
+            shouldNotBe("numEqualOfEqualVisualViewportRects", "numIterations");
+            finishJSTest();
+        }
+
+        window.addEventListener('load', runTest, false);
+    </script>
+</head>
+<body>
+<p>Tests that the visual viewport rect is updated during a scroll with the keyboard up.</p>
+<div class="spacer-above"></div>
+<input id="input" type="text"/>
+<div class="spacer-below"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4625,6 +4625,9 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
         }
 
         frameView.layoutOrVisualViewportChanged();
+    } else if (visibleContentRectUpdateInfo.unobscuredContentRect() != visibleContentRectUpdateInfo.unobscuredContentRectRespectingInputViewBounds()) {
+        frameView.setVisualViewportOverrideRect(LayoutRect(visibleContentRectUpdateInfo.unobscuredContentRectRespectingInputViewBounds()));
+        frameView.layoutOrVisualViewportChanged();
     }
 
     bool isChangingObscuredInsetsInteractively = visibleContentRectUpdateInfo.viewStability().contains(ViewStabilityFlag::ChangingObscuredInsetsInteractively);


### PR DESCRIPTION
#### 6027137b2de4527ee793e0ad300aa458b5d5ae3a
<pre>
REGRESSION: Bad flashing scrolling msn.com article when search field has focus (content-visibility)
<a href="https://bugs.webkit.org/show_bug.cgi?id=274624">https://bugs.webkit.org/show_bug.cgi?id=274624</a>
<a href="https://rdar.apple.com/127743319">rdar://127743319</a>

Reviewed by Simon Fraser.

The cause of the flashing is that the IntersectionObserver computed that the content-visibility: auto
elements were going in and out of the visual viewport rapidly. This was due to the visual viewport’s value
changing between two locations, due to the difference in how it is computed between
LocalFrameView::updateLayoutViewport and AsyncScrollingCoordinator::reconcileScrollingState. In
LocalFrameView::updateLayoutViewport, the visual viewport is used in computeLayoutViewportOrigin to
compute the new location of the layout viewport. When the keyboard is visible, m_visualViewportOverrideRect
is sent via WebPage::updateVisibleContentRects, but is not udpated during unstable state, causing
computeLayoutViewportOrigin to use a stale version of the visual viewport. The solution is to always update
the visualViewportOverrideRect value if received from the ui process.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/279448@main">https://commits.webkit.org/279448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a8f594074a27f79f8a517b7f25fc629fbc3d93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43327 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31030 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3505 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58330 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50730 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46381 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50073 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30747 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7881 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->