### PR TITLE
Update ThreadSafeDataBuffer to use `std::span<const uint8_t>` instead of `const void*`

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -47,7 +47,7 @@ Ref<IDBKey> IDBKey::createBinary(const ThreadSafeDataBuffer& buffer)
 Ref<IDBKey> IDBKey::createBinary(JSC::JSArrayBuffer& arrayBuffer)
 {
     RefPtr buffer = arrayBuffer.impl();
-    return adoptRef(*new IDBKey(ThreadSafeDataBuffer::copyData(buffer->data(), buffer->byteLength())));
+    return adoptRef(*new IDBKey(ThreadSafeDataBuffer::copyData(buffer->span())));
 }
 
 Ref<IDBKey> IDBKey::createBinary(JSC::JSArrayBufferView& arrayBufferView)
@@ -55,7 +55,7 @@ Ref<IDBKey> IDBKey::createBinary(JSC::JSArrayBufferView& arrayBufferView)
     auto bufferView = arrayBufferView.possiblySharedImpl();
     if (!bufferView)
         return createInvalid();
-    return adoptRef(*new IDBKey(ThreadSafeDataBuffer::copyData(bufferView->data(), bufferView->byteLength())));
+    return adoptRef(*new IDBKey(ThreadSafeDataBuffer::copyData(bufferView->span())));
 }
 
 IDBKey::IDBKey(IndexedDB::KeyType type, double number)

--- a/Source/WebCore/Modules/indexeddb/IDBValue.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBValue.cpp
@@ -36,7 +36,7 @@ IDBValue::IDBValue()
 }
 
 IDBValue::IDBValue(const SerializedScriptValue& scriptValue)
-    : m_data(ThreadSafeDataBuffer::copyVector(scriptValue.wireBytes()))
+    : m_data(ThreadSafeDataBuffer::copyData(scriptValue.wireBytes()))
     , m_blobURLs(scriptValue.blobURLs())
 {
 }
@@ -47,7 +47,7 @@ IDBValue::IDBValue(const ThreadSafeDataBuffer& value)
 }
 
 IDBValue::IDBValue(const SerializedScriptValue& scriptValue, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths)
-    : m_data(ThreadSafeDataBuffer::copyVector(scriptValue.wireBytes()))
+    : m_data(ThreadSafeDataBuffer::copyData(scriptValue.wireBytes()))
     , m_blobURLs(blobURLs)
     , m_blobFilePaths(blobFilePaths)
 {

--- a/Source/WebCore/platform/ThreadSafeDataBuffer.h
+++ b/Source/WebCore/platform/ThreadSafeDataBuffer.h
@@ -49,15 +49,9 @@ private:
     {
     }
 
-    ThreadSafeDataBufferImpl(const Vector<uint8_t>& data)
+    ThreadSafeDataBufferImpl(std::span<const uint8_t> data)
         : m_data(data)
     {
-    }
-
-    ThreadSafeDataBufferImpl(const void* data, unsigned length)
-        : m_data(length)
-    {
-        memcpy(m_data.data(), data, length);
     }
 
     Vector<uint8_t> m_data;
@@ -71,15 +65,10 @@ public:
     {
         return ThreadSafeDataBuffer(WTFMove(data));
     }
-    
-    static ThreadSafeDataBuffer copyVector(const Vector<uint8_t>& data)
+
+    static ThreadSafeDataBuffer copyData(std::span<const uint8_t> data)
     {
         return ThreadSafeDataBuffer(data);
-    }
-
-    static ThreadSafeDataBuffer copyData(const void* data, unsigned length)
-    {
-        return ThreadSafeDataBuffer(data, length);
     }
 
     ThreadSafeDataBuffer() = default;
@@ -120,13 +109,8 @@ private:
     {
     }
 
-    explicit ThreadSafeDataBuffer(const Vector<uint8_t>& data)
+    explicit ThreadSafeDataBuffer(std::span<const uint8_t> data)
         : m_impl(adoptRef(new ThreadSafeDataBufferImpl(data)))
-    {
-    }
-
-    explicit ThreadSafeDataBuffer(const void* data, unsigned length)
-        : m_impl(adoptRef(new ThreadSafeDataBufferImpl(data, length)))
     {
     }
 


### PR DESCRIPTION
#### 60717e784729ccc4d0239f8027f09ecebf09237d
<pre>
Update ThreadSafeDataBuffer to use `std::span&lt;const uint8_t&gt;` instead of `const void*`
<a href="https://bugs.webkit.org/show_bug.cgi?id=274684">https://bugs.webkit.org/show_bug.cgi?id=274684</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::IDBKey::createBinary):
* Source/WebCore/Modules/indexeddb/IDBValue.cpp:
(WebCore::IDBValue::IDBValue):
* Source/WebCore/platform/ThreadSafeDataBuffer.h:
(WebCore::ThreadSafeDataBufferImpl::ThreadSafeDataBufferImpl):
(WebCore::ThreadSafeDataBuffer::create):
(WebCore::ThreadSafeDataBuffer::copyData):
(WebCore::ThreadSafeDataBuffer::ThreadSafeDataBuffer):
(WebCore::ThreadSafeDataBuffer::copyVector): Deleted.

Canonical link: <a href="https://commits.webkit.org/279298@main">https://commits.webkit.org/279298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/049daceafb9d26cc36a0b020fdfc78d4e80f9832

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55150 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45795 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3117 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1934 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57926 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28193 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46015 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7798 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->