### PR TITLE
[WPE][run-benchmark] The browser is not terminated when there is a timeout

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -123,6 +123,10 @@ class LinuxBrowserDriver(BrowserDriver):
         _log.info('Launching "%s" with url "%s"' % (driver.name, url))
         driver.get(url)
 
+    def diagnose_test_failure(self, diagnose_directory, error):
+        # FIXME: store a screenshoot or some debug data for later analysis before closing the browser.
+        self.close_browsers()
+
     def _get_first_executable_path_from_list(self, searchlist):
         searchpath = [os.path.curdir] + os.environ['PATH'].split(os.pathsep)
         for program in searchlist:

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
@@ -37,6 +37,7 @@ class CogBrowserDriver(LinuxBrowserDriver):
         self._default_browser_arguments = []
         if self.process_name.endswith('run-minibrowser'):
             self._default_browser_arguments.append('--wpe')
+        self._default_browser_arguments.append('--webprocess-failure=exit')
         self._default_browser_arguments.append(url)
         super(CogBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 


### PR DESCRIPTION
#### 77548fd93ab480259f2d3644c7c63cb6f947c01e
<pre>
[WPE][run-benchmark] The browser is not terminated when there is a timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=274649">https://bugs.webkit.org/show_bug.cgi?id=274649</a>

Reviewed by Carlos Garcia Campos.

I have been observing lot of timeouts on the benchmarks that are run at the WPE perf bots
<a href="https://build.webkit.org/#/builders/WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests">https://build.webkit.org/#/builders/WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests</a>

The problem is caused because we run several benchmark plans in serial and when one of this
plans timeouts the runner exits without killing the browser, which means that the browser stays
on the screen.
So on the next run for the next benchmark the new browser invoked can&apos;t run (hangs forever)
because of the specific hardware configuration of this boards (WPE with DRM plugin; only one
browser allowed to hold a handle of the screen at a time)

So we need to ensure to terminate the current browser when the runner ends.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py:
(LinuxBrowserDriver.diagnose_test_failure):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py:
(CogBrowserDriver.launch_url):

Canonical link: <a href="https://commits.webkit.org/279349@main">https://commits.webkit.org/279349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5f35657fd996c7f2806169871e1d89fde85560

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53259 "Failed to checkout and rebase branch from PR 29051") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32608 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/5755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3729 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55357 "Failed to checkout and rebase branch from PR 29051") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/5755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/53103 "webkitpy-tests (failure)") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/5755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2141 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/5755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58134 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/5755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7822 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->