### PR TITLE
Web Inspector: At some narrow-ish widths objects and disclosure triangles in console output disappear

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -302,14 +302,6 @@
     content: ' ';
 }
 
-.console-top-level-message .object-tree {
-    display: block;
-}
-
-.console-top-level-message .object-tree .object-tree {
-    display: inline-block;
-}
-
 .console-message .timestamp {
     float: right;
     margin-inline-start: 12px;

--- a/Source/WebInspectorUI/UserInterface/Views/LocalRemoteObjectContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalRemoteObjectContentView.css
@@ -26,4 +26,5 @@
 .content-view.local-remote-object {
     padding: 10px;
     overflow: auto;
+    display: flex;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeArrayIndexTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeArrayIndexTreeElement.css
@@ -25,16 +25,24 @@
 
 .tree-outline .item.object-tree-array-index {
     position: relative;
-    left: -12px;
     margin-top: 2px;
     margin-bottom: 1px;
+}
+
+.tree-outline .item.object-tree-array-index:not(.object-tree-map-entry) {
+    inset-inline-start: -12px;
+    margin-inline-end: -12px;
 }
 
 .object-tree .object-tree-array-index > .icon {
     display: none;
 }
 
-.object-tree-array-index .index-name {
+.object-tree-array-index > .titles > .title {
+    display: flex;
+}
+
+.object-tree-array-index > .titles > .title > .index-name {
     font-family: -webkit-system-font, sans-serif;
     font-size: 11px;
     font-variant-numeric: tabular-nums;
@@ -45,18 +53,19 @@
     top: -1px;
 
     display: inline-block;
-    width: 30px;
-    text-align: right;
+    min-width: 30px;
+    text-align: end;
+}
+
+.object-tree-array-index > .titles > .title > .index-value {
+    overflow: hidden;
+    margin-inline-start: 8px;
+    text-overflow: ellipsis;
 }
 
 /* An array inside an array we should reduce the padding-start. */
 .object-tree-array-index .index-value .object-tree .tree-outline.object {
     padding-inline-start: 6px;
-}
-
-/* An array inside an ObjectTreePropertyTreeElement needs more left shift */
-.object-tree-property + ol .object-tree-array-index {
-    left: -18px;
 }
 
 /* A node inside an array we should reduce the padding-start. */

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeMapEntryTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeMapEntryTreeElement.css
@@ -24,8 +24,8 @@
  */
 
 .object-tree-array-index.object-tree-map-entry > .titles > .title > .index-name {
-    width: 40px;
-    text-align: right;
+    min-width: 40px;
+    text-align: end;
 }
 
 .object-tree-map-entry.key:not(:first-child) {

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
@@ -25,7 +25,7 @@
 
 .object-tree {
     position: relative;
-    display: inline-block;
+    display: inline;
     color: var(--text-color);
     font-family: Menlo, monospace;
     font-size: 11px;
@@ -84,10 +84,16 @@
 
 .tree-outline.object {
     margin: 0;
-    padding: 0 6px 2px;
+    padding-top: 0;
+    padding-bottom: 2px;
+    padding-inline: 6px 0;
     list-style: none;
     min-height: 18px;
     outline: none;
+}
+
+.tree-outline.object > .item {
+    padding-inline-end: 0;
 }
 
 .object-tree .tree-outline.object.compact {

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css
@@ -151,6 +151,7 @@
     padding-top: 2px;
     border-top: 1px solid var(--text-color-quaternary);
     overflow: auto;
+    display: flex;
 }
 
 .popover .debugger-popover-content.function > .body {


### PR DESCRIPTION
#### 7a3f0bd5f4ea707c63069210b01f8674ce2a5509
<pre>
Web Inspector: At some narrow-ish widths objects and disclosure triangles in console output disappear
<a href="https://rdar.apple.com/121861970">rdar://121861970</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274630">https://bugs.webkit.org/show_bug.cgi?id=274630</a>

Reviewed by Devin Rousso and Patrick Angle.

The object display, including the disclosure triangles, are instances
of ObjectTreeBaseTreeElement&apos;s subclasses, which have the
`.object-tree` class name as DOM elements. This commit improves the
styles of these elements by making them always `display: inline` since
it worked best with the text truncating feature that the elements have.

While making the `.object-tree` elements `display: inline`, the tree
element was rendered incorrectly when displayed as an indexed item,
with a preceding array index or a label like &quot;key&quot; or &quot;value&quot;.
The fix is to use a `display: flex` for the entry row instead, so
the `.index-name` (the label) and the `.index-value` (containing the
`.object-tree`) are always side by side instead of the `.index-value`
being wrapped and shown on a second line.

This commit also make it so that lines that are cut off in the object
tree elements always consistently show ellipses at the end. In addition,
we take out the existing unnecessary right padding on the tree elements
to make the cut off point vertically aligned.

* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.console-top-level-message .object-tree): Deleted.
(.console-top-level-message .object-tree .object-tree): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css:
(.object-tree):
  - Always use `display: inline` for the object tree element. It works
    well with the text-truncating styles the element has.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css:
(.tree-outline.object &gt; .item):
(.tree-outline.object):
  - Remove the unnecessary right padding.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeArrayIndexTreeElement.css:
(.object-tree-array-index &gt; .titles &gt; .title):
  - Use `display: flex` so that the name and the value elements are
    always side by side instead of the value wrapped to a second line
    when it gets wide.

(.object-tree-array-index .index-name): Deleted.
(.object-tree-array-index &gt; .titles &gt; .title &gt; .index-name):
  - Use `min-width` instead of `width` to go with the `display: flex`
    in the parent.
  - Refine the selector to make it more precise; there might be nested
    object trees inside, and we don&apos;t actually want this style to
    control those `.index-name` elements beyond the one controlled by
    the current object tree.

(.object-tree-array-index &gt; .titles &gt; .title &gt; .index-value):
  - Make ellipses show up for these lines.

(.tree-outline .item.object-tree-array-index):
  - Move the `left` style into the
    `.object-tree-array-index &gt; .titles &gt; .title` selector instead so
    that we expand the element&apos;s viewable area rather than moving the
    element. (Moving the element resulted in the right edge being
    shifted to the left and made the cut off point not align vertically
    with the parent&apos;s right margin.)

(.tree-outline .item.object-tree-array-index:not(.object-tree-map-entry)):
  - The map entry element does not need the left expansion like the
    array entry. Undo the `margin-left` style.

(.object-tree-property + ol .object-tree-array-index): Deleted.
  - This is no longer required.

* Source/WebInspectorUI/UserInterface/Views/LocalRemoteObjectContentView.css:
(.content-view.local-remote-object):
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css:
(.popover .debugger-popover-content &gt; .body):
  - The object trees within these containers were allowed to overflow
    horizontally and were scrollable to the right. The `display: inline`
    change would make them not scrollable anymore. So, we make these
    containers that expect the object tree child to be scrollable
    `display: flex`, and we must commit to doing the same to all
    such containers of scrollable object trees in the future.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeMapEntryTreeElement.css:
(.object-tree-array-index.object-tree-map-entry &gt; .titles &gt; .title &gt; .index-name):
  - Use `min-width` instead of `width` to go with the `display: flex`
    in the parent.

Canonical link: <a href="https://commits.webkit.org/279894@main">https://commits.webkit.org/279894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a616289aa76f0264ae927ab67980dd9a6a92c34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/54526 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/33943 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/7094 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/57804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/5258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/41484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/5261 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/57804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/5258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/56622 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/41484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/7094 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/57804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/41484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/7094 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/3399 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/41484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/7094 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/59395 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29758 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/5261 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/59395 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30906 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/7094 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/59395 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12050 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31888 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30696 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->