### PR TITLE
[WebGPU] Integer overflow in RenderBundleEncoder::runIndexBufferValidation

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_274703-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274703-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: validation error
+CONSOLE MESSAGE: Encoder state is locked
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274703.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274703.html
@@ -1,0 +1,80 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let earlierBuffer = device.createBuffer({size: 256, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+    let earlierU32 = new Uint32Array(earlierBuffer.getMappedRange());
+    earlierU32.fill(123456789);
+    earlierBuffer.unmap();
+    let vertexBuffer = device.createBuffer({size: 0, usage: GPUBufferUsage.VERTEX});
+    let code = `
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) @interpolate(flat) something: u32,
+}
+
+@vertex
+fn v(@location(0) fromVertexBuffer: u32) -> VertexOutput {
+  var v = VertexOutput();
+  v.something = fromVertexBuffer;
+  return v;
+}
+
+@fragment
+fn f(@location(0) @interpolate(flat) something: u32) -> @location(0) u32 {
+  return something;
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [{
+          arrayStride: earlierBuffer.size,
+          stepMode: 'instance',
+          attributes: [{format: 'uint32', offset: 0, shaderLocation: 0}],
+        }],
+      },
+      fragment: {module, targets: [{format: 'r32uint'}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format: 'r32uint', size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC});
+    let renderPassDescriptor = {
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    };
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    renderPassEncoder.setPipeline(pipeline);
+    renderPassEncoder.setVertexBuffer(0, vertexBuffer);
+    let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 4});
+    renderPassEncoder.setIndexBuffer(indexBuffer, 'uint32');
+    renderPassEncoder.drawIndexed(1, 1, 0, 0, 2 ** 32 - 1);
+    renderPassEncoder.end();
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyTextureToBuffer({texture}, {buffer: outputBuffer}, {width: 1, height: 1, depthOrArrayLayers: 1});
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+    outputBuffer.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -93,7 +93,6 @@ public:
     Device& device() const { return m_device; }
     bool isDestroyed() const;
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
-    uint32_t maxIndex(MTLIndexType) const;
     uint8_t* getBufferContents();
     bool indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType) const;
     void indirectBufferRecomputed(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType);
@@ -133,8 +132,6 @@ private:
 
     const Ref<Device> m_device;
     mutable WeakHashSet<CommandEncoder> m_commandEncoders;
-    mutable uint16_t m_max16BitIndex { 0 };
-    mutable uint32_t m_max32BitIndex { 0 };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -400,12 +400,6 @@ bool Buffer::isDestroyed() const
     return state() == State::Destroyed;
 }
 
-uint32_t Buffer::maxIndex(MTLIndexType indexType) const
-{
-    ASSERT(m_usage & WGPUBufferUsage_Index);
-    return indexType == MTLIndexTypeUInt16 ? m_max16BitIndex : m_max32BitIndex;
-}
-
 id<MTLBuffer> Buffer::indirectBuffer() const
 {
     return m_indirectBuffer;


### PR DESCRIPTION
#### 825c235203559922b2b51bb8fd75758878b26f6b
<pre>
[WebGPU] Integer overflow in RenderBundleEncoder::runIndexBufferValidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=274703">https://bugs.webkit.org/show_bug.cgi?id=274703</a>
&lt;radar://128618591&gt;

Reviewed by Tadeu Zagallo.

Use checked arithmetic to avoid overflow and out of bounds reads.

* LayoutTests/fast/webgpu/regression/repro_274703-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274703.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::maxIndex const): Deleted.
This was not being used, the values are computed using a shader now.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::runIndexBufferValidation):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::runIndexBufferValidation):

Canonical link: <a href="https://commits.webkit.org/279390@main">https://commits.webkit.org/279390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e29ea6786ac89c0275d4747a2a1de127422bedb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4109 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43284 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2696 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2265 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58258 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->