### PR TITLE
[WebGPU] When creating bind groups, a buffer's binding offset is not considered in validation

### DIFF
--- a/LayoutTests/fast/webgpu/fuzz-126848520-auto-layout-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-auto-layout-expected.txt
@@ -1,5 +1,5 @@
      0                0
      8                0
-GPUDevice.createBindGroup: entrySize == 0 or entrySize(16) > buffer size(16) or layoutBinding->minBindingSize(1073741820) > entrySize(16)
+GPUDevice.createBindGroup: entrySize == 0 or entrySize(16) + entryOffset(0) > buffer size(16) or layoutBinding->minBindingSize(1073741820) > entrySize(16)
 done
 

--- a/LayoutTests/fast/webgpu/regression/repro_274737-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274737-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: no validation error
+CONSOLE MESSAGE: the end
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274737.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274737.html
@@ -1,0 +1,55 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    try {
+      let adapter = await navigator.gpu.requestAdapter({});
+      let device = await adapter.requestDevice({});
+      device.pushErrorScope('validation');
+      let buffer = device.createBuffer({size: 4096, usage: GPUBufferUsage.STORAGE});
+      let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.MAP_READ});
+      let bindGroupLayout = device.createBindGroupLayout({
+        entries: [{binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}}],
+      });
+      let bindGroup = device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: [{binding: 0, resource: {buffer, offset: buffer.size - 256}}],
+      });
+      let module = device.createShaderModule({
+        code: `
+@group(0) @binding(0) var<storage, read_write> arr: array<u32>;
+
+@compute @workgroup_size(1)
+fn foo() {
+  arr[0x40]=1234567890;
+}
+`,
+      });
+      let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});
+      let pipeline = device.createComputePipeline({compute: {module}, layout: pipelineLayout});
+      let commandEncoder = device.createCommandEncoder({});
+      let computePassEncoder = commandEncoder.beginComputePass({});
+      computePassEncoder.setPipeline(pipeline);
+      computePassEncoder.setBindGroup(0, bindGroup, []);
+      computePassEncoder.dispatchWorkgroups(1);
+      computePassEncoder.end();
+      let commandBuffer = commandEncoder.finish();
+      device.queue.submit([commandBuffer]);
+      await device.queue.onSubmittedWorkDone();
+      await outputBuffer.mapAsync(GPUMapMode.READ);
+      log(new Uint32Array(outputBuffer.getMappedRange()));
+      let error = await device.popErrorScope();
+      if (error) {
+        log(error.message);
+      } else {
+        log('no validation error');
+      }
+      log('the end');
+    } catch (e) {
+      log('error');
+      log(e);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_274737b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274737b-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: GPUDevice.createBindGroup: entrySize == 0 or entrySize(4096) + entryOffset(3840) > buffer size(4096) or layoutBinding->minBindingSize(0) > entrySize(4096)
+CONSOLE MESSAGE: the end
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274737b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274737b.html
@@ -1,0 +1,55 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    try {
+      let adapter = await navigator.gpu.requestAdapter({});
+      let device = await adapter.requestDevice({});
+      device.pushErrorScope('validation');
+      let buffer = device.createBuffer({size: 4096, usage: GPUBufferUsage.STORAGE});
+      let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.MAP_READ});
+      let bindGroupLayout = device.createBindGroupLayout({
+        entries: [{binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}}],
+      });
+      let bindGroup = device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: [{binding: 0, resource: {buffer, offset: buffer.size - 256, size: buffer.size}}],
+      });
+      let module = device.createShaderModule({
+        code: `
+@group(0) @binding(0) var<storage, read_write> arr: array<u32>;
+
+@compute @workgroup_size(1)
+fn foo() {
+  arr[0x40]=1234567890;
+}
+`,
+      });
+      let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});
+      let pipeline = device.createComputePipeline({compute: {module}, layout: pipelineLayout});
+      let commandEncoder = device.createCommandEncoder({});
+      let computePassEncoder = commandEncoder.beginComputePass({});
+      computePassEncoder.setPipeline(pipeline);
+      computePassEncoder.setBindGroup(0, bindGroup, []);
+      computePassEncoder.dispatchWorkgroups(1);
+      computePassEncoder.end();
+      let commandBuffer = commandEncoder.finish();
+      device.queue.submit([commandBuffer]);
+      await device.queue.onSubmittedWorkDone();
+      await outputBuffer.mapAsync(GPUMapMode.READ);
+      log(new Uint32Array(outputBuffer.getMappedRange()));
+      let error = await device.popErrorScope();
+      if (error) {
+        log(error.message);
+      } else {
+        log('no validation error');
+      }
+      log('the end');
+    } catch (e) {
+      log('error');
+      log(e);
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>


### PR DESCRIPTION
#### 183fd57756fe8071461981b25aabf2a53a1961c9
<pre>
[WebGPU] When creating bind groups, a buffer&apos;s binding offset is not considered in validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=274737">https://bugs.webkit.org/show_bug.cgi?id=274737</a>
&lt;radar://128610873&gt;

Reviewed by Tadeu Zagallo.

Buffer&apos;s offset was not considered when performing range validation.

Correct validation and add regression test.

* LayoutTests/fast/webgpu/regression/repro_274737-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274737.html: Added.
* LayoutTests/fast/webgpu/regression/repro_274737b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274737b.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):

Canonical link: <a href="https://commits.webkit.org/279463@main">https://commits.webkit.org/279463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a69fbf65a1d6146a4bf9f690f4a381584da64eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4294 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43419 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2821 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55666 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2450 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58445 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50824 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29932 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11673 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->