### PR TITLE
[JSC] add support for `Uint8Array.prototype.toBase64` and `Uint8Array.prototype.toHex`

### DIFF
--- a/JSTests/stress/uint8array-toBase64.js
+++ b/JSTests/stress/uint8array-toBase64.js
@@ -1,0 +1,258 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+shouldBe((new Uint8Array([])).toBase64(), "");
+shouldBe((new Uint8Array([0])).toBase64(), "AA==");
+shouldBe((new Uint8Array([1])).toBase64(), "AQ==");
+shouldBe((new Uint8Array([128])).toBase64(), "gA==");
+shouldBe((new Uint8Array([254])).toBase64(), "/g==");
+shouldBe((new Uint8Array([255])).toBase64(), "/w==");
+shouldBe((new Uint8Array([0, 1])).toBase64(), "AAE=");
+shouldBe((new Uint8Array([254, 255])).toBase64(), "/v8=");
+shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64(), "AAGA/v8=");
+
+shouldBe((new Uint8Array([])).toBase64({}), "");
+shouldBe((new Uint8Array([0])).toBase64({}), "AA==");
+shouldBe((new Uint8Array([1])).toBase64({}), "AQ==");
+shouldBe((new Uint8Array([128])).toBase64({}), "gA==");
+shouldBe((new Uint8Array([254])).toBase64({}), "/g==");
+shouldBe((new Uint8Array([255])).toBase64({}), "/w==");
+shouldBe((new Uint8Array([0, 1])).toBase64({}), "AAE=");
+shouldBe((new Uint8Array([254, 255])).toBase64({}), "/v8=");
+shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({}), "AAGA/v8=");
+
+for (let omitPadding of [undefined, null, false, 0, ""]) {
+    shouldBe((new Uint8Array([])).toBase64({omitPadding}), "");
+    shouldBe((new Uint8Array([0])).toBase64({omitPadding}), "AA==");
+    shouldBe((new Uint8Array([1])).toBase64({omitPadding}), "AQ==");
+    shouldBe((new Uint8Array([128])).toBase64({omitPadding}), "gA==");
+    shouldBe((new Uint8Array([254])).toBase64({omitPadding}), "/g==");
+    shouldBe((new Uint8Array([255])).toBase64({omitPadding}), "/w==");
+    shouldBe((new Uint8Array([0, 1])).toBase64({omitPadding}), "AAE=");
+    shouldBe((new Uint8Array([254, 255])).toBase64({omitPadding}), "/v8=");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({omitPadding}), "AAGA/v8=");
+
+    shouldBe((new Uint8Array([])).toBase64({get omitPadding() { return omitPadding; }}), "");
+    shouldBe((new Uint8Array([0])).toBase64({get omitPadding() { return omitPadding; }}), "AA==");
+    shouldBe((new Uint8Array([1])).toBase64({get omitPadding() { return omitPadding; }}), "AQ==");
+    shouldBe((new Uint8Array([128])).toBase64({get omitPadding() { return omitPadding; }}), "gA==");
+    shouldBe((new Uint8Array([254])).toBase64({get omitPadding() { return omitPadding; }}), "/g==");
+    shouldBe((new Uint8Array([255])).toBase64({get omitPadding() { return omitPadding; }}), "/w==");
+    shouldBe((new Uint8Array([0, 1])).toBase64({get omitPadding() { return omitPadding; }}), "AAE=");
+    shouldBe((new Uint8Array([254, 255])).toBase64({get omitPadding() { return omitPadding; }}), "/v8=");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get omitPadding() { return omitPadding; }}), "AAGA/v8=");
+}
+
+for (let omitPadding of [true, 42, "test", [], {}]) {
+    shouldBe((new Uint8Array([])).toBase64({omitPadding}), "");
+    shouldBe((new Uint8Array([0])).toBase64({omitPadding}), "AA");
+    shouldBe((new Uint8Array([1])).toBase64({omitPadding}), "AQ");
+    shouldBe((new Uint8Array([128])).toBase64({omitPadding}), "gA");
+    shouldBe((new Uint8Array([254])).toBase64({omitPadding}), "/g");
+    shouldBe((new Uint8Array([255])).toBase64({omitPadding}), "/w");
+    shouldBe((new Uint8Array([0, 1])).toBase64({omitPadding}), "AAE");
+    shouldBe((new Uint8Array([254, 255])).toBase64({omitPadding}), "/v8");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({omitPadding}), "AAGA/v8");
+
+    shouldBe((new Uint8Array([])).toBase64({get omitPadding() { return omitPadding; }}), "");
+    shouldBe((new Uint8Array([0])).toBase64({get omitPadding() { return omitPadding; }}), "AA");
+    shouldBe((new Uint8Array([1])).toBase64({get omitPadding() { return omitPadding; }}), "AQ");
+    shouldBe((new Uint8Array([128])).toBase64({get omitPadding() { return omitPadding; }}), "gA");
+    shouldBe((new Uint8Array([254])).toBase64({get omitPadding() { return omitPadding; }}), "/g");
+    shouldBe((new Uint8Array([255])).toBase64({get omitPadding() { return omitPadding; }}), "/w");
+    shouldBe((new Uint8Array([0, 1])).toBase64({get omitPadding() { return omitPadding; }}), "AAE");
+    shouldBe((new Uint8Array([254, 255])).toBase64({get omitPadding() { return omitPadding; }}), "/v8");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get omitPadding() { return omitPadding; }}), "AAGA/v8");
+}
+
+for (let alphabet of [undefined, "base64"]) {
+    shouldBe((new Uint8Array([])).toBase64({alphabet}), "");
+    shouldBe((new Uint8Array([0])).toBase64({alphabet}), "AA==");
+    shouldBe((new Uint8Array([1])).toBase64({alphabet}), "AQ==");
+    shouldBe((new Uint8Array([128])).toBase64({alphabet}), "gA==");
+    shouldBe((new Uint8Array([254])).toBase64({alphabet}), "/g==");
+    shouldBe((new Uint8Array([255])).toBase64({alphabet}), "/w==");
+    shouldBe((new Uint8Array([0, 1])).toBase64({alphabet}), "AAE=");
+    shouldBe((new Uint8Array([254, 255])).toBase64({alphabet}), "/v8=");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({alphabet}), "AAGA/v8=");
+
+    shouldBe((new Uint8Array([])).toBase64({get alphabet() { return alphabet; }}), "");
+    shouldBe((new Uint8Array([0])).toBase64({get alphabet() { return alphabet; }}), "AA==");
+    shouldBe((new Uint8Array([1])).toBase64({get alphabet() { return alphabet; }}), "AQ==");
+    shouldBe((new Uint8Array([128])).toBase64({get alphabet() { return alphabet; }}), "gA==");
+    shouldBe((new Uint8Array([254])).toBase64({get alphabet() { return alphabet; }}), "/g==");
+    shouldBe((new Uint8Array([255])).toBase64({get alphabet() { return alphabet; }}), "/w==");
+    shouldBe((new Uint8Array([0, 1])).toBase64({get alphabet() { return alphabet; }}), "AAE=");
+    shouldBe((new Uint8Array([254, 255])).toBase64({get alphabet() { return alphabet; }}), "/v8=");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return alphabet; }}), "AAGA/v8=");
+
+    for (let omitPadding of [undefined, null, false, 0, ""]) {
+        shouldBe((new Uint8Array([])).toBase64({alphabet, omitPadding}), "");
+        shouldBe((new Uint8Array([0])).toBase64({alphabet, omitPadding}), "AA==");
+        shouldBe((new Uint8Array([1])).toBase64({alphabet, omitPadding}), "AQ==");
+        shouldBe((new Uint8Array([128])).toBase64({alphabet, omitPadding}), "gA==");
+        shouldBe((new Uint8Array([254])).toBase64({alphabet, omitPadding}), "/g==");
+        shouldBe((new Uint8Array([255])).toBase64({alphabet, omitPadding}), "/w==");
+        shouldBe((new Uint8Array([0, 1])).toBase64({alphabet, omitPadding}), "AAE=");
+        shouldBe((new Uint8Array([254, 255])).toBase64({alphabet, omitPadding}), "/v8=");
+        shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({alphabet, omitPadding}), "AAGA/v8=");
+
+        shouldBe((new Uint8Array([])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "");
+        shouldBe((new Uint8Array([0])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AA==");
+        shouldBe((new Uint8Array([1])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AQ==");
+        shouldBe((new Uint8Array([128])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "gA==");
+        shouldBe((new Uint8Array([254])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "/g==");
+        shouldBe((new Uint8Array([255])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "/w==");
+        shouldBe((new Uint8Array([0, 1])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AAE=");
+        shouldBe((new Uint8Array([254, 255])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "/v8=");
+        shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AAGA/v8=");
+    }
+
+    for (let omitPadding of [true, 42, "test", [], {}]) {
+        shouldBe((new Uint8Array([])).toBase64({alphabet, omitPadding}), "");
+        shouldBe((new Uint8Array([0])).toBase64({alphabet, omitPadding}), "AA");
+        shouldBe((new Uint8Array([1])).toBase64({alphabet, omitPadding}), "AQ");
+        shouldBe((new Uint8Array([128])).toBase64({alphabet, omitPadding}), "gA");
+        shouldBe((new Uint8Array([254])).toBase64({alphabet, omitPadding}), "/g");
+        shouldBe((new Uint8Array([255])).toBase64({alphabet, omitPadding}), "/w");
+        shouldBe((new Uint8Array([0, 1])).toBase64({alphabet, omitPadding}), "AAE");
+        shouldBe((new Uint8Array([254, 255])).toBase64({alphabet, omitPadding}), "/v8");
+        shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({alphabet, omitPadding}), "AAGA/v8");
+
+        shouldBe((new Uint8Array([])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "");
+        shouldBe((new Uint8Array([0])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AA");
+        shouldBe((new Uint8Array([1])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AQ");
+        shouldBe((new Uint8Array([128])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "gA");
+        shouldBe((new Uint8Array([254])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "/g");
+        shouldBe((new Uint8Array([255])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "/w");
+        shouldBe((new Uint8Array([0, 1])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AAE");
+        shouldBe((new Uint8Array([254, 255])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "/v8");
+        shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return alphabet; }, get omitPadding() { return omitPadding; }}), "AAGA/v8");
+    }
+}
+
+shouldBe((new Uint8Array([])).toBase64({alphabet: "base64url"}), "");
+shouldBe((new Uint8Array([0])).toBase64({alphabet: "base64url"}), "AA==");
+shouldBe((new Uint8Array([1])).toBase64({alphabet: "base64url"}), "AQ==");
+shouldBe((new Uint8Array([128])).toBase64({alphabet: "base64url"}), "gA==");
+shouldBe((new Uint8Array([254])).toBase64({alphabet: "base64url"}), "_g==");
+shouldBe((new Uint8Array([255])).toBase64({alphabet: "base64url"}), "_w==");
+shouldBe((new Uint8Array([0, 1])).toBase64({alphabet: "base64url"}), "AAE=");
+shouldBe((new Uint8Array([254, 255])).toBase64({alphabet: "base64url"}), "_v8=");
+shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({alphabet: "base64url"}), "AAGA_v8=");
+
+shouldBe((new Uint8Array([])).toBase64({get alphabet() { return "base64url"; }}), "");
+shouldBe((new Uint8Array([0])).toBase64({get alphabet() { return "base64url"; }}), "AA==");
+shouldBe((new Uint8Array([1])).toBase64({get alphabet() { return "base64url"; }}), "AQ==");
+shouldBe((new Uint8Array([128])).toBase64({get alphabet() { return "base64url"; }}), "gA==");
+shouldBe((new Uint8Array([254])).toBase64({get alphabet() { return "base64url"; }}), "_g==");
+shouldBe((new Uint8Array([255])).toBase64({get alphabet() { return "base64url"; }}), "_w==");
+shouldBe((new Uint8Array([0, 1])).toBase64({get alphabet() { return "base64url"; }}), "AAE=");
+shouldBe((new Uint8Array([254, 255])).toBase64({get alphabet() { return "base64url"; }}), "_v8=");
+shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return "base64url"; }}), "AAGA_v8=");
+
+for (let omitPadding of [undefined, null, false, 0, ""]) {
+    shouldBe((new Uint8Array([])).toBase64({alphabet: "base64url", omitPadding}), "");
+    shouldBe((new Uint8Array([0])).toBase64({alphabet: "base64url", omitPadding}), "AA==");
+    shouldBe((new Uint8Array([1])).toBase64({alphabet: "base64url", omitPadding}), "AQ==");
+    shouldBe((new Uint8Array([128])).toBase64({alphabet: "base64url", omitPadding}), "gA==");
+    shouldBe((new Uint8Array([254])).toBase64({alphabet: "base64url", omitPadding}), "_g==");
+    shouldBe((new Uint8Array([255])).toBase64({alphabet: "base64url", omitPadding}), "_w==");
+    shouldBe((new Uint8Array([0, 1])).toBase64({alphabet: "base64url", omitPadding}), "AAE=");
+    shouldBe((new Uint8Array([254, 255])).toBase64({alphabet: "base64url", omitPadding}), "_v8=");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({alphabet: "base64url", omitPadding}), "AAGA_v8=");
+
+    shouldBe((new Uint8Array([])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "");
+    shouldBe((new Uint8Array([0])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AA==");
+    shouldBe((new Uint8Array([1])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AQ==");
+    shouldBe((new Uint8Array([128])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "gA==");
+    shouldBe((new Uint8Array([254])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "_g==");
+    shouldBe((new Uint8Array([255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "_w==");
+    shouldBe((new Uint8Array([0, 1])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AAE=");
+    shouldBe((new Uint8Array([254, 255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "_v8=");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AAGA_v8=");
+}
+
+for (let omitPadding of [true, 42, "test", [], {}]) {
+    shouldBe((new Uint8Array([])).toBase64({alphabet: "base64url", omitPadding}), "");
+    shouldBe((new Uint8Array([0])).toBase64({alphabet: "base64url", omitPadding}), "AA");
+    shouldBe((new Uint8Array([1])).toBase64({alphabet: "base64url", omitPadding}), "AQ");
+    shouldBe((new Uint8Array([128])).toBase64({alphabet: "base64url", omitPadding}), "gA");
+    shouldBe((new Uint8Array([254])).toBase64({alphabet: "base64url", omitPadding}), "_g");
+    shouldBe((new Uint8Array([255])).toBase64({alphabet: "base64url", omitPadding}), "_w");
+    shouldBe((new Uint8Array([0, 1])).toBase64({alphabet: "base64url", omitPadding}), "AAE");
+    shouldBe((new Uint8Array([254, 255])).toBase64({alphabet: "base64url", omitPadding}), "_v8");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({alphabet: "base64url", omitPadding}), "AAGA_v8");
+
+    shouldBe((new Uint8Array([])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "");
+    shouldBe((new Uint8Array([0])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AA");
+    shouldBe((new Uint8Array([1])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AQ");
+    shouldBe((new Uint8Array([128])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "gA");
+    shouldBe((new Uint8Array([254])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "_g");
+    shouldBe((new Uint8Array([255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "_w");
+    shouldBe((new Uint8Array([0, 1])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AAE");
+    shouldBe((new Uint8Array([254, 255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "_v8");
+    shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AAGA_v8");
+}
+
+try {
+    let uint8array = new Uint8Array;
+    $.detachArrayBuffer(uint8array.buffer);
+    uint8array.toBase64();
+} catch (e) {
+    shouldBe(e instanceof TypeError, true);
+}
+
+for (let alphabet of [undefined, "base64", "base64url"]) {
+    try {
+        let uint8array = new Uint8Array;
+        uint8array.toBase64({
+            get alphabet() {
+                $.detachArrayBuffer(uint8array.buffer);
+                return alphabet;
+            },
+        });
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+
+    try {
+        (new Uint8Array).toBase64({
+            alphabet: {
+                toString() {
+                    return alphabet;
+                },
+            },
+        });
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+}
+
+for (let options of [undefined, null, false, true, 42, "test", []]) {
+    try {
+        (new Uint8Array).toBase64(options);
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+}
+
+for (let alphabet of [null, false, true, 42, "invalid", {}, []]) {
+    try {
+        (new Uint8Array).toBase64({alphabet});
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+
+    try {
+        (new Uint8Array).toBase64({
+            get alphabet() { return alphabet; },
+        });
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+}

--- a/JSTests/stress/uint8array-toHex.js
+++ b/JSTests/stress/uint8array-toHex.js
@@ -1,0 +1,24 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+shouldBe((new Uint8Array([])).toHex(), "");
+shouldBe((new Uint8Array([0])).toHex(), "00");
+shouldBe((new Uint8Array([1])).toHex(), "01");
+shouldBe((new Uint8Array([128])).toHex(), "80");
+shouldBe((new Uint8Array([254])).toHex(), "fe");
+shouldBe((new Uint8Array([255])).toHex(), "ff");
+shouldBe((new Uint8Array([0, 1])).toHex(), "0001");
+shouldBe((new Uint8Array([254, 255])).toHex(), "feff");
+shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toHex(), "000180feff");
+
+try {
+    let uint8array = new Uint8Array;
+    $.detachArrayBuffer(uint8array.buffer);
+    uint8array.toHex();
+} catch (e) {
+    shouldBe(e instanceof TypeError, true);
+}

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4726,6 +4726,7 @@
 		918E15BD2447B22600447A56 /* AggregateErrorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorPrototype.h; sourceTree = "<group>"; };
 		918E15BE2447B22700447A56 /* AggregateErrorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AggregateErrorPrototype.cpp; sourceTree = "<group>"; };
 		918E15BF2447B22700447A56 /* AggregateErrorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorConstructor.h; sourceTree = "<group>"; };
+		91C3265D2BFFB2BF009C7E2B /* JSGenericTypedArrayViewPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGenericTypedArrayViewPrototype.cpp; sourceTree = "<group>"; };
 		91D1578C24E0BE35001F4CED /* Breakpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Breakpoint.cpp; sourceTree = "<group>"; };
 		91F548A52A4CF448007292DE /* MapConstructor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = MapConstructor.js; sourceTree = "<group>"; };
 		91FD55322A4CF52100F5D482 /* MapConstructor.lut.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapConstructor.lut.h; sourceTree = "<group>"; };
@@ -8335,6 +8336,7 @@
 				0F2B66C417B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h */,
 				0F2B66C517B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructorInlines.h */,
 				0F2B66C617B6B5AB00A7AE3F /* JSGenericTypedArrayViewInlines.h */,
+				91C3265D2BFFB2BF009C7E2B /* JSGenericTypedArrayViewPrototype.cpp */,
 				0F2B66C717B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototype.h */,
 				53917E7A1B7906E4000EBD33 /* JSGenericTypedArrayViewPrototypeFunctions.h */,
 				0F2B66C817B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototypeInlines.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -917,6 +917,7 @@ runtime/JSFinalizationRegistry.cpp
 runtime/JSFunction.cpp
 runtime/JSGenerator.cpp
 runtime/JSGeneratorFunction.cpp
+runtime/JSGenericTypedArrayViewPrototype.cpp
 runtime/JSGlobalLexicalEnvironment.cpp
 runtime/JSGlobalObject.cpp
 runtime/JSGlobalObjectDebuggable.cpp

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -72,6 +72,7 @@
     macro(__lookupSetter__) \
     macro(add) \
     macro(additionalJettisonReason) \
+    macro(alphabet) \
     macro(anonymous) \
     macro(arguments) \
     macro(as) \
@@ -221,6 +222,7 @@
     macro(numberingSystem) \
     macro(numeric) \
     macro(of) \
+    macro(omitPadding) \
     macro(opcode) \
     macro(origin) \
     macro(osrExitSites) \

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSGenericTypedArrayViewPrototype.h"
+
+#include "ParseInt.h"
+#include <wtf/text/Base64.h>
+
+namespace JSC {
+
+JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
+    if (UNLIKELY(!uint8Array))
+        return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that |this| be a Uint8Array"_s);
+
+    OptionSet<Base64EncodeOption> options;
+
+    JSValue optionsValue = callFrame->argument(0);
+    if (!optionsValue.isUndefined()) {
+        JSObject* optionsObject = jsDynamicCast<JSObject*>(optionsValue);
+        if (UNLIKELY(!optionsObject))
+            return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that options be an object"_s);
+
+        JSValue alphabetValue = optionsObject->get(globalObject, vm.propertyNames->alphabet);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!alphabetValue.isUndefined()) {
+            JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
+            if (UNLIKELY(!alphabetString))
+                return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
+
+            StringView alphabetStringView = alphabetString->view(globalObject);
+            if (alphabetStringView == "base64url"_s)
+                options.add(Base64EncodeOption::URL);
+            else if (alphabetStringView != "base64"_s)
+                return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
+        }
+
+        JSValue omitPaddingValue = optionsObject->get(globalObject, vm.propertyNames->omitPadding);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (omitPaddingValue.toBoolean(globalObject))
+            options.add(Base64EncodeOption::OmitPadding);
+    }
+
+    IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> byteLengthGetter;
+    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
+        return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
+
+    const uint8_t* data = uint8Array->typedVector();
+    size_t length = uint8Array->length();
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, base64EncodeToString({ data, length }, options))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
+    if (UNLIKELY(!uint8Array))
+        return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toHex requires that |this| be a Uint8Array"_s);
+
+    IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> byteLengthGetter;
+    if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
+        return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
+
+    StringBuilder builder;
+    builder.reserveCapacity(uint8Array->length() * 2);
+
+    const uint8_t* data = uint8Array->typedVector();
+    size_t length = uint8Array->length();
+    for (size_t i = 0; i < length; ++i) {
+        builder.append(radixDigits[data[i] / 16]);
+        builder.append(radixDigits[data[i] % 16]);
+    }
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, builder.toString())));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h
@@ -56,4 +56,7 @@ private:
     void finishCreation(VM&, JSGlobalObject*);
 };
 
+JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeToBase64);
+JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeToHex);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
@@ -27,6 +27,8 @@
 
 #include "JSGenericTypedArrayViewPrototype.h"
 
+#include "JSTypedArrays.h"
+
 namespace JSC {
     
 template<typename ViewClass>
@@ -44,6 +46,14 @@ void JSGenericTypedArrayViewPrototype<ViewClass>::finishCreation(
     ASSERT(inherits(info()));
 
     putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
+
+    if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
+        if (Options::useUint8ArrayBase64Methods()) {
+            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toBase64"_s, uint8ArrayPrototypeToBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toHex"_s, uint8ArrayPrototypeToHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+        }
+    }
+
     globalObject->installTypedArrayIteratorProtocolWatchpoint(this, ViewClass::TypedArrayStorageType);
 }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -599,6 +599,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
+    v(Bool, useUint8ArrayBase64Methods, false, Normal, "Expose methods for converting Uint8Array to/from base64 and hex."_s) \
     v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec."_s) \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal."_s) \
     v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \


### PR DESCRIPTION
#### 2596e190eeb8bcb7062e415c7896c7f875e0d080
<pre>
[JSC] add support for `Uint8Array.prototype.toBase64` and `Uint8Array.prototype.toHex`
<a href="https://bugs.webkit.org/show_bug.cgi?id=274635">https://bugs.webkit.org/show_bug.cgi?id=274635</a>

Reviewed by Yusuke Suzuki.

These methods will make it easier for developers to encode typed character/byte data.

Note that there are other methods in the related proposal, but for ease of reviewing they will be implemented separately.

Spec: &lt;<a href="https://tc39.es/proposal-arraybuffer-base64/spec/">https://tc39.es/proposal-arraybuffer-base64/spec/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-arraybuffer-base64">https://github.com/tc39/proposal-arraybuffer-base64</a>&gt;

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h:
(JSC::JSGenericTypedArrayViewPrototype&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp: Added.
(JSC::uint8ArrayPrototypeToBase64):
(JSC::uint8ArrayPrototypeToHex):

* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
Create builtin identifiers for `alphabet` and `omitPadding`.

* Source/JavaScriptCore/runtime/OptionsList.h:
Add a `useUint8ArrayBase64Methods` feature flag for these new methods (and the others that are part of the proposal that haven&apos;t been implemented yet).

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:

* JSTests/stress/uint8array-toBase64.js: Added.
* JSTests/stress/uint8array-toHex.js: Added.

Canonical link: <a href="https://commits.webkit.org/280654@main">https://commits.webkit.org/280654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e28c23380b0e02e1fbe5d168d351a79bd3d518f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7862 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5402 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59259 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6726 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6677 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50321 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62530 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56471 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49449 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/961 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78231 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12966 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33471 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->