### PR TITLE
[Cococa] Ensure temporary PDF file paths are written matching the meaning of their relevant file URLs

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -442,7 +442,9 @@ static NSString *pathToPDFOnDisk(const String& suggestedFilename)
         return nil;
     }
 
-    NSString *path = [pdfDirectoryPath stringByAppendingPathComponent:suggestedFilename];
+    // The NSFileManager expects a path string, while NSWorkspace uses file URLs, and will decode any percent encoding
+    // in its passed URLs before loading from disk. Create the files using decoded file paths so they match up.
+    NSString *path = [[pdfDirectoryPath stringByAppendingPathComponent:suggestedFilename] stringByRemovingPercentEncoding];
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:path]) {
@@ -475,7 +477,6 @@ void WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication(const St
         WTFLogAlways("Cannot save file without .pdf extension to the temporary directory.");
         return;
     }
-
     auto nsPath = retainPtr(pathToPDFOnDisk(sanitizedFilename));
 
     if (!nsPath)


### PR DESCRIPTION
#### ae3780f0dcc35faca0a21110e00f5955a0cd00c7
<pre>
[Cococa] Ensure temporary PDF file paths are written matching the meaning of their relevant file URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=274695">https://bugs.webkit.org/show_bug.cgi?id=274695</a>
&lt;<a href="https://rdar.apple.com/127379128">rdar://127379128</a>&gt;

Reviewed by Abrar Rahman Protyasha.

Correct pathToPDFOnDisk so that it creates un-encoded files from file URLs, since NSWorkspace
always decodes it&apos;s URL path arguments before passing to relevant helper applications to open.

This ensures that an attempt to open a temporary file for a PDF like &quot;some%20test.pdf&quot; will
create a temporary &quot;some\ test.pdf&quot; on disk, which will then be found by NSWorkspace when it
is given the encoded file URL.

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):

Canonical link: <a href="https://commits.webkit.org/279359@main">https://commits.webkit.org/279359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db111c7db6cdb9f64a413a29d53277d746b59b54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3818 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43052 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27217 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57969 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28236 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3266 "Found 1 new test failure: media/track/track-text-track-destructor-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50457 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49762 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30375 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7830 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->