### PR TITLE
[Xcode] Add "maccatalyst" as a supported platform in the xcfilelist generator

### DIFF
--- a/Tools/Scripts/webkitpy/generate_xcfilelists_lib/generators.py
+++ b/Tools/Scripts/webkitpy/generate_xcfilelists_lib/generators.py
@@ -726,7 +726,7 @@ class BaseGenerator(object):
 
 
 class JavaScriptCoreGenerator(BaseGenerator):
-    VALID_PLATFORMS = ("macosx", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
+    VALID_PLATFORMS = ("macosx", "maccatalyst", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
     VALID_CONFIGURATIONS = ("Debug", "Release", "Production", "Profiling")
 
     @util.LogEntryExit
@@ -743,7 +743,7 @@ class JavaScriptCoreGenerator(BaseGenerator):
 
 
 class WebCoreGenerator(BaseGenerator):
-    VALID_PLATFORMS = ("macosx", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
+    VALID_PLATFORMS = ("macosx", "maccatalyst", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
     VALID_CONFIGURATIONS = ("Debug", "Release", "Production")
 
     @util.LogEntryExit
@@ -760,7 +760,7 @@ class WebCoreGenerator(BaseGenerator):
 
 
 class WebKitGenerator(BaseGenerator):
-    VALID_PLATFORMS = ("macosx", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
+    VALID_PLATFORMS = ("macosx", "maccatalyst", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
     VALID_CONFIGURATIONS = ("Debug", "Release", "Production")
 
     @util.LogEntryExit
@@ -781,7 +781,7 @@ class WebKitGenerator(BaseGenerator):
 
 
 class WebKitLegacyGenerator(BaseGenerator):
-    VALID_PLATFORMS = ("macosx", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
+    VALID_PLATFORMS = ("macosx", "maccatalyst", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
     VALID_CONFIGURATIONS = ("Debug", "Release", "Production")
 
     @util.LogEntryExit
@@ -820,7 +820,7 @@ class WebKitTestRunnerGenerator(BaseGenerator):
 
 
 class TestWebKitAPIGenerator(BaseGenerator):
-    VALID_PLATFORMS = ("macosx", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
+    VALID_PLATFORMS = ("macosx", "maccatalyst", "iphoneos", "iphonesimulator", "watchos", "watchsimulator", "appletvos", "appletvsimulator", "xros", "xrsimulator")
     VALID_CONFIGURATIONS = ("Debug", "Release", "Production")
 
     @util.LogEntryExit


### PR DESCRIPTION
#### be37d4df4d8ebe2e4a7e387ae8d78cc1849c108e
<pre>
[Xcode] Add &quot;maccatalyst&quot; as a supported platform in the xcfilelist generator
<a href="https://rdar.apple.com/128709129">rdar://128709129</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274690">https://bugs.webkit.org/show_bug.cgi?id=274690</a>

Reviewed by Alexey Proskuryakov.

As of 278812@main, generate_xcfilelists_lib is using WK_PLATFORM_NAME,
which means it needs to handle Mac Catalyst. Add it as a supported
platform. In practice this does not change xcfilelist contents, since
the generator was already running in Catalyst builds, it was just
considering them to be the &quot;macosx&quot; platform.

* Tools/Scripts/webkitpy/generate_xcfilelists_lib/generators.py:
(JavaScriptCoreGenerator):
(WebCoreGenerator):
(WebKitGenerator):
(WebKitLegacyGenerator):
(TestWebKitAPIGenerator):

Canonical link: <a href="https://commits.webkit.org/279301@main">https://commits.webkit.org/279301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63f7c60abaeff68141cbf921b5b5cf60d912d2fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5574 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3537 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/56366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55185 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45820 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52931 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3146 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1969 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57961 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46044 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11580 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->