### PR TITLE
Drop negative margin when shrinking width to avoid floats

### DIFF
--- a/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-expected.txt
+++ b/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-expected.txt
@@ -1,0 +1,14 @@
+A box with negative margin should drop it in order to fit next to floats rather than push below the floats. This behaviour is not defined by CSS2.1, but the behaviour enforced by this test makes us match IE and FF.
+
+Header
+PASS
+Header
+PASS
+Header
+PASS
+Header
+PASS
+Header
+PASS
+Header
+PASS

--- a/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-with-margin-on-parent-expected.txt
+++ b/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-with-margin-on-parent-expected.txt
@@ -1,0 +1,17 @@
+A box with negative margin should drop it in order to fit next to floats rather than push below the floats. It should drop the margin even when there is margin available in the containing block for the box to expand into. The behaviour here is not defined by CSS2.1 so this behaviour is for compatibility with IE and FF. IE expands the table into the margin of the parent, FF does not. We match FF. Presto expanded all the boxes into parent's margin.
+
+float
+margin-left:-200px; overflow:auto;
+PASS
+float
+margin-left:-200px; overflow:hidden;
+PASS
+float
+margin-left:0; overflow:auto;
+PASS
+float
+margin-left:-200px; overflow:visible;
+PASS
+float
+margin-left:-200px; display:table; blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+PASS

--- a/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-with-margin-on-parent.html
+++ b/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-with-margin-on-parent.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0 0 0 200px;
+        padding: 10;
+        border: 5px solid #00f;
+        width: 800px;
+    }
+    .flo {
+        float: right;
+        background-color: #cf9;
+        width: 300px;
+    }
+    .box {
+        margin-left: -200px;
+        border: 5px solid #00f;
+        overflow: auto;
+        height: 20px;
+    }
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<body>
+    <p> A box with negative margin should drop it in order to fit next to floats rather than push below the floats. It should drop the margin even when there is 
+        margin available in the containing block for the box to expand into.
+        The behaviour here is not defined by CSS2.1 so this behaviour is for compatibility with IE and FF. IE expands the table into the margin of the parent,
+        FF does not. We match FF. Presto expanded all the boxes into parent's margin.</p>
+    <div class="flo">float</div>
+    <div class="box" data-expected-width=500>margin-left:-200px; overflow:auto;</div>
+    <div class="flo">float</div>
+    <div class="box" style="overflow: hidden" data-expected-width=500>margin-left:-200px; overflow:hidden;</div>
+    <div class="flo">float</div>
+    <div class="box" style="margin-left: 0" data-expected-width=500>margin-left:0; overflow:auto;</div>
+    <div class="flo">float</div>
+    <div class="box" style="overflow: visible" data-expected-width=1000>margin-left:-200px; overflow:visible;</div>
+    <div class="flo">float</div>
+    <div class="box" style="overflow: visible; display: table" data-expected-width=500>
+        margin-left:-200px; display:table;
+        blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+        blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+        blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+    </div>
+    <script>checkLayout('.box')</script>
+</body>

--- a/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats.html
+++ b/LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<style>
+    body {
+        padding: 10;
+        width: 800px;
+    }
+    .float {
+        background-color: green;
+        width: 150px;
+        height: 150px;
+    }
+    .right { float: right; }
+    .left { float: left; }
+    .box {
+        overflow: hidden;
+        background-color: blue;
+    }
+    .margin-left { margin-left: -400px; }
+    .margin-right {margin-right: -400px; }
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<body>
+    <p> A box with negative margin should drop it in order to fit next to floats rather than push below the floats. This behaviour is not
+       defined by CSS2.1, but the behaviour enforced by this test makes us match IE and FF.</p>
+    <div style="overflow:hidden">
+        <div class="float right"></div>
+        <div class="box margin-left" data-expected-width=650>Header</div>
+    </div>
+    <div style="overflow:hidden">
+        <div class="float right"></div>
+        <div class="box margin-right" data-expected-width=650>Header</div>
+    </div>
+    <div style="overflow:hidden">
+        <div class="float left"></div>
+        <div class="box margin-left" data-expected-width=650>Header</div>
+    </div>
+    <div style="overflow:hidden">
+        <div class="float left"></div>
+        <div class="box margin-right" data-expected-width=650>Header</div>
+    </div>
+
+    <div style="overflow:hidden">
+        <div class="float right"></div>
+        <div class="float left"></div>
+        <div class="box margin-left" data-expected-width=500>Header</div>
+    </div>
+    <div style="overflow:hidden">
+        <div class="float right"></div>
+        <div class="float left"></div>
+        <div class="box margin-right" data-expected-width=500>Header</div>
+    </div>
+    <script>checkLayout('.box')</script>
+</body>


### PR DESCRIPTION
<pre>
Drop negative margin when shrinking width to avoid floats
<a href="https://bugs.webkit.org/show_bug.cgi?id=274627">https://bugs.webkit.org/show_bug.cgi?id=274627</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://github.com/chromium/chromium/commit/5b2007212d4e01184e91edd4278e6501413478c5">https://github.com/chromium/chromium/commit/5b2007212d4e01184e91edd4278e6501413478c5</a>

When a box that avoids floats (e.g. overflow:hidden) has negative inline
margins and needs to shrink width in order to stay on the same line as a float
then drop the negative margins completely (i.e. set them to zero). Do this because negative
inline margins increase the width of a box and if we keep them they will
push the box below the float.

This treatment makes us compatible with IE and FF - the 'correct' behaviour
is not defined by CSS (<a href="http://www.w3.org/TR/CSS2/visuren.html#bfc-next-to-float">http://www.w3.org/TR/CSS2/visuren.html#bfc-next-to-float</a>:
"CSS2 does not define when a UA may put said element next to the float or by how
much said element may become narrower.") - so its purely a question of behaving
as consistently as possible with other browsers.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::portionOfMarginNotConsumedByFloat):
(WebCore::RenderBox::shrinkLogicalWidthToAvoidFloats const):
(WebCore::RenderBox::computeInlineDirectionMargins const):
* LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats.html: Add Test Case
* LayoutTests/fast/block/float/negative-margin-on-element-avoiding-floats-with-margin-on-parent.html: Add Test Case
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c29dcf858bf41de907f6ebe74837c9fda796f9ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3369 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42932 "Found 4 new test failures: fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55019 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29963 "Found 5 new test failures: fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin.html, http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27036 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3001 "Found 4 new test failures: fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48892 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3157 "Found 4 new test failures: fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57793 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28062 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3122 "Found 4 new test failures: fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50326 "Found 4 new test failures: fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-left-margin.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin-vertical.html, fast/shapes/shape-outside-floats/shape-overflow-hidden-right-margin.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49616 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29036 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->