### PR TITLE
Rebase JSC toLocaleString tests for ICU 7.2 or higher.

### DIFF
--- a/JSTests/stress/bigint-toLocaleString.js
+++ b/JSTests/stress/bigint-toLocaleString.js
@@ -42,7 +42,11 @@ shouldBe(BigInt(1).toLocaleString(), '1');
 shouldThrow(() => 0n.toLocaleString('i'), RangeError);
 
 // Test that locale parameter is passed through properly.
-shouldBe(123456789n.toLocaleString('ar'), '١٢٣٬٤٥٦٬٧٨٩');
+print("$vm.icuVersion()", $vm.icuVersion());
+if ($vm.icuVersion() >= 74 && $vm.icuMinorVersion() >= 2)
+    shouldBe(123456789n.toLocaleString('ar'), '123,456,789');
+else
+    shouldBe(123456789n.toLocaleString('ar'), '١٢٣٬٤٥٦٬٧٨٩');
 shouldBe(123456789n.toLocaleString('zh-Hans-CN-u-nu-hanidec'), '一二三,四五六,七八九');
 
 // Test that options parameter is passed through properly.

--- a/JSTests/stress/number-toLocaleString.js
+++ b/JSTests/stress/number-toLocaleString.js
@@ -44,7 +44,10 @@ shouldThrow(() => (0).toLocaleString('i'), RangeError);
 shouldBe(Infinity.toLocaleString(), '∞');
 
 // Test that locale parameter is passed through properly.
-shouldBe((123456.789).toLocaleString('ar'), '١٢٣٬٤٥٦٫٧٨٩');
+if ($vm.icuVersion() >= 74 && $vm.icuMinorVersion() >= 2)
+    shouldBe((123456.789).toLocaleString('ar'), '123,456.789');
+else
+    shouldBe((123456.789).toLocaleString('ar'), '١٢٣٬٤٥٦٫٧٨٩');
 shouldBe((123456.789).toLocaleString('zh-Hans-CN-u-nu-hanidec'), '一二三,四五六.七八九');
 
 // Test that options parameter is passed through properly.

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2226,6 +2226,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionHasOwnLengthProperty);
 static JSC_DECLARE_HOST_FUNCTION(functionRejectPromiseAsHandled);
 static JSC_DECLARE_HOST_FUNCTION(functionSetUserPreferredLanguages);
 static JSC_DECLARE_HOST_FUNCTION(functionICUVersion);
+static JSC_DECLARE_HOST_FUNCTION(functionICUMinorVersion);
 static JSC_DECLARE_HOST_FUNCTION(functionICUHeaderVersion);
 static JSC_DECLARE_HOST_FUNCTION(functionAssertEnabled);
 static JSC_DECLARE_HOST_FUNCTION(functionSecurityAssertEnabled);
@@ -3816,24 +3817,37 @@ JSC_DEFINE_HOST_FUNCTION(functionSetUserPreferredLanguages, (JSGlobalObject* glo
     return JSValue::encode(jsUndefined());
 }
 
+// Usage: $vm.icuVersion()
 JSC_DEFINE_HOST_FUNCTION(functionICUVersion, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsNumber(WTF::ICU::majorVersion()));
 }
 
+// Usage: $vm.icuMinorVersion()
+JSC_DEFINE_HOST_FUNCTION(functionICUMinorVersion, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(jsNumber(WTF::ICU::minorVersion()));
+}
+
+// Usage: $vm.icuHeaderVersion()
 JSC_DEFINE_HOST_FUNCTION(functionICUHeaderVersion, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsNumber(U_ICU_VERSION_MAJOR_NUM));
 }
 
+// Returns true if Debug ASSERTs are enabled.
+// Usage: $vm.assertEnabled()
 JSC_DEFINE_HOST_FUNCTION(functionAssertEnabled, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(ASSERT_ENABLED));
 }
 
+// Returns true if Security ASSERTs are enabled.
+// Usage: $vm.securityAssertEnabled()
 JSC_DEFINE_HOST_FUNCTION(functionSecurityAssertEnabled, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
@@ -3844,12 +3858,16 @@ JSC_DEFINE_HOST_FUNCTION(functionSecurityAssertEnabled, (JSGlobalObject*, CallFr
 #endif
 }
 
+// Returns true if ASAN ASSERTs are enabled.
+// Usage: $vm.assertEnabled()
 JSC_DEFINE_HOST_FUNCTION(functionAsanEnabled, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(ASAN_ENABLED));
 }
 
+// Returns true if this platform is memory limited.
+// Usage: $vm.isMemoryLimited()
 JSC_DEFINE_HOST_FUNCTION(functionIsMemoryLimited, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
@@ -3860,24 +3878,32 @@ JSC_DEFINE_HOST_FUNCTION(functionIsMemoryLimited, (JSGlobalObject*, CallFrame*))
 #endif
 }
 
+// Returns true if JIT is enabled.
+// Usage: $vm.useJIT()
 JSC_DEFINE_HOST_FUNCTION(functionUseJIT, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(Options::useJIT()));
 }
 
+// Returns true if DFG JIT is enabled.
+// Usage: $vm.useDFGJIT()
 JSC_DEFINE_HOST_FUNCTION(functionUseDFGJIT, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(Options::useDFGJIT()));
 }
 
+// Returns true if FTL JIT is enabled.
+// Usage: $vm.useFTLJIT()
 JSC_DEFINE_HOST_FUNCTION(functionUseFTLJIT, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
     return JSValue::encode(jsBoolean(Options::useFTLJIT()));
 }
 
+// Returns true if Gigacage is enabled.
+// Usage: $vm.isGigacageEnabled()
 JSC_DEFINE_HOST_FUNCTION(functionIsGigacageEnabled, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
@@ -4278,6 +4304,7 @@ void JSDollarVM::finishCreation(VM& vm)
 
     addFunction(vm, "setUserPreferredLanguages"_s, functionSetUserPreferredLanguages, 1);
     addFunction(vm, "icuVersion"_s, functionICUVersion, 0);
+    addFunction(vm, "icuMinorVersion"_s, functionICUMinorVersion, 0);
     addFunction(vm, "icuHeaderVersion"_s, functionICUHeaderVersion, 0);
 
     addFunction(vm, "assertEnabled"_s, functionAssertEnabled, 0);


### PR DESCRIPTION
#### 72ee89f4349904a4581b6226020da2fc2259b4bc
<pre>
Rebase JSC toLocaleString tests for ICU 7.2 or higher.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274708">https://bugs.webkit.org/show_bug.cgi?id=274708</a>
<a href="https://rdar.apple.com/127302910">rdar://127302910</a>

Reviewed by Alexey Shvayka.

Also added a $vm.icuMinorVersion() function to enable this rebasing.
Also added how-to-use comments in JSDollarVM.cpp for some $vm functions.

* JSTests/stress/bigint-toLocaleString.js:
* JSTests/stress/number-toLocaleString.js:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/279317@main">https://commits.webkit.org/279317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d77c20dcb1601df7d7fcc683040152e98d55a3a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43073 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24203 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2012 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46486 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58005 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52643 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50475 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46088 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30410 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64948 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7808 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29245 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12330 "Found 7 new JSC stress test failures: stress/put-non-reified-static-function-or-custom.js.dfg-eager, wasm.yaml/wasm/function-tests/add-12.js.wasm-eager, wasm.yaml/wasm/function-tests/i32-load8-s.js.wasm-eager, wasm.yaml/wasm/function-tests/loop-sum.js.wasm-eager, wasm.yaml/wasm/references/is_null.js.wasm-eager, wasm.yaml/wasm/stress/catch-with-delegate.js.wasm-eager, wasm.yaml/wasm/stress/exception-thrown-from-js-to-wasm-catchall-rethrow.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->