### PR TITLE
Crash with ruby and continuations

### DIFF
--- a/LayoutTests/fast/ruby/ruby-continuation-crash-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-continuation-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/ruby/ruby-continuation-crash.html
+++ b/LayoutTests/fast/ruby/ruby-continuation-crash.html
@@ -1,0 +1,12 @@
+<style>
+#abs_pos {
+  position: absolute;
+}
+</style>
+<ruby id=abs_pos><ruby id=inner_ruby></ruby><span><div>This test passes if it doesn't crash.</div></span></ruby>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+document.body.offsetHeight;
+inner_ruby.remove();
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -874,32 +874,32 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
         return *destroyRoot;
     };
 
-    auto& destroyRoot = destroyRootIncludingAnonymous();
+    WeakPtr destroyRoot = destroyRootIncludingAnonymous();
 
     auto clearFloatsAndOutOfFlowPositionedObjects = [&] {
         // Remove floats and out-of-flow positioned objects from their containing block before detaching
         // the renderer from the tree. It includes all the anonymous block descendants that we are about
         // to destroy as well as part of the cleanup process below.
-        auto* destroyRootElement = dynamicDowncast<RenderElement>(destroyRoot);
+        WeakPtr destroyRootElement = dynamicDowncast<RenderElement>(destroyRoot.get());
         if (!destroyRootElement)
             return;
         for (auto& descendant : descendantsOfType<RenderBox>(*destroyRootElement)) {
             if (descendant.isFloatingOrOutOfFlowPositioned())
                 descendant.removeFloatingOrPositionedChildFromBlockLists();
         }
-        if (CheckedPtr box = dynamicDowncast<RenderBox>(destroyRoot); box && box->isFloatingOrOutOfFlowPositioned())
+        if (CheckedPtr box = dynamicDowncast<RenderBox>(destroyRoot.get()); box && box->isFloatingOrOutOfFlowPositioned())
             box->removeFloatingOrPositionedChildFromBlockLists();
     };
     clearFloatsAndOutOfFlowPositionedObjects();
 
     auto collapseAndDestroyAnonymousSiblings = [&] {
         // FIXME: Probably need to handle other table parts here as well.
-        if (CheckedPtr cell = dynamicDowncast<RenderTableCell>(destroyRoot)) {
+        if (CheckedPtr cell = dynamicDowncast<RenderTableCell>(destroyRoot.get())) {
             tableBuilder().collapseAndDestroyAnonymousSiblingCells(*cell);
             return;
         }
 
-        if (CheckedPtr row = dynamicDowncast<RenderTableRow>(destroyRoot)) {
+        if (CheckedPtr row = dynamicDowncast<RenderTableRow>(destroyRoot.get())) {
             tableBuilder().collapseAndDestroyAnonymousSiblingRows(*row);
             return;
         }
@@ -907,12 +907,15 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
     collapseAndDestroyAnonymousSiblings();
 
     // FIXME: Do not try to collapse/cleanup the anonymous wrappers inside destroy (see webkit.org/b/186746).
-    WeakPtr destroyRootParent = *destroyRoot.parent();
-    if (&rendererToDestroy != &destroyRoot) {
+    WeakPtr destroyRootParent = destroyRoot->parent();
+    if (&rendererToDestroy != destroyRoot.get()) {
         // Destroy the child renderer first, before we start tearing down the anonymous wrapper ancestor chain.
         destroy(rendererToDestroy);
     }
-    destroy(destroyRoot);
+
+    if (destroyRoot)
+        destroy(*destroyRoot);
+
     if (!destroyRootParent)
         return;
     removeAnonymousWrappersForInlineChildrenIfNeeded(*destroyRootParent);


### PR DESCRIPTION
#### bb30fdac92be85496b875235c1372a152134ac22
<pre>
Crash with ruby and continuations
<a href="https://bugs.webkit.org/show_bug.cgi?id=271167">https://bugs.webkit.org/show_bug.cgi?id=271167</a>
<a href="https://rdar.apple.com/124432235">rdar://124432235</a>

Reviewed by Ryosuke Niwa.

* LayoutTests/fast/ruby/ruby-continuation-crash-expected.txt: Added.
* LayoutTests/fast/ruby/ruby-continuation-crash.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers):

Improve robustness by using WeakPtr for destroyRoot and null checking before calling destroy(*destroyRoot)
as it might get deleted by an earlier destroy() call.

Originally-landed-as: 272448.763@safari-7618-branch (df9629adcf83). <a href="https://rdar.apple.com/128549808">rdar://128549808</a>
Canonical link: <a href="https://commits.webkit.org/279408@main">https://commits.webkit.org/279408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03e0678f66cdacf006bb62b4022be49a8751e301

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43303 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2713 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24436 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2293 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50703 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50042 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30703 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7855 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->