### PR TITLE
Switch from RefPtr to Ref in PushMessageData binding code

### DIFF
--- a/Source/WebCore/Modules/push-api/PushMessageData.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageData.cpp
@@ -38,25 +38,25 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(PushMessageData);
 
-ExceptionOr<RefPtr<JSC::ArrayBuffer>> PushMessageData::arrayBuffer()
+ExceptionOr<Ref<JSC::ArrayBuffer>> PushMessageData::arrayBuffer()
 {
-    auto buffer = ArrayBuffer::tryCreate(m_data.span());
+    RefPtr buffer = ArrayBuffer::tryCreate(m_data.span());
     if (!buffer)
         return Exception { ExceptionCode::OutOfMemoryError };
-    return buffer;
+    return buffer.releaseNonNull();
 }
 
-RefPtr<Blob> PushMessageData::blob(ScriptExecutionContext& context)
+Ref<Blob> PushMessageData::blob(ScriptExecutionContext& context)
 {
     return Blob::create(&context, Vector<uint8_t> { m_data }, { });
 }
 
-ExceptionOr<RefPtr<JSC::Uint8Array>> PushMessageData::bytes()
+ExceptionOr<Ref<JSC::Uint8Array>> PushMessageData::bytes()
 {
-    auto view = Uint8Array::tryCreate(m_data.span());
+    RefPtr view = Uint8Array::tryCreate(m_data.span());
     if (!view)
         return Exception { ExceptionCode::OutOfMemoryError };
-    return view;
+    return view.releaseNonNull();
 }
 
 ExceptionOr<JSC::JSValue> PushMessageData::json(JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/Modules/push-api/PushMessageData.h
+++ b/Source/WebCore/Modules/push-api/PushMessageData.h
@@ -43,9 +43,9 @@ class PushMessageData final : public RefCounted<PushMessageData> {
 public:
     static Ref<PushMessageData> create(Vector<uint8_t>&& data) { return adoptRef(*new PushMessageData(WTFMove(data))); }
 
-    ExceptionOr<RefPtr<JSC::ArrayBuffer>> arrayBuffer();
-    RefPtr<Blob> blob(ScriptExecutionContext&);
-    ExceptionOr<RefPtr<JSC::Uint8Array>> bytes();
+    ExceptionOr<Ref<JSC::ArrayBuffer>> arrayBuffer();
+    Ref<Blob> blob(ScriptExecutionContext&);
+    ExceptionOr<Ref<JSC::Uint8Array>> bytes();
     ExceptionOr<JSC::JSValue> json(JSDOMGlobalObject&);
     String text();
 


### PR DESCRIPTION
#### 98062d50b937aa77fd4aa9f42fde6e305c554871
<pre>
Switch from RefPtr to Ref in PushMessageData binding code
<a href="https://bugs.webkit.org/show_bug.cgi?id=274652">https://bugs.webkit.org/show_bug.cgi?id=274652</a>

Reviewed by Darin Adler.

Some additional cleanup following 279263@main.

* Source/WebCore/Modules/push-api/PushMessageData.cpp:
(WebCore::PushMessageData::arrayBuffer):
(WebCore::PushMessageData::blob):
(WebCore::PushMessageData::bytes):
* Source/WebCore/Modules/push-api/PushMessageData.h:

Canonical link: <a href="https://commits.webkit.org/279310@main">https://commits.webkit.org/279310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140d332f41d0ab58a3d4aa5525f92ea650ccff46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42976 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2383 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50378 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49680 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30254 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7804 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->