### PR TITLE
When converting HTML that contains an image to an attributed string and back using `HTMLConverter::editingAttributedString`, the image is lost

### DIFF
--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.h
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.h
@@ -29,5 +29,6 @@
 #import <Foundation/Foundation.h>
 #import <wtf/Forward.h>
 
+WEBCORE_EXPORT NSString *suggestedFilenameWithMIMEType(NSURL *, const String& MIMEType, const String& defaultValue);
 WEBCORE_EXPORT NSString *suggestedFilenameWithMIMEType(NSURL *, const String& MIMEType);
 WEBCORE_EXPORT NSString *filenameByFixingIllegalCharacters(NSString *);

--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
@@ -41,6 +41,11 @@ using namespace WebCore;
 
 NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
 {
+    return suggestedFilenameWithMIMEType(url, mimeType, copyImageUnknownFileLabel());
+}
+
+NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType, const String& defaultValue)
+{
     // Get the filename from the URL. Try the lastPathComponent first.
     NSString *lastPathComponent = [[url path] lastPathComponent];
     NSString *filename = filenameByFixingIllegalCharacters(lastPathComponent);
@@ -51,8 +56,8 @@ NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
         auto host = URL(url).host().createNSString();
         filename = filenameByFixingIllegalCharacters(host.get());
         if ([filename length] == 0) {
-            // Can't make a filename using this URL, use "unknown".
-            filename = copyImageUnknownFileLabel();
+            // Can't make a filename using this URL, use the default value.
+            filename = defaultValue;
         }
     } else {
         // Save the extension for later correction. Only correct the extension of the lastPathComponent.


### PR DESCRIPTION
#### 71e39c7bd8fc08ef9171cf4bfbaed96673158980
<pre>
When converting HTML that contains an image to an attributed string and back using `HTMLConverter::editingAttributedString`, the image is lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=274701">https://bugs.webkit.org/show_bug.cgi?id=274701</a>
<a href="https://rdar.apple.com/128717614">rdar://128717614</a>

Reviewed by Aditya Keerthi.

When converting an NSAttributedString to an HTML document fragment, if the attributed string
contains a text attachment backed by a file wrapper without a preferred file name, the attachment
is dropped and not converted to HTML.

Fix by ensuring that a file wrapper for an image always has a preferred file name when converting
HTML to an attributed string inside of `HTMLConverter::editingAttributedString` using the following
mechanism:

1. If the image is backed by an attachment, use the attachment&apos;s title as the preferred name.
2. Otherwise, try to use the image&apos;s alt attribute&apos;s value as the preferred name, if present.
3. Otherwise, try to convert the image&apos;s url into a filename and use that as the preferred name.
4. If all else fails, use the default &quot;unknown&quot; file name as the preferred name.

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::HTMLConverter):
(HTMLConverter::_addLinkForElement):
(HTMLConverter::_processElement):
(preferredFilenameForElement):
(fileWrapperForElement):

Canonical link: <a href="https://commits.webkit.org/279425@main">https://commits.webkit.org/279425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f3cb8ddff1290e3af0d7c2c55a9d7042ebe5f16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55779 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/40292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3979 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2747 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55571 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31013 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24476 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3526 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2355 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58348 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28630 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46402 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11650 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30765 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7867 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->