### PR TITLE
[WebGPU] Device::hasFeature() and Adapter::hasFeature() only check that list is not empty

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2090,6 +2090,9 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Debug ] fast/workers/worker-cloneport.html [ Slow ]
 [ Debug ] fast/webgpu/present-without-compute-pipeline.html [ Slow ]
 [ Debug ] fast/webgpu/multidimensional-texture-bounds.html [ Slow ]
+
+fast/webgpu/regression [ Pass ]
+
 [ Debug ] fast/webgpu/fuzz-272863.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-272863.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-272903.html [ Skip ]

--- a/LayoutTests/fast/webgpu/regression/repro_274664-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274664-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: rg11b10ufloat
+CONSOLE MESSAGE: createTexture: descriptor.usage & WGPUTextureUsage_RenderAttachment && !isRenderableFormat(descriptor.format, *this)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274664.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274664.html
@@ -1,0 +1,19 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({requiredFeatures: ['depth32float-stencil8']});
+    device.pushErrorScope('validation');
+    let texture = device.createTexture({format: 'rg11b10ufloat', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    log(texture.format);
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_274664b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274664b-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: rg11b10ufloat
+CONSOLE MESSAGE: createTexture: descriptor.usage & WGPUTextureUsage_RenderAttachment && !isRenderableFormat(descriptor.format, *this)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274664b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274664b.html
@@ -1,0 +1,19 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let texture = device.createTexture({format: 'rg11b10ufloat', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    log(texture.format);
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_274664c-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274664c-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: rg11b10ufloat
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274664c.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274664c.html
@@ -1,0 +1,19 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({requiredFeatures: ['rg11b10ufloat-renderable']});
+    device.pushErrorScope('validation');
+    let texture = device.createTexture({format: 'rg11b10ufloat', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    log(texture.format);
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -79,7 +79,7 @@ void Adapter::getProperties(WGPUAdapterProperties& properties)
 
 bool Adapter::hasFeature(WGPUFeatureName feature)
 {
-    return std::find(m_capabilities.features.begin(), m_capabilities.features.end(), feature);
+    return m_capabilities.features.contains(feature);
 }
 
 void Adapter::requestDevice(const WGPUDeviceDescriptor& descriptor, CompletionHandler<void(WGPURequestDeviceStatus, Ref<Device>&&, String&&)>&& callback)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -305,7 +305,7 @@ Queue& Device::getQueue()
 
 bool Device::hasFeature(WGPUFeatureName feature) const
 {
-    return std::find(m_capabilities.features.begin(), m_capabilities.features.end(), feature);
+    return m_capabilities.features.contains(feature);
 }
 
 auto Device::currentErrorScope(WGPUErrorFilter type) -> ErrorScope*


### PR DESCRIPTION
#### 862497bc118b951c5a0ad67dab4fc78809aa1006
<pre>
[WebGPU] Device::hasFeature() and Adapter::hasFeature() only check that list is not empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=274664">https://bugs.webkit.org/show_bug.cgi?id=274664</a>
&lt;radar://128671215&gt;

Reviewed by Tadeu Zagallo.

std::find here was incorrect, we can use contains() instead however.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/regression/repro_274664-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274664.html: Added.
* LayoutTests/fast/webgpu/regression/repro_274664b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274664b.html: Added.
* LayoutTests/fast/webgpu/regression/repro_274664c-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274664c.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Adapter.mm:
(WebGPU::Adapter::hasFeature):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::hasFeature const):

Canonical link: <a href="https://commits.webkit.org/279293@main">https://commits.webkit.org/279293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99768d3f3158cc783579aa2446e60113598ffb44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56293 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3737 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3463 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55112 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24126 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1896 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57888 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3204 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45978 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11576 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->