### PR TITLE
mask-mode breaks mask-size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style type="text/css">
+      div {
+        position: absolute;
+
+        width: 100px;
+        height: 25px;
+        left: 10px;
+
+        background-image: url(support/blue-luminance-100x100.svg);
+      }
+
+      #top {
+        top: 10px;
+      }
+
+      #bottom {
+        top: 60px;
+      }
+
+    </style>
+  </head>
+  <body>
+    <div id="top"></div>
+    <div id="bottom"></div>
+  </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style type="text/css">
+      div {
+        position: absolute;
+
+        width: 100px;
+        height: 25px;
+        left: 10px;
+
+        background-image: url(support/blue-luminance-100x100.svg);
+      }
+
+      #top {
+        top: 10px;
+      }
+
+      #bottom {
+        top: 60px;
+      }
+
+    </style>
+  </head>
+  <body>
+    <div id="top"></div>
+    <div id="bottom"></div>
+  </body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Masking: 'mask-mode: luminance' with 'mask-size'</title>
+    <link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+    <link rel="help" href="https://www.w3.org/TR/css-masking-1/#propdef-mask-mode">
+    <link rel="match" href="mask-mode-luminance-with-mask-size-ref.html">
+    <meta name="assert" content="Test checks that mask a PNG image referenced by mask-image is correct with 'mask mode: luminance', partial transparency and 'mask-mode'.">
+    <style type="text/css">
+      div {
+        background-color: blue;
+        position: absolute;
+
+        width: 100px;
+        height: 100px;
+
+        top: 10px;
+        left: 10px;
+
+        mask-mode: luminance;
+        mask-size: 100px 50px;
+        mask-image: url(support/transparent-100x50-blue-100x50.png);
+      }
+
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3662,7 +3662,6 @@ webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/dynamic-base
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/dynamic-baseline-change.html [ Pass ]
 webkit.org/b/212046 imported/w3c/web-platform-tests/css/css-flexbox/percentage-heights-014.html [ Pass ]
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-items/replaced-element-015.html [ Pass ]
-webkit.org/b/149828 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-mask-image.html [ Pass ]
 webkit.org/b/214456 imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic-2.html [ Pass ]
 webkit.org/b/214456 imported/w3c/web-platform-tests/css/css-images/tiled-conic-gradients.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-polygon-013.html [ Pass ]

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -123,6 +123,7 @@ private:
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions = { }) final;
     void drawPattern(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
+    void drawLuminanceMaskPattern(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions);
 
     void dump(WTF::TextStream&) const final;
 


### PR DESCRIPTION
#### 2e41b0f5e31e945a4dc8ae2185e6a3183c0873af
<pre>
mask-mode breaks mask-size
<a href="https://bugs.webkit.org/show_bug.cgi?id=264800">https://bugs.webkit.org/show_bug.cgi?id=264800</a>
<a href="https://rdar.apple.com/118396665">rdar://118396665</a>

Reviewed by Simon Fraser.

In `BitmapImage::drawPattern()`, we should be using `createImageBuffer()` instead of `createAlignedImageBuffer()`
since we create the temporary `ImageBuffer` to work on the pixels of the image and, as such, should not be scaled
to match the `GraphicsContext` resolution.

We should use the `ImageBuffer` rect instead of tileRect when drawing to or from the `ImageBuffer` since the `tileRect`
is in the destination `GraphicsContext` coordinates.

Patch logic by Said Abou-Hallawa, refactoring and test by Antoine Quint.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-luminance-with-mask-size.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::drawPattern):
(WebCore::BitmapImage::drawLuminanceMaskPattern):
* Source/WebCore/platform/graphics/BitmapImage.h:

Canonical link: <a href="https://commits.webkit.org/279312@main">https://commits.webkit.org/279312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceeb67ede709f835cefa8be0a2566adaf4a87f4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5616 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3581 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/56408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/55227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/45859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/3187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2011 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/3345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28270 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/58004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7806 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->