### PR TITLE
Use Markable in NodeWithIndex instead of a separate boolean

### DIFF
--- a/Source/WebCore/dom/NodeWithIndex.h
+++ b/Source/WebCore/dom/NodeWithIndex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,6 @@ class NodeWithIndex {
 public:
     explicit NodeWithIndex(Node* node)
         : m_node(node)
-        , m_haveIndex(false)
     {
         ASSERT(node);
     }
@@ -44,18 +43,16 @@ public:
 
     int index() const
     {
-        if (!m_haveIndex) {
+        if (!m_index) {
             m_index = m_node->computeNodeIndex();
-            m_haveIndex = true;
         }
-        ASSERT(m_index == static_cast<int>(m_node->computeNodeIndex()));
-        return m_index;
+        ASSERT(*m_index == static_cast<int>(m_node->computeNodeIndex()));
+        return *m_index;
     }
 
 private:
     Node* m_node;
-    mutable bool m_haveIndex;
-    mutable int m_index;
+    mutable Markable<int, IntegralMarkableTraits<int, -1>> m_index;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c6158e01cbd38705b351f27c910dad4bcfb12ef6
<pre>
Use Markable in NodeWithIndex instead of a separate boolean
<a href="https://bugs.webkit.org/show_bug.cgi?id=255829">https://bugs.webkit.org/show_bug.cgi?id=255829</a>
<a href="https://rdar.apple.com/108699717">rdar://108699717</a>

Reviewed by Matthieu Dubet, Darin Adler and Ryosuke Niwa.

* Source/WebCore/dom/NodeWithIndex.h:
(WebCore::NodeWithIndex::NodeWithIndex):
(WebCore::NodeWithIndex::index const):

Canonical link: <a href="https://commits.webkit.org/279311@main">https://commits.webkit.org/279311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f086b042d5032891a8a5766d18453eaece82ddfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42984 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55084 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30073 "Found 1 new test failure: http/tests/site-isolation/draw-after-cross-origin-navigation-between-two-remote-frames.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3051 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50386 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49697 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30266 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7805 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->