### PR TITLE
Drop ArrayBuffer constructors taking in a raw pointer, in favor of std::span

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -265,17 +265,14 @@ class ArrayBuffer final : public GCIncomingRefCounted<ArrayBuffer> {
 public:
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(size_t numElements, unsigned elementByteSize);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(ArrayBuffer&);
-    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(const void* source, size_t byteLength);
-    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(std::span<uint8_t>);
+    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(std::span<const uint8_t> = { });
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(ArrayBufferContents&&);
-    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(const Vector<uint8_t>&);
-    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createAdopted(const void* data, size_t byteLength);
+    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createAdopted(std::span<const uint8_t>);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createFromBytes(const void* data, size_t byteLength, ArrayBufferDestructorFunction&&);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createShared(Ref<SharedArrayBufferContents>&&);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength = std::nullopt);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(ArrayBuffer&);
-    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(const void* source, size_t byteLength);
-    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(std::span<const uint8_t>);
+    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(std::span<const uint8_t> = { });
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreateShared(VM&, size_t numElements, unsigned elementByteSize, size_t maxByteLength);
 
     // Only for use by Uint8ClampedArray::tryCreateUninitialized and FragmentedSharedBuffer::tryCreateArrayBuffer.

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -290,11 +290,10 @@ ArrayBuffer* JSArrayBufferView::slowDownAndWasteMemory()
     Structure* structure = this->structure();
 
     RefPtr<ArrayBuffer> buffer;
-    size_t byteLength = this->byteLength();
 
     switch (m_mode) {
     case FastTypedArray: {
-        buffer = ArrayBuffer::tryCreate(vector(), byteLength);
+        buffer = ArrayBuffer::tryCreate(span());
         if (!buffer)
             return nullptr;
         break;
@@ -304,7 +303,7 @@ ArrayBuffer* JSArrayBufferView::slowDownAndWasteMemory()
         // FIXME: consider doing something like "subtracting" from extra memory
         // cost, since right now this case will cause the GC to think that we reallocated
         // the whole buffer.
-        buffer = ArrayBuffer::createAdopted(vector(), byteLength);
+        buffer = ArrayBuffer::createAdopted(span());
         break;
     }
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -281,6 +281,8 @@ public:
     bool hasVector() const { return !!m_vector; }
     void* vector() const { return m_vector.getMayBeNull(); }
     void* vectorWithoutPACValidation() const { return m_vector.getUnsafe(); }
+
+    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(vector()), byteLength() }; }
     
     size_t byteOffset() const
     {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -88,7 +88,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleCustomSections, (JSGlobalObject* globa
     for (const Wasm::CustomSection& section : customSections) {
         // FIXME: Add a function that compares a String with a span<char8_t> so we don't need to make a string.
         if (WTF::makeString(section.name) == sectionNameString) {
-            auto buffer = ArrayBuffer::tryCreate(section.payload.data(), section.payload.size());
+            auto buffer = ArrayBuffer::tryCreate(section.payload.span());
             if (!buffer)
                 return JSValue::encode(throwException(globalObject, throwScope, createOutOfMemoryError(globalObject)));
 

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -94,8 +94,12 @@ void GPUBuffer::mapAsync(GPUMapModeFlags mode, std::optional<GPUSize64> offset, 
 
 static auto makeArrayBuffer(auto source, size_t offset, auto byteLength, auto& cachedArrayBuffers, auto& device, auto& buffer)
 {
-    auto arrayBuffer = ArrayBuffer::create(source, byteLength);
-    cachedArrayBuffers.append({ arrayBuffer.ptr(), offset });
+    RefPtr<ArrayBuffer> arrayBuffer;
+    if constexpr (std::is_pointer_v<decltype(source)>)
+        arrayBuffer = ArrayBuffer::create({ source, static_cast<size_t>(byteLength) });
+    else
+        arrayBuffer = ArrayBuffer::create(source, byteLength);
+    cachedArrayBuffers.append({ arrayBuffer.get(), offset });
     cachedArrayBuffers.last().buffer->pin();
     if (device)
         device->addBufferToUnmap(buffer);

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -185,15 +185,15 @@ void FetchBody::consumeAsStream(FetchBodyOwner& owner, FetchBodySource& source)
 {
     bool closeStream = false;
     if (isArrayBuffer())
-        closeStream = source.enqueue(ArrayBuffer::tryCreate(arrayBufferBody().data(), arrayBufferBody().byteLength()));
+        closeStream = source.enqueue(ArrayBuffer::tryCreate(arrayBufferBody().span()));
     else if (isArrayBufferView())
-        closeStream = source.enqueue(ArrayBuffer::tryCreate(arrayBufferViewBody().baseAddress(), arrayBufferViewBody().byteLength()));
+        closeStream = source.enqueue(ArrayBuffer::tryCreate(arrayBufferViewBody().span()));
     else if (isText()) {
         auto data = PAL::TextCodecUTF8::encodeUTF8(textBody());
-        closeStream = source.enqueue(ArrayBuffer::tryCreate(data.data(), data.size()));
+        closeStream = source.enqueue(ArrayBuffer::tryCreate(data));
     } else if (isURLSearchParams()) {
         auto data = PAL::TextCodecUTF8::encodeUTF8(urlSearchParamsBody().toString());
-        closeStream = source.enqueue(ArrayBuffer::tryCreate(data.data(), data.size()));
+        closeStream = source.enqueue(ArrayBuffer::tryCreate(data));
     } else if (isBlob())
         owner.loadBlob(blobBody(), nullptr);
     else if (isFormData())

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -323,7 +323,7 @@ void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchB
             return;
         }
 
-        if (!source->enqueue(ArrayBuffer::tryCreate(value.data(), value.size())))
+        if (!source->enqueue(ArrayBuffer::tryCreate(value)))
             m_formDataConsumer->cancel();
     });
 }

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -40,10 +40,8 @@ RTCEncodedFrame::RTCEncodedFrame(Ref<RTCRtpTransformableFrame>&& frame)
 
 RefPtr<JSC::ArrayBuffer> RTCEncodedFrame::data() const
 {
-    if (!m_data) {
-        auto data = m_frame->data();
-        m_data = JSC::ArrayBuffer::create(data.data(), data.size());
-    }
+    if (!m_data)
+        m_data = JSC::ArrayBuffer::create(m_frame->data());
     return m_data;
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
@@ -95,7 +95,7 @@ void LibWebRTCDtlsTransportBackendObserver::updateState(webrtc::DtlsTransportInf
         }
     }
     m_client->onStateChanged(toRTCDtlsTransportState(info.state()), map(certificates, [](auto& certificate) -> Ref<JSC::ArrayBuffer> {
-        return JSC::ArrayBuffer::create(certificate.data(), certificate.size());
+        return JSC::ArrayBuffer::create(certificate);
     }));
 }
 

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOptions.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOptions.cpp
@@ -52,7 +52,7 @@ const Vector<uint8_t>& PushSubscriptionOptions::serverVAPIDPublicKey() const
 ExceptionOr<RefPtr<JSC::ArrayBuffer>> PushSubscriptionOptions::applicationServerKey() const
 {
     if (!m_applicationServerKey) {
-        m_applicationServerKey = ArrayBuffer::tryCreate(m_serverVAPIDPublicKey.data(), m_serverVAPIDPublicKey.size());
+        m_applicationServerKey = ArrayBuffer::tryCreate(m_serverVAPIDPublicKey);
         if (!m_applicationServerKey)
             return Exception { ExceptionCode::OutOfMemoryError };
     }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp
@@ -44,8 +44,8 @@ Ref<AuthenticatorAssertionResponse> AuthenticatorAssertionResponse::create(const
 {
     RefPtr<ArrayBuffer> userhandleBuffer;
     if (!userHandle.isEmpty())
-        userhandleBuffer = ArrayBuffer::create(userHandle.data(), userHandle.size());
-    return create(ArrayBuffer::create(rawId.data(), rawId.size()), ArrayBuffer::create(authenticatorData.data(), authenticatorData.size()), ArrayBuffer::create(signature.data(), signature.size()), WTFMove(userhandleBuffer), std::nullopt, attachment);
+        userhandleBuffer = ArrayBuffer::create(userHandle);
+    return create(ArrayBuffer::create(rawId), ArrayBuffer::create(authenticatorData), ArrayBuffer::create(signature), WTFMove(userhandleBuffer), std::nullopt, attachment);
 }
 
 Ref<AuthenticatorAssertionResponse> AuthenticatorAssertionResponse::create(Ref<ArrayBuffer>&& rawId, RefPtr<ArrayBuffer>&& userHandle, String&& name, SecAccessControlRef accessControl, AuthenticatorAttachment attachment)
@@ -55,7 +55,7 @@ Ref<AuthenticatorAssertionResponse> AuthenticatorAssertionResponse::create(Ref<A
 
 void AuthenticatorAssertionResponse::setAuthenticatorData(Vector<uint8_t>&& authenticatorData)
 {
-    m_authenticatorData = ArrayBuffer::create(authenticatorData.data(), authenticatorData.size());
+    m_authenticatorData = ArrayBuffer::create(authenticatorData);
 }
 
 AuthenticatorAssertionResponse::AuthenticatorAssertionResponse(Ref<ArrayBuffer>&& rawId, Ref<ArrayBuffer>&& authenticatorData, Ref<ArrayBuffer>&& signature, RefPtr<ArrayBuffer>&& userHandle, AuthenticatorAttachment attachment)

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -74,7 +74,7 @@ Ref<AuthenticatorAttestationResponse> AuthenticatorAttestationResponse::create(R
 
 Ref<AuthenticatorAttestationResponse> AuthenticatorAttestationResponse::create(const Vector<uint8_t>& rawId, const Vector<uint8_t>& attestationObject, AuthenticatorAttachment attachment, Vector<AuthenticatorTransport>&& transports)
 {
-    return create(ArrayBuffer::create(rawId.data(), rawId.size()), ArrayBuffer::create(attestationObject.data(), attestationObject.size()), attachment, WTFMove(transports));
+    return create(ArrayBuffer::create(rawId), ArrayBuffer::create(attestationObject), attachment, WTFMove(transports));
 }
 
 AuthenticatorAttestationResponse::AuthenticatorAttestationResponse(Ref<ArrayBuffer>&& rawId, Ref<ArrayBuffer>&& attestationObject, AuthenticatorAttachment attachment, Vector<AuthenticatorTransport>&& transports)
@@ -107,7 +107,7 @@ RefPtr<ArrayBuffer> AuthenticatorAttestationResponse::getAuthenticatorData() con
         return nullptr;
     }
     auto authData = it->second.getByteString();
-    return ArrayBuffer::tryCreate(authData.data(), authData.size());
+    return ArrayBuffer::tryCreate(authData);
 }
 
 int64_t AuthenticatorAttestationResponse::getPublicKeyAlgorithm() const
@@ -175,7 +175,7 @@ RefPtr<ArrayBuffer> AuthenticatorAttestationResponse::getPublicKey() const
         if (!peerKey)
             return nullptr;
         auto keySpki = peerKey->exportSpki(UseCryptoKit::No).releaseReturnValue();
-        return ArrayBuffer::tryCreate(keySpki.data(), keySpki.size());
+        return ArrayBuffer::tryCreate(keySpki);
     }
     default:
         break;

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -178,9 +178,7 @@ Ref<ArrayBuffer> buildClientDataJson(ClientDataType type, const BufferSource& ch
     if (scope != WebAuthn::Scope::SameOrigin)
         object->setBoolean("crossOrigin"_s, scope != WebAuthn::Scope::SameOrigin);
 
-    auto utf8JSONString = object->toJSONString().utf8();
-
-    return ArrayBuffer::create(utf8JSONString.data(), utf8JSONString.length());
+    return ArrayBuffer::create(object->toJSONString().utf8().span());
 }
 
 Vector<uint8_t> buildClientDataJsonHash(const ArrayBuffer& clientDataJson)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -222,7 +222,7 @@ void WebCodecsAudioDecoder::isConfigSupported(ScriptExecutionContext& context, W
         ScriptExecutionContext::postTaskTo(identifier, [success = result.has_value(), config = WTFMove(config).isolatedCopyWithoutDescription(), description = WTFMove(description), promisePtr](auto& context) mutable {
             if (auto promise = context.takeDeferredPromise(promisePtr)) {
                 if (description.size())
-                    config.description = RefPtr { JSC::ArrayBuffer::create(description.data(), description.size()) };
+                    config.description = RefPtr { JSC::ArrayBuffer::create(description) };
                 promise->template resolve<IDLDictionary<WebCodecsAudioDecoderSupport>>(WebCodecsAudioDecoderSupport { success, WTFMove(config) });
             }
         });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -195,7 +195,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
             if (m_state != WebCodecsCodecState::Configured)
                 return;
 
-            RefPtr<JSC::ArrayBuffer> buffer = JSC::ArrayBuffer::create(result.data.data(), result.data.size());
+            RefPtr buffer = JSC::ArrayBuffer::create(result.data);
             auto chunk = WebCodecsEncodedAudioChunk::create(WebCodecsEncodedAudioChunk::Init {
                 result.isKeyFrame ? WebCodecsEncodedAudioChunkType::Key : WebCodecsEncodedAudioChunkType::Delta,
                 result.timestamp,

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -258,7 +258,7 @@ void WebCodecsVideoDecoder::isConfigSupported(ScriptExecutionContext& context, W
         ScriptExecutionContext::postTaskTo(identifier, [success = result.has_value(), config = WTFMove(config).isolatedCopyWithoutDescription(), description = WTFMove(description), promisePtr](auto& context) mutable {
             if (auto promise = context.takeDeferredPromise(promisePtr)) {
                 if (description.size())
-                    config.description = RefPtr { JSC::ArrayBuffer::create(description.data(), description.size()) };
+                    config.description = RefPtr { JSC::ArrayBuffer::create(description) };
                 promise->template resolve<IDLDictionary<WebCodecsVideoDecoderSupport>>(WebCodecsVideoDecoderSupport { success, WTFMove(config) });
             }
         });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -185,7 +185,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
             if (m_state != WebCodecsCodecState::Configured)
                 return;
 
-            RefPtr<JSC::ArrayBuffer> buffer = JSC::ArrayBuffer::create(result.data.data(), result.data.size());
+            RefPtr<JSC::ArrayBuffer> buffer = JSC::ArrayBuffer::create(result.data);
             auto chunk = WebCodecsEncodedVideoChunk::create(WebCodecsEncodedVideoChunk::Init {
                 result.isKeyFrame ? WebCodecsEncodedVideoChunkType::Key : WebCodecsEncodedVideoChunkType::Delta,
                 result.timestamp,

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -581,7 +581,7 @@ void WebSocket::didReceiveBinaryData(Vector<uint8_t>&& binaryData)
             dispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), WTFMove(binaryData), emptyString()), SecurityOrigin::create(m_url)->toString()));
             break;
         case BinaryType::Arraybuffer:
-            dispatchEvent(MessageEvent::create(ArrayBuffer::create(binaryData.data(), binaryData.size()), SecurityOrigin::create(m_url)->toString()));
+            dispatchEvent(MessageEvent::create(ArrayBuffer::create(binaryData), SecurityOrigin::create(m_url)->toString()));
             break;
         }
     });

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -48,7 +48,7 @@ public:
         : m_variant(WTFMove(variant))
     { }
     explicit BufferSource(std::span<const uint8_t> span)
-        : m_variant(JSC::ArrayBuffer::tryCreate(span.data(), span.size_bytes())) { }
+        : m_variant(JSC::ArrayBuffer::tryCreate(span)) { }
 
     const VariantType& variant() const { return m_variant; }
 

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -165,7 +165,7 @@ JSValue toJS(JSGlobalObject& lexicalGlobalObject, JSGlobalObject& globalObject, 
             return jsNull();
         }
 
-        auto arrayBuffer = ArrayBuffer::create(data->data(), data->size());
+        auto arrayBuffer = ArrayBuffer::create(*data);
         Structure* structure = globalObject.arrayBufferStructure(arrayBuffer->sharingMode());
         if (!structure)
             return jsNull();

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3683,7 +3683,7 @@ private:
             return false;
         if (m_ptr + length > m_end)
             return false;
-        arrayBuffer = ArrayBuffer::tryCreate(m_ptr, length);
+        arrayBuffer = ArrayBuffer::tryCreate({ m_ptr, static_cast<size_t>(length) });
         if (!arrayBuffer)
             return false;
         m_ptr += length;

--- a/Source/WebCore/bindings/js/StructuredClone.cpp
+++ b/Source/WebCore/bindings/js/StructuredClone.cpp
@@ -60,7 +60,7 @@ static EncodedJSValue cloneArrayBufferImpl(JSGlobalObject* lexicalGlobalObject, 
         int srcLength = static_cast<int>(callFrame->uncheckedArgument(2).toNumber(lexicalGlobalObject));
         return JSValue::encode(JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), buffer->slice(srcByteOffset, srcByteOffset + srcLength)));
     }
-    return JSValue::encode(JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), ArrayBuffer::tryCreate(buffer->data(), buffer->byteLength())));
+    return JSValue::encode(JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), ArrayBuffer::tryCreate(buffer->span())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(cloneArrayBuffer, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -681,7 +681,7 @@ void SharedBufferBuilder::initialize(Ref<FragmentedSharedBuffer>&& buffer)
 
 RefPtr<ArrayBuffer> SharedBufferBuilder::tryCreateArrayBuffer() const
 {
-    return m_buffer ? m_buffer->tryCreateArrayBuffer() : ArrayBuffer::tryCreate(nullptr, 0);
+    return m_buffer ? m_buffer->tryCreateArrayBuffer() : ArrayBuffer::tryCreate();
 }
 
 Ref<FragmentedSharedBuffer> SharedBufferBuilder::take()
@@ -697,7 +697,7 @@ Ref<SharedBuffer> SharedBufferBuilder::takeAsContiguous()
 RefPtr<ArrayBuffer> SharedBufferBuilder::takeAsArrayBuffer()
 {
     if (!m_buffer)
-        return ArrayBuffer::tryCreate(nullptr, 0);
+        return ArrayBuffer::tryCreate();
     return take()->tryCreateArrayBuffer();
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -518,7 +518,7 @@ void InbandTextTrackPrivateAVF::processNativeSamples(CFArrayRef nativeSamples, c
             continue;
 
         while (true) {
-            buffer = ArrayBuffer::create(m_sampleInputBuffer.data(), m_sampleInputBuffer.size());
+            buffer = ArrayBuffer::create(m_sampleInputBuffer);
             auto view = JSC::DataView::create(WTFMove(buffer), 0, buffer->byteLength());
 
             auto peekResult = ISOBox::peekBox(view, 0);
@@ -607,7 +607,7 @@ bool InbandTextTrackPrivateAVF::readNativeSampleBuffer(CFArrayRef nativeSamples,
     m_sampleInputBuffer.grow(m_sampleInputBuffer.size() + bufferLength);
     CMBlockBufferCopyDataBytes(blockBuffer, 0, bufferLength, m_sampleInputBuffer.data() + m_sampleInputBuffer.size() - bufferLength);
 
-    buffer = ArrayBuffer::create(m_sampleInputBuffer.data(), m_sampleInputBuffer.size());
+    buffer = ArrayBuffer::create(m_sampleInputBuffer);
 
     formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -42,6 +42,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/UUID.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebCore {
 
@@ -110,8 +111,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    auto keyRequestBuffer = ArrayBuffer::create([keyRequest bytes], [keyRequest length]);
-    return Uint8Array::create(WTFMove(keyRequestBuffer));
+    return Uint8Array::create(ArrayBuffer::create(span(keyRequest.get())));
 }
 
 void CDMSessionAVFoundationObjC::releaseKeys()

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -723,7 +723,7 @@ std::optional<VP8FrameHeader> parseVP8FrameHeader(std::span<const uint8_t> frame
     VP8FrameHeader header;
     size_t headerSize = 11;
 
-    auto view = JSC::DataView::create(ArrayBuffer::create(frameData.data(), headerSize), 0, headerSize);
+    auto view = JSC::DataView::create(ArrayBuffer::create(frameData.first(headerSize)), 0, headerSize);
     bool status = true;
 
     auto uncompressedChunk = view->get<uint32_t>(0, true, &status);

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -38,6 +38,8 @@
 #import <JavaScriptCore/JSObjectRef.h>
 #import <JavaScriptCore/JavaScriptCore.h>
 #import <objc/runtime.h>
+#import <wtf/cocoa/SpanCocoa.h>
+
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
 namespace WebCore {
@@ -136,7 +138,7 @@ static JSValue *jsValueWithValueInContext(id value, JSContext *context)
 
 static JSValue *jsValueWithDataInContext(NSData *data, JSContext *context)
 {
-    auto dataArray = ArrayBuffer::tryCreate([data bytes], [data length]);
+    auto dataArray = ArrayBuffer::tryCreate(span(data));
 
     auto* lexicalGlobalObject = toJS([context JSGlobalContextRef]);
     JSC::JSValue array = toJS(lexicalGlobalObject, JSC::jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), dataArray.get());

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -147,7 +147,7 @@ Ref<MediaPromise> MockSourceBufferPrivate::appendInternal(Ref<SharedBuffer>&& da
     m_inputBuffer.appendVector(data->extractData());
 
     while (m_inputBuffer.size()) {
-        auto buffer = ArrayBuffer::create(m_inputBuffer.data(), m_inputBuffer.size());
+        auto buffer = ArrayBuffer::create(m_inputBuffer);
         uint64_t boxLength = MockBox::peekLength(buffer.ptr());
         if (boxLength > buffer->byteLength())
             break;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4230,8 +4230,7 @@ ExceptionOr<String> Internals::getCurrentCursorInfo()
 
 Ref<ArrayBuffer> Internals::serializeObject(const RefPtr<SerializedScriptValue>& value) const
 {
-    auto& bytes = value->wireBytes();
-    return ArrayBuffer::create(bytes.data(), bytes.size());
+    return ArrayBuffer::create(value->wireBytes());
 }
 
 Ref<SerializedScriptValue> Internals::deserializeBuffer(ArrayBuffer& buffer) const

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -145,9 +145,9 @@ static inline Ref<ArrayBuffer> toArrayBuffer(NSData *data)
     return ArrayBuffer::create(span(data));
 }
 
-static inline Ref<ArrayBuffer> toArrayBuffer(const Vector<uint8_t>& data)
+static inline Ref<ArrayBuffer> toArrayBuffer(std::span<const uint8_t> data)
 {
-    return ArrayBuffer::create(data.data(), data.size());
+    return ArrayBuffer::create(data);
 }
 
 static Vector<AuthenticatorTransport> transports()

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -113,14 +113,14 @@ using namespace WebCore;
 
 static inline Ref<ArrayBuffer> toArrayBuffer(NSData *data)
 {
-    return ArrayBuffer::create(reinterpret_cast<const uint8_t *>(data.bytes), data.length);
+    return ArrayBuffer::create(span(data));
 }
 
 static inline RefPtr<ArrayBuffer> toArrayBufferNilIfEmpty(NSData *data)
 {
     if (!data || !data.length)
         return nullptr;
-    return ArrayBuffer::create(reinterpret_cast<const uint8_t *>(data.bytes), data.length);
+    return ArrayBuffer::create(span(data));
 }
 
 static inline RetainPtr<NSData> toNSData(const Vector<uint8_t>& data)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1463,7 +1463,7 @@ void MediaPlayerPrivateRemote::waitingForKeyChanged(bool waitingForKey)
 
 void MediaPlayerPrivateRemote::initializationDataEncountered(const String& initDataType, std::span<const uint8_t> initData)
 {
-    auto initDataBuffer = ArrayBuffer::create(initData.data(), initData.size());
+    auto initDataBuffer = ArrayBuffer::create(initData);
     if (auto player = m_player.get())
         player->initializationDataEncountered(initDataType, WTFMove(initDataBuffer));
 }

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1547,7 +1547,7 @@ JSValueRef JSSharedMemory::readBytes(JSContextRef context, JSObjectRef, JSObject
             length = *lengthValue;
     }
 
-    auto arrayBuffer = JSC::ArrayBuffer::create(static_cast<uint8_t*>(jsSharedMemory->m_sharedMemory->data()) + offset, length);
+    auto arrayBuffer = JSC::ArrayBuffer::create(jsSharedMemory->m_sharedMemory->span().subspan(offset, length));
     JSC::JSArrayBuffer* jsArrayBuffer = nullptr;
     if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
         jsArrayBuffer = JSC::JSArrayBuffer::create(vm, structure, WTFMove(arrayBuffer));
@@ -1684,7 +1684,6 @@ JSValueRef JSIPCStreamConnectionBuffer::readBytes(JSContextRef context, JSObject
 {
     size_t offset = 0;
     size_t length = span.size();
-    uint8_t* data = span.data();
     auto* globalObject = toJS(context);
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
@@ -1711,7 +1710,7 @@ JSValueRef JSIPCStreamConnectionBuffer::readBytes(JSContextRef context, JSObject
             length = *lengthValue;
     }
 
-    auto arrayBuffer = JSC::ArrayBuffer::create(data + offset, length);
+    auto arrayBuffer = JSC::ArrayBuffer::create(span.subspan(offset, length));
     JSC::JSArrayBuffer* jsArrayBuffer = nullptr;
     if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
         jsArrayBuffer = JSC::JSArrayBuffer::create(vm, structure, WTFMove(arrayBuffer));

--- a/Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp
@@ -46,7 +46,7 @@ TEST(ISOBox, ISOProtectionSchemeInfoBox)
     ASSERT_TRUE(sinfArray);
     ASSERT_EQ(97UL, sinfArray->size());
 
-    auto view = JSC::DataView::create(ArrayBuffer::create(sinfArray->data(), sinfArray->size()), 0, sinfArray->size());
+    auto view = JSC::DataView::create(ArrayBuffer::create(*sinfArray), 0, sinfArray->size());
 
     ISOProtectionSchemeInfoBox sinfBox;
     ASSERT_TRUE(sinfBox.read(view));
@@ -82,7 +82,7 @@ TEST(ISOBox, ISOFairPlayStreamingPsshBox)
     ASSERT_TRUE(psshArray);
     ASSERT_EQ(176UL, psshArray->size());
 
-    auto view = JSC::DataView::create(ArrayBuffer::create(psshArray->data(), psshArray->size()), 0, psshArray->size());
+    auto view = JSC::DataView::create(ArrayBuffer::create(*psshArray), 0, psshArray->size());
 
     ISOFairPlayStreamingPsshBox psshBox;
 


### PR DESCRIPTION
#### d3dc83426c85179bcfac48a7b40cf93e50c402e1
<pre>
Drop ArrayBuffer constructors taking in a raw pointer, in favor of std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=274698">https://bugs.webkit.org/show_bug.cgi?id=274698</a>

Reviewed by Darin Adler and Yusuke Suzuki.

This is to promote adoption of std::span throughout the code base.

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::create):
(JSC::ArrayBuffer::createAdopted):
(JSC::ArrayBuffer::tryCreate):
(JSC::ArrayBuffer::sliceWithClampedIndex const):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::slowDownAndWasteMemory):
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::JSArrayBufferView::span const):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::makeArrayBuffer):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consumeAsStream):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::consumeFormDataAsStream):
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::data const):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp:
(WebCore::LibWebRTCDtlsTransportBackendObserver::updateState):
* Source/WebCore/Modules/push-api/PushSubscription.cpp:
(WebCore::PushSubscription::getKey const):
* Source/WebCore/Modules/push-api/PushSubscriptionOptions.cpp:
(WebCore::PushSubscriptionOptions::applicationServerKey const):
* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp:
(WebCore::AuthenticatorAssertionResponse::create):
(WebCore::AuthenticatorAssertionResponse::setAuthenticatorData):
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::AuthenticatorAttestationResponse::create):
(WebCore::AuthenticatorAttestationResponse::getAuthenticatorData const):
(WebCore::AuthenticatorAttestationResponse::getPublicKey const):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::buildClientDataJson):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::didReceiveBinaryData):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Bridge::send):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::BufferSource::BufferSource):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readArrayBufferImpl):
* Source/WebCore/bindings/js/StructuredClone.cpp:
(WebCore::cloneArrayBufferImpl):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::SharedBufferBuilder::tryCreateArrayBuffer const):
(WebCore::SharedBufferBuilder::takeAsArrayBuffer):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processNativeSamples):
(WebCore::InbandTextTrackPrivateAVF::readNativeSampleBuffer):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::generateKeyRequest):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::parseVP8FrameHeader):
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::jsValueWithDataInContext):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::appendInternal):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::serializeObject const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::toArrayBuffer):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toArrayBuffer):
(WebKit::toArrayBufferNilIfEmpty):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::initializationDataEncountered):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSSharedMemory::readBytes):
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::readBytes):
* Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp:
(TestWebKitAPI::TEST(ISOBox, ISOProtectionSchemeInfoBox)):
(TestWebKitAPI::TEST(ISOBox, ISOFairPlayStreamingPsshBox)):

Canonical link: <a href="https://commits.webkit.org/279393@main">https://commits.webkit.org/279393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f9316a96a9db2c4937ad4aaf782d779aec9a7a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3893 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43100 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2524 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3229 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2052 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46526 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58045 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52683 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50503 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49818 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30451 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64988 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7848 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29287 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12366 "Found 9 new JSC stress test failures: stress/map-iteration.js.dfg-eager, stress/proxy-set-prototype-of.js.bytecode-cache, stress/proxy-set-prototype-of.js.no-llint, stress/setter-frame-flush.js.default, stress/spread-non-array.js.default, stress/spread-non-array.js.no-llint, wasm.yaml/wasm/function-tests/brTableWithLoop.js.wasm-eager, wasm.yaml/wasm/stress/js-to-wasm-i64-register.js.wasm-eager, wasm.yaml/wasm/stress/osr-entry-many-locals-i32.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->