### PR TITLE
WebKit release build fails in WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR with gcc 14

### DIFF
--- a/Source/WTF/wtf/SingleThreadIntegralWrapper.h
+++ b/Source/WTF/wtf/SingleThreadIntegralWrapper.h
@@ -40,7 +40,14 @@ public:
     SingleThreadIntegralWrapper& operator++();
     SingleThreadIntegralWrapper& operator--();
 
-    IntegralType valueWithoutThreadCheck() const { return m_value; }
+    IntegralType valueWithoutThreadCheck() const
+    {
+        // This is called after the destructor in WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR,
+        // the compiler can see it as uninitialized.
+        IGNORE_GCC_WARNINGS_BEGIN("uninitialized")
+        return m_value;
+        IGNORE_GCC_WARNINGS_END
+    }
 
 private:
 #if ASSERT_ENABLED && !USE(WEB_THREAD)


### PR DESCRIPTION
#### 18e2b7994ecc47cbe6d41538f92b00c4e53ce5e8
<pre>
WebKit release build fails in WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR with gcc 14
<a href="https://bugs.webkit.org/show_bug.cgi?id=274587">https://bugs.webkit.org/show_bug.cgi?id=274587</a>

Reviewed by Geoffrey Garen.

The use of member variables after the destructor is reported as -Wuninitialized.
Disabling the warning in WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR doesn&apos;t work in all
cases, we have to do it in SingleThreadIntegralWrapper::valueWithoutThreadCheck.

* Source/WTF/wtf/SingleThreadIntegralWrapper.h:
(WTF::SingleThreadIntegralWrapper::valueWithoutThreadCheck const):

Canonical link: <a href="https://commits.webkit.org/289012@main">https://commits.webkit.org/289012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b11333550d36da881feb199c162a1a671f93d46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56340 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43031 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24159 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1943 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46417 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57935 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52574 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50427 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49727 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/18260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28202 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64879 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29422 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12313 "Found 12 new JSC stress test failures: stress/spread-non-array.js.dfg-eager, stress/spread-non-array.js.mini-mode, stress/spread-non-array.js.no-llint, wasm.yaml/wasm/function-tests/br-as-return.js.wasm-eager, wasm.yaml/wasm/function-tests/br-if-loop-less-than.js.wasm-eager, wasm.yaml/wasm/function-tests/factorial.js.wasm-eager, wasm.yaml/wasm/function-tests/i32-load8-s.js.wasm-eager, wasm.yaml/wasm/function-tests/memory-grow-invalid.js.wasm-eager, wasm.yaml/wasm/function-tests/shr-s.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-store-2.js.wasm-eager ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->