### PR TITLE
[JSC] `Intl.DurationFormat#resolvedOptions().fractionalDigits` should be `undefined` if `fractionalDigits` is `undefined`.

### DIFF
--- a/JSTests/stress/intl-durationformat-fractionaldigits-undefined.js
+++ b/JSTests/stress/intl-durationformat-fractionaldigits-undefined.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--useIntlDurationFormat=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const durationFormat = new Intl.DurationFormat("en", { fractionalDigits: undefined });
+shouldBe(durationFormat.resolvedOptions().fractionalDigits, undefined);

--- a/JSTests/stress/intl-durationformat.js
+++ b/JSTests/stress/intl-durationformat.js
@@ -170,7 +170,7 @@ function test() {
         shouldThrow(() => df.format(null), TypeError);
         shouldThrow(() => df.format(undefined), TypeError);
         shouldThrow(() => df.format([null]), TypeError);
-        shouldBe(JSON.stringify(df.resolvedOptions()), `{"locale":"en","style":"long","years":"long","yearsDisplay":"auto","months":"long","monthsDisplay":"auto","weeks":"long","weeksDisplay":"auto","days":"long","daysDisplay":"auto","hours":"long","hoursDisplay":"auto","minutes":"long","minutesDisplay":"auto","seconds":"long","secondsDisplay":"auto","milliseconds":"long","millisecondsDisplay":"auto","microseconds":"long","microsecondsDisplay":"auto","nanoseconds":"long","nanosecondsDisplay":"auto","fractionalDigits":0,"numberingSystem":"latn"}`);
+        shouldBe(JSON.stringify(df.resolvedOptions()), `{"locale":"en","style":"long","years":"long","yearsDisplay":"auto","months":"long","monthsDisplay":"auto","weeks":"long","weeksDisplay":"auto","days":"long","daysDisplay":"auto","hours":"long","hoursDisplay":"auto","minutes":"long","minutesDisplay":"auto","seconds":"long","secondsDisplay":"auto","milliseconds":"long","millisecondsDisplay":"auto","microseconds":"long","microsecondsDisplay":"auto","nanoseconds":"long","nanosecondsDisplay":"auto","numberingSystem":"latn"}`);
         shouldBe(JSON.stringify(Reflect.getOwnPropertyDescriptor(Intl.DurationFormat.prototype, Symbol.toStringTag)), `{"value":"Intl.DurationFormat","writable":false,"enumerable":false,"configurable":true}`);
     }
     {

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1026,9 +1026,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
   strict mode: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
-test/intl402/DurationFormat/constructor-options-fractionalDigits-valid.js:
-  default: 'Test262Error: undefined is supported by DurationFormat Expected SameValue(«0», «undefined») to be true'
-  strict mode: 'Test262Error: undefined is supported by DurationFormat Expected SameValue(«0», «undefined») to be true'
 test/intl402/DurationFormat/prototype/format/fractions-of-subsecond-units-en.js:
   default: 'Test262Error: DurationFormat output when microseconds first "numeric" unit Expected SameValue(«3 sec, 444 ms», «3 sec, 444.055006 ms») to be true'
   strict mode: 'Test262Error: DurationFormat output when microseconds first "numeric" unit Expected SameValue(«3 sec, 444 ms», «3 sec, 444.055006 ms») to be true'
@@ -1054,8 +1051,8 @@ test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero
   default: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
   strict mode: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
 test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js:
-  default: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06») to be true'
+  default: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
+  strict mode: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
 test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js:
   default: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«-1 year, -2 months, -3 weeks, -3 days, -4 hours, -5 minutes, -6 seconds, -7 milliseconds, -8 microseconds, -9 nanoseconds», «-1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds») to be true'
   strict mode: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«-1 year, -2 months, -3 weeks, -3 days, -4 hours, -5 minutes, -6 seconds, -7 milliseconds, -8 microseconds, -9 nanoseconds», «-1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds») to be true'
@@ -1072,17 +1069,23 @@ test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-
   default: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
   strict mode: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
 test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
-  default: 'Test262Error: Duration is {"seconds":9007199254740991,"milliseconds":9007199254740991,"microseconds":9007199254740991,"nanoseconds":9007199254740991} Expected SameValue(«0:00:9,016,215,470,202,186», «0:00:9,016,215,470,202,185») to be true'
-  strict mode: 'Test262Error: Duration is {"seconds":9007199254740991,"milliseconds":9007199254740991,"microseconds":9007199254740991,"nanoseconds":9007199254740991} Expected SameValue(«0:00:9,016,215,470,202,186», «0:00:9,016,215,470,202,185») to be true'
+  default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000», «0:00:10,000,000.000000001») to be true'
+  strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000», «0:00:10,000,000.000000001») to be true'
+test/intl402/DurationFormat/prototype/format/style-digital-en.js:
+  default: 'Test262Error: Assert DurationFormat format output using digital style option Expected SameValue(«1 yr, 2 mths, 3 wks, 3 days, 4:05:06», «1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
+  strict mode: 'Test262Error: Assert DurationFormat format output using digital style option Expected SameValue(«1 yr, 2 mths, 3 wks, 3 days, 4:05:06», «1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
 test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js:
   default: 'Test262Error: format output with nanosecond digits and fractionalDigits: undefined using digital style option Expected SameValue(«1:22:33», «1:22:33.111222333») to be true'
   strict mode: 'Test262Error: format output with nanosecond digits and fractionalDigits: undefined using digital style option Expected SameValue(«1:22:33», «1:22:33.111222333») to be true'
+test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-digital-en.js:
+  default: 'Test262Error: Using style : digital: length Expected SameValue(«5», «7») to be true'
+  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«5», «7») to be true'
 test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js:
   default: 'Test262Error: Using style : default: length Expected SameValue(«49», «40») to be true'
   strict mode: 'Test262Error: Using style : default: length Expected SameValue(«49», «40») to be true'
 test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js:
-  default: 'Test262Error: Using style : digital: length Expected SameValue(«28», «22») to be true'
-  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«28», «22») to be true'
+  default: 'Test262Error: Using style : digital: length Expected SameValue(«28», «24») to be true'
+  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«28», «24») to be true'
 test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js:
   default: 'Test262Error: Using style : long: length Expected SameValue(«49», «40») to be true'
   strict mode: 'Test262Error: Using style : long: length Expected SameValue(«49», «40») to be true'


### PR DESCRIPTION
#### a43717459fdb2af1b6dee3dbdb68488943c17710
<pre>
[JSC] `Intl.DurationFormat#resolvedOptions().fractionalDigits` should be `undefined` if `fractionalDigits` is `undefined`.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274733">https://bugs.webkit.org/show_bug.cgi?id=274733</a>

Reviewed by Ross Kirsling.

According to the spec[1], when creating a `DurationFormat` instance with
`new Intl.DurationFormat(locales, { fractionalDigits: undefined });`,
`Intl.DurationFormat#resolvedOptions().fractionalDigits` should be `undefined`. However, in the
current JSC, it is `0`. This was occurring because, according to the spec[2], the
`fallback` argument of the `GetNumberOption` abstract operation should be `undefined`, but we were
passing `0`.

This patch makes the following changes:

- Pass `numeric_limits&lt;unsigned&gt;::max()`, representing `undefined`, to the `fallback` argument of
the `intlNumberOption`
function, which corresponds to the `GetNumberOption` abstract operation, when initializing
`DurationFormat` instances.
- In the `DurationFormat#resolvedOption` function, set the `fractionalDigits` field to
`jsUndefined()` if `m_fractionalDigits` is `numeric_limits&lt;unsigned&gt;::max()`.

[1]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.resolvedOptions">https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat.prototype.resolvedOptions</a>
[2]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat">https://tc39.es/proposal-intl-duration-format/#sec-Intl.DurationFormat</a>

* JSTests/stress/intl-durationformat-fractionaldigits-undefined.js: Added.
(shouldBe):
* JSTests/stress/intl-durationformat.js:
(test):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::initializeDurationFormat):
(JSC::collectElements):
(JSC::IntlDurationFormat::resolvedOptions const):

Canonical link: <a href="https://commits.webkit.org/279503@main">https://commits.webkit.org/279503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7e5b5a24e0bf65928122b7b14b465db43e214a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24612 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2549 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47028 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58543 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28831 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46562 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11694 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65484 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12476 "Passed tests") | 
<!--EWS-Status-Bubble-End-->