### PR TITLE
Use std::span more in DataCue related code

### DIFF
--- a/Source/WebCore/html/track/DataCue.cpp
+++ b/Source/WebCore/html/track/DataCue.cpp
@@ -50,9 +50,9 @@ DataCue::DataCue(Document& document, const MediaTime& start, const MediaTime& en
     setData(data);
 }
 
-DataCue::DataCue(Document& document, const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
+DataCue::DataCue(Document& document, const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
     : TextTrackCue(document, start, end)
-    , m_data(ArrayBuffer::create(data, length))
+    , m_data(ArrayBuffer::create(data))
 {
 }
 
@@ -70,9 +70,9 @@ DataCue::DataCue(Document& document, const MediaTime& start, const MediaTime& en
 {
 }
 
-Ref<DataCue> DataCue::create(Document& document, const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
+Ref<DataCue> DataCue::create(Document& document, const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
 {
-    auto dataCue = adoptRef(*new DataCue(document, start, end, data, length));
+    auto dataCue = adoptRef(*new DataCue(document, start, end, data));
     dataCue->suspendIfNeeded();
     return dataCue;
 }

--- a/Source/WebCore/html/track/DataCue.h
+++ b/Source/WebCore/html/track/DataCue.h
@@ -48,7 +48,7 @@ class DataCue final : public TextTrackCue {
 public:
     static Ref<DataCue> create(Document&, double start, double end, ArrayBuffer& data);
     static Ref<DataCue> create(Document&, double start, double end, JSC::JSValue, const String& type);
-    static Ref<DataCue> create(Document&, const MediaTime& start, const MediaTime& end, const void* data, unsigned length);
+    static Ref<DataCue> create(Document&, const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data);
     static Ref<DataCue> create(Document&, const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&&, const String& type);
 
     virtual ~DataCue();
@@ -66,7 +66,7 @@ public:
 
 private:
     DataCue(Document&, const MediaTime& start, const MediaTime& end, ArrayBuffer&, const String&);
-    DataCue(Document&, const MediaTime& start, const MediaTime& end, const void*, unsigned);
+    DataCue(Document&, const MediaTime& start, const MediaTime& end, std::span<const uint8_t>);
     DataCue(Document&, const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&&, const String&);
     DataCue(Document&, const MediaTime& start, const MediaTime& end, JSC::JSValue, const String&);
 

--- a/Source/WebCore/html/track/InbandDataTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandDataTextTrack.cpp
@@ -52,11 +52,11 @@ Ref<InbandDataTextTrack> InbandDataTextTrack::create(ScriptExecutionContext& con
 
 InbandDataTextTrack::~InbandDataTextTrack() = default;
 
-void InbandDataTextTrack::addDataCue(const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
+void InbandDataTextTrack::addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
 {
     // FIXME: handle datacue creation on worker.
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext()))
-        addCue(DataCue::create(*document, start, end, data, length));
+        addCue(DataCue::create(*document, start, end, data));
 }
 
 #if ENABLE(DATACUE_VALUE)

--- a/Source/WebCore/html/track/InbandDataTextTrack.h
+++ b/Source/WebCore/html/track/InbandDataTextTrack.h
@@ -43,7 +43,7 @@ public:
 private:
     InbandDataTextTrack(ScriptExecutionContext&, InbandTextTrackPrivate&);
 
-    void addDataCue(const MediaTime& start, const MediaTime& end, const void*, unsigned) final;
+    void addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t>) final;
 
     bool shouldPurgeCuesFromUnbufferedRanges() const final { return true; }
 

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -71,7 +71,7 @@ private:
     void languageChanged(const AtomString&) override;
     void willRemove() override;
 
-    void addDataCue(const MediaTime&, const MediaTime&, const void*, unsigned) override { ASSERT_NOT_REACHED(); }
+    void addDataCue(const MediaTime&, const MediaTime&, std::span<const uint8_t>) override { ASSERT_NOT_REACHED(); }
 
 #if ENABLE(DATACUE_VALUE)
     void addDataCue(const MediaTime&, const MediaTime&, Ref<SerializedPlatformDataCue>&&, const String&) override { ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
@@ -48,7 +48,7 @@ public:
 
     constexpr Type type() const final { return Type::Text; }
 
-    virtual void addDataCue(const MediaTime& start, const MediaTime& end, const void*, unsigned) = 0;
+    virtual void addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t>) = 0;
 
 #if ENABLE(DATACUE_VALUE)
     virtual void addDataCue(const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&&, const String&) = 0;

--- a/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
@@ -45,13 +45,13 @@ public:
     AtomString inBandMetadataTrackDispatchType() const override { return m_inBandMetadataTrackDispatchType; }
     void setInBandMetadataTrackDispatchType(const AtomString& value) { m_inBandMetadataTrackDispatchType = value; }
 
-    void addDataCue(const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
+    void addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
     {
         ASSERT(isMainThread());
         ASSERT(cueFormat() == CueFormat::Data);
 
         notifyMainThreadClient([&](auto& client) {
-            downcast<InbandTextTrackPrivateClient>(client).addDataCue(start, end, data, length);
+            downcast<InbandTextTrackPrivateClient>(client).addDataCue(start, end, data);
         });
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2261,7 +2261,7 @@ void MediaPlayerPrivateGStreamer::processMpegTsSection(GstMpegtsSection* section
         gsize size;
         const void* bytes = g_bytes_get_data(data.get(), &size);
 
-        track->addDataCue(currentTime(), currentTime(), bytes, size);
+        track->addDataCue(currentTime(), currentTime(), { static_cast<const uint8_t*>(bytes), size });
     }
 }
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -111,12 +111,12 @@ void RemoteTextTrackProxy::languageChanged(const AtomString&)
     configurationChanged();
 }
 
-void RemoteTextTrackProxy::addDataCue(const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
+void RemoteTextTrackProxy::addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
 {
     auto connection = m_connectionToWebProcess.get();
     if (!connection)
         return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::AddDataCue(m_trackPrivate->id(), start, end, std::span(static_cast<const uint8_t*>(data), length)), m_mediaPlayerIdentifier);
+    connection->connection().send(Messages::MediaPlayerPrivateRemote::AddDataCue(m_trackPrivate->id(), start, end, data), m_mediaPlayerIdentifier);
 }
 
 #if ENABLE(DATACUE_VALUE)

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -65,7 +65,7 @@ private:
     RemoteTextTrackProxy(GPUConnectionToWebProcess&, WebCore::InbandTextTrackPrivate&, WebCore::MediaPlayerIdentifier);
 
     // InbandTextTrackPrivateClient
-    virtual void addDataCue(const MediaTime& start, const MediaTime& end, const void*, unsigned);
+    virtual void addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t>);
 
 #if ENABLE(DATACUE_VALUE)
     virtual void addDataCue(const MediaTime& start, const MediaTime& end, Ref<WebCore::SerializedPlatformDataCue>&&, const String&);

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -153,7 +153,7 @@ void TextTrackPrivateRemote::addDataCue(MediaTime&& start, MediaTime&& end, std:
 {
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
-        downcast<InbandTextTrackPrivateClient>(client).addDataCue(WTFMove(start), WTFMove(end), data.data(), data.size());
+        downcast<InbandTextTrackPrivateClient>(client).addDataCue(WTFMove(start), WTFMove(end), data);
     });
 }
 


### PR DESCRIPTION
#### 48bf352aedccdf0d00050a9c7640d49d1aab8a03
<pre>
Use std::span more in DataCue related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=274633">https://bugs.webkit.org/show_bug.cgi?id=274633</a>

Reviewed by Darin Adler.

* Source/WebCore/html/track/DataCue.cpp:
(WebCore::DataCue::DataCue):
(WebCore::DataCue::create):
* Source/WebCore/html/track/DataCue.h:
* Source/WebCore/html/track/InbandDataTextTrack.cpp:
(WebCore::InbandDataTextTrack::addDataCue):
* Source/WebCore/html/track/InbandDataTextTrack.h:
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h:
* Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h:
(WebCore::InbandMetadataTextTrackPrivateGStreamer::addDataCue):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::processMpegTsSection):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::addDataCue):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp:
(WebKit::TextTrackPrivateRemote::addDataCue):

Canonical link: <a href="https://commits.webkit.org/279272@main">https://commits.webkit.org/279272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f52337410fb223f92c0200fb825ef63c40f8ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3430 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55079 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45737 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1863 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57855 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3175 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45953 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30261 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7780 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->