### PR TITLE
Remove SecKeychainItemRef from CFTypeRef serialization

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -104,9 +104,6 @@ enum class CFType : uint8_t {
     CFString,
     CFURL,
     SecCertificate,
-#if HAVE(SEC_KEYCHAIN)
-    SecKeychainItem,
-#endif
 #if HAVE(SEC_ACCESS_CONTROL)
     SecAccessControl,
 #endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.h
@@ -49,9 +49,6 @@ class CoreIPCCFURL;
 class CoreIPCCGColorSpace;
 class CoreIPCSecCertificate;
 class CoreIPCSecTrust;
-#if HAVE(SEC_KEYCHAIN)
-class CoreIPCSecKeychainItem;
-#endif
 #if HAVE(SEC_ACCESS_CONTROL)
 class CoreIPCSecAccessControl;
 #endif
@@ -72,9 +69,6 @@ using CFObjectValue = std::variant<
     CoreIPCSecTrust,
     CoreIPCCGColorSpace,
     WebCore::Color
-#if HAVE(SEC_KEYCHAIN)
-    , CoreIPCSecKeychainItem
-#endif
 #if HAVE(SEC_ACCESS_CONTROL)
     , CoreIPCSecAccessControl
 #endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.mm
@@ -35,7 +35,6 @@
 #import "CoreIPCCGColorSpace.h"
 #import "CoreIPCSecAccessControl.h"
 #import "CoreIPCSecCertificate.h"
-#import "CoreIPCSecKeychainItem.h"
 #import "CoreIPCSecTrust.h"
 #import "CoreIPCTypes.h"
 #import "StreamConnectionEncoder.h"
@@ -67,10 +66,6 @@ static CFObjectValue variantFromCFType(CFTypeRef cfType)
         return CoreIPCCFURL((CFURLRef)cfType);
     case IPC::CFType::SecCertificate:
         return CoreIPCSecCertificate((SecCertificateRef)const_cast<void*>(cfType));
-#if HAVE(SEC_KEYCHAIN)
-    case IPC::CFType::SecKeychainItem:
-        return CoreIPCSecKeychainItem((SecKeychainItemRef)const_cast<void*>(cfType));
-#endif
 #if HAVE(SEC_ACCESS_CONTROL)
     case IPC::CFType::SecAccessControl:
         return CoreIPCSecAccessControl((SecAccessControlRef)const_cast<void*>(cfType));
@@ -136,10 +131,6 @@ RetainPtr<CFTypeRef> CoreIPCCFType::toCFType() const
         return colorSpace.toCF();
     }, [] (const WebCore::Color& color) -> RetainPtr<CFTypeRef> {
         return WebCore::cachedCGColor(color);
-#if HAVE(SEC_KEYCHAIN)
-    }, [] (const CoreIPCSecKeychainItem& keychainItem) -> RetainPtr<CFTypeRef> {
-        return keychainItem.createSecKeychainItem();
-#endif
 #if HAVE(SEC_ACCESS_CONTROL)
     }, [] (const CoreIPCSecAccessControl& accessControl) -> RetainPtr<CFTypeRef> {
         return accessControl.createSecAccessControl();
@@ -183,12 +174,6 @@ CFType typeFromCFTypeRef(CFTypeRef type)
         return CFType::CGColor;
     if (typeID == SecCertificateGetTypeID())
         return CFType::SecCertificate;
-#if HAVE(SEC_KEYCHAIN)
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (typeID == SecKeychainItemGetTypeID())
-        return CFType::SecKeychainItem;
-    ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
 #if HAVE(SEC_ACCESS_CONTROL)
     if (typeID == SecAccessControlGetTypeID())
         return CFType::SecAccessControl;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFType.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFType.serialization.in
@@ -30,8 +30,4 @@ webkit_platform_headers: "CoreIPCCFType.h"
 
 #endif // USE(CF)
 
-#if HAVE(SEC_KEYCHAIN)
-using WebKit::CFObjectValue = std::variant<std::nullptr_t, WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL, WebKit::CoreIPCSecCertificate, WebKit::CoreIPCSecTrust, WebKit::CoreIPCCGColorSpace, WebCore::Color, WebKit::CoreIPCSecKeychainItem, WebKit::CoreIPCSecAccessControl>
-#else
 using WebKit::CFObjectValue = std::variant<std::nullptr_t, WebKit::CoreIPCCFArray, WebKit::CoreIPCBoolean, WebKit::CoreIPCCFCharacterSet, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCCFDictionary, WebKit::CoreIPCNull, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCCFURL, WebKit::CoreIPCSecCertificate, WebKit::CoreIPCSecTrust, WebKit::CoreIPCCGColorSpace, WebCore::Color, WebKit::CoreIPCSecAccessControl>
-#endif

--- a/Source/WebKit/Shared/mac/SecItemResponseData.serialization.in
+++ b/Source/WebKit/Shared/mac/SecItemResponseData.serialization.in
@@ -21,6 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class WebKit::SecItemResponseData {
-    OSStatus m_resultCode;
-    RetainPtr<CFTypeRef> m_resultObject;
+    OSStatus resultCode()
+#if HAVE(SEC_KEYCHAIN)
+    std::variant<std::nullptr_t, Vector<RetainPtr<SecCertificateRef>>, Vector<RetainPtr<SecKeychainItemRef>>, RetainPtr<CFTypeRef>> resultObject()
+#else
+    std::variant<std::nullptr_t, Vector<RetainPtr<SecCertificateRef>>, RetainPtr<CFTypeRef>> resultObject()
+#endif
 }

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
@@ -34,7 +34,16 @@
 #include "SecItemResponseData.h"
 #include "SecItemShimProxyMessages.h"
 #include <Security/SecBase.h>
+#include <Security/SecIdentity.h>
 #include <Security/SecItem.h>
+#include <wtf/cf/VectorCF.h>
+
+#if HAVE(SEC_KEYCHAIN)
+#import <Security/SecKeychainItem.h>
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+WTF_DECLARE_CF_TYPE_TRAIT(SecKeychainItem);
+ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
 
 namespace WebKit {
 
@@ -92,9 +101,34 @@ void SecItemShimProxy::secItemRequest(IPC::Connection& connection, const SecItem
         break;
 
     case SecItemRequestData::Type::CopyMatching: {
-        CFTypeRef resultObject = nullptr;
-        OSStatus resultCode = SecItemCopyMatching(request.query(), &resultObject);
-        response(SecItemResponseData { resultCode, adoptCF(resultObject) });
+        CFTypeRef resultRawObject = nullptr;
+        OSStatus resultCode = SecItemCopyMatching(request.query(), &resultRawObject);
+        auto result = adoptCF(resultRawObject);
+
+        SecItemResponseData::Result resultData;
+        if (result) {
+            auto resultType = CFGetTypeID(result.get());
+            CFArrayRef resultArray = (CFArrayRef)result.get();
+            if (resultType == CFArrayGetTypeID() && CFArrayGetCount(resultArray)) {
+                auto containedType = CFGetTypeID(CFArrayGetValueAtIndex(resultArray, 0));
+                if (containedType == SecCertificateGetTypeID()) {
+                    resultData = Vector<RetainPtr<SecCertificateRef>>(makeVector(resultArray, [] (SecCertificateRef element) {
+                        return std::optional(RetainPtr<SecCertificateRef> { element });
+                    }));
+#if HAVE(SEC_KEYCHAIN)
+                    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+                } else if (containedType == SecKeychainItemGetTypeID()) {
+                    resultData = Vector<RetainPtr<SecKeychainItemRef>>(makeVector(resultArray, [] (SecKeychainItemRef element) {
+                        return std::optional(RetainPtr<SecKeychainItemRef> { element });
+                    }));
+                    ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
+                } else
+                    resultData = WTFMove(result);
+            } else
+                resultData = WTFMove(result);
+        }
+        response(SecItemResponseData { resultCode, WTFMove(resultData) });
         break;
     }
 


### PR DESCRIPTION
#### 8da8cdb10ac1e7f81579589d658e8359a236d427
<pre>
Remove SecKeychainItemRef from CFTypeRef serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=274670">https://bugs.webkit.org/show_bug.cgi?id=274670</a>
<a href="https://rdar.apple.com/126271015">rdar://126271015</a>

Reviewed by Brady Eidson.

SecKeychainItemRef is one of several types that can be returned from a call to SecItemCopyMatching.
Because we have SecItemShim and SecItemShimProxy which proxy calls to the UI process from the network
process, SecKeychainItemRef needs to be serialized across IPC.  Historically, the only way to express
that multiple types can be sent across IPC at one endpoint was to send a RetainPtr&lt;CFTypeRef&gt;, which
required adding SecKeychainItemRef to the list of CFTypeRefs that can be serialized.  The problem with
that is that everywhere we send or receive a CFDictionaryRef or a CFArrayRef we also use a
RetainPtr&lt;CFTypeRef&gt; to serialize their contents, which can be of many types.  We don&apos;t need all the
dictionaries and arrays to be able to serialize a SecKeychainItemRef, and we have historically prevented
this from being the cause of IPC-reachable exploits by adding this release assertion:
RELEASE_ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessCredentials));
This worked well, but that assertion is often hit by IPC fuzzers.  To properly solve this, in this PR
I remove SecKeychainItemRef from the list of things that can be contained by CFDictionaryRef and
CFArrayRef and add a new variant of types that allows it only where needed: in SecItemResponseData.

* Source/WebKit/NetworkProcess/mac/SecItemShim.cpp:
(WebKit::webSecItemCopyMatching):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.h:
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.mm:
(WebKit::variantFromCFType):
(WebKit::CoreIPCCFType::toCFType const):
(IPC::typeFromCFTypeRef):
* Source/WebKit/Shared/Cocoa/CoreIPCCFType.serialization.in:
* Source/WebKit/Shared/mac/SecItemResponseData.h:
(WebKit::SecItemResponseData::SecItemResponseData):
(WebKit::SecItemResponseData::resultObject):
(WebKit::SecItemResponseData::resultObject const):
* Source/WebKit/Shared/mac/SecItemResponseData.serialization.in:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp:
(WebKit::SecItemShimProxy::secItemRequest):

Canonical link: <a href="https://commits.webkit.org/279354@main">https://commits.webkit.org/279354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a063d32218a3d4fd4d3eaf1719b04a69f12be309

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43064 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2486 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27213 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57997 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50467 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49773 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30402 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7826 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->