### PR TITLE
Drop FixedVector::data() in favor of span() / mutableSpan()

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -105,7 +105,7 @@ void UnlinkedCodeBlock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         visitor.append(barrier);
     for (auto& barrier : thisObject->m_functionExprs)
         visitor.append(barrier);
-    visitor.appendValues(thisObject->m_constantRegisters.data(), thisObject->m_constantRegisters.size());
+    visitor.appendValues(thisObject->m_constantRegisters);
     size_t extraMemory = thisObject->metadataSizeInBytes();
     if (thisObject->m_instructions)
         extraMemory += thisObject->m_instructions->sizeInBytes();

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13065,7 +13065,7 @@ void SpeculativeJIT::emitSwitchIntJump(
     addBranch(
         branch32(AboveOrEqual, value, Imm32(linkedTable.m_ctiOffsets.size())),
         data->fallThrough.block);
-    move(TrustedImmPtr(linkedTable.m_ctiOffsets.data()), scratch);
+    move(TrustedImmPtr(linkedTable.m_ctiOffsets.mutableSpan().data()), scratch);
 
 #if USE(JSVALUE64)
     farJump(BaseIndex(scratch, value, ScalePtr), JSSwitchPtrTag);

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
@@ -49,6 +49,7 @@ class VM;
 class VerifierSlotVisitor;
 template<typename T> class Weak;
 template<typename T, typename Traits> class WriteBarrierBase;
+template<typename T, typename Traits> class WriteBarrier;
 class WriteBarrierStructureID;
 
 class AbstractSlotVisitor {
@@ -148,6 +149,7 @@ public:
     void append(const WriteBarrierStructureID&);
     void appendHidden(const WriteBarrierStructureID&);
     template<typename Iterator> void append(Iterator begin , Iterator end);
+    ALWAYS_INLINE void appendValues(std::span<const WriteBarrier<Unknown, RawValueTraits<Unknown>>>);
     ALWAYS_INLINE void appendValues(const WriteBarrierBase<Unknown, RawValueTraits<Unknown>>*, size_t count);
     ALWAYS_INLINE void appendValuesHidden(const WriteBarrierBase<Unknown, RawValueTraits<Unknown>>*, size_t count);
 

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
@@ -185,6 +185,12 @@ ALWAYS_INLINE void AbstractSlotVisitor::append(Iterator begin, Iterator end)
         append(*it);
 }
 
+ALWAYS_INLINE void AbstractSlotVisitor::appendValues(std::span<const WriteBarrier<Unknown, RawValueTraits<Unknown>>> barriers)
+{
+    for (auto& barrier : barriers)
+        append(barrier);
+}
+
 ALWAYS_INLINE void AbstractSlotVisitor::appendValues(const WriteBarrierBase<Unknown>* barriers, size_t count)
 {
     for (size_t i = 0; i < count; ++i)

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -96,6 +96,7 @@ public:
     void append(const WriteBarrierStructureID&);
     void appendHidden(const WriteBarrierStructureID&);
     template<typename Iterator> void append(Iterator begin , Iterator end);
+    ALWAYS_INLINE void appendValues(std::span<const WriteBarrier<Unknown, RawValueTraits<Unknown>>>);
     ALWAYS_INLINE void appendValues(const WriteBarrierBase<Unknown, RawValueTraits<Unknown>>*, size_t count);
     ALWAYS_INLINE void appendValuesHidden(const WriteBarrierBase<Unknown, RawValueTraits<Unknown>>*, size_t count);
 

--- a/Source/JavaScriptCore/heap/SlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/SlotVisitorInlines.h
@@ -133,6 +133,12 @@ ALWAYS_INLINE void SlotVisitor::append(Iterator begin, Iterator end)
         append(*it);
 }
 
+ALWAYS_INLINE void SlotVisitor::appendValues(std::span<const WriteBarrier<Unknown>> barriers)
+{
+    for (auto& barrier : barriers)
+        append(barrier);
+}
+
 ALWAYS_INLINE void SlotVisitor::appendValues(const WriteBarrierBase<Unknown>* barriers, size_t count)
 {
     for (size_t i = 0; i < count; ++i)

--- a/Source/JavaScriptCore/jit/BaselineJITCode.cpp
+++ b/Source/JavaScriptCore/jit/BaselineJITCode.cpp
@@ -57,7 +57,7 @@ BaselineJITCode::~BaselineJITCode() = default;
 
 CodeLocationLabel<JSInternalPtrTag> BaselineJITCode::getCallLinkDoneLocationForBytecodeIndex(BytecodeIndex bytecodeIndex) const
 {
-    auto* result = binarySearch<const BaselineUnlinkedCallLinkInfo, BytecodeIndex>(m_unlinkedCalls.data(), m_unlinkedCalls.size(), bytecodeIndex,
+    auto* result = binarySearch<const BaselineUnlinkedCallLinkInfo, BytecodeIndex>(m_unlinkedCalls.span().data(), m_unlinkedCalls.size(), bytecodeIndex,
         [](const auto& value) {
             return value->bytecodeIndex;
         });

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1288,7 +1288,7 @@ void JIT::emit_op_switch_imm(const JSInstruction* currentInstruction)
     sub32(Imm32(unlinkedTable.m_min), jsRegT10.payloadGPR());
 
     addJump(branch32(AboveOrEqual, jsRegT10.payloadGPR(), Imm32(linkedTable.m_ctiOffsets.size())), defaultOffset);
-    move(TrustedImmPtr(linkedTable.m_ctiOffsets.data()), regT2);
+    move(TrustedImmPtr(linkedTable.m_ctiOffsets.mutableSpan().data()), regT2);
     loadPtr(BaseIndex(regT2, jsRegT10.payloadGPR(), ScalePtr), regT2);
     farJump(regT2, JSSwitchPtrTag);
 

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -186,7 +186,7 @@ static inline void buildEntryBufferForCatch(Probe::Context& context)
     JSValue thrownValue = JSValue::decode(exception);
     void* payload = nullptr;
     if (JSWebAssemblyException* wasmException = jsDynamicCast<JSWebAssemblyException*>(thrownValue))
-        payload = bitwise_cast<void*>(wasmException->payload().data());
+        payload = bitwise_cast<void*>(wasmException->payload().span().data());
 
     context.gpr(GPRInfo::argumentGPR0) = bitwise_cast<uintptr_t>(buffer);
     context.gpr(GPRInfo::argumentGPR1) = exception;

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -212,7 +212,7 @@ EncodedJSValue createArrayFromDataSegment(Instance* instance, FieldType elementT
         return JSValue::encode(jsNull());
 
     // Copy the data from the segment into the temp `values` vector
-    if (!instance->copyDataSegment(dataSegmentIndex, offset, arrayLengthInBytes, reinterpret_cast<uint8_t*>(tempValues.data()))) {
+    if (!instance->copyDataSegment(dataSegmentIndex, offset, arrayLengthInBytes, reinterpret_cast<uint8_t*>(tempValues.mutableSpan().data()))) {
         // If copyDataSegment() returns false, the segment access is out of bounds.
         // In that case, the caller is responsible for throwing an exception.
         return JSValue::encode(jsNull());
@@ -225,7 +225,7 @@ EncodedJSValue createArrayFromDataSegment(Instance* instance, FieldType elementT
 inline EncodedJSValue createArrayFromElementSegment(Instance* instance, size_t arraySize, unsigned elemSegmentIndex, unsigned offset, FixedVector<uint64_t>&& tempValues, RefPtr<const Wasm::RTT> rtt)
 {
     // Copy the data from the segment into the temp `values` vector
-    instance->copyElementSegment(instance->module().moduleInformation().elements[elemSegmentIndex], offset, arraySize, tempValues.data());
+    instance->copyElementSegment(instance->module().moduleInformation().elements[elemSegmentIndex], offset, arraySize, tempValues.mutableSpan().data());
 
     // Finally, return a JS value representing an array of the values from `tempValues`
     return createArrayValue(instance, FieldType { StorageType { Types::I64 }, Mutability::Mutable }, arraySize, WTFMove(tempValues), rtt);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1083,7 +1083,7 @@ WASM_SLOW_PATH_DECL(retrieve_and_clear_exception)
     const auto& handleCatch = [&](const auto& instruction) {
         JSWebAssemblyException* wasmException = jsDynamicCast<JSWebAssemblyException*>(thrownValue);
         RELEASE_ASSERT(!!wasmException);
-        payload = bitwise_cast<void*>(wasmException->payload().data());
+        payload = bitwise_cast<void*>(wasmException->payload().span().data());
         callFrame->uncheckedR(instruction.m_exception) = thrownValue;
     };
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -74,20 +74,20 @@ public:
         if (m_elementType.type.is<Wasm::PackedType>()) {
             switch (m_elementType.type.as<Wasm::PackedType>()) {
             case Wasm::PackedType::I8:
-                return reinterpret_cast<uint8_t*>(m_payload8.data());
+                return m_payload8.mutableSpan().data();
             case Wasm::PackedType::I16:
-                return reinterpret_cast<uint8_t*>(m_payload16.data());
+                return reinterpret_cast<uint8_t*>(m_payload16.mutableSpan().data());
             }
         }
         ASSERT(m_elementType.type.is<Wasm::Type>());
         switch (m_elementType.type.as<Wasm::Type>().kind) {
         case Wasm::TypeKind::I32:
         case Wasm::TypeKind::F32:
-            return reinterpret_cast<uint8_t*>(m_payload32.data());
+            return reinterpret_cast<uint8_t*>(m_payload32.mutableSpan().data());
         case Wasm::TypeKind::V128:
-            return reinterpret_cast<uint8_t*>(m_payload128.data());
+            return reinterpret_cast<uint8_t*>(m_payload128.mutableSpan().data());
         default:
-            return reinterpret_cast<uint8_t*>(m_payload64.data());
+            return reinterpret_cast<uint8_t*>(m_payload64.mutableSpan().data());
         }
 
         ASSERT_NOT_REACHED();
@@ -97,7 +97,7 @@ public:
     uint64_t* reftypeData()
     {
         RELEASE_ASSERT(m_elementType.type.unpacked().isRef() || m_elementType.type.unpacked().isRefNull());
-        return m_payload64.data();
+        return m_payload64.mutableSpan().data();
     }
 
     uint64_t get(uint32_t index)
@@ -153,7 +153,7 @@ public:
         case Wasm::TypeKind::Funcref:
         case Wasm::TypeKind::Ref:
         case Wasm::TypeKind::RefNull: {
-            WriteBarrier<Unknown>* pointer = bitwise_cast<WriteBarrier<Unknown>*>(m_payload64.data());
+            WriteBarrier<Unknown>* pointer = bitwise_cast<WriteBarrier<Unknown>*>(m_payload64.mutableSpan().data());
             pointer += index;
             pointer->set(vm(), this, JSValue::decode(static_cast<EncodedJSValue>(value)));
             break;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -66,7 +66,7 @@ JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject
 
 const uint8_t* JSWebAssemblyStruct::fieldPointer(uint32_t fieldIndex) const
 {
-    return m_payload.data() + structType()->offsetOfFieldInternal(fieldIndex);
+    return m_payload.span().data() + structType()->offsetOfFieldInternal(fieldIndex);
 }
 
 uint8_t* JSWebAssemblyStruct::fieldPointer(uint32_t fieldIndex)

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -133,11 +133,9 @@ public:
     bool isEmpty() const { return m_storage ? m_storage->isEmpty() : true; }
     size_t byteSize() const { return m_storage ? m_storage->byteSize() : 0; }
 
-    T* data() { return m_storage ? m_storage->data() : nullptr; }
     iterator begin() { return m_storage ? m_storage->begin() : nullptr; }
     iterator end() { return m_storage ? m_storage->end() : nullptr; }
 
-    const T* data() const { return const_cast<FixedVector*>(this)->data(); }
     const_iterator begin() const { return const_cast<FixedVector*>(this)->begin(); }
     const_iterator end() const { return const_cast<FixedVector*>(this)->end(); }
 
@@ -192,8 +190,8 @@ public:
 
     Storage* storage() { return m_storage.get(); }
 
-    std::span<const T> span() const { return { data(), size() }; }
-    std::span<T> mutableSpan() { return { data(), size() }; }
+    std::span<const T> span() const { return { m_storage ? m_storage->data() : nullptr, size() }; }
+    std::span<T> mutableSpan() { return { m_storage ? m_storage->data() : nullptr, size() }; }
 
     Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
     {

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -57,10 +57,10 @@ ExceptionOr<void> DOMTokenList::validateToken(StringView token)
     return { };
 }
 
-ExceptionOr<void> DOMTokenList::validateTokens(const AtomString* tokens, size_t length)
+ExceptionOr<void> DOMTokenList::validateTokens(std::span<const AtomString> tokens)
 {
-    for (size_t i = 0; i < length; ++i) {
-        auto result = validateToken(tokens[i]);
+    for (auto& token : tokens) {
+        auto result = validateToken(token);
         if (result.hasException())
             return result;
     }
@@ -72,20 +72,20 @@ bool DOMTokenList::contains(const AtomString& token) const
     return tokens().contains(token);
 }
 
-inline ExceptionOr<void> DOMTokenList::addInternal(const AtomString* newTokens, size_t length)
+inline ExceptionOr<void> DOMTokenList::addInternal(std::span<const AtomString> newTokens)
 {
     // This is usually called with a single token.
     Vector<AtomString, 1> uniqueNewTokens;
-    uniqueNewTokens.reserveInitialCapacity(length);
+    uniqueNewTokens.reserveInitialCapacity(newTokens.size());
 
     auto& tokens = this->tokens();
 
-    for (size_t i = 0; i < length; ++i) {
-        auto result = validateToken(newTokens[i]);
+    for (auto& newToken : newTokens) {
+        auto result = validateToken(newToken);
         if (result.hasException())
             return result;
-        if (!tokens.contains(newTokens[i]) && !uniqueNewTokens.contains(newTokens[i]))
-            uniqueNewTokens.append(newTokens[i]);
+        if (!tokens.contains(newToken) && !uniqueNewTokens.contains(newToken))
+            uniqueNewTokens.append(newToken);
     }
 
     if (!uniqueNewTokens.isEmpty())
@@ -98,23 +98,23 @@ inline ExceptionOr<void> DOMTokenList::addInternal(const AtomString* newTokens, 
 
 ExceptionOr<void> DOMTokenList::add(const FixedVector<AtomString>& tokens)
 {
-    return addInternal(tokens.data(), tokens.size());
+    return addInternal(tokens);
 }
 
 ExceptionOr<void> DOMTokenList::add(const AtomString& token)
 {
-    return addInternal(&token, 1);
+    return addInternal({ &token, 1 });
 }
 
-inline ExceptionOr<void> DOMTokenList::removeInternal(const AtomString* tokensToRemove, size_t length)
+inline ExceptionOr<void> DOMTokenList::removeInternal(std::span<const AtomString> tokensToRemove)
 {
-    auto result = validateTokens(tokensToRemove, length);
+    auto result = validateTokens(tokensToRemove);
     if (result.hasException())
         return result;
 
     auto& tokens = this->tokens();
-    for (size_t i = 0; i < length; ++i)
-        tokens.removeFirst(tokensToRemove[i]);
+    for (auto& tokenToRemove : tokensToRemove)
+        tokens.removeFirst(tokenToRemove);
 
     updateAssociatedAttributeFromTokens();
 
@@ -123,12 +123,12 @@ inline ExceptionOr<void> DOMTokenList::removeInternal(const AtomString* tokensTo
 
 ExceptionOr<void> DOMTokenList::remove(const FixedVector<AtomString>& tokens)
 {
-    return removeInternal(tokens.data(), tokens.size());
+    return removeInternal(tokens);
 }
 
 ExceptionOr<void> DOMTokenList::remove(const AtomString& token)
 {
-    return removeInternal(&token, 1);
+    return removeInternal({ &token, 1 });
 }
 
 ExceptionOr<bool> DOMTokenList::toggle(const AtomString& token, std::optional<bool> force)

--- a/Source/WebCore/html/DOMTokenList.h
+++ b/Source/WebCore/html/DOMTokenList.h
@@ -67,9 +67,9 @@ private:
     const Vector<AtomString, 1>& tokens() const { return const_cast<DOMTokenList&>(*this).tokens(); }
 
     static ExceptionOr<void> validateToken(StringView);
-    static ExceptionOr<void> validateTokens(const AtomString* tokens, size_t length);
-    ExceptionOr<void> addInternal(const AtomString* tokens, size_t length);
-    ExceptionOr<void> removeInternal(const AtomString* tokens, size_t length);
+    static ExceptionOr<void> validateTokens(std::span<const AtomString> tokens);
+    ExceptionOr<void> addInternal(std::span<const AtomString> tokens);
+    ExceptionOr<void> removeInternal(std::span<const AtomString> tokens);
 
     Element& m_element;
     const WebCore::QualifiedName& m_attributeName;

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -363,16 +363,16 @@ TEST(WTF_FixedVector, MoveKeepsData)
 {
     {
         FixedVector<unsigned> vec1(3);
-        auto* data1 = vec1.data();
+        auto* data1 = vec1.span().data();
         FixedVector<unsigned> vec2(WTFMove(vec1));
-        EXPECT_EQ(data1, vec2.data());
+        EXPECT_EQ(data1, vec2.span().data());
     }
     {
         FixedVector<unsigned> vec1(3);
-        auto* data1 = vec1.data();
+        auto* data1 = vec1.span().data();
         FixedVector<unsigned> vec2;
         vec2 = WTFMove(vec1);
-        EXPECT_EQ(data1, vec2.data());
+        EXPECT_EQ(data1, vec2.span().data());
     }
 }
 
@@ -381,19 +381,19 @@ TEST(WTF_FixedVector, MoveKeepsDataNested)
     {
         Vector<FixedVector<unsigned>> vec1;
         vec1.append(FixedVector<unsigned>(3));
-        auto* data1 = vec1[0].data();
+        auto* data1 = vec1[0].span().data();
         FixedVector<FixedVector<unsigned>> vec2(WTFMove(vec1));
         EXPECT_EQ(1U, vec2.size());
-        EXPECT_EQ(data1, vec2[0].data());
+        EXPECT_EQ(data1, vec2[0].span().data());
     }
     {
         Vector<FixedVector<unsigned>> vec1;
         vec1.append(FixedVector<unsigned>(3));
-        auto* data1 = vec1[0].data();
+        auto* data1 = vec1[0].span().data();
         FixedVector<FixedVector<unsigned>> vec2;
         vec2 = WTFMove(vec1);
         EXPECT_EQ(1U, vec2.size());
-        EXPECT_EQ(data1, vec2[0].data());
+        EXPECT_EQ(data1, vec2[0].span().data());
     }
 }
 


### PR DESCRIPTION
#### a3a31351878e1f3f436e2551572df4bad46d0cff
<pre>
Drop FixedVector::data() in favor of span() / mutableSpan()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274707">https://bugs.webkit.org/show_bug.cgi?id=274707</a>

Reviewed by Sam Weinig and Ryosuke Niwa.

This is to promote to use of std::span throughout the code base.

* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::visitChildrenImpl):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/jit/BaselineJITCode.cpp:
(JSC::BaselineJITCode::getCallLinkDoneLocationForBytecodeIndex const):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_switch_imm):
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::buildEntryBufferForCatch):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::createArrayFromDataSegment):
(JSC::Wasm::createArrayFromElementSegment):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::fill):
(JSC::JSWebAssemblyArray::copy):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::fieldPointer const):
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::span const):
(WTF::FixedVector::mutableSpan):
(WTF::FixedVector::data): Deleted.
(WTF::FixedVector::data const): Deleted.
* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::DOMTokenList::validateTokens):
(WebCore::DOMTokenList::addInternal):
(WebCore::DOMTokenList::add):
(WebCore::DOMTokenList::removeInternal):
(WebCore::DOMTokenList::remove):
* Source/WebCore/html/DOMTokenList.h:
* Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp:
(TestWebKitAPI::TEST(WTF_FixedVector, MoveKeepsData)):
(TestWebKitAPI::TEST(WTF_FixedVector, MoveKeepsDataNested)):

Canonical link: <a href="https://commits.webkit.org/279328@main">https://commits.webkit.org/279328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be6da08dacf96032cfa817f0eed1b1af0b3fed6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43104 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2523 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24234 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2051 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46525 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58044 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52682 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50505 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49820 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30450 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64987 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7812 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29286 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/12365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->