### PR TITLE
[WebGPU] RemoteBuffer::copy can result in an out of bounds write

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_274678-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274678-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: ReferenceError: Can't find variable: IPC
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274678.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274678.html
@@ -1,0 +1,25 @@
+<script>
+    globalThis.testRunner?.waitUntilDone();
+    const log = console.debug;
+function fuzz() {
+  o4=IPC.pageID;
+  o5=IPC.webPageProxyID;
+  let pair = IPC.createStreamClientConnection(14);
+  o17=pair[1];
+  IPC.sendMessage('GPU',0,IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name, [{type: 'uint64_t', value: 243}, {type: 'uint64_t', value: o5}, {type: 'uint64_t', value: o4}, {type: 'StreamServerConnectionHandle', value: o17}]);
+  o18=243;
+  pair = IPC.createStreamClientConnection(14);
+  o19=pair[0];
+  o20=pair[1];
+  o19.open();
+  IPC.sendMessage('GPU', 0, IPC.messages.GPUConnectionToWebProcess_CreateRemoteGPU.name, [{type: 'uint64_t', value: 1000},{type: 'uint64_t', value:  o18},{type: 'StreamServerConnectionHandle', value: o20}]);
+  o19.sendSyncMessage(1000, IPC.messages.RemoteGPU_RequestAdapter.name, 0.1,[{type:'bool', value:1},{type:'bool', value:1},{type:'uint64_t', value:1001}]);
+  o19.sendSyncMessage(1001, IPC.messages.RemoteAdapter_RequestDevice.name, 0.1,[{type:'String', value:''},{type: 'Vector', value: []},{type:'Vector', value:[]},{type:'uint64_t', value:1002},{type:'uint64_t', value:1003}]);
+  o19.sendMessage(1002, IPC.messages.RemoteDevice_CreateBuffer.name, 0.1,[{type:'String', value:"pageUp:"},{type:'uint64_t', value:6969994},{type:'uint16_t', value:532},{type:'bool', value:0},{type:'uint64_t', value:1433}]);
+  o19.sendMessage(1433,IPC.messages.RemoteBuffer_Destroy.name,0.1,[]);
+  o19.sendWithAsyncReply(1433,IPC.messages.RemoteBuffer_MapAsync.name,0.1,[{type: 'uint8_t',value: 2},{type: 'uint64_t',value: 714},{type: 'bool',value: 0}],()=>{});
+  o19.sendMessage(1433,IPC.messages.RemoteBuffer_Copy.name,0.1,[{type: 'Vector',value: [[{type: 'uint8_t',value: 177}],[{type: 'uint8_t',value: 228}],[{type: 'uint8_t',value: 229}],[{type: 'uint8_t',value: 89}],[{type: 'uint8_t',value: 194}],[{type: 'uint8_t',value: 83}],[{type: 'uint8_t',value: 225}],[{type: 'uint8_t',value: 215}],[{type: 'uint8_t',value: 251}],[{type: 'uint8_t',value: 65}]]},{type: 'uint64_t',value: 5511920}]);
+}
+    globalThis.testRunner?.notifyDone();
+</script>
+<body onload='fuzz()'></body>

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -47,7 +47,7 @@ static Size64 getMappedSize(WGPUBuffer buffer, std::optional<Size64> size, Size6
     if (size.has_value())
         return size.value();
 
-    auto bufferSize = wgpuBufferGetSize(buffer);
+    auto bufferSize = wgpuBufferGetInitialSize(buffer);
     return bufferSize > offset ? (bufferSize - offset) : 0;
 }
 
@@ -77,7 +77,7 @@ void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, Funct
     // FIXME: Check the casts.
     auto* pointer = wgpuBufferGetMappedRange(m_backing.get(), static_cast<size_t>(offset), static_cast<size_t>(usedSize));
     // FIXME: Check the type narrowing.
-    auto bufferSize = wgpuBufferGetSize(m_backing.get());
+    auto bufferSize = wgpuBufferGetInitialSize(m_backing.get());
     size_t actualSize = pointer ? static_cast<size_t>(bufferSize) : 0;
     size_t actualOffset = pointer ? static_cast<size_t>(offset) : 0;
     callback({ static_cast<uint8_t*>(pointer) - actualOffset, actualSize });
@@ -89,7 +89,7 @@ auto BufferImpl::getBufferContents() -> MappedRange
         return { nullptr, 0 };
 
     auto* pointer = wgpuBufferGetBufferContents(m_backing.get());
-    auto bufferSize = wgpuBufferGetSize(m_backing.get());
+    auto bufferSize = wgpuBufferGetCurrentSize(m_backing.get());
     return { static_cast<uint8_t*>(pointer), static_cast<size_t>(bufferSize) };
 }
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -487,9 +487,14 @@ void* wgpuBufferGetBufferContents(WGPUBuffer buffer)
     return WebGPU::fromAPI(buffer).getBufferContents();
 }
 
-uint64_t wgpuBufferGetSize(WGPUBuffer buffer)
+uint64_t wgpuBufferGetInitialSize(WGPUBuffer buffer)
 {
     return WebGPU::fromAPI(buffer).initialSize();
+}
+
+uint64_t wgpuBufferGetCurrentSize(WGPUBuffer buffer)
+{
+    return WebGPU::fromAPI(buffer).currentSize();
 }
 
 void wgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapCallback callback, void* userdata)

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1598,7 +1598,8 @@ WGPU_EXPORT void const * wgpuBufferGetConstMappedRange(WGPUBuffer buffer, size_t
 WGPU_EXPORT WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void * wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void * wgpuBufferGetBufferContents(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT uint64_t wgpuBufferGetSize(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT uint64_t wgpuBufferGetInitialSize(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT uint64_t wgpuBufferGetCurrentSize(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT WGPUBufferUsageFlags wgpuBufferGetUsage(WGPUBuffer buffer) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuBufferSetLabel(WGPUBuffer buffer, char const * label) WGPU_FUNCTION_ATTRIBUTE;


### PR DESCRIPTION
#### 0fa174e18a820faa0c61c796fabe4288683a81d2
<pre>
[WebGPU] RemoteBuffer::copy can result in an out of bounds write
<a href="https://bugs.webkit.org/show_bug.cgi?id=274678">https://bugs.webkit.org/show_bug.cgi?id=274678</a>
&lt;radar://128591350&gt;

Reviewed by Tadeu Zagallo.

RemoteBuffer::copy should use the actual buffer size, not the initial size.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp:
(WebCore::WebGPU::BufferImpl::getBufferContents):
* Source/WebGPU/WebGPU/Buffer.mm:
(wgpuBufferGetActualSize):
* Source/WebGPU/WebGPU/WebGPU.h:

* LayoutTests/fast/webgpu/regression/repro_274678-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274678.html: Added.
Add regression test for running locally.

Canonical link: <a href="https://commits.webkit.org/279368@main">https://commits.webkit.org/279368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d31a64262d89e9c4f54accdc04938c686836f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43232 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55417 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24362 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3373 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2201 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58194 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3529 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46262 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11613 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->