### PR TITLE
Scan BidiRTL possibility via SIMD

### DIFF
--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -31,24 +31,69 @@
 
 namespace WTF::SIMD {
 
-constexpr simde_uint8x16_t splat(uint8_t code)
+template<typename LaneType>
+struct LaneToVector;
+
+template<>
+struct LaneToVector<uint8_t> {
+    using Type = simde_uint8x16_t;
+};
+
+template<>
+struct LaneToVector<uint16_t> {
+    using Type = simde_uint16x8_t;
+};
+
+template<>
+struct LaneToVector<uint32_t> {
+    using Type = simde_uint32x4_t;
+};
+
+template<>
+struct LaneToVector<uint64_t> {
+    using Type = simde_uint64x2_t;
+};
+
+template<typename LaneType>
+using VectorType = typename LaneToVector<LaneType>::Type;
+
+
+template<typename LaneType>
+inline constexpr size_t stride = 16 / sizeof(LaneType);
+
+constexpr simde_uint8x16_t splat8(uint8_t code)
 {
     return simde_uint8x16_t { code, code, code, code, code, code, code, code, code, code, code, code, code, code, code, code };
 }
 
-constexpr simde_uint16x8_t splat(uint16_t code)
+constexpr simde_uint16x8_t splat16(uint16_t code)
 {
     return simde_uint16x8_t { code, code, code, code, code, code, code, code };
 }
 
-constexpr simde_uint32x4_t splat(uint32_t code)
+constexpr simde_uint32x4_t splat32(uint32_t code)
 {
     return simde_uint32x4_t { code, code, code, code };
 }
 
-constexpr simde_uint64x2_t splat(uint64_t code)
+constexpr simde_uint64x2_t splat64(uint64_t code)
 {
     return simde_uint64x2_t { code, code };
+}
+
+template<typename LaneType>
+ALWAYS_INLINE constexpr decltype(auto) splat(LaneType lane)
+{
+    if constexpr (sizeof(LaneType) == sizeof(uint8_t))
+        return splat8(static_cast<uint8_t>(lane));
+    else if constexpr (sizeof(LaneType) == sizeof(uint16_t))
+        return splat16(static_cast<uint16_t>(lane));
+    else if constexpr (sizeof(LaneType) == sizeof(uint32_t))
+        return splat32(static_cast<uint32_t>(lane));
+    else {
+        static_assert(sizeof(LaneType) == sizeof(uint64_t));
+        return splat64(static_cast<uint64_t>(lane));
+    }
 }
 
 ALWAYS_INLINE simde_uint8x16_t load(const uint8_t* ptr)
@@ -91,24 +136,111 @@ ALWAYS_INLINE void store(simde_uint64x2_t value, uint64_t* ptr)
     return simde_vst1q_u64(ptr, value);
 }
 
-ALWAYS_INLINE simde_uint8x16_t merge(simde_uint8x16_t accumulated, simde_uint8x16_t input)
+ALWAYS_INLINE simde_uint8x16_t merge2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
 {
     return simde_vorrq_u8(accumulated, input);
 }
 
-ALWAYS_INLINE simde_uint16x8_t merge(simde_uint16x8_t accumulated, simde_uint16x8_t input)
+ALWAYS_INLINE simde_uint16x8_t merge2(simde_uint16x8_t accumulated, simde_uint16x8_t input)
 {
     return simde_vorrq_u16(accumulated, input);
 }
 
-ALWAYS_INLINE simde_uint32x4_t merge(simde_uint32x4_t accumulated, simde_uint32x4_t input)
+ALWAYS_INLINE simde_uint32x4_t merge2(simde_uint32x4_t accumulated, simde_uint32x4_t input)
 {
     return simde_vorrq_u32(accumulated, input);
 }
 
-ALWAYS_INLINE simde_uint64x2_t merge(simde_uint64x2_t accumulated, simde_uint64x2_t input)
+ALWAYS_INLINE simde_uint64x2_t merge2(simde_uint64x2_t accumulated, simde_uint64x2_t input)
 {
     return simde_vorrq_u64(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint8x16_t bitOr2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
+{
+    return simde_vorrq_u8(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint16x8_t bitOr2(simde_uint16x8_t accumulated, simde_uint16x8_t input)
+{
+    return simde_vorrq_u16(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint32x4_t bitOr2(simde_uint32x4_t accumulated, simde_uint32x4_t input)
+{
+    return simde_vorrq_u32(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint64x2_t bitOr2(simde_uint64x2_t accumulated, simde_uint64x2_t input)
+{
+    return simde_vorrq_u64(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint8x16_t bitAnd2(simde_uint8x16_t accumulated, simde_uint8x16_t input)
+{
+    return simde_vandq_u8(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint16x8_t bitAnd2(simde_uint16x8_t accumulated, simde_uint16x8_t input)
+{
+    return simde_vandq_u16(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint32x4_t bitAnd2(simde_uint32x4_t accumulated, simde_uint32x4_t input)
+{
+    return simde_vandq_u32(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint64x2_t bitAnd2(simde_uint64x2_t accumulated, simde_uint64x2_t input)
+{
+    return simde_vandq_u64(accumulated, input);
+}
+
+template<typename VectorType, typename... Args>
+ALWAYS_INLINE decltype(auto) merge(VectorType a0, VectorType a1, Args... args)
+{
+    if constexpr (!sizeof...(args))
+        return merge2(a0, a1);
+    else
+        return merge2(a0, merge(a1, std::forward<Args>(args)...));
+}
+
+template<typename VectorType, typename... Args>
+ALWAYS_INLINE decltype(auto) bitOr(VectorType a0, VectorType a1, Args... args)
+{
+    if constexpr (!sizeof...(args))
+        return bitOr2(a0, a1);
+    else
+        return bitOr2(a0, bitOr(a1, std::forward<Args>(args)...));
+}
+
+template<typename VectorType, typename... Args>
+ALWAYS_INLINE decltype(auto) bitAnd(VectorType a0, VectorType a1, Args... args)
+{
+    if constexpr (!sizeof...(args))
+        return bitAnd2(a0, a1);
+    else
+        return bitAnd2(a0, bitAnd(a1, std::forward<Args>(args)...));
+}
+
+ALWAYS_INLINE simde_uint8x16_t bitNot(simde_uint8x16_t input)
+{
+    return simde_vmvnq_u8(input);
+}
+
+ALWAYS_INLINE simde_uint16x8_t bitNot(simde_uint16x8_t input)
+{
+    return simde_vmvnq_u16(input);
+}
+
+ALWAYS_INLINE simde_uint32x4_t bitNot(simde_uint32x4_t input)
+{
+    return simde_vmvnq_u32(input);
+}
+
+ALWAYS_INLINE simde_uint64x2_t bitNot(simde_uint64x2_t input)
+{
+    return simde_vreinterpretq_u64_u32(simde_vmvnq_u32(simde_vreinterpretq_u32_u64(input)));
 }
 
 ALWAYS_INLINE bool isNonZero(simde_uint8x16_t accumulated)
@@ -277,6 +409,66 @@ ALWAYS_INLINE simde_uint32x4_t lessThan(simde_uint32x4_t lhs, simde_uint32x4_t r
 ALWAYS_INLINE simde_uint64x2_t lessThan(simde_uint64x2_t lhs, simde_uint64x2_t rhs)
 {
     return simde_vcltq_u64(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint8x16_t lessThanOrEqual(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vcleq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t lessThanOrEqual(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vcleq_u16(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint32x4_t lessThanOrEqual(simde_uint32x4_t lhs, simde_uint32x4_t rhs)
+{
+    return simde_vcleq_u32(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint64x2_t lessThanOrEqual(simde_uint64x2_t lhs, simde_uint64x2_t rhs)
+{
+    return simde_vcleq_u64(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint8x16_t greaterThan(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vcgtq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t greaterThan(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vcgtq_u16(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint32x4_t greaterThan(simde_uint32x4_t lhs, simde_uint32x4_t rhs)
+{
+    return simde_vcgtq_u32(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint64x2_t greaterThan(simde_uint64x2_t lhs, simde_uint64x2_t rhs)
+{
+    return simde_vcgtq_u64(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint8x16_t greaterThanOrEqual(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vcgeq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t greaterThanOrEqual(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vcgeq_u16(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint32x4_t greaterThanOrEqual(simde_uint32x4_t lhs, simde_uint32x4_t rhs)
+{
+    return simde_vcgeq_u32(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint64x2_t greaterThanOrEqual(simde_uint64x2_t lhs, simde_uint64x2_t rhs)
+{
+    return simde_vcgeq_u64(lhs, rhs);
 }
 
 }

--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -39,7 +39,7 @@ const float* findFloatAlignedImpl(const float* pointer, float target, size_t len
     ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
     ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
     const float* cursor = pointer;
-    constexpr size_t stride = 16 / sizeof(float);
+    constexpr size_t stride = SIMD::stride<float>;
 
     simde_float32x4_t targetsVector = simde_vdupq_n_f32(target);
 
@@ -69,7 +69,7 @@ const double* findDoubleAlignedImpl(const double* pointer, double target, size_t
     ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
     ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
     const double* cursor = pointer;
-    constexpr size_t stride = 16 / sizeof(double);
+    constexpr size_t stride = SIMD::stride<double>;
 
     simde_float64x2_t targetsVector = simde_vdupq_n_f64(target);
 
@@ -100,7 +100,7 @@ const LChar* find8NonASCIIAlignedImpl(std::span<const LChar> data)
     ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
     ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
     const uint8_t* cursor = bitwise_cast<const uint8_t*>(pointer);
-    constexpr size_t stride = 16 / sizeof(uint8_t);
+    constexpr size_t stride = SIMD::stride<uint8_t>;
 
     simde_uint8x16_t charactersVector = simde_vdupq_n_u8(0x80);
 
@@ -132,7 +132,7 @@ const UChar* find16NonASCIIAlignedImpl(std::span<const UChar> data)
     ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
     ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
     const uint16_t* cursor = bitwise_cast<const uint16_t*>(pointer);
-    constexpr size_t stride = 16 / sizeof(uint16_t);
+    constexpr size_t stride = SIMD::stride<uint16_t>;
 
     simde_uint16x8_t charactersVector = simde_vdupq_n_u16(0x80);
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -487,7 +487,48 @@ bool TextUtil::containsStrongDirectionalityText(StringView text)
     if (text.is8Bit())
         return false;
 
-    if (text.containsOnly<isNotBidiRTL>())
+    if (![&](auto span) ALWAYS_INLINE_LAMBDA {
+        using UnsignedType = std::make_unsigned_t<typename decltype(span)::value_type>;
+        constexpr size_t stride = SIMD::stride<UnsignedType>;
+        if (span.size() >= stride) {
+            auto* cursor = span.data();
+            auto* end = cursor + span.size();
+            constexpr auto c0590 = SIMD::splat<UnsignedType>(0x0590);
+            constexpr auto c2010 = SIMD::splat<UnsignedType>(0x2010);
+            constexpr auto c2029 = SIMD::splat<UnsignedType>(0x2029);
+            constexpr auto c206A = SIMD::splat<UnsignedType>(0x206A);
+            constexpr auto cD7FF = SIMD::splat<UnsignedType>(0xD7FF);
+            constexpr auto cFF00 = SIMD::splat<UnsignedType>(0xFF00);
+            auto maybeBidiRTL = [&](auto* cursor) ALWAYS_INLINE_LAMBDA {
+                auto input = SIMD::load(bitwise_cast<const UnsignedType*>(cursor));
+                // ch < 0x0590
+                auto cond0 = SIMD::lessThan(input, c0590);
+                // General Punctuation such as curly quotes.
+                // ch >= 0x2010 && ch <= 0x2029
+                auto cond1 = SIMD::bitAnd(SIMD::greaterThanOrEqual(input, c2010), SIMD::lessThanOrEqual(input, c2029));
+                // CJK etc., up to Surrogate Pairs.
+                // ch >= 0x206A && ch <= 0xD7FF
+                auto cond2 = SIMD::bitAnd(SIMD::greaterThanOrEqual(input, c206A), SIMD::lessThanOrEqual(input, cD7FF));
+                // Common in CJK.
+                // ch >= 0xFF00 && ch <= 0xFFFF
+                auto cond3 = SIMD::greaterThanOrEqual(input, cFF00);
+                return SIMD::bitNot(SIMD::bitOr(cond0, cond1, cond2, cond3));
+            };
+
+            auto result = SIMD::splat<UnsignedType>(0);
+            for (; cursor + (stride - 1) < end; cursor += stride)
+                result = SIMD::bitOr(result, maybeBidiRTL(cursor));
+            if (cursor < end)
+                result = SIMD::bitOr(result, maybeBidiRTL(end - stride));
+            return SIMD::isNonZero(result);
+        }
+
+        for (auto character : span) {
+            if (mayBeBidiRTL(character))
+                return true;
+        }
+        return false;
+    }(text.span16()))
         return false;
 
     for (char32_t character : text.codePoints()) {


### PR DESCRIPTION
#### 3e50aeaaa02169629761b2f64041cedd72c4fedd
<pre>
Scan BidiRTL possibility via SIMD
<a href="https://bugs.webkit.org/show_bug.cgi?id=274705">https://bugs.webkit.org/show_bug.cgi?id=274705</a>
<a href="https://rdar.apple.com/128719350">rdar://128719350</a>

Reviewed by Sam Weinig.

Deploy optimization for BidiRTL possibility scanning via SIMD.
We clean up SIMDHelpers more to make code simpler

1. Add variadic bitOr / bitAnd / merge to simplify existing implementations.
2. Add all comparisons (lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual).
3. Make splat more easy-to-use form.
4. Add SIMD::stride helper inline variable to compute stride easily.

For existing implementations, I just deployed this new form. But in the furture, we would like
to extract common pattern and further simplifies the implementations. But for now, let&apos;s just
make BidiRTL scanning fast.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType&gt;::append):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexString):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::splat8):
(WTF::SIMD::splat16):
(WTF::SIMD::splat32):
(WTF::SIMD::splat64):
(WTF::SIMD::splat):
(WTF::SIMD::merge2):
(WTF::SIMD::bitOr2):
(WTF::SIMD::bitAnd2):
(WTF::SIMD::merge):
(WTF::SIMD::bitOr):
(WTF::SIMD::bitAnd):
(WTF::SIMD::bitNot):
(WTF::SIMD::lessThanOrEqual):
(WTF::SIMD::greaterThan):
(WTF::SIMD::greaterThanOrEqual):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::findImpl):
(WTF::charactersContain):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanAttributeValue):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::containsStrongDirectionalityText):

Canonical link: <a href="https://commits.webkit.org/279356@main">https://commits.webkit.org/279356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7841a3fefefb234d272b8c855302919358347a60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3750 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24322 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2161 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/46635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/3494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58154 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52793 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28426 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46223 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65097 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7828 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29404 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12403 "Found 6 new JSC stress test failures: stress/proxy-set-prototype-of.js.mini-mode, stress/spread-non-array.js.no-llint, wasm.yaml/wasm/function-tests/i32-const.js.wasm-eager, wasm.yaml/wasm/function-tests/invalid-duplicate-export.js.wasm-eager, wasm.yaml/wasm/references/is_null.js.wasm-eager, wasm.yaml/wasm/stress/wasm-to-wasm.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->