### PR TITLE
Toggling visibility:hidden on the parent of a <canvas> can cause the previous frame's contents to be shown.

### DIFF
--- a/LayoutTests/compositing/canvas/copy-backing-store-visibility-hidden-expected.html
+++ b/LayoutTests/compositing/canvas/copy-backing-store-visibility-hidden-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/compositing/canvas/copy-backing-store-visibility-hidden.html
+++ b/LayoutTests/compositing/canvas/copy-backing-store-visibility-hidden.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script>
+
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+}
+
+async function doTest() {
+  var canvasElement = document.getElementById("canvas");
+
+  let ctx = canvas.getContext('2d');
+
+  ctx.fillStyle = 'green';
+  ctx.fillRect(0, 0, 100, 100);
+
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  ctx.fillStyle = 'green';
+  ctx.fillRect(0, 0, 100, 100);
+
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.getElementById("parent").style.visibility = "hidden";
+
+  if (window.testRunner) {
+    testRunner.notifyDone();
+  }
+}
+
+window.addEventListener('load', doTest, false);
+</script>
+</head>
+
+<body>
+<div id="parent">
+  <canvas id="canvas"></canvas>
+</div>
+</body>
+
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1155,7 +1155,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         layerConfigChanged = true;
     }
 
-    bool shouldPaintUsingCompositeCopy = unscaledBitmap && is<RenderHTMLCanvas>(renderer());
+    bool shouldPaintUsingCompositeCopy = unscaledBitmap && is<RenderHTMLCanvas>(renderer()) && m_owningLayer.hasVisibleContent();
     if (shouldPaintUsingCompositeCopy != m_shouldPaintUsingCompositeCopy) {
         m_shouldPaintUsingCompositeCopy = shouldPaintUsingCompositeCopy;
         m_graphicsLayer->setShouldPaintUsingCompositeCopy(shouldPaintUsingCompositeCopy);


### PR DESCRIPTION
#### d6114259cba014fee42ac469271069b0c4f887d4
<pre>
Toggling visibility:hidden on the parent of a &lt;canvas&gt; can cause the previous frame&apos;s contents to be shown.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274262">https://bugs.webkit.org/show_bug.cgi?id=274262</a>
&lt;<a href="https://rdar.apple.com/128226178">rdar://128226178</a>&gt;

Reviewed by Simon Fraser.

We should only try to use &apos;copy&apos; compositing mode to transfer the canvas buffer into the layer (and thus
omit any pixel clearing) if there is visible content to copy.

* LayoutTests/compositing/canvas/copy-backing-store-visibility-hidden-expected.html: Added.
* LayoutTests/compositing/canvas/copy-backing-store-visibility-hidden.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):

Canonical link: <a href="https://commits.webkit.org/279302@main">https://commits.webkit.org/279302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02af82c6f2720e2c439fbdf41a1ecbc95853e5d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42946 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2354 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55035 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57809 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50341 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49639 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11581 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->