### PR TITLE
[webkitscmpy] Replace whichcraft with shutil.which

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/run
+++ b/Tools/Scripts/libraries/reporelaypy/run
@@ -26,6 +26,7 @@ import argparse
 import json
 import math
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -41,7 +42,6 @@ if os.path.isdir(os.path.join(scripts, 'webkitpy')):
 from reporelaypy import Checkout, HookProcessor, HookReceiver, Redirector
 from webkitflaskpy import Database
 from webkitcorepy import arguments, AutoInstall
-from whichcraft import which
 
 
 def main(args=None):
@@ -189,7 +189,7 @@ def main(args=None):
     processor = HookProcessor(checkout=checkout, database=database) if args.hooks else None
 
     with subprocess.Popen(
-        [which('gunicorn'), 'reporelaypy.webserver:app'],
+        [shutil.which('gunicorn'), 'reporelaypy.webserver:app'],
         cwd=os.path.dirname(os.path.dirname(reporelaypy.__file__)),
         env=passenv,
     ) as webserver:

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.17.0',
+    version='1.0.0',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[
@@ -60,7 +60,6 @@ setup(
         'requests',
         'six',
         'tblib',
-        'whichcraft',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,9 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(0, 17, 0)
+version = Version(1, 0, 0)
+if sys.version_info < (3, 0):
+    raise ImportError('webkitcorepy no longer supports Python 2')
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):
@@ -97,7 +99,6 @@ AutoInstall.register(Package('tblib', Version(1, 7, 0)))
 AutoInstall.register(Package('urllib3', Version(1, 26, 17)))
 
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))
-AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('cffi', Version(1, 15, 1)))
 
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import shutil
 
 from webkitcorepy.subprocess_utils import run
 from webkitcorepy.decorators import hybridmethod
@@ -37,8 +38,7 @@ class Editor(object):
 
     @classmethod
     def sublime(cls):
-        from whichcraft import which
-        path = which('subl') or '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'
+        path = shutil.which('subl') or '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'
         return cls(
             name='Sublime',
             path=path,
@@ -48,8 +48,7 @@ class Editor(object):
 
     @classmethod
     def bbedit(cls):
-        from whichcraft import which
-        path = which('bbedit') or '/Applications/BBEdit.app/Contents/Helpers/bbedit_tool'
+        path = shutil.which('bbedit') or '/Applications/BBEdit.app/Contents/Helpers/bbedit_tool'
         return cls(
             name='BBEdit',
             path=path,
@@ -59,19 +58,17 @@ class Editor(object):
 
     @classmethod
     def textmate(cls):
-        from whichcraft import which
         return cls(
             name='TextMate',
-            path=which('mate') or '/Applications/TextMate.app/Contents/Resources/mate',
+            path=shutil.which('mate') or '/Applications/TextMate.app/Contents/Resources/mate',
             wait=['-w'],
         )
 
     @classmethod
     def xcode(cls):
-        from whichcraft import which
         return cls(
             name='Xcode',
-            path=which('xed') or '/Applications/Xcode.app/Contents/Developer/usr/bin/xed',
+            path=shutil.which('xed') or '/Applications/Xcode.app/Contents/Developer/usr/bin/xed',
             wait=['-w'],
         )
 
@@ -86,8 +83,7 @@ class Editor(object):
 
     @classmethod
     def vscode(cls):
-        from whichcraft import which
-        path = which('code') or '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+        path = shutil.which('code') or '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
         return cls(
             name='VSCode',
             path=path,
@@ -97,8 +93,7 @@ class Editor(object):
 
     @classmethod
     def vi(cls):
-        from whichcraft import which
-        path = which('vi')
+        path = shutil.which('vi')
         return cls(
             name='vi',
             path=path,
@@ -107,8 +102,7 @@ class Editor(object):
 
     @classmethod
     def default(cls):
-        from whichcraft import which
-        path = which('open')
+        path = shutil.which('open')
         return cls(
             name='open',
             path=path,

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -189,8 +189,7 @@ class Terminal(object):
                 process = run(['explorer', url])
             else:
                 # TODO: Use shutil directly when Python 2.7 is removed
-                from whichcraft import which
-                if sys.platform.startswith('linux') and which('xdg-open'):
+                if sys.platform.startswith('linux') and shutil.which('xdg-open'):
                     process = run(['xdg-open', url])
                 else:
                     process = run(['open', url])

--- a/Tools/Scripts/libraries/webkitscmpy/README.md
+++ b/Tools/Scripts/libraries/webkitscmpy/README.md
@@ -7,7 +7,6 @@ Provides a utilities for interacting with a git or svn repository.
 - webkitcorepy
 - fasteners
 - monotonic
-- whichcraft
 - xmltodict
 
 ## Command Line

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.9.0',
+    version='7.0.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +46,9 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 9, 0)
+version = Version(7, 0, 0)
+if sys.version_info < (3, 0):
+    raise ImportError('webkitscmpy no longer supports Python 2')
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -23,6 +23,7 @@
 import json
 import os
 import re
+import shutil
 
 from webkitbugspy import Tracker, bugzilla, github, radar
 from webkitcorepy import decorators, string_utils
@@ -37,9 +38,7 @@ class Scm(ScmBase):
 
     @classmethod
     def executable(cls, program):
-        # TODO: Use shutil directly when Python 2.7 is removed
-        from whichcraft import which
-        path = which(program)
+        path = shutil.which(program)
         if path is None:
             raise OSError("Cannot find '{}' program".format(program))
         return os.path.realpath(path)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -775,10 +775,9 @@ nothing to commit, working tree clean
 
     def __enter__(self):
         from mock import patch
+        from shutil import which
 
-        # TODO: Use shutil directly when Python 2.7 is removed
-        from whichcraft import which
-        self.patches.append(patch('whichcraft.which', lambda cmd: dict(git=self.executable).get(cmd, which(cmd))))
+        self.patches.append(patch('shutil.which', lambda cmd: dict(git=self.executable).get(cmd, which(cmd))))
         return super(Git, self).__enter__()
 
     @property

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -170,10 +170,9 @@ class Svn(mocks.Subprocess):
 
     def __enter__(self):
         from mock import patch
+        from shutil import which
 
-        # TODO: Use shutil directly when Python 2.7 is removed
-        from whichcraft import which
-        self.patches.append(patch('whichcraft.which', lambda cmd: dict(svn=self.executable).get(cmd, which(cmd))))
+        self.patches.append(patch('shutil.which', lambda cmd: dict(svn=self.executable).get(cmd, which(cmd))))
         return super(Svn, self).__enter__()
 
     @property

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -23,6 +23,7 @@
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -119,8 +120,6 @@ class FilteredCommand(Command):
 
     @classmethod
     def pager(cls, args, repository, file=None, **kwargs):
-        from whichcraft import which
-
         if not repository:
             sys.stderr.write('No repository provided\n')
             return 1
@@ -143,7 +142,7 @@ class FilteredCommand(Command):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            more = subprocess.Popen([which('more')] + (['-F', '-R'] if platform.system() == 'Darwin' else []), stdin=child.stdout)
+            more = subprocess.Popen([shutil.which('more')] + (['-F', '-R'] if platform.system() == 'Darwin' else []), stdin=child.stdout)
 
             try:
                 while more.poll() is None and not child.poll():

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_git_lfs.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_git_lfs.py
@@ -50,7 +50,6 @@ class InstallGitLFS(Command):
     @classmethod
     def url(cls, mirror_resolver_func=None):
         _url = None
-        from whichcraft import which
         if platform.system() == 'Darwin':
             version_str = '{}.{}.{}'.format(cls.VERSION[0], cls.VERSION[1], cls.VERSION[2])
             if platform.machine() == 'arm64':

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_git_lfs_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_git_lfs_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -80,13 +80,13 @@ class TestInstallGitLFS(testing.PathTestCase):
                 'https://github.com/git-lfs/git-lfs/releases/download/v3.4.0/git-lfs-darwin-amd64-v3.4.0.zip',
             )
 
-        with patch('platform.system', lambda: 'Darwin'), patch('platform.machine', lambda: 'arm64'), patch('whichcraft.which', lambda name: '/bin/{}'.format(name)):
+        with patch('platform.system', lambda: 'Darwin'), patch('platform.machine', lambda: 'arm64'), patch('shutil.which', lambda name: '/bin/{}'.format(name)):
             self.assertEqual(
                 program.InstallGitLFS.url(),
                 'https://github.com/git-lfs/git-lfs/releases/download/v3.4.0/git-lfs-darwin-arm64-v3.4.0.zip',
             )
 
-        with patch('platform.system', lambda: 'Darwin'), patch('platform.machine', lambda: 'arm64'), patch('whichcraft.which', lambda name: None):
+        with patch('platform.system', lambda: 'Darwin'), patch('platform.machine', lambda: 'arm64'), patch('shutil.which', lambda name: None):
             self.assertEqual(
                 program.InstallGitLFS.url(),
                 'https://github.com/git-lfs/git-lfs/releases/download/v3.4.0/git-lfs-darwin-arm64-v3.4.0.zip',


### PR DESCRIPTION
#### 81c6c7892c49c607a5335a58b40b085d926db7ca
<pre>
[webkitscmpy] Replace whichcraft with shutil.which
<a href="https://bugs.webkit.org/show_bug.cgi?id=274667">https://bugs.webkit.org/show_bug.cgi?id=274667</a>
<a href="https://rdar.apple.com/128691428">rdar://128691428</a>

Reviewed by Elliott Williams.

Replace all whichcraft calls with `shutil.which`.

* Tools/Scripts/libraries/reporelaypy/run:
(main):
* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py:
(Editor.sublime):
(Editor.bbedit):
(Editor.textmate):
(Editor.xcode):
(Editor.vscode):
(Editor.vi):
(Editor.default):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py:
(Terminal.open_url):
* Tools/Scripts/libraries/webkitscmpy/README.md:
* Tools/Scripts/libraries/webkitscmpy/setup.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py:
(Scm.executable):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py:
(Svn.__enter__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py:
(FilteredCommand.pager):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_git_lfs.py:
(InstallGitLFS.url):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_git_lfs_unittest.py:
(TestInstallGitLFS.test_url):

Canonical link: <a href="https://commits.webkit.org/279289@main">https://commits.webkit.org/279289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e6b56b24cd15cc9ee07947377a735d7c454b704

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55114 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45765 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52860 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1898 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57890 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28157 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/53023 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45982 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7792 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->