### PR TITLE
Add entitlement to give the WebProcess a higher jetsam limit

### DIFF
--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -22,6 +22,7 @@ function mac_process_jsc_entitlements()
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+            plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
         fi
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
@@ -46,6 +47,7 @@ function mac_process_testapi_entitlements()
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+            plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
         fi
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
@@ -73,6 +75,7 @@ function maccatalyst_process_jsc_entitlements()
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+            plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
         fi
     fi
 
@@ -99,6 +102,7 @@ function maccatalyst_process_testapi_entitlements()
     then
         plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
         plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+        plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
     fi
 
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 && -z "${SKIP_ROSETTA_BREAKING_ENTITLEMENTS}" ))
@@ -129,6 +133,7 @@ function ios_family_process_jsc_entitlements()
         fi
     fi
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
     plistbuddy Add :com.apple.security.fatal-exceptions array
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
 }

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -24,6 +24,7 @@ function mac_process_webcontent_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+            plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
             plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
             plistbuddy Add :com.apple.pac.shared_region_id string WebContent
             plistbuddy Add :com.apple.private.pac.exception bool YES
@@ -59,6 +60,7 @@ function mac_process_webcontent_captiveportal_entitlements()
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+            plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
             plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
             plistbuddy Add :com.apple.pac.shared_region_id string WebContent
             plistbuddy Add :com.apple.private.pac.exception bool YES
@@ -306,6 +308,7 @@ function maccatalyst_process_webcontent_entitlements()
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
     then
         plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+        plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
         plistbuddy Add :com.apple.pac.shared_region_id string WebContent
         plistbuddy Add :com.apple.private.pac.exception bool YES
         plistbuddy Add :com.apple.private.security.message-filter bool YES
@@ -346,6 +349,7 @@ function maccatalyst_process_webcontent_captiveportal_entitlements()
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
     then
         plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+        plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
         plistbuddy Add :com.apple.pac.shared_region_id string WebContent
         plistbuddy Add :com.apple.private.pac.exception bool YES
         plistbuddy Add :com.apple.private.security.message-filter bool YES
@@ -465,6 +469,7 @@ function ios_family_process_webcontent_entitlements()
         fi
     fi
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
 
     ios_family_process_webcontent_shared_entitlements
 }
@@ -474,6 +479,7 @@ function ios_family_process_webcontent_captiveportal_entitlements()
     plistbuddy Add :com.apple.private.webkit.lockdown-mode bool YES
 
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.developer.kernel.increased-memory-limit bool YES
 
     plistbuddy Add :com.apple.imageio.allowabletypes array
     plistbuddy Add :com.apple.imageio.allowabletypes:0 string org.webmproject.webp


### PR DESCRIPTION
#### f0e281b2885ed9c8776156b0e2c53c226143f8d4
<pre>
Add entitlement to give the WebProcess a higher jetsam limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=274637">https://bugs.webkit.org/show_bug.cgi?id=274637</a>

Reviewed by NOBODY (OOPS!).

Lots of websites (and apps that use web content) could probably benefit from a higher jetsam limit &lt;<a href="https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit">https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit</a>&gt;, similar to how a larger virtual address space is helpful/necessary (see &lt;<a href="https://commits.webkit.org/246553@main">https://commits.webkit.org/246553@main</a>&gt;, &lt;<a href="https://commits.webkit.org/270484@main">https://commits.webkit.org/270484@main</a>&gt;, and &lt;<a href="https://commits.webkit.org/271394@main">https://commits.webkit.org/271394@main</a>&gt;).

* Source/JavaScriptCore/Scripts/process-entitlements.sh:
* Source/WebKit/Scripts/process-entitlements.sh:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0e281b2885ed9c8776156b0e2c53c226143f8d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56234 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42958 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24081 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52799 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3030 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1837 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46309 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57828 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52468 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49652 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30235 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64772 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29070 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12298 "Passed tests") | 
<!--EWS-Status-Bubble-End-->