### PR TITLE
Refactor WTF::Vector::contains() to be more efficient

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1121,7 +1121,11 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 template<typename U>
 bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(const U& value) const
 {
-    return find(value) != notFound;
+    for (const auto& elem : *this) {
+        if (value == elem)
+            return true;
+    }
+    return false;
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>


### PR DESCRIPTION
#### fb103ab2abc95b4a2e865dc2f8b213f0dbdd8f67
<pre>
Refactor WTF::Vector::contains() to be more efficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=274625">https://bugs.webkit.org/show_bug.cgi?id=274625</a>
<a href="https://rdar.apple.com/128643387">rdar://128643387</a>

Reviewed by NOBODY (OOPS!).

Should be faster:
  * avoid redundant bound check
  * doing less stuff (no index, no lambda)

Port of Chromium patch <a href="https://chromium-review.googlesource.com/c/chromium/src/+/5493389">https://chromium-review.googlesource.com/c/chromium/src/+/5493389</a>

* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::contains const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb103ab2abc95b4a2e865dc2f8b213f0dbdd8f67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56712 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4158 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43328 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2314 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46792 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58307 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50063 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30724 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65252 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29566 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12443 "Passed tests") | 
<!--EWS-Status-Bubble-End-->