### PR TITLE
Drop SharedBufferReference::data()

### DIFF
--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -82,17 +82,17 @@ RefPtr<WebCore::SharedBuffer> SharedBufferReference::unsafeBuffer() const
     return nullptr;
 }
 
-const uint8_t* SharedBufferReference::data() const
+std::span<const uint8_t> SharedBufferReference::span() const
 {
 #if !USE(UNIX_DOMAIN_SOCKETS)
     RELEASE_ASSERT_WITH_MESSAGE(isEmpty() || (!m_buffer && m_memory), "Must only be called on IPC's receiver side");
 
     if (m_memory)
-        return static_cast<uint8_t*>(m_memory->data());
+        return m_memory->span().first(m_size);
 #endif
     if (!m_buffer || !m_buffer->isContiguous())
-        return nullptr;
-    return downcast<SharedBuffer>(m_buffer.get())->span().data();
+        return { };
+    return downcast<SharedBuffer>(m_buffer.get())->span().first(m_size);
 }
 
 RefPtr<WebCore::SharedMemory> SharedBufferReference::sharedCopy() const

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.h
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.h
@@ -81,8 +81,7 @@ public:
     // It relies on an implementation detail that makes m_buffer become a contiguous SharedBuffer
     // once it's deserialised over IPC.
     RefPtr<WebCore::SharedBuffer> unsafeBuffer() const;
-    const uint8_t* data() const;
-    std::span<const uint8_t> span() const { return { data(), size() }; }
+    std::span<const uint8_t> span() const;
     RefPtr<WebCore::SharedMemory> sharedCopy() const;
 
 private:


### PR DESCRIPTION
#### 1f8cd038e45ab6c758e1fa10ac04a73955ea53df
<pre>
Drop SharedBufferReference::data()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274740">https://bugs.webkit.org/show_bug.cgi?id=274740</a>

Reviewed by Darin Adler.

Drop SharedBufferReference::data() to promote to use of std::span.

* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::span const):
(IPC::SharedBufferReference::data const): Deleted.
* Source/WebKit/Platform/IPC/SharedBufferReference.h:
(IPC::SharedBufferReference::span const): Deleted.

Canonical link: <a href="https://commits.webkit.org/279353@main">https://commits.webkit.org/279353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbd816b3e28219801076903e058a9ac146d6e8de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3954 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/39931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43148 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2571 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55326 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30687 "16 new passes 11 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24279 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2110 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58103 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28373 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3410 "Found 1 new test failure: media/video-webkit-playsinline.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50549 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46178 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49867 "Found 1 new API test failure: /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30510 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7825 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->