### PR TITLE
Web Inspector: At some narrow-ish widths objects and disclosure triangles in console output disappear

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -302,14 +302,6 @@
     content: ' ';
 }
 
-.console-top-level-message .object-tree {
-    display: block;
-}
-
-.console-top-level-message .object-tree .object-tree {
-    display: inline-block;
-}
-
 .console-message .timestamp {
     float: right;
     margin-inline-start: 12px;

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeMapEntryTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeMapEntryTreeElement.css
@@ -23,9 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.object-tree-array-index.object-tree-map-entry > .titles > .title {
+    display: flex;
+    gap: 8px;
+}
+
 .object-tree-array-index.object-tree-map-entry > .titles > .title > .index-name {
-    width: 40px;
+    min-width: 40px;
     text-align: right;
+}
+
+.object-tree-array-index.object-tree-map-entry > .titles > .title > .index-value {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .object-tree-map-entry.key:not(:first-child) {

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
@@ -25,7 +25,7 @@
 
 .object-tree {
     position: relative;
-    display: inline-block;
+    display: inline;
     color: var(--text-color);
     font-family: Menlo, monospace;
     font-size: 11px;


### PR DESCRIPTION
#### f43fc2c8d672a79a562cebfe619406130401cf9c
<pre>
Web Inspector: At some narrow-ish widths objects and disclosure triangles in console output disappear
<a href="https://rdar.apple.com/121861970">rdar://121861970</a>

The object display, including the disclosure triangles, are instances
of ObjectTreeBaseTreeElement&apos;s subclasses, which have the
`.object-tree` class name as DOM elements. This commit improves the
styles of these elements by using them always `display: inline` since
it worked best with the text truncating feature that the elements have.

While making the `.object-tree` elements `display: inline`, the tree
element was rendered incorrectly when displayed as an indexed item,
with a preceding array index or a label like &quot;key&quot; or &quot;value&quot;.
The fix is to use a `display: flex` for the entry row instead, so
the `.index-name` (the label) and the `.index-value` (containing the
`.object-tree`) are always side by side instead of the `.index-value`
being wrapped and shown on a second line.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css:
(.object-tree):
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.console-top-level-message .object-tree): Deleted.
(.console-top-level-message .object-tree .object-tree): Deleted.
  - Always use `display: inline` for the object tree element. It works
    well with the text-truncating styles the element has.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeMapEntryTreeElement.css:
(.object-tree-array-index.object-tree-map-entry &gt; .titles &gt; .title):
  - Use `display: flex` so that the name and the value elements are
    always side by side instead of the value wrapped to a second line
    when it gets wide.

(.object-tree-array-index.object-tree-map-entry &gt; .titles &gt; .title &gt; .index-name):
  - Use `min-width` instead of `width` to go with the `display: flex`
    in the parent.

(.object-tree-array-index.object-tree-map-entry &gt; .titles &gt; .title &gt; .index-value):
  - Technically not needed for this fix, but without this change when
    window gets narrow, there are no ellipses at the end of the object
    preview elements that are now cut off. This change simply make
    ellipses show up so the UI is more consistent with ellipses already
    showing up elsewhere that an object tree shows up. (But not console
    outputs that are strings, as filed in https://webkit.org/b/270992.)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f43fc2c8d672a79a562cebfe619406130401cf9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56213 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3382 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55032 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/29982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/3010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1816 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/3166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57806 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/45907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->