### PR TITLE
Add script to filter layout tests to minimize buildbot logging

### DIFF
--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import argparse
+import sys
+
+
+def parser():
+    parser = argparse.ArgumentParser(description='filter test output')
+    parser.add_argument(
+        'filter_type',
+        choices=['jsc', 'layout', 'scan-build'],
+        help='Choose which test logs to filter'
+    )
+    parser.add_argument(
+        '--output',
+        help='output directory for unfiltered log',
+        default='logs.txt'
+    )
+
+    return parser.parse_args()
+
+
+def filter_jsc_tests(log_file_name):
+    log_file = os.path.abspath(f'{log_file_name}')
+    with open(log_file, 'w') as f:
+        print_line = False
+        for line in sys.stdin:
+            f.write(line)
+            if print_line:
+                print(line, end='')
+            elif line.startswith('**') or line.startswith('Results'):
+                print_line = True
+                print(line, end='')
+
+
+def filter_layout_tests(log_file_name):
+    log_file = os.path.abspath(f'{log_file_name}')
+    with open(log_file, 'w') as f:
+        print_line = False
+        for line in sys.stdin:
+            f.write(line)
+            if print_line:
+                print(line, end='')
+            elif line.startswith('=> Results') or 'Exiting early' in line or 'leaks found' in line:
+                print_line = True
+                print(line, end='')
+
+
+def filter_scan_build(log_file_name):
+    log_file = os.path.abspath(f'{log_file_name}')
+    with open(log_file, 'w') as f:
+        print_all_lines = False
+        for line in sys.stdin:
+            f.write(line)
+            if line.startswith('====='):
+                print(line, end='')
+            if print_all_lines:
+                print(line, end='')
+            # A success or failure is always preceeded by **
+            if line.startswith('**'):
+                print_all_lines = True
+                print(line, end='')
+
+
+def main():
+    args = parser()
+    if args.filter_type == 'jsc':
+        filter_jsc_tests(args.output)
+    elif args.filter_type == 'layout':
+        filter_layout_tests(args.output)
+    elif args.filter_type == 'scan-build':
+        filter_scan_build(args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### 2e51cc753a270436ea8154ac0f74d69f9cff9059
<pre>
Add script to filter layout tests to minimize buildbot logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=274673">https://bugs.webkit.org/show_bug.cgi?id=274673</a>
<a href="https://rdar.apple.com/128694401">rdar://128694401</a>

Reviewed by Aakash Jain.

Condenses all existing log-filtering scripts into one and adds a method for layout tests.
The filter ensures that any logs being parsed by the buildmaster for results are still printed.

* Tools/Scripts/filter-test-logs: Added.
(parser):
(filter_jsc_test):
(filter_layout_tests):
(filter_scan_build):
(main):

Canonical link: <a href="https://commits.webkit.org/279384@main">https://commits.webkit.org/279384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba118682445e084646d42a09f260e65d6f253ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43023 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3120 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49044 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3277 "Found 1 new test failure: imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57927 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50421 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49729 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30333 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7842 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->