### PR TITLE
[view-transitions] Async animation of snapshot position via transform looks jumpy with sync animation of size

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2568,6 +2568,16 @@ void KeyframeEffect::computeHasSizeDependentTransform()
 {
     m_animatesSizeAndSizeDependentTransform = (m_blendingKeyframes.hasWidthDependentTransform() && m_blendingKeyframes.containsProperty(CSSPropertyWidth))
         || (m_blendingKeyframes.hasHeightDependentTransform() && m_blendingKeyframes.containsProperty(CSSPropertyHeight));
+
+    // If this is a ::view-transition-group pseudo element with the UA-generated transform
+    // and width/height animations, then prevent the transform component from being applied
+    // asynchronously to ensure they remain synchronized. Since the transform usually animates
+    // the position at the same time as the size animates, even slight desynchronizations look
+    // stuttery.
+    if (auto target = targetStyleable()) {
+        if (target->pseudoElementIdentifier && target->pseudoElementIdentifier->pseudoId == PseudoId::ViewTransitionGroup)
+            m_animatesSizeAndSizeDependentTransform |= ((m_blendingKeyframes.containsProperty(CSSPropertyWidth) || m_blendingKeyframes.containsProperty(CSSPropertyHeight)) && m_blendingKeyframes.containsProperty(CSSPropertyTransform));
+    }
 }
 
 void KeyframeEffect::effectStackNoLongerPreventsAcceleration()

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -341,10 +341,14 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
     if (!renderer)
         return;
 
-    generatedContent().updateBackdropRenderer(*renderer);
-    generatedContent().updateWritingSuggestionsRenderer(*renderer);
+    StyleDifference minimalStyleDifference = StyleDifference::Equal;
+    if (update && update->recompositeLayer)
+        minimalStyleDifference = StyleDifference::RecompositeLayer;
+
+    generatedContent().updateBackdropRenderer(*renderer, minimalStyleDifference);
+    generatedContent().updateWritingSuggestionsRenderer(*renderer, minimalStyleDifference);
     if (&element == element.document().documentElement())
-        viewTransition().updatePseudoElementTree(*renderer);
+        viewTransition().updatePseudoElementTree(*renderer, minimalStyleDifference);
 
     m_builder.updateAfterDescendants(*renderer);
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -207,7 +207,7 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
     m_updater.m_builder.updateAfterDescendants(*pseudoElementRenderer);
 }
 
-void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& renderer)
+void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& renderer, StyleDifference minimalStyleDifference)
 {
     auto destroyBackdropIfNeeded = [&renderer, this]() {
         if (WeakPtr backdropRenderer = renderer.backdropRenderer())
@@ -228,7 +228,7 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
 
     auto newStyle = RenderStyle::clone(*style);
     if (auto backdropRenderer = renderer.backdropRenderer())
-        backdropRenderer->setStyle(WTFMove(newStyle));
+        backdropRenderer->setStyle(WTFMove(newStyle), minimalStyleDifference);
     else {
         auto newBackdropRenderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, renderer.document(), WTFMove(newStyle));
         newBackdropRenderer->initializeStyle();
@@ -266,7 +266,7 @@ void RenderTreeUpdater::GeneratedContent::removeAfterPseudoElement(Element& elem
     element.clearAfterPseudoElement();
 }
 
-void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(RenderElement& renderer)
+void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(RenderElement& renderer, StyleDifference minimalStyleDifference)
 {
     auto destroyWritingSuggestionsIfNeeded = [&renderer, this]() {
         if (!renderer.element())
@@ -326,7 +326,7 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
 
     auto newStyle = RenderStyle::clone(*style);
     if (auto writingSuggestionsRenderer = editor.writingSuggestionRenderer()) {
-        writingSuggestionsRenderer->setStyle(WTFMove(newStyle));
+        writingSuggestionsRenderer->setStyle(WTFMove(newStyle), minimalStyleDifference);
 
         auto* writingSuggestionsText = dynamicDowncast<RenderText>(writingSuggestionsRenderer->firstChild());
         if (!writingSuggestionsText) {

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -38,11 +38,11 @@ class RenderTreeUpdater::GeneratedContent {
 public:
     GeneratedContent(RenderTreeUpdater&);
 
-    void updateBackdropRenderer(RenderElement&);
+    void updateBackdropRenderer(RenderElement&, StyleDifference minimalStyleDifference);
     void updatePseudoElement(Element&, const Style::ElementUpdate&, PseudoId);
     void updateRemainingQuotes();
     void updateCounters();
-    void updateWritingSuggestionsRenderer(RenderElement&);
+    void updateWritingSuggestionsRenderer(RenderElement&, StyleDifference minimalStyleDifference);
 
     static void removeBeforePseudoElement(Element&, RenderTreeBuilder&);
     static void removeAfterPseudoElement(Element&, RenderTreeBuilder&);

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -45,7 +45,7 @@ RenderTreeUpdater::ViewTransition::ViewTransition(RenderTreeUpdater& updater)
 
 // The contents and ordering of the named elements map should remain stable during the duration of the transition.
 // We should only need to handle changes in the `display` CSS property by recreating / deleting renderers as needed.
-void RenderTreeUpdater::ViewTransition::updatePseudoElementTree(RenderElement& documentElementRenderer)
+void RenderTreeUpdater::ViewTransition::updatePseudoElementTree(RenderElement& documentElementRenderer, StyleDifference minimalStyleDifference)
 {
     auto destroyPseudoElementTreeIfNeeded = [&documentElementRenderer, this]() {
         if (WeakPtr viewTransitionRoot = documentElementRenderer.view().viewTransitionRoot())
@@ -75,7 +75,7 @@ void RenderTreeUpdater::ViewTransition::updatePseudoElementTree(RenderElement& d
     // Create ::view-transition as needed.
     WeakPtr viewTransitionRoot = documentElementRenderer.view().viewTransitionRoot();
     if (viewTransitionRoot)
-        viewTransitionRoot->setStyle(WTFMove(newRootStyle));
+        viewTransitionRoot->setStyle(WTFMove(newRootStyle), minimalStyleDifference);
     else {
         auto newViewTransitionRoot = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, documentElementRenderer.document(), WTFMove(newRootStyle), RenderObject::BlockFlowFlag::IsViewTransitionContainer);
         newViewTransitionRoot->initializeStyle();
@@ -98,7 +98,7 @@ void RenderTreeUpdater::ViewTransition::updatePseudoElementTree(RenderElement& d
             if (!style || style->display() == DisplayType::None)
                 descendantsToDelete.append(currentGroup);
             else
-                updatePseudoElementGroup(*style, downcast<RenderElement>(*currentGroup), documentElementRenderer);
+                updatePseudoElementGroup(*style, downcast<RenderElement>(*currentGroup), documentElementRenderer, minimalStyleDifference);
             currentGroup = currentGroup->nextSibling();
         } else
             buildPseudoElementGroup(name, documentElementRenderer, currentGroup);
@@ -160,13 +160,13 @@ void RenderTreeUpdater::ViewTransition::buildPseudoElementGroup(const AtomString
         m_updater.m_builder.attach(*documentElementRenderer.view().viewTransitionRoot(), WTFMove(viewTransitionGroup), beforeChild);
 }
 
-void RenderTreeUpdater::ViewTransition::updatePseudoElementGroup(const RenderStyle& groupStyle, RenderElement& group, RenderElement& documentElementRenderer)
+void RenderTreeUpdater::ViewTransition::updatePseudoElementGroup(const RenderStyle& groupStyle, RenderElement& group, RenderElement& documentElementRenderer, StyleDifference minimalStyleDifference)
 {
     auto& documentElementStyle = documentElementRenderer.style();
     auto name = groupStyle.pseudoElementNameArgument();
 
     auto newGroupStyle = RenderStyle::clone(groupStyle);
-    group.setStyle(WTFMove(newGroupStyle));
+    group.setStyle(WTFMove(newGroupStyle), minimalStyleDifference);
 
     enum class ShouldDeleteRenderer : bool { No, Yes };
     auto updateRenderer = [&](RenderObject& renderer) -> ShouldDeleteRenderer {
@@ -175,7 +175,7 @@ void RenderTreeUpdater::ViewTransition::updatePseudoElementGroup(const RenderSty
             return ShouldDeleteRenderer::Yes;
 
         auto newStyle = RenderStyle::clone(*style);
-        downcast<RenderElement>(renderer).setStyle(WTFMove(newStyle));
+        downcast<RenderElement>(renderer).setStyle(WTFMove(newStyle), minimalStyleDifference);
         return ShouldDeleteRenderer::No;
     };
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
@@ -38,10 +38,10 @@ class RenderTreeUpdater::ViewTransition {
 public:
     ViewTransition(RenderTreeUpdater&);
 
-    void updatePseudoElementTree(RenderElement&);
+    void updatePseudoElementTree(RenderElement&, StyleDifference minimalStyleDifference);
 private:
     void buildPseudoElementGroup(const AtomString&, RenderElement&, RenderObject* = nullptr);
-    void updatePseudoElementGroup(const RenderStyle&, RenderElement&, RenderElement&);
+    void updatePseudoElementGroup(const RenderStyle&, RenderElement&, RenderElement&, StyleDifference minimalStyleDifference);
     RenderTreeUpdater& m_updater;
 };
 


### PR DESCRIPTION
#### f74645a452f8d62be08217bb1def567fd4d9b96e
<pre>
[view-transitions] Async animation of snapshot position via transform looks jumpy with sync animation of size
<a href="https://bugs.webkit.org/show_bug.cgi?id=274437">https://bugs.webkit.org/show_bug.cgi?id=274437</a>
&lt;<a href="https://rdar.apple.com/128441578">rdar://128441578</a>&gt;

Reviewed by Cameron McCormack.

The default pseudo element structure results in an asynchronous animation of the snapshot position via
transform, and a sync animation of the width/height.

If there&apos;s any slowness at all on the main thread, then this looks super jumpy.

Also fixes a bug where Element::invalidateStyleForAnimation()&apos;s forced composition update wasn&apos;t being
propagated to some pseudo elements, even if it originated from an animation on those pseudos.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeHasSizeDependentTransform):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):
(WebCore::RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h:

Canonical link: <a href="https://commits.webkit.org/279362@main">https://commits.webkit.org/279362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b31c79f9befc5afc85ff96b45f05e63cba85ee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43203 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2623 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24333 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2173 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58166 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50602 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49933 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11611 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->