### PR TITLE
Sync `html/syntax/speculative-parsing/generated` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+
+    <!-- speculative case in document.write -->
+    <template><div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=b79c85d3-422b-4bb4-80f9-7772f364508a&amp;encodingcheck=&Gbreve;"></script></template></div></template>
+
+
+
+PASS Speculative parsing, document.write(): nested-template-shadowrootmode-1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): nested-template-shadowrootmode-1</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'nested-template-shadowrootmode-1', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <template><div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"><\/script></template></div></template>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: nested-template-shadowrootmode-2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+
+    <!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><template><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=9c699e63-3ce9-481c-88fd-451e81f0c2ac&amp;encodingcheck=&Gbreve;"></script></template></template></div>
+
+
+
+PASS Speculative parsing, document.write(): nested-template-shadowrootmode-2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): nested-template-shadowrootmode-2</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'nested-template-shadowrootmode-2', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><template><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"><\/script></template></template></div>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: template-img-src
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+
+    <!-- speculative case in document.write -->
+    <template><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=7bae30f5-e4cd-42a6-95fb-7dba0b3cdfe0&amp;encodingcheck=&Gbreve;"></template>
+
+
+
+PASS Speculative parsing, document.write(): template-img-src
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): template-img-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'template-img-src', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <template><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"></template>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-link-stylesheet.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-link-stylesheet.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+
+    <!-- speculative case in document.write -->
+    <template><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=ef773b25-dfe5-4ed7-8b4c-841403b712c8&amp;encodingcheck=&Gbreve;"></template>
+
+
+
+PASS Speculative parsing, document.write(): template-link-stylesheet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-link-stylesheet.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-link-stylesheet.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): template-link-stylesheet</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'template-link-stylesheet', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <template><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"></template>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+    <!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=d8ca7a97-e8c3-4d61-8912-aff8350abd50&amp;encodingcheck=&Gbreve;"></template></div>
+
+
+FAIL Speculative parsing, document.write(): template-shadowrootmode-img-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): template-shadowrootmode-img-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'template-shadowrootmode-img-src', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"></template></div>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+    <!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=4bdd6438-73b9-4b3d-a8c7-58b5e5aace62&amp;encodingcheck=&Gbreve;"></template></div>
+
+
+FAIL Speculative parsing, document.write(): template-shadowrootmode-link-stylesheet Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): template-shadowrootmode-link-stylesheet</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'template-shadowrootmode-link-stylesheet', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"></template></div>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+    <!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=6f013501-95b1-4d24-abac-9e33c7c8ee6b&amp;encodingcheck=&Gbreve;"></script></template></div>
+
+
+FAIL Speculative parsing, document.write(): template-shadowrootmode-script-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, document.write(): template-shadowrootmode-script-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'template-shadowrootmode-script-src', true))
+    .then(done);
+  document.write(`
+    <script src="/common/slow.py?delay=1500"><\/script>
+    <script>
+     document.write('<plaintext>');
+    <\/script>
+    <\!-- speculative case in document.write -->
+    <div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=${uuid}&amp;encodingcheck=&Gbreve;"><\/script></template></div>
+  `);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/w3c-import.log
@@ -44,6 +44,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/meta-csp-img-src-none.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/meta-referrer-no-referrer-img-src.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/meta-viewport-link-stylesheet-media.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-br-img.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-no-img.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/picture-source-nomatch-media.tentative.sub.html
@@ -64,6 +66,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/svg-script-href.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/svg-script-src.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/svg-script-xlinkhref.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-link-stylesheet.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-script-src.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/video-poster.tentative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/xmp-script-src.tentative.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: nested-template-shadowrootmode-1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: nested-template-shadowrootmode-1</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/nested-template-shadowrootmode-1-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'nested-template-shadowrootmode-1', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: nested-template-shadowrootmode-2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: nested-template-shadowrootmode-2</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/nested-template-shadowrootmode-2-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'nested-template-shadowrootmode-2', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-1-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-1-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): nested-template-shadowrootmode-1</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<template><div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></script></template></div></template>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-2-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-2-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): nested-template-shadowrootmode-2</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<div><template shadowrootmode="closed"><template><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></script></template></template></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-img-src-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-img-src-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): template-img-src</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<template><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-link-stylesheet-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-link-stylesheet-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): template-link-stylesheet</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<template><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-img-src-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-img-src-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): template-shadowrootmode-img-src</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<div><template shadowrootmode="closed"><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-link-stylesheet-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-link-stylesheet-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): template-shadowrootmode-link-stylesheet</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<div><template shadowrootmode="closed"><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-script-src-framed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-script-src-framed.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load (helper file): template-shadowrootmode-script-src</title>
+<script src="/common/slow.py?delay=1500"></script>
+<script>
+  document.write('<plaintext>');
+</script>
+<!-- speculative case -->
+<div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></script></template></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/w3c-import.log
@@ -44,6 +44,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/meta-csp-img-src-none-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/meta-referrer-no-referrer-img-src-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/meta-viewport-link-stylesheet-media-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-1-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-2-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-br-img-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-no-img-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-nomatch-media-framed.sub.html
@@ -64,6 +66,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/svg-script-href-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/svg-script-src-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/svg-script-xlinkhref-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-img-src-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-link-stylesheet-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-script-src-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-img-src-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-link-stylesheet-framed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-script-src-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/video-poster-framed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/xmp-script-src-framed.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: template-img-src
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: template-img-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/template-img-src-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'template-img-src', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Speculative parsing, page load: template-link-stylesheet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: template-link-stylesheet</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/template-link-stylesheet-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, false)
+    .then(compare_with_nonspeculative(uuid, 'template-link-stylesheet', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+
+FAIL Speculative parsing, page load: template-shadowrootmode-img-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: template-shadowrootmode-img-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/template-shadowrootmode-img-src-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'template-shadowrootmode-img-src', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+
+FAIL Speculative parsing, page load: template-shadowrootmode-link-stylesheet Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: template-shadowrootmode-link-stylesheet</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/template-shadowrootmode-link-stylesheet-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'template-shadowrootmode-link-stylesheet', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+
+FAIL Speculative parsing, page load: template-shadowrootmode-script-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, page load: template-shadowrootmode-script-src</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
+<script src=/html/syntax/speculative-parsing/resources/speculative-parsing-util.js></script>
+<body>
+<script>
+  setup({single_test: true});
+  const uuid = token();
+  const iframe = document.createElement('iframe');
+  iframe.src = `resources/template-shadowrootmode-script-src-framed.sub.html?uuid=${uuid}`;
+  document.body.appendChild(iframe);
+  expect_fetched_onload(uuid, true)
+    .then(compare_with_nonspeculative(uuid, 'template-shadowrootmode-script-src', true))
+    .then(done);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/w3c-import.log
@@ -44,6 +44,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/meta-csp-img-src-none.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/meta-referrer-no-referrer-img-src.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/meta-viewport-link-stylesheet-media.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-br-img.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-no-img.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-nomatch-media.tentative.html
@@ -64,6 +66,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-href.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-src.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-xlinkhref.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-script-src.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/video-poster.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/xmp-script-src.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-1-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-1-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): nested-template-shadowrootmode-1</title>
+<!-- non-speculative case -->
+<template><div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></script></template></div></template>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-2-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-2-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): nested-template-shadowrootmode-2</title>
+<!-- non-speculative case -->
+<div><template shadowrootmode="closed"><template><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></script></template></template></div>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-img-src-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-img-src-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): template-img-src</title>
+<!-- non-speculative case -->
+<template><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-link-stylesheet-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-link-stylesheet-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): template-link-stylesheet</title>
+<!-- non-speculative case -->
+<template><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-img-src-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-img-src-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): template-shadowrootmode-img-src</title>
+<!-- non-speculative case -->
+<div><template shadowrootmode="closed"><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template></div>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-link-stylesheet-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-link-stylesheet-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): template-shadowrootmode-link-stylesheet</title>
+<!-- non-speculative case -->
+<div><template shadowrootmode="closed"><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></template></div>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-script-src-nonspeculative.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-script-src-nonspeculative.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- DO NOT EDIT. This file has been generated. Source:
+     /html/syntax/speculative-parsing/tools/generate.py
+-->
+<meta charset=utf-8>
+<title>Speculative parsing, non-speculative (helper file): template-shadowrootmode-script-src</title>
+<!-- non-speculative case -->
+<div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid={{GET[uuid]}}&amp;encodingcheck=&Gbreve;"></script></template></div>
+<!-- block the load event for a bit: -->
+<script src="/common/slow.py?delay=1500"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/w3c-import.log
@@ -43,6 +43,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/meta-csp-img-src-none-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/meta-referrer-no-referrer-img-src-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/meta-viewport-link-stylesheet-media-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-1-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-2-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-br-img-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-no-img-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/picture-source-nomatch-media-nonspeculative.sub.html
@@ -63,6 +65,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/svg-script-href-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/svg-script-src-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/svg-script-xlinkhref-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-img-src-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-link-stylesheet-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-script-src-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-img-src-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-link-stylesheet-nonspeculative.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-script-src-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/video-poster-nonspeculative.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/xmp-script-src-nonspeculative.sub.html


### PR DESCRIPTION
#### c076205ec69bcffbc6f47108e6f5826d765bcae0
<pre>
Sync `html/syntax/speculative-parsing/generated` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=274655">https://bugs.webkit.org/show_bug.cgi?id=274655</a>

Reviewed by Anne van Kesteren.

This patch is to sync tests from WPT:

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3c073b202df2c52ccd6ab4055cae72e5e24e0132">https://github.com/web-platform-tests/wpt/commit/3c073b202df2c52ccd6ab4055cae72e5e24e0132</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-script-src-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-link-stylesheet-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-shadowrootmode-img-src-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-link-stylesheet-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/template-img-src-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-2-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/resources/nested-template-shadowrootmode-1-nonspeculative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-script-src-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-link-stylesheet-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-shadowrootmode-img-src-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-link-stylesheet-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/template-img-src-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-2-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/resources/nested-template-shadowrootmode-1-framed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-link-stylesheet.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-1.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-img-src.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-2.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/nested-template-shadowrootmode-1.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/nested-template-shadowrootmode-2.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-img-src.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-link-stylesheet.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub-expected.txt:

Canonical link: <a href="https://commits.webkit.org/279385@main">https://commits.webkit.org/279385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5eb7e40db44d6fedbb303efb824e7610364fb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4057 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43243 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2656 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55429 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24374 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2213 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58206 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50639 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->