### PR TITLE
[WGSL] textureGather is missing validation

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1384,6 +1384,19 @@ void TypeChecker::visit(AST::CallExpression& call)
                 m_shaderModule.setUsesDot4U8Packed();
             else if (targetName == "extractBits"_s)
                 m_shaderModule.setUsesExtractBits();
+            else if (targetName == "textureGather"_s) {
+                auto& component = call.arguments()[0];
+                if (satisfies(component.inferredType(), Constraints::ConcreteInteger)) {
+                    auto& constant = component.constantValue();
+                    if (!constant)
+                        typeError(InferBottom::No, component.span(), "the component argument must be a const-expression"_s);
+                    else {
+                        auto componentValue = constant->integerValue();
+                        if (componentValue < 0 || componentValue > 3)
+                            typeError(InferBottom::No, component.span(), "the component argument must be at least 0 and at most 3. component is "_s, String::number(componentValue));
+                    }
+                }
+            }
             target.m_inferredType = result;
             return;
         }

--- a/Source/WebGPU/WGSL/tests/invalid/texture-gather.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/texture-gather.wgsl
@@ -1,0 +1,14 @@
+// RUN: %not %wgslc | %check
+
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+
+@fragment
+fn main() {
+  // CHECK-L: the component argument must be at least 0 and at most 3. component is 4
+  _ = textureGather(4, t, s, vec2());
+
+  var c = 4;
+  // CHECK-L: the component argument must be a const-expression
+  _ = textureGather(c, t, s, vec2());
+}


### PR DESCRIPTION
#### 8f05ced05e3ddafe3629b900b6c001fc658eb3ff
<pre>
[WGSL] textureGather is missing validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=274668">https://bugs.webkit.org/show_bug.cgi?id=274668</a>
<a href="https://rdar.apple.com/128664891">rdar://128664891</a>

Reviewed by Mike Wyrzykowski.

We were missing the validation that when the first argument to `textureGather`
is the integer &quot;component&quot; argument, it must be a constant value between 0 and 3.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/texture-gather.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/279345@main">https://commits.webkit.org/279345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53a9569784579872571e037302aab065cf515597

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3738 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43000 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27133 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57889 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50406 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11605 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->