### PR TITLE
Web Inspector: Cleaning: remove an extra semicolon in HTMLTreeBuilderFormatter.js

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js
@@ -148,7 +148,7 @@ HTMLTreeBuilderFormatter = class HTMLTreeBuilderFormatter
             this._implicitlyCloseTagNamesInsideParentTagNames(["option"], ["select"]);
             break;
         case "optgroup": {
-            let didClose = this._implicitlyCloseTagNamesInsideParentTagNames(["optgroup"], ["select"]);;
+            let didClose = this._implicitlyCloseTagNamesInsideParentTagNames(["optgroup"], ["select"]);
             if (!didClose)
                 this._implicitlyCloseTagNamesInsideParentTagNames(["option"], ["select"]);
             break;


### PR DESCRIPTION
#### 81421035efcc53c1dcbbccc287884ece39f60428
<pre>
Web Inspector: Cleaning: remove an extra semicolon in HTMLTreeBuilderFormatter.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=274736">https://bugs.webkit.org/show_bug.cgi?id=274736</a>

Reviewed by Tim Nguyen.

Remove an extra semicolon at the end of line 151.
There should be one semicolon in Javascript.

* Source/WebInspectorUI/UserInterface/Workers/Formatter/HTMLTreeBuilderFormatter.js:
(HTMLTreeBuilderFormatter.prototype._implicitlyCloseHTMLNodesForOpenTag):

Canonical link: <a href="https://commits.webkit.org/279335@main">https://commits.webkit.org/279335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bf117f6c771d639183989f479092b33fe50ed56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3943 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43140 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55315 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24271 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2099 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58092 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50542 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46170 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49859 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11600 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->