### PR TITLE
Avoid using CanvasBase::buffer() when accessing drawing buffer contents for inspector and painting

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -100,9 +100,10 @@ AffineTransform CanvasBase::baseTransform() const
 RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     if (auto* context = renderingContext()) {
-        context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
+        RefPtr buffer = context->surfaceBufferToImageBuffer(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
         if (m_canvasNoiseHashSalt && shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes)
-            m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer(), *m_canvasNoiseHashSalt, context->is2d() ? CanvasNoiseInjectionPostProcessArea::DirtyRect : CanvasNoiseInjectionPostProcessArea::FullBuffer);
+            m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer.get(), *m_canvasNoiseHashSalt, context->is2d() ? CanvasNoiseInjectionPostProcessArea::DirtyRect : CanvasNoiseInjectionPostProcessArea::FullBuffer);
+        return buffer;
     }
     return buffer();
 }

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -153,6 +153,8 @@ public:
     void setNoiseInjectionSalt(NoiseInjectionHashSalt salt) { m_canvasNoiseHashSalt = salt; }
     bool havePendingCanvasNoiseInjection() const { return m_canvasNoiseInjection.haveDirtyRects(); }
 
+    virtual bool hasCreatedImageBuffer() const { return false; }
+
 protected:
     explicit CanvasBase(IntSize, const std::optional<NoiseInjectionHashSalt>&);
 
@@ -161,8 +163,6 @@ protected:
     virtual void setSize(const IntSize&);
 
     RefPtr<ImageBuffer> setImageBuffer(RefPtr<ImageBuffer>&&) const;
-    virtual bool hasCreatedImageBuffer() const { return false; }
-
     RefPtr<ImageBuffer> allocateImageBuffer() const;
     String lastFillText() const { return m_lastFillText; }
     void addCanvasNeedingPreparationForDisplayOrFlush();

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -480,19 +480,15 @@ std::unique_ptr<DetachedOffscreenCanvas> OffscreenCanvas::detach()
 
 void OffscreenCanvas::commitToPlaceholderCanvas()
 {
-    RefPtr imageBuffer = buffer();
-    if (!imageBuffer)
-        return;
     if (!m_placeholderData)
         return;
-
-    // FIXME: Transfer texture over if we're using accelerated compositing
-    if (m_context && (m_context->isWebGL() || m_context->isAccelerated())) {
-        if (m_context->compositingResultsNeedUpdating())
-            m_context->prepareForDisplay();
-        m_context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
-    }
-
+    if  (!m_context)
+        return;
+    if (m_context->compositingResultsNeedUpdating())
+        m_context->prepareForDisplay();
+    RefPtr imageBuffer = m_context->surfaceBufferToImageBuffer(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
+    if (!imageBuffer)
+        return;
     if (auto pipeSource = m_placeholderData->pipeSource())
         pipeSource->handle(*imageBuffer);
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -87,6 +87,17 @@ void CanvasRenderingContext::deref() const
     m_canvas.derefCanvasBase();
 }
 
+RefPtr<ImageBuffer> CanvasRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
+{
+    // This will be removed once all contexts store their own buffers.
+    return canvasBase().buffer();
+}
+
+bool CanvasRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
+{
+    return false;
+}
+
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext::layerContentsDisplayDelegate()
 {
     return nullptr;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -91,7 +91,8 @@ public:
     };
 
     // Draws the source buffer to the canvasBase().buffer().
-    virtual void drawBufferToCanvas(SurfaceBuffer) { }
+    virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer);
+    virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -262,6 +262,13 @@ bool CanvasRenderingContext2DBase::isAccelerated() const
 #endif
 }
 
+bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
+{
+    // Before the first draw (or first access to the drawing buffer), the drawing buffer is transparent black.
+    // Currently the canvas does not support alpha == false.
+    return !canvasBase().hasCreatedImageBuffer();
+}
+
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext2DBase::layerContentsDisplayDelegate()
 {
     if (auto buffer = canvasBase().buffer())

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -456,7 +456,7 @@ private:
     template<class T> void fullCanvasCompositedDrawImage(T&, const FloatRect&, const FloatRect&, CompositeOperator);
 
     bool isAccelerated() const override;
-
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const override;
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
     bool hasDeferredOperations() const final;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -65,7 +65,8 @@ public:
     PixelFormat pixelFormat() const override;
     void reshape(int width, int height, int oldWidth, int oldHeight) override;
 
-    void drawBufferToCanvas(SurfaceBuffer) override;
+
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) override;
     // GPUCanvasContext methods:
     CanvasType canvas() override;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -180,7 +180,7 @@ void GPUCanvasContextCocoa::reshape(int width, int height, int oldWidth, int old
     }
 }
 
-void GPUCanvasContextCocoa::drawBufferToCanvas(SurfaceBuffer)
+RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuffer)
 {
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     m_compositorIntegration->prepareForDisplay([this, weakThis = WeakPtr { *this }] {
@@ -196,6 +196,7 @@ void GPUCanvasContextCocoa::drawBufferToCanvas(SurfaceBuffer)
             present();
         }
     });
+    return canvasBase().buffer();
 }
 
 ExceptionOr<RefPtr<ImageBitmap>> GPUCanvasContextCocoa::getCurrentTextureAsImageBitmap(ImageBuffer& buffer, bool originClean)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -772,15 +772,16 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cal
     return combinedClear;
 }
 
-void WebGLRenderingContextBase::drawBufferToCanvas(SurfaceBuffer sourceBuffer)
+
+RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(SurfaceBuffer sourceBuffer)
 {
-    if (isContextLost())
-        return;
-    if (m_canvasBufferContents == sourceBuffer)
-        return;
     auto buffer = canvasBase().buffer();
+    if (isContextLost())
+        return buffer;
     if (!buffer)
-        return;
+        return buffer;
+    if (m_canvasBufferContents == sourceBuffer)
+        return buffer;
     if (sourceBuffer == SurfaceBuffer::DrawingBuffer)
         clearIfComposited(CallerTypeOther);
     m_canvasBufferContents = sourceBuffer;
@@ -789,6 +790,7 @@ void WebGLRenderingContextBase::drawBufferToCanvas(SurfaceBuffer sourceBuffer)
     // canvas element repeatedly.
     buffer->flushDrawingContext();
     m_context->drawSurfaceBufferToImageBuffer(toGCGLSurfaceBuffer(sourceBuffer), *buffer);
+    return buffer;
 }
 
 RefPtr<PixelBuffer> WebGLRenderingContextBase::drawingBufferToPixelBuffer(GraphicsContextGL::FlipY flipY)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -439,7 +439,7 @@ public:
 
     void reshape(int width, int height, int oldWidth, int oldHeight) override;
 
-    void drawBufferToCanvas(SurfaceBuffer) final;
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
 
     RefPtr<PixelBuffer> drawingBufferToPixelBuffer(GraphicsContextGL::FlipY);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -1011,11 +1011,12 @@ Ref<Inspector::Protocol::Recording::Recording> InspectorCanvas::releaseObjectFor
 
 Inspector::Protocol::ErrorStringOr<String> InspectorCanvas::getContentAsDataURL(CanvasRenderingContext& context)
 {
+    RefPtr<ImageBuffer> buffer;
     if (context.compositingResultsNeedUpdating())
-        context.drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
+        buffer = context.surfaceBufferToImageBuffer(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
     else
-        context.drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
-    if (auto* buffer = context.canvasBase().buffer())
+        buffer = context.surfaceBufferToImageBuffer(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
+    if (buffer)
         return buffer->toDataURL("image/png"_s);
     return emptyString();
 }
@@ -1169,8 +1170,8 @@ int InspectorCanvas::indexForData(DuplicateDataVariant data)
         [&] (const RefPtr<OffscreenCanvas> offscreenCanvas) {
             String dataURL = "data:,"_s;
 
-            if (offscreenCanvas->originClean() && offscreenCanvas->hasCreatedImageBuffer()) {
-                if (auto *buffer = offscreenCanvas->buffer())
+            if (offscreenCanvas->originClean()) {
+                if (RefPtr buffer = offscreenCanvas->makeRenderingResultsAvailable())
                     dataURL = buffer->toDataURL("image/png"_s);
             }
 


### PR DESCRIPTION
#### 5ab485a4c7c8f6831dd00ac8b87bedae3205baac
<pre>
Avoid using CanvasBase::buffer() when accessing drawing buffer contents for inspector and painting
<a href="https://bugs.webkit.org/show_bug.cgi?id=274646">https://bugs.webkit.org/show_bug.cgi?id=274646</a>
<a href="https://rdar.apple.com/128677907">rdar://128677907</a>

Reviewed by Matt Woodrow.

Before, getting the buffer was:
 - call CanvaRenderingContext::drawBufferToCanvas()
 - access CanvasBase::buffer()

 After,
  - obtain the buffer from CanvasRenderingContext::surfaceBufferToImageBuffer.

This way these call sites do not need to call CanvasBase::buffer().
This is work towards CanvasRenderingContext subclasses themselves managing
the copied buffers.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::paint):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::surfaceBufferToImageBuffer):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::drawBufferToCanvas): Deleted.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::drawBufferToCanvas): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::drawBufferToCanvas): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::getContentAsDataURL):
(WebCore::InspectorCanvas::indexForData):

Canonical link: <a href="https://commits.webkit.org/279437@main">https://commits.webkit.org/279437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f758f8744f999121800abf866a67908619a6e347

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43364 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3553 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2381 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50767 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29863 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11664 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->