### PR TITLE
[visionOS] Captions are missing in fullscreen mode

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -230,10 +230,23 @@ void MediaControlsHost::updateTextTrackContainer()
         m_textTrackContainer->updateDisplay();
 }
 
+TextTrackRepresentation* MediaControlsHost::textTrackRepresentation() const
+{
+    if (m_textTrackContainer)
+        return m_textTrackContainer->textTrackRepresentation();
+    return nullptr;
+}
+
 void MediaControlsHost::updateTextTrackRepresentationImageIfNeeded()
 {
     if (m_textTrackContainer)
         m_textTrackContainer->updateTextTrackRepresentationImageIfNeeded();
+}
+
+void MediaControlsHost::requiresTextTrackRepresentationChanged()
+{
+    if (m_textTrackContainer)
+        m_textTrackContainer->requiresTextTrackRepresentationChanged();
 }
 
 void MediaControlsHost::enteredFullscreen()

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -45,6 +45,7 @@ class HTMLMediaElement;
 class MediaControlTextTrackContainerElement;
 class TextTrack;
 class TextTrackList;
+class TextTrackRepresentation;
 class VoidCallback;
 
 class MediaControlsHost final : public RefCounted<MediaControlsHost>, public CanMakeWeakPtr<MediaControlsHost> {
@@ -74,6 +75,7 @@ public:
     void setSelectedTextTrack(TextTrack*);
     Element* textTrackContainer();
     void updateTextTrackContainer();
+    TextTrackRepresentation* textTrackRepresentation() const;
     bool allowsInlineMediaPlayback() const;
     bool supportsFullscreen() const;
     bool isVideoLayerInline() const;
@@ -88,6 +90,7 @@ public:
     void updateTextTrackRepresentationImageIfNeeded();
     void enteredFullscreen();
     void exitedFullscreen();
+    void requiresTextTrackRepresentationChanged();
 
     String externalDeviceDisplayName() const;
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -440,6 +440,8 @@ public:
     void videoTrackSelectedChanged(VideoTrack&) final;
     void willRemoveVideoTrack(VideoTrack&) final;
 
+    void setTextTrackRepresentataionBounds(const IntRect&);
+    void setRequiresTextTrackRepresentation(bool);
     bool requiresTextTrackRepresentation() const;
     void setTextTrackRepresentation(TextTrackRepresentation*);
     void syncTextTrackBounds();
@@ -1264,6 +1266,7 @@ private:
     bool m_shouldVideoPlaybackRequireUserGesture : 1;
     bool m_volumeLocked : 1;
     bool m_cachedIsInVisibilityAdjustmentSubtree : 1 { false };
+    bool m_requiresTextTrackRepresentation : 1 { false };
 
     enum class ControlsState : uint8_t { None, Initializing, Ready, PartiallyDeinitialized };
     friend String convertEnumerationToString(HTMLMediaElement::ControlsState enumerationValue);

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -351,6 +351,12 @@ void MediaControlTextTrackContainerElement::updateTextTrackStyle()
     removeInlineStyleProperty(CSSPropertyTop);
 }
 
+void MediaControlTextTrackContainerElement::requiresTextTrackRepresentationChanged()
+{
+    updateTextTrackRepresentationIfNeeded();
+    updateSizes(ForceUpdate::Yes);
+}
+
 void MediaControlTextTrackContainerElement::enteredFullscreen()
 {
     updateTextTrackRepresentationIfNeeded();

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -57,7 +57,9 @@ public:
     void updateSizes(ForceUpdate force = ForceUpdate::No);
     void updateDisplay();
 
+    TextTrackRepresentation* textTrackRepresentation() const { return m_textTrackRepresentation.get(); }
     void updateTextTrackRepresentationImageIfNeeded();
+    void requiresTextTrackRepresentationChanged();
 
     void enteredFullscreen();
     void exitedFullscreen();

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
@@ -36,7 +36,10 @@ VideoFullscreenCaptions::~VideoFullscreenCaptions() = default;
 
 void VideoFullscreenCaptions::setTrackRepresentationImage(PlatformImagePtr textTrack)
 {
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
     [m_captionsLayer setContents:(__bridge id)textTrack.get()];
+    [CATransaction commit];
 }
 
 void VideoFullscreenCaptions::setTrackRepresentationContentsScale(float scale)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -70,6 +70,7 @@ public:
     virtual void requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) = 0;
     virtual void setVideoLayerFrame(FloatRect) = 0;
     virtual void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) = 0;
+    virtual void setVideoFullscreenFrame(FloatRect) = 0;
     virtual void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) = 0;
 
     virtual FloatSize videoDimensions() const = 0;
@@ -92,6 +93,8 @@ public:
     virtual void didExitFullscreen() { };
     virtual void didCleanupFullscreen() { };
     virtual void fullscreenMayReturnToInline() { };
+    virtual void setRequiresTextTrackRepresentation(bool) { }
+    virtual void setTextTrackRepresentationBounds(const IntRect&) { }
 
     virtual void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&& completionHandler) { completionHandler(RouteSharingPolicy::Default, emptyString()); }
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -67,6 +67,7 @@ public:
     WEBCORE_EXPORT void requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) final;
     WEBCORE_EXPORT void setVideoLayerFrame(FloatRect) final;
     WEBCORE_EXPORT void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) final;
+    WEBCORE_EXPORT void setVideoFullscreenFrame(FloatRect) final;
     WEBCORE_EXPORT void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) final;
     FloatSize videoDimensions() const final { return m_videoDimensions; }
     bool hasVideo() const final { return m_hasVideo; }
@@ -74,6 +75,8 @@ public:
     WEBCORE_EXPORT void setVideoSizeFenced(const FloatSize&, WTF::MachSendRight&&);
 
     WEBCORE_EXPORT void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&&) final;
+    WEBCORE_EXPORT void setRequiresTextTrackRepresentation(bool) final;
+    WEBCORE_EXPORT void setTextTrackRepresentationBounds(const IntRect&) final;
 
 #if !RELEASE_LOG_DISABLED
     const Logger* loggerPtr() const final;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -225,6 +225,13 @@ void VideoPresentationModelVideoElement::setVideoSizeFenced(const FloatSize& siz
     m_videoElement->setVideoFullscreenFrame({ { }, size });
 }
 
+void VideoPresentationModelVideoElement::setVideoFullscreenFrame(FloatRect rect)
+{
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, rect.size());
+    if (RefPtr videoElement = m_videoElement.get())
+        videoElement->setVideoFullscreenFrame(rect);
+}
+
 void VideoPresentationModelVideoElement::setVideoLayerGravity(MediaPlayer::VideoGravity gravity)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, gravity);
@@ -339,6 +346,26 @@ void VideoPresentationModelVideoElement::didExitPictureInPicture()
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->didExitPictureInPicture();
+}
+
+void VideoPresentationModelVideoElement::setRequiresTextTrackRepresentation(bool requiresTextTrackRepresentation)
+{
+    RefPtr videoElement = m_videoElement;
+    if (!videoElement)
+        return;
+
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+    videoElement->setRequiresTextTrackRepresentation(requiresTextTrackRepresentation);
+}
+
+void VideoPresentationModelVideoElement::setTextTrackRepresentationBounds(const IntRect& bounds)
+{
+    RefPtr videoElement = m_videoElement;
+    if (!videoElement)
+        return;
+
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, bounds.size());
+    videoElement->setTextTrackRepresentataionBounds(bounds);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1603,11 +1603,6 @@ void MediaPlayer::removeVideoTrack(VideoTrackPrivate& track)
     client().mediaPlayerDidRemoveVideoTrack(track);
 }
 
-bool MediaPlayer::requiresTextTrackRepresentation() const
-{
-    return m_private->requiresTextTrackRepresentation();
-}
-
 void MediaPlayer::setTextTrackRepresentation(TextTrackRepresentation* representation)
 {
     m_private->setTextTrackRepresentation(representation);

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -634,7 +634,6 @@ public:
     void onNewVideoFrameMetadata(VideoFrameMetadata&&, RetainPtr<CVPixelBufferRef>&&);
 #endif
 
-    bool requiresTextTrackRepresentation() const;
     void setTextTrackRepresentation(TextTrackRepresentation*);
     void syncTextTrackBounds();
     void tracksChanged();

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -281,7 +281,6 @@ public:
     virtual void setShouldContinueAfterKeyNeeded(bool) { }
 #endif
 
-    virtual bool requiresTextTrackRepresentation() const { return false; }
     virtual void setTextTrackRepresentation(TextTrackRepresentation*) { }
     virtual void syncTextTrackBounds() { };
     virtual void tracksChanged() { };

--- a/Source/WebCore/platform/graphics/TextTrackRepresentation.cpp
+++ b/Source/WebCore/platform/graphics/TextTrackRepresentation.cpp
@@ -38,6 +38,7 @@ public:
     void update() final { }
     PlatformLayer* platformLayer() final { return nullptr; }
     void setContentScale(float) final { }
+    void setBounds(const IntRect&) final { }
     IntRect bounds() const final { return IntRect(); }
     void setHidden(bool) const final { }
 };

--- a/Source/WebCore/platform/graphics/TextTrackRepresentation.h
+++ b/Source/WebCore/platform/graphics/TextTrackRepresentation.h
@@ -54,6 +54,7 @@ public:
     virtual void update() = 0;
     virtual PlatformLayer* platformLayer() = 0;
     virtual void setContentScale(float) = 0;
+    virtual void setBounds(const IntRect&) = 0;
     virtual IntRect bounds() const = 0;
     virtual void setHidden(bool) const = 0;
 };

--- a/Source/WebCore/platform/graphics/VideoLayerManager.h
+++ b/Source/WebCore/platform/graphics/VideoLayerManager.h
@@ -50,7 +50,6 @@ public:
     virtual void updateVideoFullscreenInlineImage(PlatformImagePtr) = 0;
 #endif
 
-    virtual bool requiresTextTrackRepresentation() const = 0;
     virtual void setTextTrackRepresentationLayer(PlatformLayer*) = 0;
     virtual void syncTextTrackBounds() = 0;
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -246,7 +246,6 @@ private:
 
     MediaTime getStartDate() const final;
 
-    bool requiresTextTrackRepresentation() const final;
     void setTextTrackRepresentation(TextTrackRepresentation*) final;
     void syncTextTrackBounds() final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2625,11 +2625,6 @@ void MediaPlayerPrivateAVFoundationObjC::updateVideoTracks()
     ALWAYS_LOG(LOGIDENTIFIER, "track count was ", count, ", is ", m_videoTracks.size());
 }
 
-bool MediaPlayerPrivateAVFoundationObjC::requiresTextTrackRepresentation() const
-{
-    return m_videoLayerManager->requiresTextTrackRepresentation();
-}
-
 void MediaPlayerPrivateAVFoundationObjC::syncTextTrackBounds()
 {
     m_videoLayerManager->syncTextTrackBounds();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -128,7 +128,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void setVideoFullscreenFrame(FloatRect) override;
 #endif
 
-    bool requiresTextTrackRepresentation() const override;
     void setTextTrackRepresentation(TextTrackRepresentation*) override;
     void syncTextTrackBounds() override;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1542,11 +1542,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenFrame(FloatRect fra
     m_videoLayerManager->setVideoFullscreenFrame(frame);
 }
 
-bool MediaPlayerPrivateMediaSourceAVFObjC::requiresTextTrackRepresentation() const
-{
-    return m_videoLayerManager->videoFullscreenLayer();
-}
-
 void MediaPlayerPrivateMediaSourceAVFObjC::syncTextTrackBounds()
 {
     m_videoLayerManager->syncTextTrackBounds();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
@@ -70,7 +70,6 @@ public:
     WEBCORE_EXPORT void updateVideoFullscreenInlineImage(PlatformImagePtr) final;
 #endif
 
-    WEBCORE_EXPORT bool requiresTextTrackRepresentation() const final;
     WEBCORE_EXPORT void setTextTrackRepresentationLayer(PlatformLayer*) final;
     WEBCORE_EXPORT void syncTextTrackBounds() final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -179,15 +179,6 @@ void VideoLayerManagerObjC::updateVideoFullscreenInlineImage(PlatformImagePtr im
 
 #endif
 
-bool VideoLayerManagerObjC::requiresTextTrackRepresentation() const
-{
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-    return m_videoFullscreenLayer;
-#else
-    return false;
-#endif
-}
-
 void VideoLayerManagerObjC::syncTextTrackBounds()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -177,7 +177,6 @@ private:
     void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) final;
     void setVideoFullscreenFrame(FloatRect) final;
 
-    bool requiresTextTrackRepresentation() const final;
     void setTextTrackRepresentation(TextTrackRepresentation*) final;
     void syncTextTrackBounds() final;
         

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -821,11 +821,6 @@ void MediaPlayerPrivateWebM::setVideoFullscreenFrame(FloatRect frame)
     m_videoLayerManager->setVideoFullscreenFrame(frame);
 }
 
-bool MediaPlayerPrivateWebM::requiresTextTrackRepresentation() const
-{
-    return m_videoLayerManager->videoFullscreenLayer();
-}
-
 void MediaPlayerPrivateWebM::syncTextTrackBounds()
 {
     m_videoLayerManager->syncTextTrackBounds();

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h
@@ -56,6 +56,7 @@ public:
 
     PlatformLayer* platformLayer() final { return m_layer.get(); }
 
+    WEBCORE_EXPORT void setBounds(const IntRect&) override;
     WEBCORE_EXPORT IntRect bounds() const override;
     void boundsChanged();
 

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
@@ -153,6 +153,11 @@ void TextTrackRepresentationCocoa::setHidden(bool hidden) const
     [m_layer setHidden:hidden];
 }
 
+void TextTrackRepresentationCocoa::setBounds(const IntRect& bounds)
+{
+    [m_layer setBounds:FloatRect(bounds)];
+}
+
 IntRect TextTrackRepresentationCocoa::bounds() const
 {
     return enclosingIntRect(FloatRect([m_layer bounds]));

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -615,6 +615,7 @@ void VideoPresentationInterfaceIOS::willStartPictureInPicture()
     if (auto model = videoPresentationModel()) {
         if (!m_hasVideoContentLayer)
             model->requestVideoContentLayer();
+        model->setRequiresTextTrackRepresentation(true);
         model->willEnterPictureInPicture();
     }
 }
@@ -833,12 +834,14 @@ void VideoPresentationInterfaceIOS::finalizeSetup()
             if (!m_hasVideoContentLayer && m_targetMode.hasVideo()) {
                 m_finalizeSetupNeedsVideoContentLayer = true;
                 model->requestVideoContentLayer();
+                model->setRequiresTextTrackRepresentation(true);
                 return;
             }
             m_finalizeSetupNeedsVideoContentLayer = false;
             if (m_hasVideoContentLayer && !m_targetMode.hasVideo()) {
                 m_finalizeSetupNeedsReturnVideoContentLayer = true;
                 model->returnVideoContentLayer();
+                model->setRequiresTextTrackRepresentation(false);
                 return;
             }
             m_finalizeSetupNeedsReturnVideoContentLayer = false;
@@ -876,7 +879,12 @@ void VideoPresentationInterfaceIOS::setMode(HTMLMediaElementEnums::VideoFullscre
     // Mode::mode() can be 3 (VideoFullscreenModeStandard | VideoFullscreenModePictureInPicture).
     // HTMLVideoElement does not expect such a value in the fullscreenModeChanged() callback.
     auto model = videoPresentationModel();
-    if (model && shouldNotifyModel)
+    if (!model)
+        return;
+
+    model->setRequiresTextTrackRepresentation(m_currentMode.hasVideo());
+
+    if (shouldNotifyModel)
         model->fullscreenModeChanged(mode);
 }
 
@@ -887,7 +895,12 @@ void VideoPresentationInterfaceIOS::clearMode(HTMLMediaElementEnums::VideoFullsc
 
     m_currentMode.clearMode(mode);
     auto model = videoPresentationModel();
-    if (model && shouldNotifyModel)
+    if (!model)
+        return;
+
+    model->setRequiresTextTrackRepresentation(m_currentMode.hasVideo());
+
+    if (shouldNotifyModel)
         model->fullscreenModeChanged(m_currentMode.mode());
 }
 

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -201,6 +201,7 @@ private:
     void requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) override;
     void setVideoLayerFrame(FloatRect) override;
     void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) override;
+    void setVideoFullscreenFrame(FloatRect) override { }
     void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) override;
     bool hasVideo() const override;
     FloatSize videoDimensions() const override;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -336,6 +336,7 @@ enum class PIPState {
         }
 
         model->didExitFullscreen();
+        model->setRequiresTextTrackRepresentation(false);
     }
 
     _videoPresentationInterfaceMac->clearMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
@@ -409,10 +410,14 @@ void VideoPresentationInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscre
 
     m_mode = newMode;
 
+    RefPtr model = videoPresentationModel();
+    if (model)
+        model->setRequiresTextTrackRepresentation(hasMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture));
+
     if (hasMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && !isMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture))
         return;
 
-    if (auto model = videoPresentationModel())
+    if (model)
         model->fullscreenModeChanged(m_mode);
 }
 
@@ -424,10 +429,14 @@ void VideoPresentationInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullsc
 
     m_mode = newMode;
 
+    RefPtr model = videoPresentationModel();
+    if (model)
+        model->setRequiresTextTrackRepresentation(hasMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture));
+
     if (hasMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && !isMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture))
         return;
 
-    if (auto model = videoPresentationModel())
+    if (model)
         model->fullscreenModeChanged(m_mode);
 }
 
@@ -461,8 +470,10 @@ void VideoPresentationInterfaceMac::setupFullscreen(NSView& layerHostedView, con
     [videoPresentationInterfaceObjC() setUpPIPForVideoView:&layerHostedView withFrame:(NSRect)initialRect inWindow:parentWindow];
 
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this] {
-        if (auto model = videoPresentationModel())
+        if (RefPtr model = videoPresentationModel()) {
             model->didSetupFullscreen();
+            model->setRequiresTextTrackRepresentation(true);
+        }
     });
 }
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -49,6 +49,8 @@ public:
 #endif
     ~VideoPresentationInterfaceLMK();
 
+    void captionsLayerBoundsChanged(const WebCore::FloatRect&);
+
 private:
     VideoPresentationInterfaceLMK(WebCore::PlaybackSessionInterfaceIOS&);
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -97,6 +97,7 @@ private:
     void requestFullscreenMode(WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) override;
     void setVideoLayerFrame(WebCore::FloatRect) override;
     void setVideoLayerGravity(WebCore::MediaPlayerEnums::VideoGravity) override;
+    void setVideoFullscreenFrame(WebCore::FloatRect) override;
     void fullscreenModeChanged(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) override;
     bool hasVideo() const override { return m_hasVideo; }
     WebCore::FloatSize videoDimensions() const override { return m_videoDimensions; }
@@ -122,6 +123,8 @@ private:
     void didExitFullscreen() final;
     void didCleanupFullscreen() final;
     void fullscreenMayReturnToInline() final;
+    void setRequiresTextTrackRepresentation(bool) final;
+    void setTextTrackRepresentationBounds(const WebCore::IntRect&) final;
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const final;
@@ -238,6 +241,8 @@ private:
     void textTrackRepresentationUpdate(PlaybackSessionContextIdentifier, WebCore::ShareableBitmap::Handle&& textTrack);
     void textTrackRepresentationSetContentsScale(PlaybackSessionContextIdentifier, float scale);
     void textTrackRepresentationSetHidden(PlaybackSessionContextIdentifier, bool hidden);
+    void setRequiresTextTrackRepresentation(PlaybackSessionContextIdentifier, bool);
+    void setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier, const WebCore::IntRect&);
 
     // Messages to VideoPresentationManager
     void requestFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false);
@@ -253,6 +258,7 @@ private:
     void didCleanupFullscreen(PlaybackSessionContextIdentifier);
     void setVideoLayerFrame(PlaybackSessionContextIdentifier, WebCore::FloatRect);
     void setVideoLayerGravity(PlaybackSessionContextIdentifier, WebCore::MediaPlayerEnums::VideoGravity);
+    void setVideoFullscreenFrame(PlaybackSessionContextIdentifier, WebCore::FloatRect);
     void fullscreenModeChanged(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void fullscreenMayReturnToInline(PlaybackSessionContextIdentifier);
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1481,15 +1481,6 @@ void MediaPlayerPrivateRemote::setShouldContinueAfterKeyNeeded(bool should)
 }
 #endif
 
-bool MediaPlayerPrivateRemote::requiresTextTrackRepresentation() const
-{
-#if PLATFORM(COCOA)
-    return m_videoLayerManager->requiresTextTrackRepresentation();
-#else
-    return false;
-#endif
-}
-
 void MediaPlayerPrivateRemote::setTextTrackRepresentation(WebCore::TextTrackRepresentation* representation)
 {
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -416,7 +416,6 @@ private:
     void setShouldContinueAfterKeyNeeded(bool) final;
 #endif
 
-    bool requiresTextTrackRepresentation() const final;
     void setTextTrackRepresentation(WebCore::TextTrackRepresentation*) final;
     void syncTextTrackBounds() final;
 

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/EventTarget.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/TextTrackRepresentationCocoa.h>
 
 namespace WebCore {
@@ -43,10 +44,13 @@ public:
     virtual ~WebTextTrackRepresentationCocoa() { }
 
 private:
+    void setBounds(const WebCore::IntRect&) final;
+    WebCore::IntRect bounds() const final { return m_bounds; }
     void update() final;
     void setContentScale(float) final;
     void setHidden(bool) const final;
 
+    WebCore::IntRect m_bounds;
     WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::HTMLMediaElement> m_mediaElement;
 };

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -96,6 +96,15 @@ void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
     fullscreenManager->setTextTrackRepresentationIsHiddenForVideoElement(*videoElement, hidden);
 }
 
+void WebTextTrackRepresentationCocoa::setBounds(const WebCore::IntRect& bounds)
+{
+    if (m_bounds == bounds)
+        return;
+    m_bounds = bounds;
+    client().textTrackRepresentationBoundsChanged(bounds);
+}
+
+
 } // namespace WebKit
 
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -196,12 +196,15 @@ protected:
     void didCleanupFullscreen(PlaybackSessionContextIdentifier);
     void setVideoLayerFrameFenced(PlaybackSessionContextIdentifier, WebCore::FloatRect bounds, WTF::MachSendRight&&);
     void setVideoLayerGravityEnum(PlaybackSessionContextIdentifier, unsigned gravity);
+    void setVideoFullscreenFrame(PlaybackSessionContextIdentifier, WebCore::FloatRect);
     void fullscreenModeChanged(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void fullscreenMayReturnToInline(PlaybackSessionContextIdentifier, bool isPageVisible);
     void requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&&);
     void ensureUpdatedVideoDimensions(PlaybackSessionContextIdentifier, WebCore::FloatSize existingVideoDimensions);
 
     void setCurrentlyInFullscreen(VideoPresentationInterfaceContext&, bool);
+    void setRequiresTextTrackRepresentation(PlaybackSessionContextIdentifier, bool);
+    void setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier, const WebCore::IntRect&);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -36,9 +36,12 @@ messages -> VideoPresentationManager {
     DidCleanupFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     SetVideoLayerFrameFenced(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect bounds, MachSendRight machSendRight)
     SetVideoLayerGravityEnum(WebKit::PlaybackSessionContextIdentifier contextId, unsigned gravity)
+    SetVideoFullscreenFrame(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)
     FullscreenModeChanged(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode)
     FullscreenMayReturnToInline(WebKit::PlaybackSessionContextIdentifier contextId, bool isPageVisible)
     RequestRouteSharingPolicyAndContextUID(WebKit::PlaybackSessionContextIdentifier contextId) -> (enum:uint8_t WebCore::RouteSharingPolicy routeSharingPolicy, String routingContextUID)
     EnsureUpdatedVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize existingVideoDimensions)
+    SetRequiresTextTrackRepresentation(WebKit::PlaybackSessionContextIdentifier contextId, bool requiresTextTrackRepresentation)
+    SetTextTrackRepresentationBounds(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::IntRect bounds)
 }
 #endif

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -806,6 +806,12 @@ void VideoPresentationManager::setVideoLayerFrameFenced(PlaybackSessionContextId
         model->setVideoSizeFenced(bounds.size(), WTFMove(machSendRight));
 }
 
+void VideoPresentationManager::setVideoFullscreenFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)
+{
+    INFO_LOG(LOGIDENTIFIER, contextId.toUInt64());
+    ensureModel(contextId).setVideoFullscreenFrame(frame);
+}
+
 void VideoPresentationManager::updateTextTrackRepresentationForVideoElement(WebCore::HTMLVideoElement& videoElement, ShareableBitmap::Handle&& textTrack)
 {
     if (!m_page)
@@ -830,6 +836,16 @@ void VideoPresentationManager::setTextTrackRepresentationIsHiddenForVideoElement
     auto contextId = m_videoElements.get(videoElement);
     m_page->send(Messages::VideoPresentationManagerProxy::TextTrackRepresentationSetHidden(contextId, hidden));
 
+}
+
+void VideoPresentationManager::setRequiresTextTrackRepresentation(PlaybackSessionContextIdentifier contextId, bool requiresTextTrackRepresentation)
+{
+    ensureModel(contextId).setRequiresTextTrackRepresentation(requiresTextTrackRepresentation);
+}
+
+void VideoPresentationManager::setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier contextId, const IntRect& bounds)
+{
+    ensureModel(contextId).setTextTrackRepresentationBounds(bounds);
 }
 
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### a8256bf61cd70cb214e683a81a617354b57b3a42
<pre>
[visionOS] Captions are missing in fullscreen mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=274592">https://bugs.webkit.org/show_bug.cgi?id=274592</a>
<a href="https://rdar.apple.com/128502343">rdar://128502343</a>

Reviewed by Andy Estes.

When enabling the entity-backed rendering path on visionOS, we inadventantly broke
caption display in fullscreen. The reasons are multifaceted, but stem from the lack
of a WebAVPlayerLayer containing the video content in that path.

Untangling the requirement to have a fullscreen video layer requires changes at every
process level:

- Rather than have individual MediaPlayers report whether they need a TextTrackRepresentation,
  move responibility for telling HTMLMediaPlayer so up to the UI layer (and VideoPlaybackInterface).
- Notify the HTMLMediaElement of TextTrackRepresentation size changes directly, rather than
  implicitly via fullscreen video layer size changes.
- Allow the bounds of the TextTrackRepresentation to be set directly, rather than implictly
  via the representation&apos;s layer.

This removes large swaths of text track responsibilities from MediaPlayer/Private, but requires
VideoPresentationInterface subclasess to directly notify the element when they need a
representation for text tracks to be created.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::textTrackRepresentation const):
(WebCore::MediaControlsHost::requiresTextTrackRepresentationChanged):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setTextTrackRepresentataionBounds):
(WebCore::HTMLMediaElement::setRequiresTextTrackRepresentation):
(WebCore::HTMLMediaElement::requiresTextTrackRepresentation const):
(WebCore::HTMLMediaElement::setTextTrackRepresentation):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::requiresTextTrackRepresentationChanged):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm:
(WebCore::VideoFullscreenCaptions::setTrackRepresentationImage):
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModel::setRequiresTextTrackRepresentation):
(WebCore::VideoPresentationModel::setTextTrackRepresentationBounds):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::setVideoFullscreenFrame):
(WebCore::VideoPresentationModelVideoElement::setRequiresTextTrackRepresentation):
(WebCore::VideoPresentationModelVideoElement::setTextTrackRepresentationBounds):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::requiresTextTrackRepresentation const): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::requiresTextTrackRepresentation const): Deleted.
* Source/WebCore/platform/graphics/TextTrackRepresentation.cpp:
* Source/WebCore/platform/graphics/TextTrackRepresentation.h:
* Source/WebCore/platform/graphics/VideoLayerManager.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::requiresTextTrackRepresentation const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::requiresTextTrackRepresentation const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::requiresTextTrackRepresentation const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::requiresTextTrackRepresentation const): Deleted.
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h:
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm:
(WebCore::TextTrackRepresentationCocoa::setBounds):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::willStartPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::finalizeSetup):
(WebCore::VideoPresentationInterfaceIOS::setMode):
(WebCore::VideoPresentationInterfaceIOS::clearMode):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC pipDidClose:]):
(WebCore::VideoPresentationInterfaceMac::setMode):
(WebCore::VideoPresentationInterfaceMac::clearMode):
(WebCore::VideoPresentationInterfaceMac::setupFullscreen):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(-[WKLinearMediaKitCaptionsLayer initWithParent:]):
(-[WKLinearMediaKitCaptionsLayer layoutSublayers]):
(WebKit::VideoPresentationInterfaceLMK::captionsLayer):
(WebKit::VideoPresentationInterfaceLMK::captionsLayerBoundsChanged):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::setVideoFullscreenFrame):
(WebKit::VideoPresentationModelContext::setRequiresTextTrackRepresentation):
(WebKit::VideoPresentationModelContext::setTextTrackRepresentationBounds):
(WebKit::VideoPresentationManagerProxy::setRequiresTextTrackRepresentation):
(WebKit::VideoPresentationManagerProxy::setTextTrackRepresentationBounds):
(WebKit::VideoPresentationManagerProxy::setVideoFullscreenFrame):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::requiresTextTrackRepresentation const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h:
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::setBounds):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::setVideoFullscreenFrame):
(WebKit::VideoPresentationManager::setRequiresTextTrackRepresentation):
(WebKit::VideoPresentationManager::setTextTrackRepresentationBounds):

Canonical link: <a href="https://commits.webkit.org/279405@main">https://commits.webkit.org/279405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ce2948135c1588d3a72c1697a0f6267076201c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3796 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43037 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2451 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24165 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27176 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1955 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57947 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50444 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11639 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->