### PR TITLE
Update implementation of TT enforcement for document.write(ln)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write-expected.txt
@@ -6,7 +6,7 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-abcdefghijkl
+abczxcvbnjkl
 
 PASS document.write with html assigned via policy (successful URL transformation).
 PASS document.write with multiple trusted arguments.
@@ -21,9 +21,9 @@ PASS `document.writeln(string, TrustedHTML)` throws
 PASS `document.write(null)` throws
 PASS `document.writeln(null)` throws
 PASS `document.write(string)` observes default policy
-FAIL `document.write(string, string)` observes default policy assert_equals: expected "abczxcvbnjkl" but got "abcdefghijkl"
-FAIL `document.write(string, TrustedHTML)` observes default policy assert_equals: expected "abczxcvbnjkl" but got "abcdefghijkl"
+PASS `document.write(string, string)` observes default policy
+PASS `document.write(string, TrustedHTML)` observes default policy
 PASS `document.writeln(string)` observes default policy
-FAIL `document.writeln(string, string)` observes default policy assert_equals: expected "abczxcvbnjkl" but got "abcdefghijkl"
-FAIL `document.writeln(string, TrustedHTML)` observes default policy assert_equals: expected "abczxcvbnjkl" but got "abcdefghijkl"
+PASS `document.writeln(string, string)` observes default policy
+PASS `document.writeln(string, TrustedHTML)` observes default policy
 

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -139,7 +139,7 @@ Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
     Ref document = HTMLDocument::create(nullptr, m_document->protectedSettings(), URL(), { });
     document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
     document->open();
-    document->write(nullptr, { "<!doctype html><html><head></head><body></body></html>"_s });
+    document->write(nullptr, FixedVector<String> { "<!doctype html><html><head></head><body></body></html>"_s });
     if (!title.isNull()) {
         auto titleElement = HTMLTitleElement::create(titleTag, document);
         titleElement->appendChild(document->createTextNode(WTFMove(title)));

--- a/Source/WebCore/dom/Document+HTML.idl
+++ b/Source/WebCore/dom/Document+HTML.idl
@@ -61,8 +61,8 @@ partial interface Document {
     [CEReactions=Needed, CallWith=EntryDocument, ImplementedAs=openForBindings] Document open(optional DOMString unused1, optional DOMString unused2); // both arguments are ignored.
     [CallWith=ActiveWindow&FirstWindow, ImplementedAs=openForBindings] WindowProxy open(USVString url, [AtomString] DOMString name, DOMString features);
     [CEReactions=Needed, ImplementedAs=closeForBindings] undefined close();
-    [CEReactions=Needed, CallWith=EntryDocument] undefined write(HTMLString... text);
-    [CEReactions=Needed, CallWith=EntryDocument] undefined writeln(HTMLString... text);
+    [CEReactions=Needed, CallWith=EntryDocument] undefined write((TrustedHTML or DOMString)... text);
+    [CEReactions=Needed, CallWith=EntryDocument] undefined writeln((TrustedHTML or DOMString)... text);
 
     // user interaction
     [ImplementedAs=windowProxy] readonly attribute WindowProxy? defaultView;
@@ -78,5 +78,3 @@ partial interface Document {
     // special event handler IDL attributes that only apply to Document objects
     [LegacyLenientThis] attribute EventHandler onreadystatechange;
 };
-
-typedef [StringContext=TrustedHTML] DOMString HTMLString;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -807,6 +807,8 @@ public:
     void cancelParsing();
 
     ExceptionOr<void> write(Document* entryDocument, SegmentedString&&);
+    ExceptionOr<void> write(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&&);
+    ExceptionOr<void> writeln(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&&);
     WEBCORE_EXPORT ExceptionOr<void> write(Document* entryDocument, FixedVector<String>&&);
     WEBCORE_EXPORT ExceptionOr<void> writeln(Document* entryDocument, FixedVector<String>&&);
 
@@ -1960,6 +1962,8 @@ private:
     void frameDestroyed() final;
 
     void commonTeardown();
+
+    ExceptionOr<void> write(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&&, ASCIILiteral lineFeed);
 
     WEBCORE_EXPORT Quirks& ensureQuirks();
     WEBCORE_EXPORT CachedResourceLoader& ensureCachedResourceLoader();

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
@@ -173,13 +173,13 @@
 - (void)write:(NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->write(nullptr, { String { text } });
+    IMPL->write(nullptr, FixedVector<String> { String { text } });
 }
 
 - (void)writeln:(NSString *)text
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->writeln(nullptr, { String { text} });
+    IMPL->writeln(nullptr, FixedVector<String> { String { text } });
 }
 
 - (void)clear


### PR DESCRIPTION
#### cfe83d0fa5bcf6c925c095e765d6fbf57082297e
<pre>
Update implementation of TT enforcement for document.write(ln)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273819">https://bugs.webkit.org/show_bug.cgi?id=273819</a>

Reviewed by Darin Adler.

This patch switches document.write and writeln to use a union IDL type and single call to default policy.

See whatwg/html#10328

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write-expected.txt:
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createHTMLDocument):
* Source/WebCore/dom/Document+HTML.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::write):
(WebCore::Document::writeln):
* Source/WebCore/dom/Document.h:
* Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm:
(-[DOMHTMLDocument write:]):
(-[DOMHTMLDocument writeln:]):

Canonical link: <a href="https://commits.webkit.org/279904@main">https://commits.webkit.org/279904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/565e8aa8c26229d4945e55449dfc11ef7766ed87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44417 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3776 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51840 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51253 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12058 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->