### PR TITLE
[tvOS] Add media controls layout traits

### DIFF
--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -348,8 +348,8 @@ $(PROJECT_DIR)/Modules/applepay/ApplePayCouponCodeUpdate.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDateComponents.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDateComponentsRange.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDeferredPaymentRequest.idl
-$(PROJECT_DIR)/Modules/applepay/ApplePayDisbursementRequest.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayDetailsUpdateBase.idl
+$(PROJECT_DIR)/Modules/applepay/ApplePayDisbursementRequest.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayError.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayErrorCode.idl
 $(PROJECT_DIR)/Modules/applepay/ApplePayErrorContactField.idl
@@ -729,6 +729,7 @@ $(PROJECT_DIR)/Modules/modern-media-controls/controls/time-control.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/time-label.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/time-label.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/tracks-button.js
+$(PROJECT_DIR)/Modules/modern-media-controls/controls/tvos-layout-traits.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-layout-traits.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-media-controls.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-media-controls.js
@@ -1757,7 +1758,6 @@ $(PROJECT_DIR)/mathml/mathtags.in
 $(PROJECT_DIR)/page/BarProp.idl
 $(PROJECT_DIR)/page/Crypto.idl
 $(PROJECT_DIR)/page/DOMSelection.idl
-$(PROJECT_DIR)/page/DOMWindow.idl
 $(PROJECT_DIR)/page/DOMWindow+CSSOM.idl
 $(PROJECT_DIR)/page/DOMWindow+CSSOMView.idl
 $(PROJECT_DIR)/page/DOMWindow+Compat.idl
@@ -1766,6 +1766,7 @@ $(PROJECT_DIR)/page/DOMWindow+DeviceOrientation.idl
 $(PROJECT_DIR)/page/DOMWindow+RequestIdleCallback.idl
 $(PROJECT_DIR)/page/DOMWindow+Selection.idl
 $(PROJECT_DIR)/page/DOMWindow+VisualViewport.idl
+$(PROJECT_DIR)/page/DOMWindow.idl
 $(PROJECT_DIR)/page/EventSource.idl
 $(PROJECT_DIR)/page/FragmentDirective.idl
 $(PROJECT_DIR)/page/History.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2103,6 +2103,7 @@ MODERN_MEDIA_CONTROLS_SCRIPTS = \
     $(WebCore)/Modules/modern-media-controls/controls/airplay-placard.js \
     $(WebCore)/Modules/modern-media-controls/controls/invalid-placard.js \
     $(WebCore)/Modules/modern-media-controls/controls/pip-placard.js \
+    $(WebCore)/Modules/modern-media-controls/controls/tvos-layout-traits.js \
     $(WebCore)/Modules/modern-media-controls/controls/vision-slider.js \
     $(WebCore)/Modules/modern-media-controls/controls/vision-volume-container.js \
     $(WebCore)/Modules/modern-media-controls/controls/vision-media-controls.js \

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -116,8 +116,10 @@ String MediaControlsHost::layoutTraitsClassName() const
 {
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     return "MacOSLayoutTraits"_s;
-#elif PLATFORM(IOS) || PLATFORM(APPLETV)
+#elif PLATFORM(IOS)
     return "IOSLayoutTraits"_s;
+#elif PLATFORM(APPLETV)
+    return "TVOSLayoutTraits"_s;
 #elif PLATFORM(VISION)
     return "VisionLayoutTraits"_s;
 #elif PLATFORM(WATCHOS)

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-layout-traits.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021-2024 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class TVOSLayoutTraits extends LayoutTraits
+{
+    mediaControlsClass()
+    {
+        return IOSInlineMediaControls;
+    }
+
+    overridenSupportingObjectClasses()
+    {
+        return null;
+    }
+
+    resourceDirectory()
+    {
+        return "iOS";
+    }
+
+    controlsNeverAvailable()
+    {
+        return false;
+    }
+
+    supportsIconWithFullscreenVariant()
+    {
+        return false;
+    }
+
+    supportsDurationTimeLabel()
+    {
+        return false;
+    }
+
+    supportsAirPlay()
+    {
+        return false;
+    }
+
+    supportsPiP()
+    {
+        return false;
+    }
+
+    controlsDependOnPageScaleFactor()
+    {
+        return true;
+    }
+
+    skipDuration()
+    {
+        return 10;
+    }
+
+    promoteSubMenusWhenShowingMediaControlsContextMenu()
+    {
+        return false;
+    }
+
+    inheritsBorderRadius()
+    {
+        return true;
+    }
+
+    toString()
+    {
+        return `[TVOSLayoutTraits]`;
+    }
+}
+
+window.layoutTraitsClasses["TVOSLayoutTraits"] = TVOSLayoutTraits;


### PR DESCRIPTION
#### c6e0e47ee91911726266cdc8c2f2623562e650af
<pre>
[tvOS] Add media controls layout traits
<a href="https://bugs.webkit.org/show_bug.cgi?id=274724">https://bugs.webkit.org/show_bug.cgi?id=274724</a>
<a href="https://rdar.apple.com/128748660">rdar://128748660</a>

Reviewed by Jer Noble.

Added layout traits for media controls on tvOS, which for now are based on iOS inline media controls.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::layoutTraitsClassName const):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-layout-traits.js: Added.
(TVOSLayoutTraits.prototype.mediaControlsClass):
(TVOSLayoutTraits.prototype.overridenSupportingObjectClasses):
(TVOSLayoutTraits.prototype.resourceDirectory):
(TVOSLayoutTraits.prototype.controlsNeverAvailable):
(TVOSLayoutTraits.prototype.supportsIconWithFullscreenVariant):
(TVOSLayoutTraits.prototype.supportsDurationTimeLabel):
(TVOSLayoutTraits.prototype.supportsAirPlay):
(TVOSLayoutTraits.prototype.supportsPiP):
(TVOSLayoutTraits.prototype.controlsDependOnPageScaleFactor):
(TVOSLayoutTraits.prototype.skipDuration):
(TVOSLayoutTraits.prototype.promoteSubMenusWhenShowingMediaControlsContextMenu):
(TVOSLayoutTraits.prototype.inheritsBorderRadius):
(TVOSLayoutTraits.prototype.toString):
(TVOSLayoutTraits):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/279331@main">https://commits.webkit.org/279331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9883285c2d84dc3276d87c20dda3f3707ace1d06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43118 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58066 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50518 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11598 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->