### PR TITLE
[WGSL] Type::size can still overflow

### DIFF
--- a/LayoutTests/fast/webgpu/fuzz-128677742-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-128677742-expected.txt
@@ -1,0 +1,8 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+0
+validation error:
+buffer length is 4 which is less than required bufferSize of 4294967295
+done
+

--- a/LayoutTests/fast/webgpu/fuzz-128677742.html
+++ b/LayoutTests/fast/webgpu/fuzz-128677742.html
@@ -1,0 +1,66 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+  globalThis.testRunner?.waitUntilDone();
+
+  onload = async () => {
+    let adapter0 = await navigator.gpu.requestAdapter();
+    let device = await adapter0.requestDevice();
+    try {
+      device.pushErrorScope('validation');
+      let code = `
+@group(0) @binding(0)
+var<storage, read_write> fixedSizeArray: array<array<u32, (1<<30)>, 1>;
+
+@compute @workgroup_size(1)
+fn compute0() {
+  fixedSizeArray[0][0x40] = 1234567890;
+}
+`;
+      let shaderModule = device.createShaderModule({code});
+      let bindGroupLayout0 = device.createBindGroupLayout({
+        entries: [{binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}}],
+      });
+      let pipelineLayout = device.createPipelineLayout({
+        bindGroupLayouts: [bindGroupLayout0],
+      });
+      let computePipeline = device.createComputePipeline({
+        layout: pipelineLayout,
+        compute: {module: shaderModule, entryPoint: 'compute0'},
+      });
+      let compilationInfo = await shaderModule.getCompilationInfo();
+      for (let message of compilationInfo.messages) {
+        debug(message);
+      }
+      let buffer0 = device.createBuffer({size: 4, usage: GPUBufferUsage.STORAGE});
+      let bufferToDump = device.createBuffer({size: 4, usage: GPUBufferUsage.MAP_READ});
+      let bindGroup0 = device.createBindGroup({
+        layout: bindGroupLayout0,
+        entries: [{binding: 0, resource: {buffer: buffer0}}],
+      });
+      let commandEncoder = device.createCommandEncoder();
+      let computePassEncoder = commandEncoder.beginComputePass();
+      computePassEncoder.setBindGroup(0, bindGroup0);
+      computePassEncoder.setPipeline(computePipeline);
+      computePassEncoder.dispatchWorkgroups(1);
+      computePassEncoder.end();
+      let commandBuffer = commandEncoder.finish();
+      device.queue.submit([commandBuffer]);
+      await device.queue.onSubmittedWorkDone();
+      await bufferToDump.mapAsync(GPUMapMode.READ);
+      debug(new Uint32Array(bufferToDump.getMappedRange()));
+    } catch (e) {
+      debug('error');
+      debug(e);
+    } finally {
+      let validationError = await device.popErrorScope();
+      if (validationError) {
+        debug('validation error:');
+        debug(validationError.message);
+      } else {
+        debug('no validation error');
+      }
+    }
+    debug('done');
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -326,7 +326,11 @@ unsigned Type::size() const
             CheckedUint32 size = 1;
             if (auto* constantSize = std::get_if<unsigned>(&array.size))
                 size = *constantSize;
-            size *= WTF::roundUpToMultipleOf(array.element->alignment(), array.element->size());
+            auto elementSize = array.element->size();
+            auto stride = WTF::roundUpToMultipleOf(array.element->alignment(), elementSize);
+            if (stride < elementSize)
+                return std::numeric_limits<unsigned>::max();
+            size *= stride;
             if (size.hasOverflowed())
                 return std::numeric_limits<unsigned>::max();
             return size.value();


### PR DESCRIPTION
#### 2d30b56d45745db5beeae7129a46e6c1fb39e7a0
<pre>
[WGSL] Type::size can still overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=274669">https://bugs.webkit.org/show_bug.cgi?id=274669</a>
<a href="https://rdar.apple.com/128677742">rdar://128677742</a>

Reviewed by Mike Wyrzykowski.

In 279204@main I added checks for overflow in Type::size, but I missed the case where
`array.element-&gt;size()` returns uint_max, and rounding it up to the alignment returns 0.

* LayoutTests/fast/webgpu/fuzz-128677742-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-128677742.html: Added.
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):

Canonical link: <a href="https://commits.webkit.org/279343@main">https://commits.webkit.org/279343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0c56f768ae5f90eca41bb02eed914373f711e80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3740 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43003 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27138 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3086 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57891 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11606 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->