### PR TITLE
[WebGPU] drawIndexed validation fails when the buffer stride exceeds buffer's lastStride

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_274699-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274699-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274699.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274699.html
@@ -1,0 +1,66 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let module = device.createShaderModule({
+      code: `
+@vertex
+fn v(@location(0) fromVertexBuffer: f32) -> @builtin(position) vec4f {
+  return vec4(fromVertexBuffer);
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`,
+    });
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [{
+          arrayStride: 8,
+          attributes: [{format: 'float32', offset: 0, shaderLocation: 0}],
+        }],
+      },
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let renderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: texture.createView(),
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    };
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    renderPassEncoder.setPipeline(pipeline);
+    let vertexBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.VERTEX});
+    renderPassEncoder.setVertexBuffer(0, vertexBuffer);
+    let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 16});
+    renderPassEncoder.setIndexBuffer(indexBuffer, 'uint32');
+    renderPassEncoder.drawIndexed(1, 1, 0, 1111111111, 0);
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -585,12 +585,12 @@ id<MTLRenderPipelineState> Device::indexBufferClampPipeline(MTLIndexType indexTy
     using namespace metal;
     [[vertex]] void vsUshort(device const ushort* indexBuffer [[buffer(0)]], device MTLDrawIndexedPrimitivesIndirectArguments& indexedOutput [[buffer(1)]], const constant uint* vertexCount [[buffer(2)]], uint indexId [[vertex_id]]) {
         ushort plusOneValue = 1 + indexBuffer[indexId]; // plusOne to handle primitive restarts
-        if (plusOneValue + indexedOutput.baseVertex >= vertexCount[0] + 1)
+        if (indexedOutput.baseVertex >= vertexCount[0] || plusOneValue + indexedOutput.baseVertex >= vertexCount[0] + 1)
             indexedOutput.indexCount = 0u;
     }
     [[vertex]] void vsUint(device const uint* indexBuffer [[buffer(0)]], device MTLDrawIndexedPrimitivesIndirectArguments& indexedOutput [[buffer(1)]], const constant uint* vertexCount [[buffer(2)]], uint indexId [[vertex_id]]) {
         uint plusOneValue = 1 + indexBuffer[indexId]; // plusOne to handle primitive restarts
-        if (plusOneValue + indexedOutput.baseVertex >= vertexCount[0] + 1)
+        if (indexedOutput.baseVertex >= vertexCount[0] || plusOneValue + indexedOutput.baseVertex >= vertexCount[0] + 1)
             indexedOutput.indexCount = 0u;
     })" /* NOLINT */ options:options error:&error];
         if (error) {
@@ -786,7 +786,7 @@ id<MTLRenderPipelineState> Device::icbCommandClampPipeline(MTLIndexType indexTyp
         uint indexId [[vertex_id]]) {
 
         IndexDataUint& data = *indexData;
-        if (data.indexBuffer[indexId] > data.minVertexCount) {
+        if (data.indexBuffer[indexId] >= data.minVertexCount) {
             render_command cmd(icb_container->commandBuffer, data.renderCommand);
             cmd.draw_indexed_primitives(data.primitiveType,
                 0u,
@@ -802,7 +802,7 @@ id<MTLRenderPipelineState> Device::icbCommandClampPipeline(MTLIndexType indexTyp
         uint indexId [[vertex_id]]) {
 
         IndexDataUshort& data = *indexData;
-        if (data.indexBuffer[indexId] > data.minVertexCount) {
+        if (data.indexBuffer[indexId] >= data.minVertexCount) {
             render_command cmd(icb_container->commandBuffer, data.renderCommand);
             cmd.draw_indexed_primitives(data.primitiveType,
                 0u,

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -522,9 +522,10 @@ uint32_t RenderBundleEncoder::computeMininumVertexCount() const
         auto& vertexBuffer = m_vertexBuffers[bufferIndex];
         auto bufferSize = vertexBuffer.size;
         auto stride = bufferData.stepMode == WGPUVertexStepMode_Vertex ? bufferData.stride : 1;
-        if (!stride)
+        auto lastStride = bufferData.lastStride;
+        if (!stride || bufferSize < lastStride)
             continue;
-        auto elementCount = bufferSize / stride;
+        auto elementCount = (bufferSize - lastStride) / stride + 1;
         minVertexCount = std::min<uint32_t>(minVertexCount, elementCount);
     }
     return minVertexCount;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -124,7 +124,8 @@ private:
     bool issuedDrawCall() const;
     void incrementDrawCount(uint32_t = 1);
     bool occlusionQueryIsDestroyed() const;
-    bool clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes);
+    enum class IndexCall { Draw, IndirectDraw, Skip };
+    IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes);
     uint32_t computeMininumVertexCount() const;
     std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount);
     id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount);


### PR DESCRIPTION
#### 89dad57f2bc3dc221c72677411afa2114812499b
<pre>
[WebGPU] drawIndexed validation fails when the buffer stride exceeds buffer&apos;s lastStride
<a href="https://bugs.webkit.org/show_bug.cgi?id=274699">https://bugs.webkit.org/show_bug.cgi?id=274699</a>
&lt;radar://128601247&gt;

Reviewed by Tadeu Zagallo.

The buffer&apos;s lastStride was not correctly handled, it assumed a buffer with N vertices
had size of stride * N, but the actual required size is stride * (N - 1) + lastStride.

Fix the calculation to avoid out of bounds shader access.

* LayoutTests/fast/webgpu/regression/repro_274699-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274699.html: Added.
Add regression test which asserts before this change with __XPC_MTL_SHADER_VALIDATION=1

* Source/WebGPU/WebGPU/Device.mm:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::computeMininumVertexCount const):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::computeMininumVertexCount const):
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::drawIndexed):
Fix vertex count calculation related to the lastStride of the buffer.

Canonical link: <a href="https://commits.webkit.org/279367@main">https://commits.webkit.org/279367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afdbe98dc8b2bef1ed3f557f5ff638957ff4e956

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4047 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3798 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2649 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55419 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24361 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2203 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58196 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28470 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50630 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46264 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11614 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->