### PR TITLE
Move BitmapImage metadata retrieving to a new class named BitmapImageDescriptor

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2281,6 +2281,7 @@ platform/graphics/AlphaPremultiplication.cpp
 platform/graphics/AnimationFrameRate.cpp
 platform/graphics/BifurcatedGraphicsContext.cpp
 platform/graphics/BitmapImage.cpp
+platform/graphics/BitmapImageDescriptor.cpp
 platform/graphics/BitmapImageSource.cpp
 platform/graphics/ByteArrayPixelBuffer.cpp
 platform/graphics/CachedSubimage.cpp

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BitmapImageDescriptor.h"
+
+#include "BitmapImageSource.h"
+#include "GraphicsContext.h"
+#include "ImageDecoder.h"
+
+namespace WebCore {
+
+BitmapImageDescriptor::BitmapImageDescriptor(BitmapImageSource& source)
+    : m_source(source)
+{
+}
+
+template<typename MetadataType>
+MetadataType BitmapImageDescriptor::imageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag cachedFlag, MetadataType (ImageDecoder::*functor)() const) const
+{
+    if (m_cachedFlags.contains(cachedFlag))
+        return cachedValue;
+
+    auto decoder = m_source.decoderIfExists();
+    if (!decoder)
+        return defaultValue;
+
+    if (!decoder->isSizeAvailable())
+        return defaultValue;
+
+    cachedValue = (*decoder.*functor)();
+    m_cachedFlags.add(cachedFlag);
+    const_cast<BitmapImageSource&>(m_source).didDecodeProperties(decoder->bytesDecodedToDetermineProperties());
+    return cachedValue;
+}
+
+template<typename MetadataType>
+MetadataType BitmapImageDescriptor::primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag cachedFlag, MetadataType (ImageFrame::*functor)() const) const
+{
+    if (m_cachedFlags.contains(cachedFlag))
+        return cachedValue;
+
+    auto& frame = const_cast<BitmapImageSource&>(m_source).primaryImageFrame();
+
+    // Don't cache any unavailable frame metadata. Just return the default metadata.
+    if (!frame.hasMetadata())
+        return (frame.*functor)();
+
+    cachedValue = (frame.*functor)();
+    m_cachedFlags.add(cachedFlag);
+    return cachedValue;
+}
+
+template<typename MetadataType>
+MetadataType BitmapImageDescriptor::primaryNativeImageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag cachedFlag, MetadataType (NativeImage::*functor)() const) const
+{
+    if (m_cachedFlags.contains(cachedFlag))
+        return cachedValue;
+
+    RefPtr nativeImage = const_cast<BitmapImageSource&>(m_source).primaryNativeImage();
+    if (!nativeImage)
+        return defaultValue;
+
+    cachedValue = (*nativeImage.*functor)();
+    m_cachedFlags.add(cachedFlag);
+    return cachedValue;
+}
+
+EncodedDataStatus BitmapImageDescriptor::encodedDataStatus() const
+{
+    return imageMetadata(m_encodedDataStatus, EncodedDataStatus::Unknown, CachedFlag::EncodedDataStatus, &ImageDecoder::encodedDataStatus);
+}
+
+IntSize BitmapImageDescriptor::size(ImageOrientation orientation) const
+{
+    auto densityCorrectedSize = this->densityCorrectedSize();
+    if (!densityCorrectedSize)
+        return sourceSize(orientation);
+
+    if (orientation == ImageOrientation::Orientation::FromImage)
+        orientation = this->orientation();
+
+    return orientation.usesWidthAsHeight() ? densityCorrectedSize->transposedSize() : *densityCorrectedSize;
+}
+
+IntSize BitmapImageDescriptor::sourceSize(ImageOrientation orientation) const
+{
+    IntSize size;
+
+#if !USE(CG)
+    // It's possible that we have decoded the metadata, but not frame contents yet. In that case ImageDecoder claims to
+    // have the size available, but the frame cache is empty. Return the decoder size without caching in such case.
+    auto decoder = m_source.decoderIfExists();
+    if (decoder && m_source.frames().isEmpty())
+        size = decoder->size();
+    else
+#endif
+        size = primaryImageFrameMetadata(m_size, CachedFlag::Size, &ImageFrame::size);
+
+    if (orientation == ImageOrientation::Orientation::FromImage)
+        orientation = this->orientation();
+
+    return orientation.usesWidthAsHeight() ? size.transposedSize() : size;
+}
+
+std::optional<IntSize> BitmapImageDescriptor::densityCorrectedSize() const
+{
+    return primaryImageFrameMetadata(m_densityCorrectedSize, CachedFlag::DensityCorrectedSize, &ImageFrame::densityCorrectedSize);
+}
+
+ImageOrientation BitmapImageDescriptor::orientation() const
+{
+    return primaryImageFrameMetadata(m_orientation, CachedFlag::Orientation, &ImageFrame::orientation);
+}
+
+unsigned BitmapImageDescriptor::primaryFrameIndex() const
+{
+    return imageMetadata(m_primaryFrameIndex, std::size_t(0), CachedFlag::PrimaryFrameIndex, &ImageDecoder::primaryFrameIndex);
+}
+
+unsigned BitmapImageDescriptor::frameCount() const
+{
+    return imageMetadata(m_frameCount, std::size_t(0), CachedFlag::FrameCount, &ImageDecoder::frameCount);
+}
+
+RepetitionCount BitmapImageDescriptor::repetitionCount() const
+{
+    return imageMetadata(m_repetitionCount, static_cast<RepetitionCount>(RepetitionCountNone), CachedFlag::RepetitionCount, &ImageDecoder::repetitionCount);
+}
+
+DestinationColorSpace BitmapImageDescriptor::colorSpace() const
+{
+    return primaryNativeImageMetadata(m_colorSpace, DestinationColorSpace::SRGB(), CachedFlag::ColorSpace, &NativeImage::colorSpace);
+}
+
+std::optional<Color> BitmapImageDescriptor::singlePixelSolidColor() const
+{
+    if (!m_source.hasSolidColor())
+        return std::nullopt;
+
+    return primaryNativeImageMetadata(m_singlePixelSolidColor, std::optional<Color>(), CachedFlag::SinglePixelSolidColor, &NativeImage::singlePixelSolidColor);
+}
+
+String BitmapImageDescriptor::uti() const
+{
+#if USE(CG)
+    return imageMetadata(m_uti, String(), CachedFlag::UTI, &ImageDecoder::uti);
+#else
+    return String();
+#endif
+}
+
+String BitmapImageDescriptor::filenameExtension() const
+{
+    return imageMetadata(m_filenameExtension, String(), CachedFlag::FilenameExtension, &ImageDecoder::filenameExtension);
+}
+
+String BitmapImageDescriptor::accessibilityDescription() const
+{
+    return imageMetadata(m_accessibilityDescription, String(), CachedFlag::AccessibilityDescription, &ImageDecoder::accessibilityDescription);
+}
+
+std::optional<IntPoint> BitmapImageDescriptor::hotSpot() const
+{
+    return imageMetadata(m_hotSpot, std::optional<IntPoint>(), CachedFlag::HotSpot, &ImageDecoder::hotSpot);
+}
+
+SubsamplingLevel BitmapImageDescriptor::maximumSubsamplingLevel() const
+{
+    if (m_cachedFlags.contains(CachedFlag::MaximumSubsamplingLevel))
+        return m_maximumSubsamplingLevel;
+
+    auto decoder = m_source.decoderIfExists();
+    if (!decoder)
+        return SubsamplingLevel::Default;
+
+    if (!decoder->isSizeAvailable())
+        return SubsamplingLevel::Default;
+
+    // FIXME: this value was chosen to be appropriate for Apple ports since the image
+    // subsampling is only enabled by default on Apple ports. Choose a different value
+    // if image subsampling is enabled on other platform.
+    static constexpr int maximumImageAreaBeforeSubsampling = 5 * 1024 * 1024;
+    auto level = SubsamplingLevel::First;
+
+    for (; level < SubsamplingLevel::Last; ++level) {
+        if (m_source.frameSizeAtIndex(0, level).area() < maximumImageAreaBeforeSubsampling)
+            break;
+    }
+
+    m_maximumSubsamplingLevel = level;
+    m_cachedFlags.add(CachedFlag::MaximumSubsamplingLevel);
+    return m_maximumSubsamplingLevel;
+}
+
+SubsamplingLevel BitmapImageDescriptor::subsamplingLevelForScaleFactor(GraphicsContext& context, const FloatSize& scaleFactor, AllowImageSubsampling allowImageSubsampling) const
+{
+#if USE(CG)
+    if (allowImageSubsampling == AllowImageSubsampling::No)
+        return SubsamplingLevel::Default;
+
+    // Never use subsampled images for drawing into PDF contexts.
+    if (context.hasPlatformContext() && CGContextGetType(context.platformContext()) == kCGContextTypePDF)
+        return SubsamplingLevel::Default;
+
+    float scale = std::min(float(1), std::max(scaleFactor.width(), scaleFactor.height()));
+    if (!(scale > 0 && scale <= 1))
+        return SubsamplingLevel::Default;
+
+    int result = std::ceil(std::log2(1 / scale));
+    return static_cast<SubsamplingLevel>(std::min(result, static_cast<int>(maximumSubsamplingLevel())));
+#else
+    UNUSED_PARAM(context);
+    UNUSED_PARAM(scaleFactor);
+    UNUSED_PARAM(allowImageSubsampling);
+    return SubsamplingLevel::Default;
+#endif
+}
+
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+bool BitmapImageDescriptor::shouldUseQuickLookForFullscreen() const
+{
+    if (auto decoder = m_source->decoderIfExists())
+        return decoder->shouldUseQuickLookForFullscreen();
+    return false;
+}
+#endif
+
+void BitmapImageDescriptor::dump(TextStream& ts) const
+{
+    ts.dumpProperty("size", size());
+    ts.dumpProperty("density-corrected-size", densityCorrectedSize());
+    ts.dumpProperty("primary-frame-index", primaryFrameIndex());
+    ts.dumpProperty("frame-count", frameCount());
+    ts.dumpProperty("repetition-count", repetitionCount());
+
+    ts.dumpProperty("uti", uti());
+    ts.dumpProperty("filename-extension", filenameExtension());
+    ts.dumpProperty("accessibility-description", accessibilityDescription());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "DestinationColorSpace.h"
+#include "ImageOrientation.h"
+#include "ImageTypes.h"
+#include "IntPoint.h"
+#include <wtf/OptionSet.h>
+
+namespace WebCore {
+
+class BitmapImageSource;
+class GraphicsContext;
+class ImageDecoder;
+class ImageFrame;
+class NativeImage;
+
+class BitmapImageDescriptor {
+public:
+    BitmapImageDescriptor(BitmapImageSource&);
+
+    void clear() { m_cachedFlags = { }; }
+
+    EncodedDataStatus encodedDataStatus() const;
+    IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const;
+    IntSize sourceSize(ImageOrientation = ImageOrientation::Orientation::FromImage) const;
+    std::optional<IntSize> densityCorrectedSize() const;
+    ImageOrientation orientation() const;
+    unsigned primaryFrameIndex() const;
+    unsigned frameCount() const;
+    RepetitionCount repetitionCount() const;
+    DestinationColorSpace colorSpace() const;
+    std::optional<Color> singlePixelSolidColor() const;
+
+    String uti() const;
+    String filenameExtension() const;
+    String accessibilityDescription() const;
+    std::optional<IntPoint> hotSpot() const;
+    SubsamplingLevel maximumSubsamplingLevel() const;
+    SubsamplingLevel subsamplingLevelForScaleFactor(GraphicsContext&, const FloatSize& scaleFactor, AllowImageSubsampling) const;
+
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    bool shouldUseQuickLookForFullscreen() const;
+#endif
+
+    void dump(TextStream&) const;
+
+private:
+    enum class CachedFlag : uint16_t {
+        EncodedDataStatus           = 1 << 0,
+        Size                        = 1 << 1,
+        DensityCorrectedSize        = 1 << 2,
+        Orientation                 = 1 << 3,
+        PrimaryFrameIndex           = 1 << 4,
+        FrameCount                  = 1 << 5,
+        RepetitionCount             = 1 << 6,
+        ColorSpace                  = 1 << 7,
+        SinglePixelSolidColor       = 1 << 8,
+
+        UTI                         = 1 << 9,
+        FilenameExtension           = 1 << 10,
+        AccessibilityDescription    = 1 << 11,
+        HotSpot                     = 1 << 12,
+        MaximumSubsamplingLevel     = 1 << 13,
+    };
+
+    template<typename MetadataType>
+    MetadataType imageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (ImageDecoder::*functor)() const) const;
+
+    template<typename MetadataType>
+    MetadataType primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag, MetadataType (ImageFrame::*functor)() const) const;
+
+    template<typename MetadataType>
+    MetadataType primaryNativeImageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (NativeImage::*functor)() const) const;
+
+    mutable OptionSet<CachedFlag> m_cachedFlags;
+
+    mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };
+    mutable IntSize m_size;
+    mutable std::optional<IntSize> m_densityCorrectedSize;
+    mutable ImageOrientation m_orientation;
+    mutable size_t m_primaryFrameIndex { 0 };
+    mutable size_t m_frameCount { 0 };
+    mutable RepetitionCount m_repetitionCount { RepetitionCountNone };
+    mutable DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
+    mutable std::optional<Color> m_singlePixelSolidColor;
+
+    mutable String m_uti;
+    mutable String m_filenameExtension;
+    mutable String m_accessibilityDescription;
+    mutable std::optional<IntPoint> m_hotSpot;
+    mutable SubsamplingLevel m_maximumSubsamplingLevel { SubsamplingLevel::Default };
+
+    BitmapImageSource& m_source;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BitmapImageDescriptor.h"
 #include "ImageFrameWorkQueue.h"
 #include "ImageSource.h"
 #include <wtf/Expected.h>
@@ -43,11 +44,13 @@ public:
 
     // State
     ImageDecoder* decoder(FragmentedSharedBuffer* = nullptr) const;
+    ImageDecoder* decoderIfExists() const { return m_decoder.get(); }
 
     // Encoded and decoded data
     void destroyDecodedData(bool destroyAll) final;
     void resetData();
     unsigned decodedSize() const { return m_decodedSize; }
+    void didDecodeProperties(unsigned decodedPropertiesSize);
 
     // Animation
     bool isAnimationAllowed() const;
@@ -59,8 +62,9 @@ public:
     void imageFrameDecodeAtIndexHasFinished(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&, RefPtr<NativeImage>&&);
 
     // ImageFrame
-    unsigned primaryFrameIndex() const final;
+    unsigned primaryFrameIndex() const final { return m_descriptor.primaryFrameIndex(); }
 
+    const Vector<ImageFrame>& frames() const { return m_frames; }
     const ImageFrame& primaryImageFrame() final { return frameAtIndexCacheIfNeeded(primaryFrameIndex()); }
 
     // NativeImage
@@ -69,10 +73,11 @@ public:
     RefPtr<NativeImage> primaryNativeImage() final { return nativeImageAtIndex(primaryFrameIndex()); }
 
     // Image Metadata
-    unsigned frameCount() const final;
-    RepetitionCount repetitionCount() const;
+    unsigned frameCount() const final { return m_descriptor.frameCount(); }
+    RepetitionCount repetitionCount() const { return m_descriptor.repetitionCount(); }
 
     // ImageFrame metadata
+    IntSize frameSizeAtIndex(unsigned index, SubsamplingLevel = SubsamplingLevel::Default) const;
     Seconds frameDurationAtIndex(unsigned index) const final;
     DecodingStatus frameDecodingStatusAtIndex(unsigned index) const final;
 
@@ -80,24 +85,6 @@ public:
     const char* sourceUTF8() const;
 
 private:
-    enum class CachedFlag : uint16_t {
-        EncodedDataStatus           = 1 << 0,
-        Size                        = 1 << 1,
-        DensityCorrectedSize        = 1 << 2,
-        Orientation                 = 1 << 3,
-        PrimaryFrameIndex           = 1 << 4,
-        FrameCount                  = 1 << 5,
-        RepetitionCount             = 1 << 6,
-        ColorSpace                  = 1 << 7,
-        SinglePixelSolidColor       = 1 << 8,
-
-        UTI                         = 1 << 9,
-        FilenameExtension           = 1 << 10,
-        AccessibilityDescription    = 1 << 11,
-        HotSpot                     = 1 << 12,
-        MaximumSubsamplingLevel     = 1 << 13,
-    };
-
     BitmapImageSource(BitmapImage&, AlphaOption, GammaAndColorProfileOption);
 
     // State
@@ -115,7 +102,6 @@ private:
     void decodedSizeReset(unsigned decodedSize);
     bool canDestroyDecodedData() const;
 
-    void didDecodeProperties(unsigned decodedPropertiesSize);
     void clearFrameBufferCache();
 
     // Animation
@@ -161,39 +147,27 @@ private:
     RefPtr<NativeImage> currentNativeImage() final { return nativeImageAtIndex(currentFrameIndex()); }
     RefPtr<NativeImage> currentPreTransformedNativeImage(ImageOrientation orientation) final { return preTransformedNativeImageAtIndex(currentFrameIndex(), orientation); }
 
-    // Image Metadata
-    template<typename MetadataType>
-    MetadataType imageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (ImageDecoder::*functor)() const) const;
-
-    template<typename MetadataType>
-    MetadataType primaryNativeImageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (NativeImage::*functor)() const) const;
-
-    template<typename MetadataType>
-    MetadataType primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag, MetadataType (ImageFrame::*functor)() const) const;
-
-    EncodedDataStatus encodedDataStatus() const;
-    IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final;
-    IntSize sourceSize(ImageOrientation = ImageOrientation::Orientation::FromImage) const final;
-    std::optional<IntSize> densityCorrectedSize() const;
+    EncodedDataStatus encodedDataStatus() const { return m_descriptor.encodedDataStatus(); }
+    IntSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_descriptor.size(orientation); }
+    IntSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_descriptor.sourceSize(orientation); }
+    std::optional<IntSize> densityCorrectedSize() const { return m_descriptor.densityCorrectedSize(); }
     bool hasDensityCorrectedSize() const final { return densityCorrectedSize().has_value(); }
-    ImageOrientation orientation() const final;
-    DestinationColorSpace colorSpace() const final;
-    std::optional<Color> singlePixelSolidColor() const final;
+    ImageOrientation orientation() const final { return m_descriptor.orientation(); }
+    DestinationColorSpace colorSpace() const final { return m_descriptor.colorSpace(); }
+    std::optional<Color> singlePixelSolidColor() const final { return m_descriptor.singlePixelSolidColor(); }
 
-    String uti() const final;
-    String filenameExtension() const final;
-    String accessibilityDescription() const final;
-    std::optional<IntPoint> hotSpot() const final;
-    SubsamplingLevel maximumSubsamplingLevel() const;
-
-    SubsamplingLevel subsamplingLevelForScaleFactor(GraphicsContext&, const FloatSize& scaleFactor, AllowImageSubsampling) final;
+    String uti() const final { return m_descriptor.uti(); }
+    String filenameExtension() const final { return m_descriptor.filenameExtension(); }
+    String accessibilityDescription() const final { return m_descriptor.accessibilityDescription(); }
+    std::optional<IntPoint> hotSpot() const final { return m_descriptor.hotSpot(); }
+    SubsamplingLevel maximumSubsamplingLevel() const { return m_descriptor.maximumSubsamplingLevel(); }
+    SubsamplingLevel subsamplingLevelForScaleFactor(GraphicsContext& context, const FloatSize& scaleFactor, AllowImageSubsampling allowImageSubsampling) final { return m_descriptor.subsamplingLevelForScaleFactor(context, scaleFactor, allowImageSubsampling); }
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    bool shouldUseQuickLookForFullscreen() const;
+    bool shouldUseQuickLookForFullscreen() const final { return m_descriptor.shouldUseQuickLookForFullscreen(); }
 #endif
 
     // ImageFrame metadata
-    IntSize frameSizeAtIndex(unsigned index, SubsamplingLevel = SubsamplingLevel::Default) const;
     ImageOrientation frameOrientationAtIndex(unsigned index) const final;
 
     // BitmapImage metadata
@@ -217,29 +191,11 @@ private:
     GammaAndColorProfileOption m_gammaAndColorProfileOption { GammaAndColorProfileOption::Applied };
     bool m_allDataReceived { false };
 
+    BitmapImageDescriptor m_descriptor;
     mutable RefPtr<ImageDecoder> m_decoder;
     mutable std::unique_ptr<ImageFrameAnimator> m_frameAnimator;
     mutable RefPtr<ImageFrameWorkQueue> m_workQueue;
     Vector<Function<void(DecodingStatus)>> m_decodeCallbacks;
-
-    // Metadata
-    mutable OptionSet<CachedFlag> m_cachedFlags;
-
-    mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };
-    mutable IntSize m_size;
-    mutable std::optional<IntSize> m_densityCorrectedSize;
-    mutable ImageOrientation m_orientation;
-    mutable size_t m_primaryFrameIndex { 0 };
-    mutable size_t m_frameCount { 0 };
-    mutable RepetitionCount m_repetitionCount { RepetitionCountNone };
-    mutable DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
-    mutable std::optional<Color> m_singlePixelSolidColor;
-
-    mutable String m_uti;
-    mutable String m_filenameExtension;
-    mutable String m_accessibilityDescription;
-    mutable std::optional<IntPoint> m_hotSpot;
-    mutable SubsamplingLevel m_maximumSubsamplingLevel { SubsamplingLevel::Default };
 
     // ImageFrame
     Vector<ImageFrame> m_frames;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -54,6 +54,7 @@
 #endif
 
 namespace Nicosia {
+using namespace WebCore;
 
 Lock Buffer::s_layersMemoryUsageLock;
 double Buffer::s_currentLayersMemoryUsage = 0.0;


### PR DESCRIPTION
#### b6e2e8c138383ce2f31e2c3b550246835682b577
<pre>
Move BitmapImage metadata retrieving to a new class named BitmapImageDescriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=274716">https://bugs.webkit.org/show_bug.cgi?id=274716</a>
<a href="https://rdar.apple.com/128738620">rdar://128738620</a>

Reviewed by Cameron McCormack.

This will decouple retrieving and caching the BitmapImage metadata from the
heavy weight class BitmapImageSource.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp: Added.
(WebCore::BitmapImageDescriptor::BitmapImageDescriptor):
(WebCore::BitmapImageDescriptor::imageMetadata const):
(WebCore::BitmapImageDescriptor::primaryImageFrameMetadata const):
(WebCore::BitmapImageDescriptor::primaryNativeImageMetadata const):
(WebCore::BitmapImageDescriptor::encodedDataStatus const):
(WebCore::BitmapImageDescriptor::size const):
(WebCore::BitmapImageDescriptor::sourceSize const):
(WebCore::BitmapImageDescriptor::densityCorrectedSize const):
(WebCore::BitmapImageDescriptor::orientation const):
(WebCore::BitmapImageDescriptor::primaryFrameIndex const):
(WebCore::BitmapImageDescriptor::frameCount const):
(WebCore::BitmapImageDescriptor::repetitionCount const):
(WebCore::BitmapImageDescriptor::colorSpace const):
(WebCore::BitmapImageDescriptor::singlePixelSolidColor const):
(WebCore::BitmapImageDescriptor::uti const):
(WebCore::BitmapImageDescriptor::filenameExtension const):
(WebCore::BitmapImageDescriptor::accessibilityDescription const):
(WebCore::BitmapImageDescriptor::hotSpot const):
(WebCore::BitmapImageDescriptor::maximumSubsamplingLevel const):
(WebCore::BitmapImageDescriptor::subsamplingLevelForScaleFactor const):
(WebCore::BitmapImageDescriptor::shouldUseQuickLookForFullscreen const):
(WebCore::BitmapImageDescriptor::dump const):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h: Added.
(WebCore::BitmapImageDescriptor::clear):
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::BitmapImageSource):
(WebCore::BitmapImageSource::dataChanged):
(WebCore::BitmapImageSource::dump const):
(WebCore::BitmapImageSource::imageMetadata const): Deleted.
(WebCore::BitmapImageSource::primaryNativeImageMetadata const): Deleted.
(WebCore::BitmapImageSource::primaryImageFrameMetadata const): Deleted.
(WebCore::BitmapImageSource::encodedDataStatus const): Deleted.
(WebCore::BitmapImageSource::size const): Deleted.
(WebCore::BitmapImageSource::sourceSize const): Deleted.
(WebCore::BitmapImageSource::densityCorrectedSize const): Deleted.
(WebCore::BitmapImageSource::orientation const): Deleted.
(WebCore::BitmapImageSource::primaryFrameIndex const): Deleted.
(WebCore::BitmapImageSource::frameCount const): Deleted.
(WebCore::BitmapImageSource::repetitionCount const): Deleted.
(WebCore::BitmapImageSource::colorSpace const): Deleted.
(WebCore::BitmapImageSource::singlePixelSolidColor const): Deleted.
(WebCore::BitmapImageSource::uti const): Deleted.
(WebCore::BitmapImageSource::filenameExtension const): Deleted.
(WebCore::BitmapImageSource::accessibilityDescription const): Deleted.
(WebCore::BitmapImageSource::hotSpot const): Deleted.
(WebCore::BitmapImageSource::maximumSubsamplingLevel const): Deleted.
(WebCore::BitmapImageSource::subsamplingLevelForScaleFactor): Deleted.
(WebCore::BitmapImageSource::shouldUseQuickLookForFullscreen const): Deleted.
* Source/WebCore/platform/graphics/BitmapImageSource.h:
(WebCore::BitmapImageSource::decoderIfExists const):
(WebCore::BitmapImageSource::frames const):
(WebCore::BitmapImageSource::repetitionCount const):
(WebCore::BitmapImageSource::encodedDataStatus const):
(WebCore::BitmapImageSource::densityCorrectedSize const):
(WebCore::BitmapImageSource::maximumSubsamplingLevel const):
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:

Canonical link: <a href="https://commits.webkit.org/279710@main">https://commits.webkit.org/279710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f0af231fd73220f3f63449b124f2ad8bd7dc7d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56534 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/41189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43931 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56327 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/41189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25073 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/41189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4297 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3104 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/41189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59100 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51349 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50711 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11818 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->