### PR TITLE
Web Inspector: isSimiliarNode should be isSimilarNode

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/DOMUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/DOMUtilities.js
@@ -365,7 +365,7 @@ WI.xpathIndex = function(node)
     //   - look for a unique localName
     //   - fallback to index
 
-    function isSimiliarNode(a, b) {
+    function isSimilarNode(a, b) {
         if (a === b)
             return true;
 
@@ -389,7 +389,7 @@ WI.xpathIndex = function(node)
 
     let xPathIndexCounter = 1; // XPath indices start at 1.
     for (let sibling of siblings) {
-        if (!isSimiliarNode(node, sibling))
+        if (!isSimilarNode(node, sibling))
             continue;
 
         if (node === sibling) {


### PR DESCRIPTION
#### 07edec8d5d0d20d618ca2cbe90d8597cbd60b11a
<pre>
Web Inspector: isSimiliarNode should be isSimilarNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=274715">https://bugs.webkit.org/show_bug.cgi?id=274715</a>

Reviewed by Devin Rousso.

I am changing two instances of isSimilarNode to isSimilarNode.

* Source/WebInspectorUI/UserInterface/Base/DOMUtilities.js:

Canonical link: <a href="https://commits.webkit.org/279325@main">https://commits.webkit.org/279325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa7051245b3bc4e5918fe594034a8eff029d8075

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3869 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43086 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2510 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2028 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58021 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50490 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->