### PR TITLE
Speculative mitigation against a crash involving CodeBlock::m_metadata.

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -852,12 +852,11 @@ CodeBlock::~CodeBlock()
         vm.m_perBytecodeProfiler->notifyDestruction(this);
 
     if (LIKELY(!vm.heap.isShuttingDown())) {
-        if (m_metadata) {
+        // FIXME: This check should really not be necessary, see https://webkit.org/b/272787
+        ASSERT(!m_metadata || m_metadata->unlinkedMetadata());
+        if (m_metadata && !m_metadata->isDestroyed()) {
             auto unlinkedMetadata = m_metadata->unlinkedMetadata();
-
-            // FIXME: This check should really not be necessary, see https://webkit.org/b/272787
-            ASSERT(unlinkedMetadata);
-            if (unlinkedMetadata && unlinkedMetadata->didOptimize() == TriState::Indeterminate)
+            if (unlinkedMetadata->didOptimize() == TriState::Indeterminate)
                 unlinkedMetadata->setDidOptimize(TriState::False);
         }
     }

--- a/Source/JavaScriptCore/bytecode/MetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.cpp
@@ -61,15 +61,16 @@ MetadataTable::~MetadataTable()
 
 void MetadataTable::destroy(MetadataTable* table)
 {
-    RefPtr<UnlinkedMetadataTable> unlinkedMetadata = WTFMove(table->linkingData().unlinkedMetadata);
-
-    table->~MetadataTable();
-
     // FIXME: This check should really not be necessary, see https://webkit.org/b/272787
-    if (UNLIKELY(!unlinkedMetadata)) {
+    if (table->isDestroyed()) {
         ASSERT_NOT_REACHED();
         return;
     }
+
+    RefPtr<UnlinkedMetadataTable> unlinkedMetadata = WTFMove(table->linkingData().unlinkedMetadata);
+    ASSERT(table->isDestroyed());
+
+    table->~MetadataTable();
 
     // Since UnlinkedMetadata::unlink frees the underlying memory of MetadataTable.
     // We need to destroy LinkingData before calling it.

--- a/Source/JavaScriptCore/bytecode/MetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,6 +128,12 @@ public:
     void validate() const;
 
     RefPtr<UnlinkedMetadataTable> unlinkedMetadata() const { return static_reference_cast<UnlinkedMetadataTable>(linkingData().unlinkedMetadata); }
+
+    bool isDestroyed() const
+    {
+        uintptr_t unlinkedMetadataPtr = *bitwise_cast<uintptr_t*>(&linkingData().unlinkedMetadata);
+        return !unlinkedMetadataPtr;
+    }
 
 private:
     MetadataTable(UnlinkedMetadataTable&);


### PR DESCRIPTION
#### 59012130505d6145ec4e7a8dc6e718106a8baba7
<pre>
Speculative mitigation against a crash involving CodeBlock::m_metadata.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274691">https://bugs.webkit.org/show_bug.cgi?id=274691</a>
<a href="https://rdar.apple.com/127571559">rdar://127571559</a>

Reviewed by Yijia Huang and Yusuke Suzuki.

We sometimes see crashes due to CodeBlock::m_metadata-&gt;unlinkedMetadata() being null.
This change adds a speculative null check to mitigate against stepping on this.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::~CodeBlock):
* Source/JavaScriptCore/bytecode/MetadataTable.cpp:
(JSC::MetadataTable::destroy):
* Source/JavaScriptCore/bytecode/MetadataTable.h:
(JSC::MetadataTable::isDestroyed const):

Canonical link: <a href="https://commits.webkit.org/279300@main">https://commits.webkit.org/279300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75399ba9223a48f01bedeece35c85bffc5361c49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5570 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3533 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/56362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55181 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3145 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46439 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57957 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52596 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46043 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64901 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7799 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29198 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12317 "Found 10 new JSC stress test failures: stress/proxy-set-prototype-of.js.bytecode-cache, stress/setter-frame-flush.js.default, stress/spread-non-array.js.dfg-eager-no-cjit-validate, stress/spread-non-array.js.mini-mode, wasm.yaml/wasm/function-tests/add-12.js.wasm-eager, wasm.yaml/wasm/function-tests/i32-load8-s.js.wasm-eager, wasm.yaml/wasm/js-api/global-mutate.js.wasm-eager, wasm.yaml/wasm/stress/immutable-globals.js.wasm-eager, wasm.yaml/wasm/stress/js-to-wasm-many-double-from-js.js.wasm-eager, wasm.yaml/wasm/stress/too-many-locals.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->