### PR TITLE
Move all CacheStorageConnection callbacks to NativePromise

### DIFF
--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -30,6 +30,7 @@
 #include "RetrieveRecordsOptions.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
@@ -45,11 +46,14 @@ public:
     virtual Ref<OpenPromise> open(const ClientOrigin&, const String& cacheName) = 0;
     using RemovePromise = NativePromise<bool, DOMCacheEngine::Error>;
     virtual Ref<RemovePromise> remove(DOMCacheIdentifier) = 0;
-    virtual void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) = 0;
+    using RetrieveCachesPromise = NativePromise<DOMCacheEngine::CacheInfos, DOMCacheEngine::Error>;
+    virtual Ref<RetrieveCachesPromise> retrieveCaches(const ClientOrigin&, uint64_t updateCounter) = 0;
 
-    virtual void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) = 0;
-    virtual void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
-    virtual void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
+    using RetrieveRecordsPromise = NativePromise<Vector<DOMCacheEngine::CrossThreadRecord>, DOMCacheEngine::Error>;
+    virtual Ref<RetrieveRecordsPromise> retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&) = 0;
+    using BatchPromise = NativePromise<Vector<uint64_t>, DOMCacheEngine::Error>;
+    virtual Ref<BatchPromise> batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&) = 0;
+    virtual Ref<BatchPromise> batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&) = 0;
 
     virtual void reference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
     virtual void dereference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
@@ -59,8 +63,10 @@ public:
     uint64_t computeRecordBodySize(const FetchResponse&, const DOMCacheEngine::ResponseBody&);
 
     // Used only for testing purposes.
-    virtual void clearMemoryRepresentation(const ClientOrigin&, DOMCacheEngine::CompletionCallback&& callback) { callback(DOMCacheEngine::Error::NotImplemented); }
-    virtual void engineRepresentation(CompletionHandler<void(const String&)>&& callback) { callback(String { }); }
+    using CompletionPromise = NativePromise<void, DOMCacheEngine::Error>;
+    virtual Ref<CompletionPromise> clearMemoryRepresentation(const ClientOrigin&) { return CompletionPromise::createAndReject(DOMCacheEngine::Error::NotImplemented); }
+    using EngineRepresentationPromise = NativePromise<String, DOMCacheEngine::Error>;
+    virtual Ref<EngineRepresentationPromise> engineRepresentation() { return EngineRepresentationPromise::createAndReject(DOMCacheEngine::Error::NotImplemented); }
     virtual void updateQuotaBasedOnSpaceUsage(const ClientOrigin&) { }
 
 private:

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -486,14 +486,21 @@ void DOMCache::keys(std::optional<RequestInfo>&& info, CacheQueryOptions&& optio
 
 void DOMCache::queryCache(ResourceRequest&& request, const CacheQueryOptions& options, ShouldRetrieveResponses shouldRetrieveResponses, RecordsCallback&& callback)
 {
+    RefPtr context = scriptExecutionContext();
+    if (!context) {
+        callback(DOMCacheEngine::convertToException(DOMCacheEngine::Error::Stopped));
+        return;
+    }
+
     RetrieveRecordsOptions retrieveOptions { WTFMove(request), scriptExecutionContext()->crossOriginEmbedderPolicy(), *scriptExecutionContext()->securityOrigin(), options.ignoreSearch, options.ignoreMethod, options.ignoreVary, shouldRetrieveResponses == ShouldRetrieveResponses::Yes };
-    m_connection->retrieveRecords(m_identifier, WTFMove(retrieveOptions), [this, pendingActivity = makePendingActivity(*this), callback = WTFMove(callback)](auto&& result) mutable {
+
+    context->enqueueTaskWhenSettled(m_connection->retrieveRecords(m_identifier, WTFMove(retrieveOptions)), TaskSource::DOMManipulation, [this, pendingActivity = makePendingActivity(*this), callback = WTFMove(callback)] (auto&& result) mutable {
         if (m_isStopped) {
             callback(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), DOMCacheEngine::Error::Stopped));
             return;
         }
 
-        if (!result.has_value()) {
+        if (!result) {
             callback(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), result.error()));
             return;
         }
@@ -502,23 +509,32 @@ void DOMCache::queryCache(ResourceRequest&& request, const CacheQueryOptions& op
             return fromCrossThreadRecord(WTFMove(record));
         });
         callback(WTFMove(records));
+    }, [] (auto&& callback) {
+        callback(makeUnexpected(DOMCacheEngine::Error::Stopped));
     });
-
 }
 
 void DOMCache::batchDeleteOperation(const FetchRequest& request, CacheQueryOptions&& options, CompletionHandler<void(ExceptionOr<bool>&&)>&& callback)
 {
-    m_connection->batchDeleteOperation(m_identifier, request.internalRequest(), WTFMove(options), [this, pendingActivity = makePendingActivity(*this), callback = WTFMove(callback)](RecordIdentifiersOrError&& result) mutable {
+    RefPtr context = scriptExecutionContext();
+    if (!context) {
+        callback(DOMCacheEngine::convertToException(DOMCacheEngine::Error::Stopped));
+        return;
+    }
+
+    context->enqueueTaskWhenSettled(m_connection->batchDeleteOperation(m_identifier, request.internalRequest(), WTFMove(options)), TaskSource::DOMManipulation, [this, pendingActivity = makePendingActivity(*this), callback = WTFMove(callback)] (auto&& result) mutable {
         if (m_isStopped) {
             callback(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), DOMCacheEngine::Error::Stopped));
             return;
         }
 
-        if (!result.has_value()) {
+        if (!result) {
             callback(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), result.error()));
             return;
         }
         callback(!result.value().isEmpty());
+    }, [] (auto&& callback) {
+        callback(makeUnexpected(DOMCacheEngine::Error::Stopped));
     });
 }
 
@@ -551,20 +567,28 @@ void DOMCache::batchPutOperation(const FetchRequest& request, FetchResponse& res
 
 void DOMCache::batchPutOperation(Vector<Record>&& records, CompletionHandler<void(ExceptionOr<void>&&)>&& callback)
 {
+    RefPtr context = scriptExecutionContext();
+    if (!context) {
+        callback(DOMCacheEngine::convertToException(DOMCacheEngine::Error::Stopped));
+        return;
+    }
+
     auto crossThreadRecords = WTF::map(WTFMove(records), [](Record&& record) {
         return toCrossThreadRecord(WTFMove(record));
     });
-    m_connection->batchPutOperation(m_identifier, WTFMove(crossThreadRecords), [this, pendingActivity = makePendingActivity(*this), callback = WTFMove(callback)](auto&& result) mutable {
+    context->enqueueTaskWhenSettled(m_connection->batchPutOperation(m_identifier, WTFMove(crossThreadRecords)), TaskSource::DOMManipulation, [this, pendingActivity = makePendingActivity(*this), callback = WTFMove(callback)] (auto&& result) mutable {
         if (m_isStopped) {
             callback(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), DOMCacheEngine::Error::Stopped));
             return;
         }
 
-        if (!result.has_value()) {
+        if (!result) {
             callback(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), result.error()));
             return;
         }
         callback({ });
+    }, [] (auto&& callback) {
+        callback(makeUnexpected(DOMCacheEngine::Error::Stopped));
     });
 }
 

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.h
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.h
@@ -100,7 +100,7 @@ struct CrossThreadRecord {
         , responseBodySize(responseBodySize)
     {
     }
-    CrossThreadRecord isolatedCopy() &&;
+    WEBCORE_EXPORT CrossThreadRecord isolatedCopy() &&;
 
     uint64_t identifier;
     uint64_t updateResponseCounter;

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -178,13 +178,13 @@ void DOMCacheStorage::retrieveCaches(CompletionHandler<void(std::optional<Except
         return;
     }
 
-    m_connection->retrieveCaches(*origin, m_updateCounter, [this, callback = WTFMove(callback), pendingActivity = makePendingActivity(*this), connectionStorageLock = makeUnique<ConnectionStorageLock>(m_connection.copyRef(), *origin)](DOMCacheEngine::CacheInfosOrError&& result) mutable {
+    scriptExecutionContext()->enqueueTaskWhenSettled(m_connection->retrieveCaches(*origin, m_updateCounter), TaskSource::DOMManipulation, [this, callback = WTFMove(callback), pendingActivity = makePendingActivity(*this), connectionStorageLock = makeUnique<ConnectionStorageLock>(m_connection.copyRef(), *origin)] (auto&& result) mutable {
         if (m_isStopped) {
             callback(DOMCacheEngine::convertToException(DOMCacheEngine::Error::Stopped));
             return;
         }
         RefPtr context = scriptExecutionContext();
-        if (!result.has_value()) {
+        if (!result) {
             callback(DOMCacheEngine::convertToExceptionAndLog(context.get(), result.error()));
             return;
         }
@@ -203,6 +203,8 @@ void DOMCacheStorage::retrieveCaches(CompletionHandler<void(std::optional<Except
             });
         }
         callback(std::nullopt);
+    }, [] (auto&& callback) {
+        callback(makeUnexpected(DOMCacheEngine::Error::Stopped));
     });
 }
 
@@ -239,9 +241,9 @@ void DOMCacheStorage::doOpen(const String& name, DOMPromiseDeferred<IDLInterface
         return;
     }
 
-    context->enqueueTaskWhenSettled(m_connection->open(*origin(), name), TaskSource::DOMManipulation, [this, name, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this), connectionStorageLock = makeUnique<ConnectionStorageLock>(m_connection.copyRef(), *origin())](const DOMCacheEngine::CacheIdentifierOrError& result) mutable {
+    context->enqueueTaskWhenSettled(m_connection->open(*origin(), name), TaskSource::DOMManipulation, [this, name, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this), connectionStorageLock = makeUnique<ConnectionStorageLock>(m_connection.copyRef(), *origin())] (auto&& result) mutable {
         RefPtr context = scriptExecutionContext();
-        if (!result.has_value()) {
+        if (!result) {
             promise.reject(DOMCacheEngine::convertToExceptionAndLog(context.get(), result.error()));
             return;
         }
@@ -277,7 +279,7 @@ void DOMCacheStorage::doRemove(const String& name, DOMPromiseDeferred<IDLBoolean
     }
 
     scriptExecutionContext()->enqueueTaskWhenSettled(m_connection->remove(m_caches[position]->identifier()), TaskSource::DOMManipulation, [this, promise = WTFMove(promise), pendingActivity = makePendingActivity(*this)](const auto& result) mutable {
-        if (!result.has_value())
+        if (!result)
             promise.reject(DOMCacheEngine::convertToExceptionAndLog(scriptExecutionContext(), result.error()));
         else
             promise.resolve(result.value());

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -40,39 +40,25 @@ public:
     static Ref<WorkerCacheStorageConnection> create(WorkerGlobalScope& scope) { return adoptRef(*new WorkerCacheStorageConnection(scope)); }
     ~WorkerCacheStorageConnection();
 
-    void clearPendingRequests();
-
 private:
     explicit WorkerCacheStorageConnection(WorkerGlobalScope&);
 
     // WebCore::CacheStorageConnection.
     Ref<OpenPromise> open(const ClientOrigin&, const String& cacheName) final;
     Ref<RemovePromise> remove(DOMCacheIdentifier) final;
-    void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) final;
+    Ref<RetrieveCachesPromise> retrieveCaches(const ClientOrigin&, uint64_t updateCounter) final;
 
-    void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final;
-    void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
-    void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    Ref<RetrieveRecordsPromise> retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&) final;
+    Ref<BatchPromise> batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&) final;
+    Ref<BatchPromise> batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&) final;
 
     void reference(DOMCacheIdentifier) final;
     void dereference(DOMCacheIdentifier) final;
     void lockStorage(const ClientOrigin&) final;
     void unlockStorage(const ClientOrigin&) final;
 
-    void retrieveCachesCompleted(uint64_t requestIdentifier, DOMCacheEngine::CacheInfosOrError&&);
-    void retrieveRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::CrossThreadRecordsOrError&&);
-    void deleteRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordIdentifiersOrError&&);
-    void putRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordIdentifiersOrError&&);
-
     WorkerGlobalScope& m_scope;
-
     Ref<CacheStorageConnection> m_mainThreadConnection;
-
-    HashMap<uint64_t, DOMCacheEngine::CacheInfosCallback> m_retrieveCachesPendingRequests;
-    HashMap<uint64_t, DOMCacheEngine::CrossThreadRecordsCallback> m_retrieveRecordsPendingRequests;
-    HashMap<uint64_t, DOMCacheEngine::RecordIdentifiersCallback> m_batchDeleteAndPutPendingRequests;
-
-    uint64_t m_lastRequestIdentifier { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -368,6 +368,12 @@ public:
         }
     }
 
+    template<typename Promise, typename Task, typename Finalizer>
+    void enqueueTaskWhenSettled(Ref<Promise>&& promise, TaskSource taskSource, Task&& task, Finalizer&& finalizer)
+    {
+        enqueueTaskWhenSettled(WTFMove(promise), taskSource, CompletionHandlerWithFinalizer<void(typename Promise::Result&&)>(WTFMove(task), WTFMove(finalizer)));
+    }
+
 protected:
     class AddConsoleMessageTask : public Task {
     public:
@@ -413,7 +419,7 @@ private:
     RejectedPromiseTracker* ensureRejectedPromiseTrackerSlow();
 
     void checkConsistency() const;
-    RefCountedSerialFunctionDispatcher& nativePromiseDispatcher();
+    WEBCORE_EXPORT RefCountedSerialFunctionDispatcher& nativePromiseDispatcher();
 
     HashSet<MessagePort*> m_messagePorts;
     HashSet<ContextDestructionObserver*> m_destructionObservers;

--- a/Source/WebCore/page/CacheStorageProvider.h
+++ b/Source/WebCore/page/CacheStorageProvider.h
@@ -44,10 +44,10 @@ public:
 
         Ref<OpenPromise> open(const ClientOrigin&, const String&) final { return OpenPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
         Ref<RemovePromise> remove(DOMCacheIdentifier) final { return RemovePromise::createAndReject(DOMCacheEngine::Error::Stopped); }
-        void retrieveCaches(const ClientOrigin&, uint64_t, DOMCacheEngine::CacheInfosCallback&&) final { }
-        void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final { }
-        void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
-        void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
+        Ref<RetrieveCachesPromise> retrieveCaches(const ClientOrigin&, uint64_t)  final { return RetrieveCachesPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
+        Ref<RetrieveRecordsPromise> retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&)  final { return RetrieveRecordsPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
+        Ref<BatchPromise> batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&)  final { return BatchPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
+        Ref<BatchPromise> batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&)  final { return BatchPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
         void reference(DOMCacheIdentifier) final { }
         void dereference(DOMCacheIdentifier) final { }
         void lockStorage(const ClientOrigin&) final { }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6252,36 +6252,40 @@ void Internals::sendH2Ping(String url, DOMPromiseDeferred<IDLDouble>&& promise)
 
 void Internals::clearCacheStorageMemoryRepresentation(DOMPromiseDeferred<void>&& promise)
 {
-    auto* document = contextDocument();
+    RefPtr document = contextDocument();
     if (!document)
         return;
 
     if (!m_cacheStorageConnection) {
-        if (auto* page = contextDocument()->page())
+        if (RefPtr page = document->page())
             m_cacheStorageConnection = page->cacheStorageProvider().createCacheStorageConnection();
         if (!m_cacheStorageConnection)
             return;
     }
-    m_cacheStorageConnection->clearMemoryRepresentation(ClientOrigin { document->topOrigin().data(), document->securityOrigin().data() }, [promise = WTFMove(promise)] (auto && result) mutable {
-        ASSERT_UNUSED(result, !result);
+
+    document->enqueueTaskWhenSettled(m_cacheStorageConnection->clearMemoryRepresentation(ClientOrigin { document->topOrigin().data(), document->securityOrigin().data() }), TaskSource::DOMManipulation, [promise = WTFMove(promise)] (auto&&) mutable {
         promise.resolve();
     });
 }
 
 void Internals::cacheStorageEngineRepresentation(DOMPromiseDeferred<IDLDOMString>&& promise)
 {
-    auto* document = contextDocument();
+    RefPtr document = contextDocument();
     if (!document)
         return;
 
     if (!m_cacheStorageConnection) {
-        if (auto* page = contextDocument()->page())
+        if (RefPtr page = document->page())
             m_cacheStorageConnection = page->cacheStorageProvider().createCacheStorageConnection();
         if (!m_cacheStorageConnection)
             return;
     }
-    m_cacheStorageConnection->engineRepresentation([promise = WTFMove(promise)](const String& result) mutable {
-        promise.resolve(result);
+    document->enqueueTaskWhenSettled(m_cacheStorageConnection->engineRepresentation(), TaskSource::DOMManipulation, [promise = WTFMove(promise)](auto&& result) mutable {
+        if (!result) {
+            promise.reject(Exception { ExceptionCode::InvalidStateError, "internal error"_s });
+            return;
+        }
+        promise.resolve(WTFMove(result.value()));
     });
 }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -168,9 +168,6 @@ void WorkerGlobalScope::prepareForDestruction()
 
     stopIndexedDatabase();
 
-    if (m_cacheStorageConnection)
-        m_cacheStorageConnection->clearPendingRequests();
-
     if (m_storageConnection)
         m_storageConnection->scopeClosed();
 

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -50,26 +50,27 @@ public:
     void networkProcessConnectionClosed();
 
 private:
-    WebCacheStorageConnection(WebCacheStorageProvider&);
+    explicit WebCacheStorageConnection(WebCacheStorageProvider&);
 
     IPC::Connection& connection();
 
     // WebCore::CacheStorageConnection
     Ref<OpenPromise> open(const WebCore::ClientOrigin&, const String& cacheName) final;
     Ref<RemovePromise> remove(WebCore::DOMCacheIdentifier) final;
-    void retrieveCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&) final;
 
-    void retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&) final;
-    void batchDeleteOperation(WebCore::DOMCacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
-    void batchPutOperation(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    Ref<RetrieveCachesPromise> retrieveCaches(const WebCore::ClientOrigin&, uint64_t)  final;
+
+    Ref<RetrieveRecordsPromise> retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&)  final;
+    Ref<BatchPromise> batchDeleteOperation(WebCore::DOMCacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&)  final;
+    Ref<BatchPromise> batchPutOperation(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&)  final;
 
     void reference(WebCore::DOMCacheIdentifier) final;
     void dereference(WebCore::DOMCacheIdentifier) final;
     void lockStorage(const WebCore::ClientOrigin&) final;
     void unlockStorage(const WebCore::ClientOrigin&) final;
 
-    void clearMemoryRepresentation(const WebCore::ClientOrigin&, WebCore::DOMCacheEngine::CompletionCallback&&) final;
-    void engineRepresentation(CompletionHandler<void(const String&)>&&) final;
+    Ref<CompletionPromise> clearMemoryRepresentation(const WebCore::ClientOrigin&) final;
+    Ref<EngineRepresentationPromise> engineRepresentation() final;
     void updateQuotaBasedOnSpaceUsage(const WebCore::ClientOrigin&) final;
 
     WebCacheStorageProvider& m_provider;


### PR DESCRIPTION
#### d244968bca644b6ae5f293054c1c1ba757cef5a2
<pre>
Move all CacheStorageConnection callbacks to NativePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=274726">https://bugs.webkit.org/show_bug.cgi?id=274726</a>
<a href="https://rdar.apple.com/128755510">rdar://128755510</a>

Reviewed by Jean-Yves Avenard and Sihui Liu.

We move from completion handlers to native promise as a simplification.
We introduce a new enqueueTaskWhenSettled version that can take completion handler and a finalizer.
Covered by existing tests.

* Source/WebCore/Modules/cache/CacheStorageConnection.h:
(WebCore::CacheStorageConnection::clearMemoryRepresentation):
(WebCore::CacheStorageConnection::engineRepresentation):
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::queryCache):
(WebCore::DOMCache::batchDeleteOperation):
(WebCore::DOMCache::batchPutOperation):
* Source/WebCore/Modules/cache/DOMCacheEngine.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::retrieveCaches):
(WebCore::DOMCacheStorage::doOpen):
(WebCore::DOMCacheStorage::doRemove):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::retrieveCaches):
(WebCore::WorkerCacheStorageConnection::retrieveRecords):
(WebCore::WorkerCacheStorageConnection::batchDeleteOperation):
(WebCore::WorkerCacheStorageConnection::batchPutOperation):
(WebCore::WorkerCacheStorageConnection::retrieveCachesCompleted): Deleted.
(WebCore::WorkerCacheStorageConnection::retrieveRecordsCompleted): Deleted.
(WebCore::WorkerCacheStorageConnection::deleteRecordsCompleted): Deleted.
(WebCore::WorkerCacheStorageConnection::putRecordsCompleted): Deleted.
(WebCore::WorkerCacheStorageConnection::clearPendingRequests): Deleted.
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::enqueueTaskWhenSettled):
* Source/WebCore/page/CacheStorageProvider.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::clearCacheStorageMemoryRepresentation):
(WebCore::Internals::cacheStorageEngineRepresentation):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::prepareForDestruction):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::retrieveCaches):
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchDeleteOperation):
(WebKit::WebCacheStorageConnection::batchPutOperation):
(WebKit::WebCacheStorageConnection::clearMemoryRepresentation):
(WebKit::WebCacheStorageConnection::engineRepresentation):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/279505@main">https://commits.webkit.org/279505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d048531b8ca2c911101521226311540ba29928ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43435 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3631 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2462 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58457 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50840 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->