### PR TITLE
[WebGPU] Bind groups skip validation in some cases

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_274706-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274706-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: buffer length is 4 which is less than required bufferSize of 2147483648
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274706.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274706.html
@@ -1,0 +1,63 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    const format = 'bgra8unorm';
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let textureView = texture.createView();
+    let commandEncoder = device.createCommandEncoder();
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<uniform> uniform0: array<vec4f, (1<<27)>;
+
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return uniform0[10101];
+}
+`,
+    });
+
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [{binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: {}}],
+    });
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});
+    let renderPipeline = device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {module, buffers: []},
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+    let uniformBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.UNIFORM});
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [{binding: 0, resource: {buffer: uniformBuffer}}],
+    });
+
+    let renderPassEncoder0 = commandEncoder.beginRenderPass({
+      colorAttachments: [{view: textureView, loadOp: 'clear', storeOp: 'store'}],
+    });
+    renderPassEncoder0.setPipeline(renderPipeline);
+    renderPassEncoder0.setBindGroup(0, bindGroup0);
+    renderPassEncoder0.draw(1);
+    renderPassEncoder0.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_274706b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274706b-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: buffer length is 4 which is less than required bufferSize of 2147483648
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274706b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274706b.html
@@ -1,0 +1,63 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    const format = 'bgra8unorm';
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let textureView = texture.createView();
+    let commandEncoder = device.createCommandEncoder();
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read> readOnlyStorage0: array<vec4f, (1<<27)>;
+
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return readOnlyStorage0[10101];
+}
+`,
+    });
+
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [{binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: {type: 'read-only-storage'}}],
+    });
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});
+    let renderPipeline = device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {module, buffers: []},
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+    let uniformBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.STORAGE});
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [{binding: 0, resource: {buffer: uniformBuffer}}],
+    });
+
+    let renderPassEncoder0 = commandEncoder.beginRenderPass({
+      colorAttachments: [{view: textureView, loadOp: 'clear', storeOp: 'store'}],
+    });
+    renderPassEncoder0.setPipeline(renderPipeline);
+    renderPassEncoder0.setBindGroup(0, bindGroup0);
+    renderPassEncoder0.draw(1);
+    renderPassEncoder0.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_274706c-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274706c-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: buffer length is 16 which is less than required bufferSize of 2147483648
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274706c.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274706c.html
@@ -1,0 +1,77 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let textureView = texture.createView();
+    let commandEncoder = device.createCommandEncoder();
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read_write> readWriteStorage0: array<vec4f, (1<<27)>;
+
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  for (var i:u32 = 1; i < 128; i++) {
+    readWriteStorage0[i] = bitcast<vec4f>(vec4u(12340000+i));
+  }
+  return readWriteStorage0[10201020];
+}
+`,
+    });
+
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: {type: 'storage'}},
+      ],
+    });
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});
+    let renderPipeline = device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {module, buffers: []},
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+    let readWriteStorageBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.STORAGE});
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.MAP_READ});
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [
+        {binding: 0, resource: {buffer: readWriteStorageBuffer}},
+      ],
+    });
+
+    let renderPassEncoder0 = commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {view: textureView, loadOp: 'clear', storeOp: 'store'},
+      ],
+    });
+    renderPassEncoder0.setPipeline(renderPipeline);
+    renderPassEncoder0.setBindGroup(0, bindGroup0);
+    renderPassEncoder0.draw(1);
+    renderPassEncoder0.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log(`no validation error`);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -142,8 +142,8 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
             for (unsigned i = 0; i < wgslBindGroupLayout.entries.size(); ++i) {
                 auto& wgslBindGroupLayoutEntry = wgslBindGroupLayout.entries[i];
                 auto* wgslBufferBinding = std::get_if<WGSL::BufferBindingLayout>(&wgslBindGroupLayoutEntry.bindingMember);
-                if (wgslBufferBinding)
-                    shaderBindingSizeForBuffer.add(wgslBindGroupLayoutEntry.binding, wgslBufferBinding->minBindingSize);
+                if (wgslBufferBinding && wgslBufferBinding->minBindingSize)
+                    shaderBindingSizeForBuffer.set(wgslBindGroupLayoutEntry.binding, wgslBufferBinding->minBindingSize);
             }
         }
     }

--- a/Source/WebGPU/WebGPU/PipelineLayout.h
+++ b/Source/WebGPU/WebGPU/PipelineLayout.h
@@ -81,7 +81,7 @@ public:
     const Vector<uint32_t>* fragmentOffsets(uint32_t, const Vector<uint32_t>&);
     const Vector<uint32_t>* computeOffsets(uint32_t, const Vector<uint32_t>&);
     using BindGroupHashMap = HashMap<uint32_t, WeakPtr<BindGroup>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-    NSString* errorValidatingBindGroupCompatibility(const BindGroupHashMap&, size_t vertexStageInBufferCount = 0) const;
+    NSString* errorValidatingBindGroupCompatibility(const BindGroupHashMap&) const;
 private:
     PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&&, bool, Device&);
     PipelineLayout(Device&);

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -275,7 +275,7 @@ const Vector<uint32_t>* PipelineLayout::computeOffsets(uint32_t bindGroupIndex, 
     return offsetVectorForBindGroup(bindGroupIndex, m_computeOffsets, dynamicOffsets, WGPUShaderStage_Compute);
 }
 
-NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLayout::BindGroupHashMap& bindGroups, size_t vertexStageInBufferCount) const
+NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLayout::BindGroupHashMap& bindGroups) const
 {
     if (!m_bindGroupLayouts)
         return nil;
@@ -289,7 +289,7 @@ NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLa
         return [NSString stringWithFormat:@"number of bind groups set(%u) is less than the pipeline uses(%zu)", setBindGroupsSize, numberOfBindGroupsInPipeline];
     }
 
-    for (size_t bindGroupIndex = vertexStageInBufferCount; bindGroupIndex < numberOfBindGroupsInPipeline; ++bindGroupIndex) {
+    for (size_t bindGroupIndex = 0; bindGroupIndex < numberOfBindGroupsInPipeline; ++bindGroupIndex) {
         auto it = bindGroups.find(bindGroupIndex);
         if (it == bindGroups.end() || !it->value.get())
             return [NSString stringWithFormat:@"can not find bind group in pipeline for bindGroup index %zu", bindGroupIndex];

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -283,7 +283,7 @@ bool RenderBundleEncoder::executePreDrawCommands()
     if (!icbCommand)
         return true;
 
-    if (NSString* error = m_pipeline->pipelineLayout().errorValidatingBindGroupCompatibility(m_bindGroups, m_pipeline->vertexStageInBufferCount())) {
+    if (NSString* error = m_pipeline->pipelineLayout().errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);
         return false;
     }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -452,7 +452,7 @@ bool RenderPassEncoder::executePreDrawCommands(const Buffer* indirectBuffer)
         return false;
     }
     auto& pipeline = *m_pipeline.get();
-    if (NSString* error = pipeline.pipelineLayout().errorValidatingBindGroupCompatibility(m_bindGroups, pipeline.vertexStageInBufferCount())) {
+    if (NSString* error = pipeline.pipelineLayout().errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);
         return false;
     }

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -94,7 +94,6 @@ public:
     const RequiredBufferIndicesContainer& requiredBufferIndices() const { return m_requiredBufferIndices; }
     WGPUPrimitiveTopology primitiveTopology() const;
     MTLIndexType stripIndexFormat() const;
-    size_t vertexStageInBufferCount() const;
     const BufferBindingSizesForBindGroup* minimumBufferSizes(uint32_t) const;
 
 private:

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1559,11 +1559,6 @@ void Device::createRenderPipelineAsync(const WGPURenderPipelineDescriptor& descr
     });
 }
 
-size_t RenderPipeline::vertexStageInBufferCount() const
-{
-    return m_descriptor.vertex.bufferCount;
-}
-
 RenderPipeline::RenderPipeline(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthClipMode clipMode, MTLDepthStencilDescriptor *depthStencilDescriptor, Ref<PipelineLayout>&& pipelineLayout, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, uint32_t sampleMask, MTLRenderPipelineDescriptor* renderPipelineDescriptor, uint32_t colorAttachmentCount, const WGPURenderPipelineDescriptor& descriptor, RequiredBufferIndicesContainer&& requiredBufferIndices, BufferBindingSizesForPipeline&& minimumBufferSizes, Device& device)
     : m_renderPipelineState(renderPipelineState)
     , m_device(device)


### PR DESCRIPTION
#### 5dceca812aa0bab38c7a52a10b6368e10f162c7d
<pre>
[WebGPU] Bind groups skip validation in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=274706">https://bugs.webkit.org/show_bug.cgi?id=274706</a>
&lt;radar://128673122&gt;

Reviewed by Tadeu Zagallo.

Bind group validation was being skipped by the number of vertex buffers
a pipeline used.

RenderPipeline::vertexStageInBufferCount() was not needed at all since
the validation is handled by RenderPipeline::requiredBufferIndices().

* LayoutTests/fast/webgpu/regression/repro_274706-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274706.html: Added.
* LayoutTests/fast/webgpu/regression/repro_274706b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274706b.html: Added.
* LayoutTests/fast/webgpu/regression/repro_274706c-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274706c.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/PipelineLayout.h:
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::errorValidatingBindGroupCompatibility const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
* Source/WebGPU/WebGPU/RenderPipeline.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::vertexStageInBufferCount const): Deleted.

Canonical link: <a href="https://commits.webkit.org/279403@main">https://commits.webkit.org/279403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ce27407945ccf962eca186c7e91359c7c7340d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4133 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43300 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55505 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24433 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2289 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58282 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50699 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11630 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->